### PR TITLE
Fix pool and conv doc

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -126,7 +126,7 @@
   * **input**:
     <dl>
       <dt>X</dt>
-      <dd>Input data tensor from the previous operator; dimensions for image case are (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and the width of the data. For non image case, the dimension are in the form of (N x D1 x D2 ... Dn), where N is the batch size.</dd>
+      <dd>Input data tensor from the previous operator; dimensions for image case are (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and the width of the data. For non image case, the dimension are in the form of (N x C x D1 x D2 ... Dn), where N is the batch size.</dd>
     </dl>
   * **output**:
     <dl>
@@ -259,12 +259,12 @@
       <dt>strides</dt>
       <dd>stride along each axis.</dd>
     </dl>
-  * **input**:2 - 3
+  * **input**:
     <dl>
       <dt>X</dt>
       <dd>Input data tensor from previous layer; has size (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and width. Note that this is for the 2D image.Otherwise the size is (N x D1 x D2 ... x Dn)</dd>
-      <dt>filter</dt>
-      <dd>The filter blob that will be used in the convolutions; has size (M x C x kH x kW), where C is the number of channels, and kH and kW are the height and width of the kernel.</dd>
+      <dt>weights</dt>
+      <dd>The weight tensor that will be used in the convolutions; has size (M x C x kH x kW), where C is the number of channels, and kH and kW are the height and width of the kernel, and M is the number of feature maps. For more than 2 dimensions, the kernel shape will be (M x C x k1 x k2 x ... x kn), where is the dimenstion of the kernel</dd>
     </dl>
   * **output**:
     <dl>
@@ -294,8 +294,8 @@
     <dl>
       <dt>X</dt>
       <dd>Input data tensor from previous layer; has size (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and width. Note that this is for the 2D image.Otherwise the size is (N x D1 x D2 ... x Dn)</dd>
-      <dt>filter</dt>
-      <dd>The filter blob that will be used in the convolutions; has size (M x C x kH x kW), where C is the number of channels, and kH and kW are the height and width of the kernel.</dd>
+      <dt>weights</dt>
+      <dd>The weight tensor that will be used in the convolutions; has size (C x M x kH x kW), where C is the number of channels, and kH and kW are the height and width of the kernel, and M is the number of feature maps. For more than 2 dimensions, the kernel shape will be (C x M x k1 x k2 x ... x kn), where is the dimenstion of the kernel</dd>
     </dl>
   * **output**:
     <dl>
@@ -507,7 +507,7 @@
   * **input**:
     <dl>
       <dt>X</dt>
-      <dd>Input data tensor from the previous operator; dimensions for image case are (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and the width of the data. For non image case, the dimension are in the form of (N x D1 x D2 ... Dn), where N is the batch size.</dd>
+      <dd>Input data tensor from the previous operator; dimensions for image case are (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and the width of the data. For non image case, the dimension are in the form of (N x C x D1 x D2 ... Dn), where N is the batch size.</dd>
     </dl>
   * **output**:
     <dl>
@@ -524,7 +524,7 @@
   * **input**:
     <dl>
       <dt>X</dt>
-      <dd>Input data tensor from the previous operator; dimensions for image case are (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and the width of the data. For non image case, the dimension are in the form of (N x D1 x D2 ... Dn), where N is the batch size.</dd>
+      <dd>Input data tensor from the previous operator; dimensions for image case are (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and the width of the data. For non image case, the dimension are in the form of (N x C x D1 x D2 ... Dn), where N is the batch size.</dd>
     </dl>
   * **output**:
     <dl>
@@ -611,7 +611,7 @@
   * **input**:
     <dl>
       <dt>X</dt>
-      <dd>Input data tensor from the previous operator; dimensions for image case are (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and the width of the data. For non image case, the dimension are in the form of (N x D1 x D2 ... Dn), where N is the batch size.</dd>
+      <dd>Input data tensor from the previous operator; dimensions for image case are (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and the width of the data. For non image case, the dimension are in the form of (N x C x D1 x D2 ... Dn), where N is the batch size.</dd>
     </dl>
   * **output**:
     <dl>

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -98,7 +98,7 @@ The convolution operator consumes an input tensor and {filter_desc}, and
 computes the output.)DOC";
             ReplaceAll(doc, "{filter_desc}", filter_desc);
             schema.SetDoc(doc);
-            schema.NumInputs(2);
+            schema.NumInputs(2, 3);
             schema.NumOutputs(1);
             schema.Input(0,
                          "X",

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -32,7 +32,7 @@ namespace onnx {
                          "Input data tensor from the previous operator; dimensions for image case "
                          "are (N x C x H x W), where N is the batch size, C is the number of channels, "
                          "and H and W are the height and the width of the data. For non image case, the "
-                         "dimension are in the form of (N x D1 x D2 ... Dn), where N is the batch size.");
+                         "dimension are in the form of (N x C x D1 x D2 ... Dn), where N is the batch size.");
             schema.Output(0,
                           "Y",
                           "Output data tensor from average pooling across the input "
@@ -76,7 +76,7 @@ namespace onnx {
                          "Input data tensor from the previous operator; dimensions for image case "
                          "are (N x C x H x W), where N is the batch size, C is the number of channels, "
                          "and H and W are the height and the width of the data. For non image case, the "
-                         "dimension are in the form of (N x D1 x D2 ... Dn), where N is the batch size.");
+                         "dimension are in the form of (N x C x D1 x D2 ... Dn), where N is the batch size.");
             schema.Output(0,
                           "Y",
                           "Output data tensor from max pooling across the input "
@@ -98,7 +98,7 @@ The convolution operator consumes an input tensor and {filter_desc}, and
 computes the output.)DOC";
             ReplaceAll(doc, "{filter_desc}", filter_desc);
             schema.SetDoc(doc);
-            schema.NumInputs(2, 3);
+            schema.NumInputs(2);
             schema.NumOutputs(1);
             schema.Input(0,
                          "X",
@@ -107,10 +107,12 @@ computes the output.)DOC";
                          " H and W are the height and width. Note that this is for the 2D image."
                          "Otherwise the size is (N x D1 x D2 ... x Dn)");
             schema.Input(1,
-                         "filter",
-                         "The filter blob that will be used in the convolutions; "
+                         "weights",
+                         "The weight tensor that will be used in the convolutions; "
                          "has size (M x C x kH x kW), where C is the number of channels, "
-                         "and kH and kW are the height and width of the kernel.");
+                         "and kH and kW are the height and width of the kernel, and M is the number "
+                         "of feature maps. For more than 2 dimensions, the kernel shape will be "
+                         "(M x C x k1 x k2 x ... x kn), where is the dimenstion of the kernel");
             schema.Output(0,
                           "Y",
                           "Output data tensor that contains the result of the convolution. The "
@@ -156,10 +158,12 @@ and computes the output.)DOC";
                          " H and W are the height and width. Note that this is for the 2D image."
                          "Otherwise the size is (N x D1 x D2 ... x Dn)");
             schema.Input(1,
-                         "filter",
-                         "The filter blob that will be used in the convolutions; "
-                         "has size (M x C x kH x kW), where C is the number of channels, "
-                         "and kH and kW are the height and width of the kernel.");
+                         "weights",
+                         "The weight tensor that will be used in the convolutions; "
+                         "has size (C x M x kH x kW), where C is the number of channels, "
+                         "and kH and kW are the height and width of the kernel, and M is the number "
+                         "of feature maps. For more than 2 dimensions, the kernel shape will be "
+                         "(C x M x k1 x k2 x ... x kn), where is the dimenstion of the kernel");
             schema.Output(0,
                           "Y",
                           "Output data tensor that contains the result of the convolution. The "
@@ -206,7 +210,7 @@ namespace onnx {
                          "Input data tensor from the previous operator; dimensions for image case "
                          "are (N x C x H x W), where N is the batch size, C is the number of channels, "
                          "and H and W are the height and the width of the data. For non image case, the "
-                         "dimension are in the form of (N x D1 x D2 ... Dn), where N is the batch size.");
+                         "dimension are in the form of (N x C x D1 x D2 ... Dn), where N is the batch size.");
             schema.Output(0,
                           "Y",
                           "Output data tensor from pooling across the input "


### PR DESCRIPTION
Pool input should always have channel or depth dimension, rename convolution input from `filter` to `weights`, to avoid confusion with kernel and remove the optional third input to convolution which wasn't used.