### PR TITLE
Add discriminator to attribute proto

### DIFF
--- a/onnx/checker.py
+++ b/onnx/checker.py
@@ -15,54 +15,55 @@ from onnx.onnx_ml_pb2 import TensorProto, ValueInfoProto, NodeProto, AttributePr
     GraphProto, ModelProto, IR_VERSION
 from onnx import defs, mapping
 
-def check_attr(attr, model):
+
+
+
+def check_attr(attr, ir_version=IR_VERSION):
     """Checks if a node attribute is legal.
 
     Inputs:
         node: an AttributeProto object.
-        model: the ModelProto object this node came from.
+        ir_version: the IR_VERSION to validate against.
     Returns:
         None
     An exception is thrown if it does not pass the test.
     """
-    require_type_field = model.ir_version >= IR_VERSION
+    require_type_field = ir_version >= IR_VERSION
     has_attr_type = attr.HasField("type")
+
+    def check_mismatch(field_name, type_value, type_value_name):
+        if attr.HasField(field_name) and has_attr_type and attr.type != type_value:
+            raise RuntimeError('AttributeProto.type is wrong value (expected '
+                               + type_value_name + ').')
+
     if require_type_field and not has_attr_type:
         raise RuntimeError('AttributeProto missing type field where IR version requires it.')
-    if attr.HasField('s') and has_attr_type and attr.type != AttributeProto.STRING:
-        raise RuntimeError('AttributeProto.type is wrong value (expected STRING).')
-    if attr.HasField('f') and has_attr_type and attr.type != AttributeProto.FLOAT:
-        raise RuntimeError('AttributeProto.type is wrong value (expected FLOAT).')
-    if attr.HasField('i') and has_attr_type and attr.type != AttributeProto.INT:
-        raise RuntimeError('AttributeProto.type is wrong value (expected INT).')
-    if attr.HasField('t'):
-        if has_attr_type and attr.type != AttributeProto.TENSOR:
-            raise RuntimeError('AttributeProto.type is wrong value (expected TENSOR).')
-        check_tensor(attr.t, model)
-    if attr.HasField('g'):
-        if has_attr_type and attr.type != AttributeProto.GRAPH:
-            raise RuntimeError('AttributeProto.type is wrong value (expected GRAPH).')
-    if attr.HasField('strings') and has_attr_type and attr.type != AttributeProto.STRINGS:
-        raise RuntimeError('AttributeProto.type is wrong value (expected STRINGS).')
-    if attr.HasField('floats') and has_attr_type and attr.type != AttributeProto.FLOATS:
-        raise RuntimeError('AttributeProto.type is wrong value (expected FLOATS).')
-    if attr.HasField('ints') and has_attr_type and attr.type != AttributeProto.INTS:
-        raise RuntimeError('AttributeProto.type is wrong value (expected INTS).')
-    if attr.HasField('tensors'):
-        if has_attr_type and attr.type != AttributeProto.TENSORS:
-            raise RuntimeError('AttributeProto.type is wrong value (expected TENSORS).')
-        for tensor in attr.tensors:
-            check_tensor(tensor, model)
-    if attr.HasField('graphs'):
-        if has_attr_type and attr.type != AttributeProto.GRAPHS:
-            raise RuntimeError('AttributeProto.type is wrong value (expected GRAPHS).')
 
-def check_node(node, model):
+    check_mismatch('s', AttributeProto.STRING, 'STRING')
+    check_mismatch('f', AttributeProto.FLOAT, 'FLOAT')
+    check_mismatch('i', AttributeProto.INT, 'INT')
+    check_mismatch('t', AttributeProto.TENSOR, 'TENSOR')
+    check_mismatch('g', AttributeProto.GRAPH, 'GRAPH')
+
+    check_mismatch('strings', AttributeProto.STRINGS, 'STRINGS')
+    check_mismatch('floats', AttributeProto.FLOATS, 'FLOATS')
+    check_mismatch('ints', AttributeProto.INTS, 'INTS')
+    check_mismatch('tensors', AttributeProto.TENSORS, 'TENSORS')
+    check_mismatch('graphs', AttributeProto.GRAPHS, 'GRAPHS')
+
+    if attr.HasField('t'):
+        check_tensor(attr.t)
+    if attr.HasField('tensors'):
+        for tensor in attr.tensors:
+            check_tensor(tensor)
+
+
+def check_node(node, ir_version=IR_VERSION):
     """Checks if a node is legal.
 
     Inputs:
         node: a NodeProto object.
-        model: the ModelProto object this node came from.
+        ir_version: the IR_VERSION to check against.
     Returns:
         None
     An exception is thrown if it does not pass the test.
@@ -81,7 +82,7 @@ def check_node(node, model):
         raise ValueError(
             'NodeProto of type {} did not pass defs schema check.'.format(str(node.op_type)))
     for attr in node.attribute:
-        check_attr(attr, model)
+        check_attr(attr, ir_version)
 
 
 def check_tensor_value_info(value_info,
@@ -114,7 +115,7 @@ def check_tensor_value_info(value_info,
             'TypeProto.value should be either tensor_type or sparse_tensor_type')
 
 
-def check_tensor(tensor, model):
+def check_tensor(tensor):
     if not isinstance(tensor, TensorProto):
         raise RuntimeError('You cannot pass an object that is not TensorProto.')
 
@@ -144,11 +145,12 @@ def check_tensor(tensor, model):
                 ))
 
 
-def check_graph(graph, model):
+def check_graph(graph, ir_version=IR_VERSION):
     """Checks if a GraphProto is legal.
 
     Inputs:
         graph: a GraphProto object.
+        ir_version: the IR_VERSION to check against.
     Returns:
         None
     An exception is thrown if it does not pass the test.
@@ -163,14 +165,14 @@ def check_graph(graph, model):
     for value_info in graph.value_info:
         check_tensor_value_info(value_info)
     for node in graph.node:
-        check_node(node, model)
+        check_node(node, ir_version)
 
     input_names = {value_info.name for value_info in graph.input}
     for init in graph.initializer:
         if init.name not in input_names:
             raise ValueError(
                 '{} in initializer but not in graph input'.format(init.name))
-        check_tensor(init, model)
+        check_tensor(init)
 
 
 def check_model(model):
@@ -190,4 +192,4 @@ def check_model(model):
         logging.warning(
             'Your model ir_version is higher than the checker\'s, so it might '
             'not interpret the higher version correctly.')
-    check_graph(model.graph, model)
+    check_graph(model.graph, model.ir_version)

