### PR TITLE
fix build break in windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ class ONNXCommand(setuptools.Command):
 class build_proto_in(ONNXCommand):
     def run(self):
         log('compiling onnx.proto.in')
-        subprocess.check_call([os.path.join(SRC_DIR, "gen_proto.py")])
+        subprocess.check_call(["python", os.path.join(SRC_DIR, "gen_proto.py")])
 
 
 class build_proto(ONNXCommand):


### PR DESCRIPTION
window build was broken by recent changes (the python command should be explicitly called when generating .proto files).

Windows CI build should be setup quickly to prevent this kind of build break.