### PR TITLE
add __version__ back

### DIFF
--- a/onnx/__init__.py
+++ b/onnx/__init__.py
@@ -3,7 +3,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from .onnx_pb2 import *
+from .onnx_pb2 import *  # noqa
+from .version import version as __version__  # noqa
 
 import sys
 


### PR DESCRIPTION
Linter does not like unused import. But this is needed.