### PR TITLE
Update Conv, ConvTranspose, MaxPooling and AveragePooling.

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -191,11 +191,11 @@
   * **attribute**:
     <dl>
       <dt>auto_pad</dt>
-      <dd>auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input.In case of odd number add the extra padding at the end for SAME_UPPER and at the begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel valuesfrom the pads attribute.</dd>
+      <dd>auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input.In case of odd number add the extra padding at the end for SAME_UPPER and at the begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values from the pads attribute.</dd>
       <dt>kernel_shape</dt>
       <dd>The size of the kernel along each axis.</dd>
       <dt>pads</dt>
-      <dd>Padding for upper and lower side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.</dd>
+      <dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.</dd>
       <dt>strides</dt>
       <dd>Stride along each axis.</dd>
     </dl>
@@ -341,7 +341,7 @@
   * **attribute**:
     <dl>
       <dt>auto_pad</dt>
-      <dd>auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input.In case of odd number add the extra padding at the end for SAME_UPPER and at the begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel valuesfrom the pads attribute.</dd>
+      <dd>auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input.In case of odd number add the extra padding at the end for SAME_UPPER and at the begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values from the pads attribute.</dd>
       <dt>dilations</dt>
       <dd>dilation value along each axis of the filter.</dd>
       <dt>group</dt>
@@ -349,7 +349,7 @@
       <dt>kernel_shape</dt>
       <dd>The shape of the convolution kernel.</dd>
       <dt>pads</dt>
-      <dd>Padding for upper and lower side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.</dd>
+      <dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.</dd>
       <dt>strides</dt>
       <dd>stride along each axis.</dd>
     </dl>
@@ -376,7 +376,7 @@
   * **attribute**:
     <dl>
       <dt>auto_pad</dt>
-      <dd>auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input.In case of odd number add the extra padding at the end for SAME_UPPER and at the begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel valuesfrom the pads attribute.</dd>
+      <dd>auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input.In case of odd number add the extra padding at the end for SAME_UPPER and at the begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values from the pads attribute.</dd>
       <dt>dilations</dt>
       <dd>dilation value along each axis of the filter.</dd>
       <dt>group</dt>
@@ -386,7 +386,7 @@
       <dt>output_shape</dt>
       <dd>The shape of the output.</dd>
       <dt>pads</dt>
-      <dd>Padding for upper and lower side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.</dd>
+      <dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.</dd>
       <dt>strides</dt>
       <dd>stride along each axis.</dd>
     </dl>
@@ -780,13 +780,13 @@
   * **attribute**:
     <dl>
       <dt>auto_pad</dt>
-      <dd>auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input.In case of odd number add the extra padding at the end for SAME_UPPER and at the begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel valuesfrom the pads attribute.</dd>
+      <dd>auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input.In case of odd number add the extra padding at the end for SAME_UPPER and at the begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values from the pads attribute.</dd>
       <dt>dilations</dt>
       <dd>Dilation along each axis, 1 means no dilation.</dd>
       <dt>kernel_shape</dt>
       <dd>The size of the kernel along each axis.</dd>
       <dt>pads</dt>
-      <dd>Padding for upper and lower side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.</dd>
+      <dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.</dd>
       <dt>strides</dt>
       <dd>Stride along each axis.</dd>
     </dl>

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -190,10 +190,12 @@
    data into the output tensor Y for further processing.
   * **attribute**:
     <dl>
+      <dt>auto_pad</dt>
+      <dd>auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input.In case of odd number add the extra padding at the end for SAME_UPPER and at the begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel valuesfrom the pads attribute.</dd>
       <dt>kernel_shape</dt>
       <dd>The size of the kernel along each axis.</dd>
       <dt>pads</dt>
-      <dd>Padding along each axis, can take the value 0 (False) or non 0 (True)</dd>
+      <dd>Padding for upper and lower side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.</dd>
       <dt>strides</dt>
       <dd>Stride along each axis.</dd>
     </dl>
@@ -338,6 +340,8 @@
   computes the output.
   * **attribute**:
     <dl>
