### PR TITLE
Using more sensible assertions

### DIFF
--- a/onnx/backend/test.py
+++ b/onnx/backend/test.py
@@ -183,7 +183,11 @@ class BackendTest(object):
                     np.testing.assert_allclose(
                         ref_outputs[i],
                         outputs[i],
-                        rtol=1e-3)
+                        rtol=1e-4)
+                    np.testing.assert_allclose(
+                        ref_outputs[i],
+                        outputs[i],
+                        atol=1e-4)
 
         self._add_test('Model', test_name, run)
 
@@ -225,6 +229,10 @@ class BackendTest(object):
                 np.testing.assert_allclose(
                     ref_outputs[i],
                     outputs[i],
-                    rtol=1e-3)
+                    rtol=1e-4)
+                np.testing.assert_allclose(
+                    ref_outputs[i],
+                    outputs[i],
+                    atol=1e-4)
 
         self._add_test('Node', test_name, run)

--- a/onnx/backend/test.py
+++ b/onnx/backend/test.py
@@ -180,10 +180,10 @@ class BackendTest(object):
                 ref_outputs = test_data['outputs']
                 test_self.assertEqual(len(ref_outputs), len(outputs))
                 for i in range(len(outputs)):
-                    np.testing.assert_almost_equal(
+                    np.testing.assert_allclose(
                         ref_outputs[i],
                         outputs[i],
-                        decimal=4)
+                        rtol=1e-3)
 
         self._add_test('Model', test_name, run)
 
@@ -222,9 +222,9 @@ class BackendTest(object):
             outputs = self.backend.run_node(node_def, args, device)
             test_self.assertEqual(len(ref_outputs), len(outputs))
             for i in range(len(output_names)):
-                np.testing.assert_almost_equal(
+                np.testing.assert_allclose(
                     ref_outputs[i],
                     outputs[i],
-                    decimal=4)
+                    rtol=1e-3)
 
         self._add_test('Node', test_name, run)

--- a/onnx/backend/test.py
+++ b/onnx/backend/test.py
@@ -183,11 +183,7 @@ class BackendTest(object):
                     np.testing.assert_allclose(
                         ref_outputs[i],
                         outputs[i],
-                        rtol=1e-4)
-                    np.testing.assert_allclose(
-                        ref_outputs[i],
-                        outputs[i],
-                        atol=1e-4)
+                        rtol=1e-3)
 
         self._add_test('Model', test_name, run)
 
@@ -229,10 +225,6 @@ class BackendTest(object):
                 np.testing.assert_allclose(
                     ref_outputs[i],
                     outputs[i],
-                    rtol=1e-4)
-                np.testing.assert_allclose(
-                    ref_outputs[i],
-                    outputs[i],
-                    atol=1e-4)
+                    rtol=1e-3)
 
         self._add_test('Node', test_name, run)


### PR DESCRIPTION
Hi, 

I believe using relative tolerance is more sensible (this change roughly translates to we can tolerate 0.1% deviation) . In many model outputs, values are softmaxed, which means they are very small (in most cases, first non-zero digit starts from the third decimal place) and errors are squashed. Therefore checking 4 decimal place is not enough. This may give new backends unwarranted confidence in terms of correctness.

Best wishes,
Tian Jin.