--- a/onnx/checker.py
+++ b/onnx/checker.py
@@ -30,15 +30,16 @@ def check_attr(attr, ir_version=IR_VERSION):
     """
 
     require_type_field = ir_version >= IR_VERSION
-    has_attr_type = attr.HasField("type")
+    has_attr_type = attr.HasField('type') and attr.type != AttributeProto.UNDEFINED
+
+    if require_type_field and not has_attr_type:
+        raise RuntimeError('AttributeProto missing type field where IR version requires it.')
 
     def check_mismatch(field_name, type_value, type_value_name):
         if attr.HasField(field_name) and has_attr_type and attr.type != type_value:
             raise RuntimeError('AttributeProto.type is wrong value (expected '
                                + type_value_name + ').')
 
-    if require_type_field and not has_attr_type:
-        raise RuntimeError('AttributeProto missing type field where IR version requires it.')
 
     check_mismatch('s', AttributeProto.STRING, 'STRING')
     check_mismatch('f', AttributeProto.FLOAT, 'FLOAT')

--- a/onnx/checker.py
+++ b/onnx/checker.py
@@ -28,6 +28,7 @@ def check_attr(attr, ir_version=IR_VERSION):
         None
     An exception is thrown if it does not pass the test.
     """
+
     require_type_field = ir_version >= IR_VERSION
     has_attr_type = attr.HasField("type")
 

--- a/onnx/checker.py
+++ b/onnx/checker.py
@@ -11,7 +11,7 @@ from __future__ import unicode_literals
 import itertools
 import logging
 
-from onnx.onnx_ml_pb2 import TensorProto, ValueInfoProto, NodeProto, \
+from onnx.onnx_ml_pb2 import TensorProto, ValueInfoProto, NodeProto, AttributeProto,  \
     GraphProto, ModelProto, IR_VERSION
 from onnx import defs, mapping
 
@@ -20,37 +20,37 @@ def check_attr(attr, require_type_field):
     if require_type_field and not has_attr_type:
         raise RuntimeError('AttributeProto missing type field where IR version requires it.')
     if attr.HasField('s'):
-        if has_attr_type and attr.type != AttributeType.STRING:
+        if has_attr_type and attr.type != AttributeProto.STRING:
             raise RuntimeError('AttributeProto.type is wrong value (expected STRING).')
     if attr.HasField('f'):
-        if has_attr_type and attr.type != AttributeType.FLOAT:
+        if has_attr_type and attr.type != AttributeProto.FLOAT:
             raise RuntimeError('AttributeProto.type is wrong value (expected FLOAT).')
     if attr.HasField('i'):
-        if has_attr_type and attr.type != AttributeType.INT:
+        if has_attr_type and attr.type != AttributeProto.INT:
             raise RuntimeError('AttributeProto.type is wrong value (expected STRING).')
     if attr.HasField('t'):
-        if has_attr_type and attr.type != AttributeType.TENSOR:
+        if has_attr_type and attr.type != AttributeProto.TENSOR:
             raise RuntimeError('AttributeProto.type is wrong value (expected TENSOR).')
         check_tensor(attr.t)
     if attr.HasField('g'):
-        if has_attr_type and attr.type != AttributeType.GRAPH:
+        if has_attr_type and attr.type != AttributeProto.GRAPH:
             raise RuntimeError('AttributeProto.type is wrong value (expected GRAPH).')
     if attr.HasField('strings'):
-        if has_attr_type and attr.type != AttributeType.STRINGS:
+        if has_attr_type and attr.type != AttributeProto.STRINGS:
             raise RuntimeError('AttributeProto.type is wrong value (expected STRING).')
     if attr.HasField('floats'):
-        if has_attr_type and attr.type != AttributeType.FLOATS:
+        if has_attr_type and attr.type != AttributeProto.FLOATS:
             raise RuntimeError('AttributeProto.type is wrong value (expected FLOAT).')
     if attr.HasField('ints'):
-        if has_attr_type and attr.type != AttributeType.INTS:
+        if has_attr_type and attr.type != AttributeProto.INTS:
             raise RuntimeError('AttributeProto.type is wrong value (expected STRING).')
     if attr.HasField('tensors'):
-        if has_attr_type and attr.type != AttributeType.TENSORS:
+        if has_attr_type and attr.type != AttributeProto.TENSORS:
             raise RuntimeError('AttributeProto.type is wrong value (expected TENSORS).')
         for tensor in attr.tensors:
             check_tensor(tensor)
     if attr.HasField('graphs'):
-        if has_attr_type and attr.type != AttributeType.GRAPHS:
+        if has_attr_type and attr.type != AttributeProto.GRAPHS:
             raise RuntimeError('AttributeProto.type is wrong value (expected GRAPHS).')
 
 def check_node(node):

--- a/onnx/checker.py
+++ b/onnx/checker.py
@@ -15,6 +15,43 @@ from onnx.onnx_ml_pb2 import TensorProto, ValueInfoProto, NodeProto, \
     GraphProto, ModelProto, IR_VERSION
 from onnx import defs, mapping
 
