### PR TITLE
Read protobuf lib from environment variable and add compile option /MT

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 from distutils.spawn import find_executable
 from distutils import sysconfig
+import pkg_resources
 import setuptools
 import setuptools.command.build_py
 import setuptools.command.develop
@@ -93,11 +94,10 @@ class Protobuf(Dependency):
         super(Protobuf, self).__init__()
         # TODO: allow user specify protobuf include_dirs libraries with flags
         # and environment variables
-        assert os.getenv('PROTOBUF_LIB')
-        self.libraries = [os.path.join(os.getenv('PROTOBUF_LIB'), "lib\\libprotobuf")]
-        self.include_dirs = [os.path.join(os.getenv('PROTOBUF_LIB'), "include")]
+        assert os.getenv('CONDA_PREFIX')
+        self.libraries = [os.path.join(os.getenv('CONDA_PREFIX'), "Library", "lib", "libprotobuf")]
 
-
+        
 class Pybind11(Dependency):
     def __init__(self):
         super(Pybind11, self).__init__()
@@ -147,8 +147,7 @@ class build_py(setuptools.command.build_py.build_py):
         self.run_command('create_version')
         self.run_command('build_proto')
         setuptools.command.build_py.build_py.run(self)
-
-
+        
 class develop(setuptools.command.develop.develop):
     def run(self):
         self.run_command('create_version')
@@ -187,6 +186,7 @@ def create_extension(ExtType, name, sources, dependencies, extra_link_args, extr
         extra_compile_args.append('-stdlib=libc++')
     if os.getenv('CONDA_PREFIX'):
         include_dirs.append(os.path.join(os.getenv('CONDA_PREFIX'), "include"))
+        include_dirs.append(os.path.join(os.getenv('CONDA_PREFIX'), "Library", "Include"))
     if platform.system() == 'Windows':
         extra_compile_args.append('/MT')
     return ExtType(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 from distutils.spawn import find_executable
 from distutils import sysconfig
-import pkg_resources
 import setuptools
 import setuptools.command.build_py
 import setuptools.command.develop
@@ -94,8 +93,9 @@ class Protobuf(Dependency):
         super(Protobuf, self).__init__()
         # TODO: allow user specify protobuf include_dirs libraries with flags
         # and environment variables
-        if os.getenv('CONDA_PREFIX'):
+        if os.getenv('CONDA_PREFIX') and platform.system() == 'Windows':
             self.libraries = [os.path.join(os.getenv('CONDA_PREFIX'), "Library", "lib", "libprotobuf")]
+            self.include_dirs = [os.path.join(os.getenv('CONDA_PREFIX'), "Library", "Include")]
         else:
             self.libraries = ['protobuf'] 
 
@@ -188,7 +188,6 @@ def create_extension(ExtType, name, sources, dependencies, extra_link_args, extr
         extra_compile_args.append('-stdlib=libc++')
     if os.getenv('CONDA_PREFIX'):
         include_dirs.append(os.path.join(os.getenv('CONDA_PREFIX'), "include"))
-        include_dirs.append(os.path.join(os.getenv('CONDA_PREFIX'), "Library", "Include"))
     if platform.system() == 'Windows':
         extra_compile_args.append('/MT')
     return ExtType(

--- a/setup.py
+++ b/setup.py
@@ -94,10 +94,12 @@ class Protobuf(Dependency):
         super(Protobuf, self).__init__()
         # TODO: allow user specify protobuf include_dirs libraries with flags
         # and environment variables
-        assert os.getenv('CONDA_PREFIX')
-        self.libraries = [os.path.join(os.getenv('CONDA_PREFIX'), "Library", "lib", "libprotobuf")]
+        if os.getenv('CONDA_PREFIX'):
+            self.libraries = [os.path.join(os.getenv('CONDA_PREFIX'), "Library", "lib", "libprotobuf")]
+        else:
+            self.libraries = ['protobuf'] 
 
-        
+
 class Pybind11(Dependency):
     def __init__(self):
         super(Pybind11, self).__init__()

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,9 @@ class Protobuf(Dependency):
         super(Protobuf, self).__init__()
         # TODO: allow user specify protobuf include_dirs libraries with flags
         # and environment variables
-        self.libraries = ['protobuf']
+        assert os.getenv('PROTOBUF_LIB')
+        self.libraries = [os.path.join(os.getenv('PROTOBUF_LIB'), "lib\\libprotobuf")]
+        self.include_dirs = [os.path.join(os.getenv('PROTOBUF_LIB'), "include")]
 
 
 class Pybind11(Dependency):
@@ -185,6 +187,8 @@ def create_extension(ExtType, name, sources, dependencies, extra_link_args, extr
         extra_compile_args.append('-stdlib=libc++')
     if os.getenv('CONDA_PREFIX'):
         include_dirs.append(os.path.join(os.getenv('CONDA_PREFIX'), "include"))
+    if platform.system() == 'Windows':
+        extra_compile_args.append('/MT')
     return ExtType(
         name=name,
         sources=sources,


### PR DESCRIPTION
Read "PROTOBUF_LIB" from environment variable (in my local case it's "C:\ProgramData\Anaconda3\pkgs\protobuf-3.4.0-py36_vc14_0\Library" after running "conda install -c conda-forge protobuf numpy"), so that the include dirs. and libraries could be relative to "PROTOBUF_LIB".

Adding "/MT" when compiling to fix "MT_STATICRELEASE" and "MD_DYNAMICRELEASE" mismatch. 