### PR TITLE
BREAKING CHANGE: Reordered fields of GraphProto to enable streaming implementations to read version info first.

### DIFF
--- a/onnx/__init__.py
+++ b/onnx/__init__.py
@@ -17,12 +17,12 @@ def load(obj):
     @params
     Takes a file-like object (has to implement fileno that returns a file descriptor)
     or a string containing a file name
-    @return ONNX GraphProto object
+    @return ONNX ModelProto object
     '''
-    graph = GraphProto()
+    model = ModelProto()
     if isinstance(obj, str) or (sys.version_info[0] == 2 and isinstance(obj, unicode)):
         with open(obj, 'rb') as f:
-            graph.ParseFromString(f.read())
+            model.ParseFromString(f.read())
     else:
-        graph.ParseFromString(obj.read())
-    return graph
+        model.ParseFromString(obj.read())
+    return model

--- a/onnx/checker.py
+++ b/onnx/checker.py
@@ -10,7 +10,7 @@ from __future__ import unicode_literals
 
 import logging
 
-from onnx.onnx_pb2 import AttributeProto, NodeProto, GraphProto, ModelProto IR_VERSION
+from onnx.onnx_pb2 import AttributeProto, NodeProto, GraphProto, ModelProto, IR_VERSION
 from onnx import defs
 
 

--- a/onnx/checker.py
+++ b/onnx/checker.py
@@ -10,7 +10,7 @@ from __future__ import unicode_literals
 
 import logging
 
-from onnx.onnx_pb2 import AttributeProto, NodeProto, GraphProto, IR_VERSION
+from onnx.onnx_pb2 import AttributeProto, NodeProto, GraphProto, ModelProto IR_VERSION
 from onnx import defs
 
 
@@ -48,14 +48,28 @@ def check_graph(graph):
     """
     if not isinstance(graph, GraphProto):
         raise RuntimeError('You cannot pass an object that is not GraphProto.')
-    if not graph.HasField('ir_version'):
-        raise ValueError('The graph does not have an ir_version set properly.')
-    if graph.ir_version > IR_VERSION:
-        logging.warning(
-            'Your graph ir_version is higher than the checker\'s, so it might '
-            'not interpret the higher version correctly.')
     if not graph.name:
         raise NameError(
             'The graph does not have a proper name set.')
     for node in graph.node:
         check_node(node)
+
+
+def check_model(model):
+    """Checks if a ModelProto is legal.
+
+    Inputs:
+        model: a ModelProto object.
+    Returns:
+        None
+    An exception is thrown if it does not pass the test.
+    """
+    if not isinstance(model, ModelProto):
+        raise RuntimeError('You cannot pass an object that is not ModelProto.')
+    if not graph.HasField('ir_version'):
+        raise ValueError('The model does not have an ir_version set properly.')
+    if graph.ir_version > IR_VERSION:
+        logging.warning(
+            'Your graph ir_version is higher than the checker\'s, so it might '
+            'not interpret the higher version correctly.')
+    check_graph(model.graph)

--- a/onnx/checker.py
+++ b/onnx/checker.py
@@ -66,10 +66,10 @@ def check_model(model):
     """
     if not isinstance(model, ModelProto):
         raise RuntimeError('You cannot pass an object that is not ModelProto.')
-    if not graph.HasField('ir_version'):
+    if not model.HasField('ir_version'):
         raise ValueError('The model does not have an ir_version set properly.')
-    if graph.ir_version > IR_VERSION:
+    if model.ir_version > IR_VERSION:
         logging.warning(
-            'Your graph ir_version is higher than the checker\'s, so it might '
+            'Your model ir_version is higher than the checker\'s, so it might '
             'not interpret the higher version correctly.')
     check_graph(model.graph)

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -8,7 +8,7 @@ import numbers
 import sys
 
 from onnx.onnx_pb2 import \
-    AttributeProto, TensorProto, NodeProto, GraphProto, IR_VERSION
+    AttributeProto, TensorProto, NodeProto, GraphProto, ModelProto IR_VERSION
 import onnx.onnx_cpp2py_export as C
 
 def make_node(
@@ -38,6 +38,13 @@ def make_graph(nodes, name, inputs, outputs, initializer=[]):
     graph.output.extend(outputs)
     graph.initializer.extend(initializer)
     return graph
+
+def make_model(graph, domain, model_version):
+    model = ModelProto()
+    model.graph = graph
+    model.domain = domain
+    model.model_version = model_version
+    return model
 
 
 def make_tensor(name, data_type, dims, vals, raw=False):

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -8,7 +8,7 @@ import numbers
 import sys
 
 from onnx.onnx_pb2 import \
-    AttributeProto, TensorProto, NodeProto, GraphProto, ModelProto IR_VERSION
+    AttributeProto, TensorProto, NodeProto, GraphProto, ModelProto, IR_VERSION
 import onnx.onnx_cpp2py_export as C
 
 def make_node(

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -29,9 +29,6 @@ def make_node(
 
 def make_graph(nodes, name, inputs, outputs, initializer=[]):
     graph = GraphProto()
-    # Touch graph.ir_version so it is stored as the version from which it is
-    # generated.
-    graph.ir_version = IR_VERSION
     graph.node.extend(nodes)
     graph.name = name
     graph.input.extend(inputs)
@@ -41,6 +38,9 @@ def make_graph(nodes, name, inputs, outputs, initializer=[]):
 
 def make_model(graph, domain, model_version):
     model = ModelProto()
+    # Touch model.ir_version so it is stored as the version from which it is
+    # generated.
+    model.ir_version = IR_VERSION
     model.graph = graph
     model.domain = domain
     model.model_version = model_version

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -44,6 +44,17 @@ package onnx;
 // of "namespace {Node,Graph,Attribute,Tensor}". Framework is responsible
 // for supporting the namespaces.
 
+// To be compatible with both proto2 and proto3, we will use a version number
+// that is not defined by the default value but an explicit enum number.
+enum Version {
+  // The version field is always serialized and we will use it to store the
+  // version that the  graph is generated from. This helps us set up version
+  // control. We should use version as
+  //     xx(major) - xx(minor) - xxxx(bugfix)
+  // and we are starting with 00000001.
+  IR_VERSION = 00000001;
+}
+
 // A named attribute containing either singular float, integer, string
 // and tensor values, or repeated float, integer, string and tensor values.
 // An AttributeProto MUST contain the name field, and *only one* of the
@@ -81,44 +92,56 @@ message NodeProto {
   optional string doc_string = 6;
 }
 
-// GraphProto defines a series of nodes to form a directed acyclic graph.
-// This is the equivalent of the "network" and "graph" in many deep learning
-// frameworks.
-message GraphProto {
-  // The version of the IR this graph targets. See Version enum below.
+// ModelProto is a top-level file/container format for bundling a ML model.
+// The semantics of the model are described by the GraphProto that represents
+// a parameterized computation graph against a set of named operators that are 
+// defined independently from the graph. 
+message ModelProto {
+  // The version of the IR this model targets. See Version enum above.
   // This field MUST be present. 
   optional int64 ir_version = 1;
   
-  // The name of the framework or tool used to generate this graph.
+  // The name of the framework or tool used to generate this model.
   // This field SHOULD be present to indicate which implementation/tool/framework 
-  // emitted the graph. 
+  // emitted the model. 
   optional string producer_name = 2;
   
-  // The name of the framework or tool used to generate this graph.
+  // The version of the framework or tool used to generate this model.
   // This field SHOULD be present to indicate which implementation/tool/framework 
-  // emitted the graph. 
+  // emitted the model. 
   optional string producer_version = 3;
 
-  // The name of the graph.
-  optional string name = 4;   // namespace Graph
-
-  // Domain of the graph.
+  // Domain name of the model.
   // We use reverse domain names as name space indicators. For example:
   // `com.facebook.fair` or `com.microsoft.cognitiveservices`
   //
-  // Together with `name` and `model_version`, this forms the unique identity of
+  // Together with `model_version` and GraphProto.name, this forms the unique identity of
   // the graph.
-  optional string domain = 5;
+  optional string domain = 4;
 
   // The version of the graph encoded. See Version enum below.
-  optional int64 model_version = 6;
+  optional int64 model_version = 5;
   
+  // A human-readable documentation for this model. Markdown is allowed.
+  optional string doc_string = 6;
+  
+  // The parameterized graph that is evaluated to execute the model.
+  optional GraphProto graph = 8; 
+};
+
+// GraphProto defines a parameterized series of nodes to form a directed acyclic graph.
+// This is the equivalent of the "network" and "graph" in many deep learning
+// frameworks.
+message GraphProto {
+  // The name of the graph.
+  optional string name = 1;   // namespace Graph
+
   // A human-readable documentation for this graph. Markdown is allowed.
-  optional string doc_string = 7;
-  
+  optional string doc_string = 2;
+
   // The inputs and outputs of the graph.
-  repeated string input = 8;  // namespace Tensor
-  repeated string output = 9; // namespace Tensor
+  repeated string input = 3;  // namespace Tensor
+  repeated string output = 4; // namespace Tensor
 
   // A list of named tensor values (constants), used to specify default
   // values for some of the inputs of the graph.
@@ -127,22 +150,11 @@ message GraphProto {
   // In an evaluation, the default value specified here is used if and only if
   // user specifies no value for the corresponding input parameter.
   // May be used to pass serialized parameters for networks.
-  repeated TensorProto initializer = 10;
+  repeated TensorProto initializer = 5;
 
   // The nodes in the graph.
-  repeated NodeProto node = 11;
+  repeated NodeProto node = 6;
 };
-
-// To be compatible with both proto2 and proto3, we will use a version number
-// that is not defined by the default value but an explicit enum number.
-enum Version {
-  // The version field is always serialized and we will use it to store the
-  // version that the  graph is generated from. This helps us set up version
-  // control. We should use version as
-  //     xx(major) - xx(minor) - xxxx(bugfix)
-  // and we are starting with 00000001.
-  IR_VERSION = 00000001;
-}
 
 // A message defined to store a tensor in its serialized format.
 message TensorProto {

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -126,7 +126,7 @@ message ModelProto {
   optional string doc_string = 6;
   
   // The parameterized graph that is evaluated to execute the model.
-  optional GraphProto graph = 8; 
+  optional GraphProto graph = 7; 
 };
 
 // GraphProto defines a parameterized series of nodes to form a directed acyclic graph.

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -89,17 +89,12 @@ message GraphProto {
   // This field MUST be present. 
   optional int64 ir_version = 1;
   
-  // The name of the framework used to generate this graph in the form
-  // "framework_name[-tag]". Tag is optional and provides additional
-  // information such as `alpha` or `beta` or `rc3`.
+  // The name of the framework or tool used to generate this graph.
   // This field SHOULD be present to indicate which implementation/tool/framework 
   // emitted the graph. 
-  optional string producer_tag = 2;
+  optional string producer_name = 2;
   
-  // The version of the framework runtime that generates this graph.
-  // Because there is no universally supported format or semantics for version #'s 
-  // the producer_version is encoded as a string. Implementations MAY use the SemVer
-  // format encoded as a string. 
+  // The name of the framework or tool used to generate this graph.
   // This field SHOULD be present to indicate which implementation/tool/framework 
   // emitted the graph. 
   optional string producer_version = 3;

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -133,11 +133,11 @@ message ModelProto {
 // This is the equivalent of the "network" and "graph" in many deep learning
 // frameworks.
 message GraphProto {
-  // The name of the graph.
-  optional string name = 1;   // namespace Graph
+  // The nodes in the graph.
+  repeated NodeProto node = 1;
 
-  // A human-readable documentation for this graph. Markdown is allowed.
-  optional string doc_string = 2;
+  // The name of the graph.
+  optional string name = 2;   // namespace Graph
 
   // The inputs and outputs of the graph.
   repeated string input = 3;  // namespace Tensor
@@ -152,8 +152,14 @@ message GraphProto {
   // May be used to pass serialized parameters for networks.
   repeated TensorProto initializer = 5;
 
-  // The nodes in the graph.
-  repeated NodeProto node = 6;
+  // A human-readable documentation for this graph. Markdown is allowed.
+  optional string doc_string = 10;
+
+  // DO NOT USE the following fields, they were deprecated before
+  // optional int64 ir_version = 6;
+  // optional int64 producer_version = 7;
+  // optional string producer_tag = 8;
+  // optional string domain = 9;
 };
 
 // A message defined to store a tensor in its serialized format.

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -85,45 +85,55 @@ message NodeProto {
 // This is the equivalent of the "network" and "graph" in many deep learning
 // frameworks.
 message GraphProto {
-  // The nodes in the graph.
-  repeated NodeProto node = 1;
+  // The version of the IR this graph targets. See Version enum below.
+  // This field MUST be present. 
+  optional int64 ir_version = 1;
+  
+  // The name of the framework used to generate this graph in the form
+  // "framework_name[-tag]". Tag is optional and provides additional
+  // information such as `alpha` or `beta` or `rc3`.
+  // This field SHOULD be present to indicate which implementation/tool/framework 
+  // emitted the graph. 
+  optional string producer_tag = 2;
+  
+  // The version of the framework runtime that generates this graph.
+  // Because there is no universally supported format or semantics for version #'s 
+  // the producer_version is encoded as a string. Implementations MAY use the SemVer
+  // format encoded as a string. 
+  // This field SHOULD be present to indicate which implementation/tool/framework 
+  // emitted the graph. 
+  optional string producer_version = 3;
 
   // The name of the graph.
-  optional string name = 2;   // namespace Graph
+  optional string name = 4;   // namespace Graph
 
+  // Domain of the graph.
+  // We use reverse domain names as name space indicators. For example:
+  // `com.facebook.fair` or `com.microsoft.cognitiveservices`
+  //
+  // Together with `name` and `model_version`, this forms the unique identity of
+  // the graph.
+  optional string domain = 5;
+
+  // The version of the graph encoded. See Version enum below.
+  optional int64 model_version = 6;
+  
+  // A human-readable documentation for this graph. Markdown is allowed.
+  optional string doc_string = 7;
+  
   // The inputs and outputs of the graph.
-  repeated string input = 3;  // namespace Tensor
-  repeated string output = 4; // namespace Tensor
+  repeated string input = 8;  // namespace Tensor
+  repeated string output = 9; // namespace Tensor
 
   // An optional list of initial values for tensors in the list of input above.
   // Used to pass serialized parameters for networks.
   // Each entry specifies a value for the input whose TensorProto.name matches
   // a name in the input. This list is not required to be the same length of as
   // input since many tensors might not have initial values.
-  repeated TensorProto initializer = 5;
+  repeated TensorProto initializer = 10;
 
-  // The version of the IR this graph targets. See Version enum below.
-  optional int64 ir_version = 6;
-
-  // The version of the framework runtime that generates this graph.
-  // This producer_version has the same format as ir_version. 
-  optional int64 producer_version = 7;
-
-  // The name of the framework used to generate this graph in the form
-  // "framework_name[-tag]". Tag is optional and provides additional
-  // information such as `alpha` or `beta` or `rc3`.
-  optional string producer_tag = 8;
-
-  // Domain of the graph.
-  // We use reverse domain names as name space indicators. For example:
-  // `com.facebook.fair` or `com.microsoft.cognitiveservices`
-  //
-  // Together with `name` and `version`, this forms the unique identity of
-  // the graph.
-  optional string domain = 9;
-
-  // A human-readable documentation for this graph. Markdown is allowed.
-  optional string doc_string = 10;
+  // The nodes in the graph.
+  repeated NodeProto node = 11;
 };
 
 // To be compatible with both proto2 and proto3, we will use a version number

--- a/onnx/test/basic_test.py
+++ b/onnx/test/basic_test.py
@@ -1,5 +1,5 @@
 import onnx
-from onnx.onnx_pb2 import AttributeProto, NodeProto, GraphProto, ModelProto IR_VERSION
+from onnx.onnx_pb2 import AttributeProto, NodeProto, GraphProto, ModelProto, IR_VERSION
 import unittest
 
 

--- a/onnx/test/basic_test.py
+++ b/onnx/test/basic_test.py
@@ -1,5 +1,5 @@
 import onnx
-from onnx.onnx_pb2 import AttributeProto, NodeProto, GraphProto, IR_VERSION
+from onnx.onnx_pb2 import AttributeProto, NodeProto, GraphProto, ModelProto IR_VERSION
 import unittest
 
 
@@ -10,23 +10,24 @@ class TestProtobufExists(unittest.TestCase):
             AttributeProto
             NodeProto
             GraphProto
+            ModelProto
         except Exception as e:
             self.fail(
                 'Did not find proper onnx protobufs. Error is: {}'
                 .format(e))
 
     def test_version_exists(self):
-        graph = GraphProto()
+        model = ModelProto()
         # When we create it, graph should not have a version string.
-        self.assertFalse(graph.HasField('ir_version'))
+        self.assertFalse(model.HasField('ir_version'))
         # We should touch the version so it is annotated with the current
         # ir version of the running ONNX
-        graph.ir_version = IR_VERSION
-        graph_string = graph.SerializeToString()
-        graph.ParseFromString(graph_string)
-        self.assertTrue(graph.HasField('ir_version'))
+        model.ir_version = IR_VERSION
+        model_string = model.SerializeToString()
+        model.ParseFromString(model_string)
+        self.assertTrue(model.HasField('ir_version'))
         # Check if the version is correct.
-        self.assertEqual(graph.ir_version, IR_VERSION)
+        self.assertEqual(model.ir_version, IR_VERSION)
 
 
 if __name__ == '__main__':

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import random
 
 from onnx import helper, defs
-from onnx.onnx_pb2 import AttributeProto, TensorProto, GraphProto, IR_VERSION
+from onnx.onnx_pb2 import AttributeProto, TensorProto, GraphProto,ModelProto IR_VERSION
 
 import unittest
 
@@ -183,8 +183,6 @@ class TestHelperNodeFunctions(unittest.TestCase):
             "test",
             ["X"],
             ["Y"])
-        self.assertTrue(graph.HasField("ir_version"))
-        self.assertEqual(graph.ir_version, IR_VERSION)
         self.assertEqual(len(graph.node), 1)
         self.assertEqual(graph.node[0], node_def)
 

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import random
 
 from onnx import helper, defs
-from onnx.onnx_pb2 import AttributeProto, TensorProto, GraphProto,ModelProto IR_VERSION
+from onnx.onnx_pb2 import AttributeProto, TensorProto, GraphProto,ModelProto, IR_VERSION
 
 import unittest
 


### PR DESCRIPTION
Reordered the fields of Graph per issue #53 in order to allow streaming implementations to read version info first in order to either fail fast or quirk based on the IR version and producer version used to produce the graph.

Note that this is a breaking change to (a) any serialized GraphProto's and (b) any code that used the GraphProto.producer_version, which is now encoded as a string given that we can't assume that all frameworks/runtimes that will emit ONNX adhere to the SemVer versioning scheme.

Note, that there is one other potential BC once we reconcile typeshape and operator_library PRs.