+      <dt>auto_pad</dt>
+      <dd>auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input.In case of odd number add the extra padding at the end for SAME_UPPER and at the begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel valuesfrom the pads attribute.</dd>
       <dt>dilations</dt>
       <dd>dilation value along each axis of the filter.</dd>
       <dt>group</dt>
@@ -345,7 +349,7 @@
       <dt>kernel_shape</dt>
       <dd>The shape of the convolution kernel.</dd>
       <dt>pads</dt>
-      <dd>Padding along each axis, can take the value 0 (False) or non 0 (True)</dd>
+      <dd>Padding for upper and lower side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.</dd>
       <dt>strides</dt>
       <dd>stride along each axis.</dd>
     </dl>
@@ -355,6 +359,8 @@
       <dd>Input data tensor from previous layer; has size (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and width. Note that this is for the 2D image.Otherwise the size is (N x D1 x D2 ... x Dn)</dd>
       <dt>weights</dt>
       <dd>The weight tensor that will be used in the convolutions; has size (M x C x kH x kW), where C is the number of channels, and kH and kW are the height and width of the kernel, and M is the number of feature maps. For more than 2 dimensions, the kernel shape will be (M x C x k1 x k2 x ... x kn), where is the dimension of the kernel</dd>
+      <dt>bias</dt>
+      <dd>Optional 1D bias to be added to the convolution, has size of M.</dd>
     </dl>
   * **output**:
     <dl>
@@ -369,23 +375,29 @@
   and computes the output.
   * **attribute**:
     <dl>
+      <dt>auto_pad</dt>
+      <dd>auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input.In case of odd number add the extra padding at the end for SAME_UPPER and at the begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel valuesfrom the pads attribute.</dd>
       <dt>dilations</dt>
       <dd>dilation value along each axis of the filter.</dd>
+      <dt>group</dt>
+      <dd>number of groups input channels and output channels are divided into</dd>
       <dt>kernel_shape</dt>
       <dd>The shape of the convolution kernel.</dd>
       <dt>output_shape</dt>
       <dd>The shape of the output.</dd>
       <dt>pads</dt>
-      <dd>Padding along each axis, can take the value 0 (False) or non 0 (True)</dd>
+      <dd>Padding for upper and lower side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.</dd>
       <dt>strides</dt>
       <dd>stride along each axis.</dd>
     </dl>
-  * **input**:
+  * **input**:2 - 3
     <dl>
       <dt>X</dt>
       <dd>Input data tensor from previous layer; has size (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and width. Note that this is for the 2D image.Otherwise the size is (N x D1 x D2 ... x Dn)</dd>
       <dt>weights</dt>
       <dd>The weight tensor that will be used in the convolutions; has size (C x M x kH x kW), where C is the number of channels, and kH and kW are the height and width of the kernel, and M is the number of feature maps. For more than 2 dimensions, the kernel shape will be (C x M x k1 x k2 x ... x kn), where is the dimension of the kernel</dd>
+      <dt>bias</dt>
+      <dd>Optional 1D bias to be added to the convolution, has size of C.</dd>
     </dl>
   * **output**:
     <dl>
@@ -767,12 +779,14 @@
    data into the output tensor Y for further processing.
   * **attribute**:
     <dl>
+      <dt>auto_pad</dt>
+      <dd>auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input.In case of odd number add the extra padding at the end for SAME_UPPER and at the begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel valuesfrom the pads attribute.</dd>
       <dt>dilations</dt>
       <dd>Dilation along each axis, 1 means no dilation.</dd>
       <dt>kernel_shape</dt>
       <dd>The size of the kernel along each axis.</dd>
       <dt>pads</dt>
-      <dd>Padding along each axis, can take the value 0 (False) or non 0 (True)</dd>
+      <dd>Padding for upper and lower side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.</dd>
       <dt>strides</dt>
       <dd>Stride along each axis.</dd>
     </dl>

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -28,11 +28,11 @@ namespace onnx {
                         "auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where "
                         "SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input."
                         "In case of odd number add the extra padding at the end for SAME_UPPER and at the "
-                        "begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values"
+                        "begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values "
                         "from the pads attribute.",
                         AttrType::STRING);
             schema.Attr("pads",
-                        "Padding for upper and lower side along each axis, it can take any value greater "
+                        "Padding for lower and upper side along each axis, it can take any value greater "
                         "than or equal to 0. The value represent the number of pixels added to the lower "
                         "and upper part of the corresponding axis. So `pads` will have two values per axis, "
                         "first value corresponding to the number of pixels added to the begining of the axis "
@@ -84,11 +84,11 @@ namespace onnx {
                         "auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where "
                         "SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input."
                         "In case of odd number add the extra padding at the end for SAME_UPPER and at the "
-                        "begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values"
+                        "begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values "
                         "from the pads attribute.",
                         AttrType::STRING);
             schema.Attr("pads",
-                        "Padding for upper and lower side along each axis, it can take any value greater "
+                        "Padding for lower and upper side along each axis, it can take any value greater "
                         "than or equal to 0. The value represent the number of pixels added to the lower "
                         "and upper part of the corresponding axis. So `pads` will have two values per axis, "
                         "first value corresponding to the number of pixels added to the begining of the axis "
@@ -167,11 +167,11 @@ computes the output.)DOC";
                         "auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where "
                         "SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input."
                         "In case of odd number add the extra padding at the end for SAME_UPPER and at the "
-                        "begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values"
+                        "begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values "
                         "from the pads attribute.",
                         AttrType::STRING);
             schema.Attr("pads",
-                        "Padding for upper and lower side along each axis, it can take any value greater "
+                        "Padding for lower and upper side along each axis, it can take any value greater "
                         "than or equal to 0. The value represent the number of pixels added to the lower "
                         "and upper part of the corresponding axis. So `pads` will have two values per axis, "
                         "first value corresponding to the number of pixels added to the begining of the axis "
@@ -237,11 +237,11 @@ and computes the output.)DOC";
                         "auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where "
                         "SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input."
                         "In case of odd number add the extra padding at the end for SAME_UPPER and at the "
-                        "begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values"
+                        "begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values "
                         "from the pads attribute.",
                         AttrType::STRING);
             schema.Attr("pads",
-                        "Padding for upper and lower side along each axis, it can take any value greater "
+                        "Padding for lower and upper side along each axis, it can take any value greater "
                         "than or equal to 0. The value represent the number of pixels added to the lower "
                         "and upper part of the corresponding axis. So `pads` will have two values per axis, "
                         "first value corresponding to the number of pixels added to the begining of the axis "

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -24,9 +24,19 @@ namespace onnx {
             schema.Attr("strides",
                         "Stride along each axis.",
                         AttrType::INTS);
+            schema.Attr("auto_pad",
+                        "auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where "
+                        "SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input."
+                        "In case of odd number add the extra padding at the end for SAME_UPPER and at the "
+                        "begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values"
+                        "from the pads attribute.",
+                        AttrType::STRING);
             schema.Attr("pads",
-                        "Padding along each axis, can take the value "
-                        "0 (False) or non 0 (True)",
+                        "Padding for upper and lower side along each axis, it can take any value greater "
+                        "than or equal to 0. The value represent the number of pixels added to the lower "
+                        "and upper part of the corresponding axis. So `pads` will have two values per axis, "
+                        "first value corresponding to the number of pixels added to the begining of the axis "
+                        "and the second value corresponding to the number of pixels add at the end of the axis.",
                         AttrType::INTS);
             schema.Input(0,
                          "X",
@@ -70,9 +80,19 @@ namespace onnx {
             schema.Attr("strides",
                         "Stride along each axis.",
                         AttrType::INTS);
+            schema.Attr("auto_pad",
+                        "auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where "
+                        "SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input."
+                        "In case of odd number add the extra padding at the end for SAME_UPPER and at the "
+                        "begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values"
+                        "from the pads attribute.",
+                        AttrType::STRING);
             schema.Attr("pads",
-                        "Padding along each axis, can take the value 0 "
-                        "(False) or non 0 (True)",
+                        "Padding for upper and lower side along each axis, it can take any value greater "
+                        "than or equal to 0. The value represent the number of pixels added to the lower "
+                        "and upper part of the corresponding axis. So `pads` will have two values per axis, "
+                        "first value corresponding to the number of pixels added to the begining of the axis "
+                        "and the second value corresponding to the number of pixels add at the end of the axis.",
                         AttrType::INTS);
             schema.Attr("dilations",
                         "Dilation along each axis, 1 means no dilation.",
@@ -126,6 +146,9 @@ computes the output.)DOC";
                          "of feature maps. For more than 2 dimensions, the "
                          "kernel shape will be (M x C x k1 x k2 x ... x kn), "
                          "where is the dimension of the kernel");
+            schema.Input(2,
+                         "bias",
+                         "Optional 1D bias to be added to the convolution, has size of M.");
             schema.Output(0,
                           "Y",
                           "Output data tensor that contains the result of the "
@@ -140,8 +163,19 @@ computes the output.)DOC";
             schema.Attr("strides",
                         "stride along each axis.",
                         AttrType::INTS);
+            schema.Attr("auto_pad",
+                        "auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where "
+                        "SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input."
+                        "In case of odd number add the extra padding at the end for SAME_UPPER and at the "
+                        "begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values"
+                        "from the pads attribute.",
+                        AttrType::STRING);
             schema.Attr("pads",
-                        "Padding along each axis, can take the value 0 (False) or non 0 (True)",
+                        "Padding for upper and lower side along each axis, it can take any value greater "
+                        "than or equal to 0. The value represent the number of pixels added to the lower "
+                        "and upper part of the corresponding axis. So `pads` will have two values per axis, "
+                        "first value corresponding to the number of pixels added to the begining of the axis "
+                        "and the second value corresponding to the number of pixels add at the end of the axis.",
                         AttrType::INTS);
             schema.Attr("group",
                         "number of groups input channels and output channels are divided into",
@@ -162,7 +196,7 @@ The convolution transpose operator consumes an input tensor and {filter_desc},
 and computes the output.)DOC";
             ReplaceAll(doc, "{filter_desc}", filter_desc);
             schema.SetDoc(doc);
-            schema.NumInputs(2);
+            schema.NumInputs(2, 3);
             schema.NumOutputs(1);
             schema.Input(0,
                          "X",
@@ -179,6 +213,9 @@ and computes the output.)DOC";
                          "of feature maps. For more than 2 dimensions, the "
                          "kernel shape will be (C x M x k1 x k2 x ... x kn), "
                          "where is the dimension of the kernel");
+            schema.Input(2,
+                         "bias",
+                         "Optional 1D bias to be added to the convolution, has size of C.");
             schema.Output(0,
                           "Y",
                           "Output data tensor that contains the result of the convolution. The "
@@ -196,9 +233,23 @@ and computes the output.)DOC";
             schema.Attr("strides",
                         "stride along each axis.",
                         AttrType::INTS);
+            schema.Attr("auto_pad",
+                        "auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where "
+                        "SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input."
+                        "In case of odd number add the extra padding at the end for SAME_UPPER and at the "
+                        "begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values"
+                        "from the pads attribute.",
+                        AttrType::STRING);
             schema.Attr("pads",
-                        "Padding along each axis, can take the value 0 (False) or non 0 (True)",
+                        "Padding for upper and lower side along each axis, it can take any value greater "
+                        "than or equal to 0. The value represent the number of pixels added to the lower "
+                        "and upper part of the corresponding axis. So `pads` will have two values per axis, "
+                        "first value corresponding to the number of pixels added to the begining of the axis "
+                        "and the second value corresponding to the number of pixels add at the end of the axis.",
                         AttrType::INTS);
+            schema.Attr("group",
+                        "number of groups input channels and output channels are divided into",
+                        AttrType::INT);
         };
     }
 


### PR DESCRIPTION
This PR contains multiple changes together:

1. Add back bias to Conv and ConvTranpose, similar to GEMM this is needed for performance.
2. Add auto_pad with 3 options: SAME_UPPER, SAME_LOWER and VALID in order to cover conversion from other frameworks.
3. pads: add back lower and upper that we had in Caffe2, because now we have the auto_pad option and this is the manual option.
4. Update the documentation to cover the behavior in details.
5. MaxPool and AveragePool need to have the same behavior.
6. Add Group for ConvTranspose to be consistent with conv.
7. Add bias for ConvTranspose to be consistent with conv.
