### PR TITLE
Skip the GPU-only tests if no GPU is available 

### DIFF
--- a/onnx/backend/base.py
+++ b/onnx/backend/base.py
@@ -59,3 +59,11 @@ class Backend(object):
     @classmethod
     def run_node(cls, node, inputs, device='CPU'):
         onnx.checker.check_node(node)
+
+    @classmethod
+    def supports_device(device):
+        """
+        Checks whether the backend is compiled with particular device support.
+        In particular it's used in the testing suite.
+        """
+        return True

--- a/onnx/backend/test.py
+++ b/onnx/backend/test.py
@@ -140,6 +140,9 @@ class BackendTest(object):
             outputs (list of ndarrays): outputs to the model
         """
         def run(test_self):
+            if not self.backend.supports_device(device):
+                raise unittest.SkipTest(
+                    "Backend doesn't support device {}".format(device))
             model_dir = self._prepare_model(model_name)
             model_pb_path = os.path.join(model_dir, 'model.pb')
             model = onnx.load(model_pb_path)
@@ -175,6 +178,9 @@ class BackendTest(object):
                 the input to the operator.
         """
         def run(test_self):
+            if not self.backend.supports_device(device):
+                raise unittest.SkipTest(
+                    "Backend doesn't support device {}".format(device))
             # TODO: In some cases we should generate multiple random inputs
             # and test (ala Hypothesis)
             args = create_input(inputs)


### PR DESCRIPTION
as we now have GPU only tests for CuDNN-style RNNs