+def check_attr(attr, require_type_field):
+    has_attr_type = attr.HasField("type")
+    if require_type_field and not has_attr_type:
+        raise RuntimeError('AttributeProto missing type field where IR version requires it.')
+    if attr.HasField('s'):
+        if has_attr_type and attr.type != AttributeType.STRING:
+            raise RuntimeError('AttributeProto.type is wrong value (expected STRING).')
+    if attr.HasField('f'):
+        if has_attr_type and attr.type != AttributeType.FLOAT:
+            raise RuntimeError('AttributeProto.type is wrong value (expected FLOAT).')
+    if attr.HasField('i'):
+        if has_attr_type and attr.type != AttributeType.INT:
+            raise RuntimeError('AttributeProto.type is wrong value (expected STRING).')
+    if attr.HasField('t'):
+        if has_attr_type and attr.type != AttributeType.TENSOR:
+            raise RuntimeError('AttributeProto.type is wrong value (expected TENSOR).')
+        check_tensor(attr.t)
+    if attr.HasField('g'):
+        if has_attr_type and attr.type != AttributeType.GRAPH:
+            raise RuntimeError('AttributeProto.type is wrong value (expected GRAPH).')
+    if attr.HasField('strings'):
+        if has_attr_type and attr.type != AttributeType.STRINGS:
+            raise RuntimeError('AttributeProto.type is wrong value (expected STRING).')
+    if attr.HasField('floats'):
+        if has_attr_type and attr.type != AttributeType.FLOATS:
+            raise RuntimeError('AttributeProto.type is wrong value (expected FLOAT).')
+    if attr.HasField('ints'):
+        if has_attr_type and attr.type != AttributeType.INTS:
+            raise RuntimeError('AttributeProto.type is wrong value (expected STRING).')
+    if attr.HasField('tensors'):
+        if has_attr_type and attr.type != AttributeType.TENSORS:
+            raise RuntimeError('AttributeProto.type is wrong value (expected TENSORS).')
+        for tensor in attr.tensors:
+            check_tensor(tensor)
+    if attr.HasField('graphs'):
+        if has_attr_type and attr.type != AttributeType.GRAPHS:
+            raise RuntimeError('AttributeProto.type is wrong value (expected GRAPHS).')
 
 def check_node(node):
     """Checks if a node is legal.
@@ -39,10 +76,7 @@ def check_node(node):
         raise ValueError(
             'NodeProto of type {} did not pass defs schema check.'.format(str(node.op_type)))
     for attr in node.attribute:
-        if attr.HasField('t'):
-            check_tensor(attr.t)
-        for tensor in attr.tensors:
-            check_tensor(tensor)
+        check_attr(attr, false)
 
 
 def check_tensor_value_info(value_info,

--- a/onnx/checker.py
+++ b/onnx/checker.py
@@ -15,49 +15,54 @@ from onnx.onnx_ml_pb2 import TensorProto, ValueInfoProto, NodeProto, AttributePr
     GraphProto, ModelProto, IR_VERSION
 from onnx import defs, mapping
 
-def check_attr(attr, require_type_field):
+def check_attr(attr, model):
+    """Checks if a node attribute is legal.
+
+    Inputs:
+        node: an AttributeProto object.
+        model: the ModelProto object this node came from.
+    Returns:
+        None
+    An exception is thrown if it does not pass the test.
+    """
+    require_type_field = model.ir_version >= IR_VERSION
     has_attr_type = attr.HasField("type")
     if require_type_field and not has_attr_type:
         raise RuntimeError('AttributeProto missing type field where IR version requires it.')
-    if attr.HasField('s'):
-        if has_attr_type and attr.type != AttributeProto.STRING:
-            raise RuntimeError('AttributeProto.type is wrong value (expected STRING).')
-    if attr.HasField('f'):
-        if has_attr_type and attr.type != AttributeProto.FLOAT:
-            raise RuntimeError('AttributeProto.type is wrong value (expected FLOAT).')
-    if attr.HasField('i'):
-        if has_attr_type and attr.type != AttributeProto.INT:
-            raise RuntimeError('AttributeProto.type is wrong value (expected STRING).')
+    if attr.HasField('s') and has_attr_type and attr.type != AttributeProto.STRING:
+        raise RuntimeError('AttributeProto.type is wrong value (expected STRING).')
+    if attr.HasField('f') and has_attr_type and attr.type != AttributeProto.FLOAT:
+        raise RuntimeError('AttributeProto.type is wrong value (expected FLOAT).')
+    if attr.HasField('i') and has_attr_type and attr.type != AttributeProto.INT:
+        raise RuntimeError('AttributeProto.type is wrong value (expected INT).')
     if attr.HasField('t'):
         if has_attr_type and attr.type != AttributeProto.TENSOR:
             raise RuntimeError('AttributeProto.type is wrong value (expected TENSOR).')
-        check_tensor(attr.t)
+        check_tensor(attr.t, model)
     if attr.HasField('g'):
         if has_attr_type and attr.type != AttributeProto.GRAPH:
             raise RuntimeError('AttributeProto.type is wrong value (expected GRAPH).')
-    if attr.HasField('strings'):
-        if has_attr_type and attr.type != AttributeProto.STRINGS:
-            raise RuntimeError('AttributeProto.type is wrong value (expected STRING).')
-    if attr.HasField('floats'):
-        if has_attr_type and attr.type != AttributeProto.FLOATS:
-            raise RuntimeError('AttributeProto.type is wrong value (expected FLOAT).')
-    if attr.HasField('ints'):
-        if has_attr_type and attr.type != AttributeProto.INTS:
-            raise RuntimeError('AttributeProto.type is wrong value (expected STRING).')
+    if attr.HasField('strings') and has_attr_type and attr.type != AttributeProto.STRINGS:
+        raise RuntimeError('AttributeProto.type is wrong value (expected STRINGS).')
+    if attr.HasField('floats') and has_attr_type and attr.type != AttributeProto.FLOATS:
+        raise RuntimeError('AttributeProto.type is wrong value (expected FLOATS).')
+    if attr.HasField('ints') and has_attr_type and attr.type != AttributeProto.INTS:
+        raise RuntimeError('AttributeProto.type is wrong value (expected INTS).')
     if attr.HasField('tensors'):
         if has_attr_type and attr.type != AttributeProto.TENSORS:
             raise RuntimeError('AttributeProto.type is wrong value (expected TENSORS).')
         for tensor in attr.tensors:
-            check_tensor(tensor)
+            check_tensor(tensor, model)
     if attr.HasField('graphs'):
         if has_attr_type and attr.type != AttributeProto.GRAPHS:
             raise RuntimeError('AttributeProto.type is wrong value (expected GRAPHS).')
 
-def check_node(node):
+def check_node(node, model):
     """Checks if a node is legal.
 
     Inputs:
         node: a NodeProto object.
+        model: the ModelProto object this node came from.
     Returns:
         None
     An exception is thrown if it does not pass the test.
@@ -76,7 +81,7 @@ def check_node(node):
         raise ValueError(
             'NodeProto of type {} did not pass defs schema check.'.format(str(node.op_type)))
     for attr in node.attribute:
-        check_attr(attr, false)
+        check_attr(attr, model)
 
 
 def check_tensor_value_info(value_info,
@@ -109,7 +114,7 @@ def check_tensor_value_info(value_info,
             'TypeProto.value should be either tensor_type or sparse_tensor_type')
 
 
-def check_tensor(tensor):
+def check_tensor(tensor, model):
     if not isinstance(tensor, TensorProto):
         raise RuntimeError('You cannot pass an object that is not TensorProto.')
 
@@ -139,7 +144,7 @@ def check_tensor(tensor):
                 ))
 
 
