### PR TITLE
Fix 'ValueError: low is out of bounds for int32' error in test_int64

### DIFF
--- a/onnx/test/numpy_helper_test.py
+++ b/onnx/test/numpy_helper_test.py
@@ -23,7 +23,8 @@ class TestNumpyHelper(unittest.TestCase):
         a = np.random.randint(
             np.iinfo(dtype).min,
             np.iinfo(dtype).max,
-            size=(13, 37)).astype(dtype)
+            dtype=dtype,
+            size=(13, 37))
         tensor_def = numpy_helper.from_array(a, "test")
         self.assertEqual(tensor_def.name, "test")
         a_recover = numpy_helper.to_array(tensor_def)


### PR DESCRIPTION
The type can be specified directly to randint; casting it after the fact won't work after the min/max values given are in the i64 range.