### PR TITLE
changed documentation to make initializers disjoint from inputs

### DIFF
--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -95,9 +95,13 @@ message GraphProto {
   repeated string input = 3;  // namespace Tensor
   repeated string output = 4; // namespace Tensor
 
-  // An optional list of named tensor values (constants).
-  // Used to pass serialized parameters for networks.
-  // Each TensorProto entry must have a name (unique in the tensor name space).
+  // A list of named tensor values (constants), used to specify default
+  // values for some of the inputs of the graph.
+  // Each TensorProto entry must have a distinct name (within the list) that
+  // also appears in the input list.
+  // In an evaluation, the default value specified here is used if and only if
+  // user specifies no value for the corresponding input parameter.
+  // May be used to pass serialized parameters for networks.
   repeated TensorProto initializer = 5;
 
   // The version of the IR this graph targets. See Version enum below.

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -95,11 +95,9 @@ message GraphProto {
   repeated string input = 3;  // namespace Tensor
   repeated string output = 4; // namespace Tensor
 
-  // An optional list of initial values for tensors in the list of input above.
+  // An optional list of named tensor values (constants).
   // Used to pass serialized parameters for networks.
-  // Each entry specifies a value for the input whose TensorProto.name matches
-  // a name in the input. This list is not required to be the same length of as
-  // input since many tensors might not have initial values.
+  // Each TensorProto entry must have a name (unique in the tensor name space).
   repeated TensorProto initializer = 5;
 
   // The version of the IR this graph targets. See Version enum below.


### PR DESCRIPTION
Including the names of tensors in the initializer list also in the input list is redundant (and somewhat confusing). It is simpler to treat them as being disjoint.