### PR TITLE
Bugfixes I noticed porting latest ONNX to PyTorch

### DIFF
--- a/onnx/__init__.py
+++ b/onnx/__init__.py
@@ -6,6 +6,11 @@ from __future__ import unicode_literals
 from .onnx_ml_pb2 import *  # noqa
 from .version import version as __version__  # noqa
 
+# Import common subpackages so they're available when you 'import onnx'
+import onnx.helper  # noqa
+import onnx.checker  # noqa
+import onnx.defs  # noqa
+
 import sys
 
 def load(obj):

--- a/setup.py
+++ b/setup.py
@@ -147,6 +147,11 @@ class build_proto(ONNXCommand):
                     proto_file
                 ])
 
+        # Otherwise, you'll get mysterious errors if you 'import onnx.onnx_pb2'
+        # directly
+        if os.path.exists(os.path.join(SRC_DIR, "onnx_pb2.py")):
+            raise RuntimeError("Stale onnx/onnx_pb2.py file detected.  Please delete this file and rebuild.")
+
 
 class create_version(ONNXCommand):
     def run(self):


### PR DESCRIPTION
```
commit f0f4747e70547a78827f69a525261f37bd6fa977
Author: Edward Z. Yang <ezyang@fb.com>
Date:   Mon Oct 30 08:17:20 2017 -0700

    Complain about stale onnx_pb2 file.
    
    I noticed some library code was importing onnx_pb2 incorrectly.  The
    name of this file has changed, but the old source file was left around
    because it was generated by protoc.  This leads to weird errors like
    TypeError: 'GraphProto' object is not iterable because we're doing
    a GraphProto test with two things named GraphProto, but not the same
    thing.
    
    Easiest to tell the user to remove the stale file manually.
    
    Signed-off-by: Edward Z. Yang <ezyang@fb.com>

commit b1af2957cc8eec5d19dfc2519fdfba81af49bd80
Author: Edward Z. Yang <ezyang@fb.com>
Date:   Mon Oct 30 08:12:08 2017 -0700

    Undo BC-breaking change, restore 'import onnx' providing submodules.
    
    Signed-off-by: Edward Z. Yang <ezyang@fb.com>

commit f4868895611cecb9a35dbe776791984dc506bb03
Author: Edward Z. Yang <ezyang@fb.com>
Date:   Mon Oct 30 08:07:31 2017 -0700

    Don't call HasField on repeated fields.
    
    On my version of the protobuf library (protobuf 3.4.0),
    it raises an exception:
    
      ValueError: Protocol message has no non-repeated field "strings"
    
    Signed-off-by: Edward Z. Yang <ezyang@fb.com>
```