### PR TITLE
Improving tests: suites handling and device support

### DIFF
--- a/onnx/backend/base.py
+++ b/onnx/backend/base.py
@@ -49,13 +49,13 @@ class BackendRep(object):
 
 class Backend(object):
     @classmethod
-    def prepare(cls, model, device, **kwargs):
+    def prepare(cls, model, device='CPU', **kwargs):
         onnx.checker.check_model(model)
 
     @classmethod
-    def run_model(cls, model, inputs, device, **kwargs):
+    def run_model(cls, model, inputs, device='CPU', **kwargs):
         cls.prepare(model, device, **kwargs).run(inputs)
 
     @classmethod
-    def run_node(cls, node, inputs):
+    def run_node(cls, node, inputs, device='CPU'):
         onnx.checker.check_node(node)


### PR DESCRIPTION
1. Exposes tests to onnx-caffe2 in a better way, so that we can run only model tests or only node tests or some subset of tests. Change is backward-compatible and the only change in onnx-caffe2 needs to be:
```
globals().update(onnx.backend.test.BackendTest(c2).test_cases)
```

2. Adds device support to node_test - I need it for now for RNN tests before we have reference implementation done in Caffe2.