-def check_graph(graph):
+def check_graph(graph, model):
     """Checks if a GraphProto is legal.
 
     Inputs:
@@ -158,14 +163,14 @@ def check_graph(graph):
     for value_info in graph.value_info:
         check_tensor_value_info(value_info)
     for node in graph.node:
-        check_node(node)
+        check_node(node, model)
 
     input_names = {value_info.name for value_info in graph.input}
     for init in graph.initializer:
         if init.name not in input_names:
             raise ValueError(
                 '{} in initializer but not in graph input'.format(init.name))
-        check_tensor(init)
+        check_tensor(init, model)
 
 
 def check_model(model):
@@ -185,4 +190,4 @@ def check_model(model):
         logging.warning(
             'Your model ir_version is higher than the checker\'s, so it might '
             'not interpret the higher version correctly.')
-    check_graph(model.graph)
+    check_graph(model.graph, model)

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -148,6 +148,8 @@ class OpSchema {
   // Functions to do documentation for the operator schema.
   OpSchema& SetDoc(const std::string& doc);
 
+  // Note: this enum is structurally identical to the AttributeProto.AttributeType
+  // enum defined in onnx.proto.  If you rev one, you likely need to rev the other.
   enum class AttrType {
       FLOAT,
       INT,

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from six import text_type, integer_types, binary_type
 
-from onnx.onnx_ml_pb2 import TensorProto, AttributeProto, AttributeType, ValueInfoProto, \
+from onnx.onnx_ml_pb2 import TensorProto, AttributeProto, ValueInfoProto, \
     NodeProto, ModelProto, GraphProto, IR_VERSION
 import onnx.onnx_cpp2py_export as C
 from onnx import mapping
@@ -118,40 +118,40 @@ def make_attribute(key, value):
     # float
     if isinstance(value, float):
         attr.f = value
-        attr.type = AttributeType.FLOAT
+        attr.type = AttributeProto.FLOAT
     # integer
     elif isinstance(value, numbers.Integral):
         attr.i = value
-        attr.type = AttributeType.INT
+        attr.type = AttributeProto.INT
     # string
     elif bytes_or_false:
         attr.s = bytes_or_false
-        attr.type = AttributeType.STRING
+        attr.type = AttributeProto.STRING
     elif isinstance(value, TensorProto):
         attr.t.CopyFrom(value)
-        attr.type = AttributeType.TENSOR
+        attr.type = AttributeProto.TENSOR
     elif isinstance(value, GraphProto):
         attr.g.CopyFrom(value)
-        attr.type = AttributeType.GRAPH
+        attr.type = AttributeProto.GRAPH
     # third, iterable cases
     elif is_iterable:
         byte_array = [_to_bytes_or_false(v) for v in value]
         if all(isinstance(v, float) for v in value):
             attr.floats.extend(value)
-            attr.type = AttributeType.FLOATS
+            attr.type = AttributeProto.FLOATS
         elif all(isinstance(v, numbers.Integral) for v in value):
             # Turn np.int32/64 into Python built-in int.
             attr.ints.extend(int(v) for v in value)
-            attr.type = AttributeType.INTS
+            attr.type = AttributeProto.INTS
         elif all(byte_array):
             attr.strings.extend(byte_array)
-            attr.type = AttributeType.STRINGS
+            attr.type = AttributeProto.STRINGS
         elif all(isinstance(v, TensorProto) for v in value):
             attr.tensors.extend(value)
-            attr.type = AttributeType.TENSORS
+            attr.type = AttributeProto.TENSORS
         elif all(isinstance(v, GraphProto) for v in value):
             attr.graphs.extend(value)
-            attr.type = AttributeType.GRAPHS
+            attr.type = AttributeProto.GRAPHS
         else:
             raise ValueError(
                 "You passed in an iterable attribute but I cannot figure out "

--- a/onnx/onnx-ml.proto
+++ b/onnx/onnx-ml.proto
@@ -60,8 +60,14 @@ enum Version {
   // version that the  graph is generated from. This helps us set up version
   // control. We should use version as
   //     xx(major) - xx(minor) - xxxx(bugfix)
-  // and we are starting with 00000001.
-  IR_VERSION = 00000001;
+  // and we are starting with 0x00000001 (0.0.1), which was the
+  //  version we published on Oct 10, 2017.
+  IR_VERSION_2017_10_10 = 0x00000001;
+
+  // IR_VERSION 0.0.2 (this proto file) contains the following IR format changes
+  // - Added type discriminator to AttributeProto to support proto3 users
+
+  IR_VERSION = 0x00000002;
 }
 
 // A named attribute containing either singular float, integer, string
@@ -69,16 +75,44 @@ enum Version {
 // An AttributeProto MUST contain the name field, and *only one* of the
 // following content fields, effectively enforcing a C/C++ union equivalent.
 message AttributeProto {
+
+  // Note: this enum is structurally identical to the OpSchema::AttrType
+  // enum defined in schema.h.  If you rev one, you likely need to rev the other.
+  enum AttributeType {
+    UNDEFINED = 0;
+    FLOAT = 1;
+    INT = 2;
+    STRING = 3;
+    TENSOR = 4;
+    GRAPH = 5;
+
+    FLOATS = 6;
+    INTS = 7;
+    STRINGS = 8;
+    TENSORS = 9;
+    GRAPHS = 10;
+  }
+
   // The name field MUST be present for this version of the IR.
   optional string name = 1;           // namespace Attribute
+
+  // The type field MUST be present for this version of the IR.
+  // For 0.0.1 versions of the IR, this field was not defined, and
+  // implementations needed to use has_field hueristics to determine
+  // which value field was in use.  For IR_VERSION 0.0.2 or later, this
+  // field MUST be set and match the f|i|s|t|... field in use.  This
+  // change was made to accomodate proto3 implementations.
+  optional AttributeType type = 20;   // discriminator that indicates which field below is in use
+
+  // Exactly ONE of the following fields must be present for this version of the IR
   optional float f = 2;               // float
   optional int64 i = 3;               // int
   optional bytes s = 4;               // UTF-8 string
   optional TensorProto t = 5;         // tensor value
   optional GraphProto g = 6;          // graph
   optional ValueProto v = 12;         // value - subsumes everything but graph
-  
-  repeated float floats = 7;          // list of floats 
+
+  repeated float floats = 7;          // list of floats
   repeated int64 ints = 8;            // list of ints
   repeated bytes strings = 9;         // list of UTF-8 strings
   repeated TensorProto tensors = 10;  // list of tensors
@@ -329,7 +363,7 @@ message ValueProto {
 
   // Defines a record in its serialized format.
   // A record is a sequence of one or more
-  // typed uniquely named values, which may be of different types. 
+  // typed uniquely named values, which may be of different types.
   message RecordProto {
     repeated NameValuePairProto fields = 1;
   }
@@ -339,9 +373,9 @@ message ValueProto {
   message UnionProto {
     optional NameValuePairProto choice = 1;
   }
-  
+
   // Defines a map in its serialized format.
-  // A record is a sequence of zero or more 
+  // A record is a sequence of zero or more
   // key/value pairs all of which have unique
   // keys
   message MapProto {
@@ -349,7 +383,7 @@ message ValueProto {
   }
 
   // Alternate space-efficient encoding of map that MAY be used
-  // for maps whose value type is a scalar. 
+  // for maps whose value type is a scalar.
   message ScalarMapProto {
     // keys.DataType must be an integral type or string
     repeated TensorProto keys = 1;
@@ -359,7 +393,7 @@ message ValueProto {
   }
 
   // Defines a sequence in its serialized format.
-  // A sequence is a list of zero or more 
+  // A sequence is a list of zero or more
   // tensors, maps, records, or subsequences.
   message SequenceProto {
     repeated ValueProto elems = 1;
@@ -370,7 +404,7 @@ message ValueProto {
     TensorProto dense_tensor = 1;
 
     // A sparse tensor.
-    SparseTensorProto sparse_tensor = 2;  
+    SparseTensorProto sparse_tensor = 2;
 
     // A tuple.
     RecordProto record = 3;
@@ -415,19 +449,19 @@ message TypeProto {
     // This field MUST NOT have the value of UNDEFINED
     // This field MUST be present for this version of the IR.
     optional TensorProto.DataType elem_type = 1;
-    optional TensorShapeProto shape = 2;    
+    optional TensorShapeProto shape = 2;
   }
 
   // message T { ... }
   message RecordTypeProto {
-  // The type and optional shape of each field 
+  // The type and optional shape of each field
   // is described by a ValueInfoProto. The field
-  // names must be unique.     
+  // names must be unique.
   // This field MUST be present for this version of the IR.
     repeated ValueInfoProto field = 1;
   };
 
-  // repeated T 
+  // repeated T
   message SequenceTypeProto {
   // The type and optional shape of each element of the sequence.
   // This field MUST be present for this version of the IR.
@@ -442,12 +476,12 @@ message TypeProto {
   // This field MUST be present for this version of the IR.
     optional TypeProto value_type = 2;
   };
-        
+
   // oneof { ... }
   message UnionTypeProto {
-  // The type and optional shape of each alternative  
+  // The type and optional shape of each alternative
   // is described by a ValueInfoProto. The alternative
-  // names must be unique.     
+  // names must be unique.
   // This field MUST be present for this version of the IR.
     repeated ValueInfoProto choice = 1;
   };
@@ -464,7 +498,7 @@ message TypeProto {
     // NOTE:  DNN-only implementations of ONNX MAY elect to not support non-tensor values
     //        as input and output to graphs and nodes. These types are needed to naturally
     //        support classical ML operators.  DNN operators SHOULD restrict their input
-    //        and output types to tensors. 
+    //        and output types to tensors.
 
     // The type of a record.
     RecordTypeProto record_type = 3;

--- a/onnx/onnx-ml.proto3
+++ b/onnx/onnx-ml.proto3
@@ -60,8 +60,14 @@ enum Version {
   // version that the  graph is generated from. This helps us set up version
   // control. We should use version as
   //     xx(major) - xx(minor) - xxxx(bugfix)
-  // and we are starting with 00000001.
-  IR_VERSION = 00000001;
+  // and we are starting with 0x00000001 (0.0.1), which was the
+  //  version we published on Oct 10, 2017.
+  IR_VERSION_2017_10_10 = 0x00000001;
+
+  // IR_VERSION 0.0.2 (this proto file) contains the following IR format changes
+  // - Added type discriminator to AttributeProto to support proto3 users
+
+  IR_VERSION = 0x00000002;
 }
 
 // A named attribute containing either singular float, integer, string
@@ -69,16 +75,44 @@ enum Version {
 // An AttributeProto MUST contain the name field, and *only one* of the
 // following content fields, effectively enforcing a C/C++ union equivalent.
 message AttributeProto {
+
+  // Note: this enum is structurally identical to the OpSchema::AttrType
+  // enum defined in schema.h.  If you rev one, you likely need to rev the other.
+  enum AttributeType {
+    UNDEFINED = 0;
+    FLOAT = 1;
+    INT = 2;
+    STRING = 3;
+    TENSOR = 4;
+    GRAPH = 5;
+
+    FLOATS = 6;
+    INTS = 7;
+    STRINGS = 8;
+    TENSORS = 9;
+    GRAPHS = 10;
+  }
+
   // The name field MUST be present for this version of the IR.
   string name = 1;           // namespace Attribute
+
+  // The type field MUST be present for this version of the IR.
+  // For 0.0.1 versions of the IR, this field was not defined, and
+  // implementations needed to use has_field hueristics to determine
+  // which value field was in use.  For IR_VERSION 0.0.2 or later, this
+  // field MUST be set and match the f|i|s|t|... field in use.  This
+  // change was made to accomodate proto3 implementations.
+  AttributeType type = 20;   // discriminator that indicates which field below is in use
+
+  // Exactly ONE of the following fields must be present for this version of the IR
   float f = 2;               // float
   int64 i = 3;               // int
   bytes s = 4;               // UTF-8 string
   TensorProto t = 5;         // tensor value
   GraphProto g = 6;          // graph
   ValueProto v = 12;         // value - subsumes everything but graph
-  
-  repeated float floats = 7;          // list of floats 
+
+  repeated float floats = 7;          // list of floats
   repeated int64 ints = 8;            // list of ints
   repeated bytes strings = 9;         // list of UTF-8 strings
   repeated TensorProto tensors = 10;  // list of tensors
@@ -329,7 +363,7 @@ message ValueProto {
 
   // Defines a record in its serialized format.
   // A record is a sequence of one or more
-  // typed uniquely named values, which may be of different types. 
+  // typed uniquely named values, which may be of different types.
   message RecordProto {
     repeated NameValuePairProto fields = 1;
   }
@@ -339,9 +373,9 @@ message ValueProto {
   message UnionProto {
     NameValuePairProto choice = 1;
   }
-  
+
   // Defines a map in its serialized format.
-  // A record is a sequence of zero or more 
+  // A record is a sequence of zero or more
   // key/value pairs all of which have unique
   // keys
   message MapProto {
@@ -349,7 +383,7 @@ message ValueProto {
   }
 
   // Alternate space-efficient encoding of map that MAY be used
-  // for maps whose value type is a scalar. 
+  // for maps whose value type is a scalar.
   message ScalarMapProto {
     // keys.DataType must be an integral type or string
     repeated TensorProto keys = 1;
@@ -359,7 +393,7 @@ message ValueProto {
   }
 
   // Defines a sequence in its serialized format.
-  // A sequence is a list of zero or more 
+  // A sequence is a list of zero or more
   // tensors, maps, records, or subsequences.
   message SequenceProto {
     repeated ValueProto elems = 1;
@@ -370,7 +404,7 @@ message ValueProto {
     TensorProto dense_tensor = 1;
 
     // A sparse tensor.
-    SparseTensorProto sparse_tensor = 2;  
+    SparseTensorProto sparse_tensor = 2;
 
     // A tuple.
     RecordProto record = 3;
@@ -415,19 +449,19 @@ message TypeProto {
     // This field MUST NOT have the value of UNDEFINED
     // This field MUST be present for this version of the IR.
     TensorProto.DataType elem_type = 1;
-    TensorShapeProto shape = 2;    
+    TensorShapeProto shape = 2;
   }
 
   // message T { ... }
   message RecordTypeProto {
-  // The type and optional shape of each field 
+  // The type and optional shape of each field
   // is described by a ValueInfoProto. The field
-  // names must be unique.     
+  // names must be unique.
   // This field MUST be present for this version of the IR.
     repeated ValueInfoProto field = 1;
   };
 
-  // repeated T 
+  // repeated T
   message SequenceTypeProto {
   // The type and optional shape of each element of the sequence.
   // This field MUST be present for this version of the IR.
@@ -442,12 +476,12 @@ message TypeProto {
   // This field MUST be present for this version of the IR.
     TypeProto value_type = 2;
   };
-        
+
   // oneof { ... }
   message UnionTypeProto {
-  // The type and optional shape of each alternative  
+  // The type and optional shape of each alternative
   // is described by a ValueInfoProto. The alternative
-  // names must be unique.     
+  // names must be unique.
   // This field MUST be present for this version of the IR.
     repeated ValueInfoProto choice = 1;
   };
@@ -464,7 +498,7 @@ message TypeProto {
     // NOTE:  DNN-only implementations of ONNX MAY elect to not support non-tensor values
     //        as input and output to graphs and nodes. These types are needed to naturally
     //        support classical ML operators.  DNN operators SHOULD restrict their input
-    //        and output types to tensors. 
+    //        and output types to tensors.
 
     // The type of a record.
     RecordTypeProto record_type = 3;

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -64,24 +64,45 @@ enum Version {
   IR_VERSION = 00000001;
 }
 
+
+
 // A named attribute containing either singular float, integer, string
 // and tensor values, or repeated float, integer, string and tensor values.
 // An AttributeProto MUST contain the name field, and *only one* of the
 // following content fields, effectively enforcing a C/C++ union equivalent.
+
+enum AttributeType {
+  STRING = 0;
+  FLOAT = 1;
+  INT = 2;
+  TENSOR = 3;
+  GRAPH = 4;
+
+  STRINGS = 5;
+  FLOATS = 6;
+  INTS = 7;
+  TENSORS = 8;
+  GRAPHS = 9;
+}
+
 message AttributeProto {
   // The name field MUST be present for this version of the IR.
   optional string name = 1;           // namespace Attribute
-  optional float f = 2;               // float
-  optional int64 i = 3;               // int
-  optional bytes s = 4;               // UTF-8 string
-  optional TensorProto t = 5;         // tensor value
-  optional GraphProto g = 6;          // graph
-  
-  repeated float floats = 7;          // list of floats 
-  repeated int64 ints = 8;            // list of ints
-  repeated bytes strings = 9;         // list of UTF-8 strings
-  repeated TensorProto tensors = 10;  // list of tensors
-  repeated GraphProto graphs = 11;    // list of graph
+  // The type field MUST be present for this version of the IR.
+  optional AttributeType type = 2;         // discriminator that indicates which field below is in use
+
+  // Exactly ONE of the following fields must be present for this version of the IR
+  optional float f = 3;               // float
+  optional int64 i = 4;               // int
+  optional bytes s = 5;               // UTF-8 string
+  optional TensorProto t = 6;         // tensor value
+  optional GraphProto g = 7;          // graph
+
+  repeated float floats = 8;          // list of floats
+  repeated int64 ints = 9;            // list of ints
+  repeated bytes strings = 10;         // list of UTF-8 strings
+  repeated TensorProto tensors = 11;  // list of tensors
+  repeated GraphProto graphs = 12;    // list of graph
 }
 
 // Defines information on value, including the name, the type, and

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -61,7 +61,8 @@ enum Version {
   // control. We should use version as
   //     xx(major) - xx(minor) - xxxx(bugfix)
   // and we are starting with 00000001.
-  IR_VERSION = 00000001;
+  IR_VERSION = 00000101;
+  IR_VERSION_2017_10_10 = 00000001;
 }
 
 

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -64,10 +64,10 @@ enum Version {
   //  version we published on Oct 10, 2017.
   IR_VERSION_2017_10_10 = 0x00000001;
 
-  // IR_VERSION 1.1.0 (this proto file) contains the following IR format changes
+  // IR_VERSION 1.0.1 (this proto file) contains the following IR format changes
   // - Added type discriminator to AttributeProto to support proto3 users
 
-  IR_VERSION = 0x00000101;
+  IR_VERSION = 0x00010001;
 }
 
 

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -77,21 +77,21 @@ enum Version {
 // An AttributeProto MUST contain the name field, and *only one* of the
 // following content fields, effectively enforcing a C/C++ union equivalent.
 
-enum AttributeType {
-  FLOAT = 0;
-  INT = 1;
-  STRING = 2;
-  TENSOR = 3;
-  GRAPH = 4;
-
-  FLOATS = 5;
-  INTS = 6;
-  STRINGS = 7;
-  TENSORS = 8;
-  GRAPHS = 9;
-}
-
 message AttributeProto {
+  enum AttributeType {
+    FLOAT = 0;
+    INT = 1;
+    STRING = 2;
+    TENSOR = 3;
+    GRAPH = 4;
+  
+    FLOATS = 5;
+    INTS = 6;
+    STRINGS = 7;
+    TENSORS = 8;
+    GRAPHS = 9;
+  }
+
   // The name field MUST be present for this version of the IR.
   optional string name = 1;           // namespace Attribute
 

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -76,7 +76,6 @@ enum Version {
 // and tensor values, or repeated float, integer, string and tensor values.
 // An AttributeProto MUST contain the name field, and *only one* of the
 // following content fields, effectively enforcing a C/C++ union equivalent.
-
 message AttributeProto {
   enum AttributeType {
     FLOAT = 0;

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -60,14 +60,14 @@ enum Version {
   // version that the  graph is generated from. This helps us set up version
   // control. We should use version as
   //     xx(major) - xx(minor) - xxxx(bugfix)
-  // and we are starting with 00000001, which was the
+  // and we are starting with 0x00000001 (0.0.1), which was the
   //  version we published on Oct 10, 2017.
   IR_VERSION_2017_10_10 = 0x00000001;
 
-  // IR_VERSION 1.0.1 (this proto file) contains the following IR format changes
+  // IR_VERSION 0.0.2 (this proto file) contains the following IR format changes
   // - Added type discriminator to AttributeProto to support proto3 users
 
-  IR_VERSION = 0x00010001;
+  IR_VERSION = 0x00000002;
 }
 
 
@@ -81,26 +81,27 @@ message AttributeProto {
   // Note: this enum is structurally identical to the OpSchema::AttrType
   // enum defined in schema.h.  If you rev one, you likely need to rev the other.
   enum AttributeType {
-    FLOAT = 0;
-    INT = 1;
-    STRING = 2;
-    TENSOR = 3;
-    GRAPH = 4;
+    UNDEFINED = 0;
+    FLOAT = 1;
+    INT = 2;
+    STRING = 3;
+    TENSOR = 4;
+    GRAPH = 5;
   
-    FLOATS = 5;
-    INTS = 6;
-    STRINGS = 7;
-    TENSORS = 8;
-    GRAPHS = 9;
+    FLOATS = 6;
+    INTS = 7;
+    STRINGS = 8;
+    TENSORS = 9;
+    GRAPHS = 10;
   }
 
   // The name field MUST be present for this version of the IR.
   optional string name = 1;           // namespace Attribute
 
   // The type field MUST be present for this version of the IR.
-  // For 1.0.0 versions of the IR, this field was not defined, and
+  // For 0.0.1 versions of the IR, this field was not defined, and
   // implementations needed to use has_field hueristics to determine
-  // which value field was in use.  For IR_VERSION 1.0.1 or later, this 
+  // which value field was in use.  For IR_VERSION 0.0.2 or later, this 
   // field MUST be set and match the f|i|s|t|... field in use.  This
   // change was made to accomodate proto3 implementations. 
   optional AttributeType type = 20;   // discriminator that indicates which field below is in use

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -77,6 +77,9 @@ enum Version {
 // An AttributeProto MUST contain the name field, and *only one* of the
 // following content fields, effectively enforcing a C/C++ union equivalent.
 message AttributeProto {
+
+  // Note: this enum is structurally identical to the OpSchema::AttrType
+  // enum defined in schema.h.  If you rev one, you likely need to rev the other.
   enum AttributeType {
     FLOAT = 0;
     INT = 1;

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -60,9 +60,14 @@ enum Version {
   // version that the  graph is generated from. This helps us set up version
   // control. We should use version as
   //     xx(major) - xx(minor) - xxxx(bugfix)
-  // and we are starting with 00000001.
-  IR_VERSION = 00000101;
-  IR_VERSION_2017_10_10 = 00000001;
+  // and we are starting with 00000001, which was the
+  //  version we published on Oct 10, 2017.
+  IR_VERSION_2017_10_10 = 0x00000001;
+
+  // IR_VERSION 1.1.0 (this proto file) contains the following IR format changes
+  // - Added type discriminator to AttributeProto to support proto3 users
+
+  IR_VERSION = 0x00000101;
 }
 
 
@@ -73,15 +78,15 @@ enum Version {
 // following content fields, effectively enforcing a C/C++ union equivalent.
 
 enum AttributeType {
-  STRING = 0;
-  FLOAT = 1;
-  INT = 2;
+  FLOAT = 0;
+  INT = 1;
+  STRING = 2;
   TENSOR = 3;
   GRAPH = 4;
 
-  STRINGS = 5;
-  FLOATS = 6;
-  INTS = 7;
+  FLOATS = 5;
+  INTS = 6;
+  STRINGS = 7;
   TENSORS = 8;
   GRAPHS = 9;
 }
@@ -89,21 +94,27 @@ enum AttributeType {
 message AttributeProto {
   // The name field MUST be present for this version of the IR.
   optional string name = 1;           // namespace Attribute
+
   // The type field MUST be present for this version of the IR.
-  optional AttributeType type = 2;         // discriminator that indicates which field below is in use
+  // For 1.0.0 versions of the IR, this field was not defined, and
+  // implementations needed to use has_field hueristics to determine
+  // which value field was in use.  For IR_VERSION 1.0.1 or later, this 
+  // field MUST be set and match the f|i|s|t|... field in use.  This
+  // change was made to accomodate proto3 implementations. 
+  optional AttributeType type = 20;   // discriminator that indicates which field below is in use
 
   // Exactly ONE of the following fields must be present for this version of the IR
-  optional float f = 3;               // float
-  optional int64 i = 4;               // int
-  optional bytes s = 5;               // UTF-8 string
-  optional TensorProto t = 6;         // tensor value
-  optional GraphProto g = 7;          // graph
+  optional float f = 2;               // float
+  optional int64 i = 3;               // int
+  optional bytes s = 4;               // UTF-8 string
+  optional TensorProto t = 5;         // tensor value
+  optional GraphProto g = 6;          // graph
 
-  repeated float floats = 8;          // list of floats
-  repeated int64 ints = 9;            // list of ints
-  repeated bytes strings = 10;         // list of UTF-8 strings
-  repeated TensorProto tensors = 11;  // list of tensors
-  repeated GraphProto graphs = 12;    // list of graph
+  repeated float floats = 7;          // list of floats
+  repeated int64 ints = 8;            // list of ints
+  repeated bytes strings = 9;         // list of UTF-8 strings
+  repeated TensorProto tensors = 10;  // list of tensors
+  repeated GraphProto graphs = 11;    // list of graph
 }
 
 // Defines information on value, including the name, the type, and

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -70,8 +70,6 @@ enum Version {
   IR_VERSION = 0x00000002;
 }
 
-
-
 // A named attribute containing either singular float, integer, string
 // and tensor values, or repeated float, integer, string and tensor values.
 // An AttributeProto MUST contain the name field, and *only one* of the
@@ -87,7 +85,7 @@ message AttributeProto {
     STRING = 3;
     TENSOR = 4;
     GRAPH = 5;
-  
+
     FLOATS = 6;
     INTS = 7;
     STRINGS = 8;
@@ -101,9 +99,9 @@ message AttributeProto {
   // The type field MUST be present for this version of the IR.
   // For 0.0.1 versions of the IR, this field was not defined, and
   // implementations needed to use has_field hueristics to determine
-  // which value field was in use.  For IR_VERSION 0.0.2 or later, this 
+  // which value field was in use.  For IR_VERSION 0.0.2 or later, this
   // field MUST be set and match the f|i|s|t|... field in use.  This
-  // change was made to accomodate proto3 implementations. 
+  // change was made to accomodate proto3 implementations.
   optional AttributeType type = 20;   // discriminator that indicates which field below is in use
 
   // Exactly ONE of the following fields must be present for this version of the IR
@@ -371,7 +369,7 @@ message TypeProto {
     // This field MUST NOT have the value of UNDEFINED
     // This field MUST be present for this version of the IR.
     optional TensorProto.DataType elem_type = 1;
-    optional TensorShapeProto shape = 2;    
+    optional TensorShapeProto shape = 2;
   }
 
 

--- a/onnx/onnx.proto.in
+++ b/onnx/onnx.proto.in
@@ -55,8 +55,14 @@ enum Version {
   // version that the  graph is generated from. This helps us set up version
   // control. We should use version as
   //     xx(major) - xx(minor) - xxxx(bugfix)
-  // and we are starting with 00000001.
-  IR_VERSION = 00000001;
+  // and we are starting with 0x00000001 (0.0.1), which was the
+  //  version we published on Oct 10, 2017.
+  IR_VERSION_2017_10_10 = 0x00000001;
+
+  // IR_VERSION 0.0.2 (this proto file) contains the following IR format changes
+  // - Added type discriminator to AttributeProto to support proto3 users
+
+  IR_VERSION = 0x00000002;
 }
 
 // A named attribute containing either singular float, integer, string
@@ -64,8 +70,36 @@ enum Version {
 // An AttributeProto MUST contain the name field, and *only one* of the
 // following content fields, effectively enforcing a C/C++ union equivalent.
 message AttributeProto {
+
+  // Note: this enum is structurally identical to the OpSchema::AttrType
+  // enum defined in schema.h.  If you rev one, you likely need to rev the other.
+  enum AttributeType {
+    UNDEFINED = 0;
+    FLOAT = 1;
+    INT = 2;
+    STRING = 3;
+    TENSOR = 4;
+    GRAPH = 5;
+
+    FLOATS = 6;
+    INTS = 7;
+    STRINGS = 8;
+    TENSORS = 9;
+    GRAPHS = 10;
+  }
+
   // The name field MUST be present for this version of the IR.
   optional string name = 1;           // namespace Attribute
+
+  // The type field MUST be present for this version of the IR.
+  // For 0.0.1 versions of the IR, this field was not defined, and
+  // implementations needed to use has_field hueristics to determine
+  // which value field was in use.  For IR_VERSION 0.0.2 or later, this
+  // field MUST be set and match the f|i|s|t|... field in use.  This
+  // change was made to accomodate proto3 implementations.
+  optional AttributeType type = 20;   // discriminator that indicates which field below is in use
+
+  // Exactly ONE of the following fields must be present for this version of the IR
   optional float f = 2;               // float
   optional int64 i = 3;               // int
   optional bytes s = 4;               // UTF-8 string
@@ -74,8 +108,8 @@ message AttributeProto {
 // #if ONNX-ML
   optional ValueProto v = 12;         // value - subsumes everything but graph
 // #endif
-  
-  repeated float floats = 7;          // list of floats 
+
+  repeated float floats = 7;          // list of floats
   repeated int64 ints = 8;            // list of ints
   repeated bytes strings = 9;         // list of UTF-8 strings
   repeated TensorProto tensors = 10;  // list of tensors
@@ -327,7 +361,7 @@ message ValueProto {
 
   // Defines a record in its serialized format.
   // A record is a sequence of one or more
-  // typed uniquely named values, which may be of different types. 
+  // typed uniquely named values, which may be of different types.
   message RecordProto {
     repeated NameValuePairProto fields = 1;
   }
@@ -337,9 +371,9 @@ message ValueProto {
   message UnionProto {
     optional NameValuePairProto choice = 1;
   }
-  
+
   // Defines a map in its serialized format.
-  // A record is a sequence of zero or more 
+  // A record is a sequence of zero or more
   // key/value pairs all of which have unique
   // keys
   message MapProto {
@@ -347,7 +381,7 @@ message ValueProto {
   }
 
   // Alternate space-efficient encoding of map that MAY be used
-  // for maps whose value type is a scalar. 
+  // for maps whose value type is a scalar.
   message ScalarMapProto {
     // keys.DataType must be an integral type or string
     repeated TensorProto keys = 1;
@@ -357,7 +391,7 @@ message ValueProto {
   }
 
   // Defines a sequence in its serialized format.
-  // A sequence is a list of zero or more 
+  // A sequence is a list of zero or more
   // tensors, maps, records, or subsequences.
   message SequenceProto {
     repeated ValueProto elems = 1;
@@ -368,7 +402,7 @@ message ValueProto {
     TensorProto dense_tensor = 1;
 
     // A sparse tensor.
-    SparseTensorProto sparse_tensor = 2;  
+    SparseTensorProto sparse_tensor = 2;
 
     // A tuple.
     RecordProto record = 3;
@@ -414,20 +448,20 @@ message TypeProto {
     // This field MUST NOT have the value of UNDEFINED
     // This field MUST be present for this version of the IR.
     optional TensorProto.DataType elem_type = 1;
-    optional TensorShapeProto shape = 2;    
+    optional TensorShapeProto shape = 2;
   }
 
 // #if ONNX-ML
   // message T { ... }
   message RecordTypeProto {
-  // The type and optional shape of each field 
+  // The type and optional shape of each field
   // is described by a ValueInfoProto. The field
-  // names must be unique.     
+  // names must be unique.
   // This field MUST be present for this version of the IR.
     repeated ValueInfoProto field = 1;
   };
 
-  // repeated T 
+  // repeated T
   message SequenceTypeProto {
   // The type and optional shape of each element of the sequence.
   // This field MUST be present for this version of the IR.
@@ -442,17 +476,17 @@ message TypeProto {
   // This field MUST be present for this version of the IR.
     optional TypeProto value_type = 2;
   };
-        
+
   // oneof { ... }
   message UnionTypeProto {
-  // The type and optional shape of each alternative  
+  // The type and optional shape of each alternative
   // is described by a ValueInfoProto. The alternative
-  // names must be unique.     
+  // names must be unique.
   // This field MUST be present for this version of the IR.
     repeated ValueInfoProto choice = 1;
   };
 
-// #endif 
+// #endif
 
   oneof value {
     // The type of a tensor.
@@ -466,7 +500,7 @@ message TypeProto {
     // NOTE:  DNN-only implementations of ONNX MAY elect to not support non-tensor values
     //        as input and output to graphs and nodes. These types are needed to naturally
     //        support classical ML operators.  DNN operators SHOULD restrict their input
-    //        and output types to tensors. 
+    //        and output types to tensors.
 
     // The type of a record.
     RecordTypeProto record_type = 3;

--- a/onnx/onnx.proto3
+++ b/onnx/onnx.proto3
@@ -60,8 +60,14 @@ enum Version {
   // version that the  graph is generated from. This helps us set up version
   // control. We should use version as
   //     xx(major) - xx(minor) - xxxx(bugfix)
-  // and we are starting with 00000001.
-  IR_VERSION = 00000001;
+  // and we are starting with 0x00000001 (0.0.1), which was the
+  //  version we published on Oct 10, 2017.
+  IR_VERSION_2017_10_10 = 0x00000001;
+
+  // IR_VERSION 0.0.2 (this proto file) contains the following IR format changes
+  // - Added type discriminator to AttributeProto to support proto3 users
+
+  IR_VERSION = 0x00000002;
 }
 
 // A named attribute containing either singular float, integer, string
@@ -69,15 +75,43 @@ enum Version {
 // An AttributeProto MUST contain the name field, and *only one* of the
 // following content fields, effectively enforcing a C/C++ union equivalent.
 message AttributeProto {
+
+  // Note: this enum is structurally identical to the OpSchema::AttrType
+  // enum defined in schema.h.  If you rev one, you likely need to rev the other.
+  enum AttributeType {
+    UNDEFINED = 0;
+    FLOAT = 1;
+    INT = 2;
+    STRING = 3;
+    TENSOR = 4;
+    GRAPH = 5;
+
+    FLOATS = 6;
+    INTS = 7;
+    STRINGS = 8;
+    TENSORS = 9;
+    GRAPHS = 10;
+  }
+
   // The name field MUST be present for this version of the IR.
   string name = 1;           // namespace Attribute
+
+  // The type field MUST be present for this version of the IR.
+  // For 0.0.1 versions of the IR, this field was not defined, and
+  // implementations needed to use has_field hueristics to determine
+  // which value field was in use.  For IR_VERSION 0.0.2 or later, this
+  // field MUST be set and match the f|i|s|t|... field in use.  This
+  // change was made to accomodate proto3 implementations.
+  AttributeType type = 20;   // discriminator that indicates which field below is in use
+
+  // Exactly ONE of the following fields must be present for this version of the IR
   float f = 2;               // float
   int64 i = 3;               // int
   bytes s = 4;               // UTF-8 string
   TensorProto t = 5;         // tensor value
   GraphProto g = 6;          // graph
-  
-  repeated float floats = 7;          // list of floats 
+
+  repeated float floats = 7;          // list of floats
   repeated int64 ints = 8;            // list of ints
   repeated bytes strings = 9;         // list of UTF-8 strings
   repeated TensorProto tensors = 10;  // list of tensors
@@ -335,7 +369,7 @@ message TypeProto {
     // This field MUST NOT have the value of UNDEFINED
     // This field MUST be present for this version of the IR.
     TensorProto.DataType elem_type = 1;
-    TensorShapeProto shape = 2;    
+    TensorShapeProto shape = 2;
   }
 
 


### PR DESCRIPTION
This PR adds a type discriminator to AttributeProto to address issues for proto3 users.

Because we want to make the discriminator required in subsequent versions of the spec, I bumped the IR version patch # so that our checker can catch when it is missing.