### PR TITLE
Suggesting Conv Pads Behavior

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -248,7 +248,7 @@
 <dt><tt>kernel_shape</tt> : list of ints</dt>
 <dd>The size of the kernel along each axis.</dd>
 <dt><tt>pads</tt> : list of ints</dt>
-<dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.This attribute cannot be used simultaneously with autopad attribute.</dd>
+<dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis. This attribute cannot be used simultaneously with auto_pad attribute.</dd>
 <dt><tt>strides</tt> : list of ints</dt>
 <dd>Stride along each axis.</dd>
 </dl>
@@ -484,7 +484,7 @@
 <dt><tt>kernel_shape</tt> : list of ints</dt>
 <dd>The shape of the convolution kernel.</dd>
 <dt><tt>pads</tt> : list of ints</dt>
-<dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.This attribute cannot be used simultaneously with autopad attribute.</dd>
+<dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis. This attribute cannot be used simultaneously with auto_pad attribute.</dd>
 <dt><tt>strides</tt> : list of ints</dt>
 <dd>stride along each axis.</dd>
 </dl>
@@ -534,7 +534,7 @@
 <dt><tt>output_shape</tt> : list of ints</dt>
 <dd>The shape of the output.</dd>
 <dt><tt>pads</tt> : list of ints</dt>
-<dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.This attribute cannot be used simultaneously with autopad attribute.</dd>
+<dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis. This attribute cannot be used simultaneously with auto_pad attribute.</dd>
 <dt><tt>strides</tt> : list of ints</dt>
 <dd>stride along each axis.</dd>
 </dl>
@@ -1292,7 +1292,7 @@
 <dt><tt>kernel_shape</tt> : list of ints</dt>
 <dd>The size of the kernel along each axis.</dd>
 <dt><tt>pads</tt> : list of ints</dt>
-<dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.This attribute cannot be used simultaneously with autopad attribute.</dd>
+<dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis. This attribute cannot be used simultaneously with auto_pad attribute.</dd>
 <dt><tt>strides</tt> : list of ints</dt>
 <dd>Stride along each axis.</dd>
 </dl>

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -244,11 +244,11 @@
 
 <dl>
 <dt><tt>auto_pad</tt> : string</dt>
-<dd>auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input.In case of odd number add the extra padding at the end for SAME_UPPER and at the begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values from the pads attribute.</dd>
+<dd>auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input.In case of odd number add the extra padding at the end for SAME_UPPER and at the begining for SAME_LOWER. VALID mean no padding.</dd>
 <dt><tt>kernel_shape</tt> : list of ints</dt>
 <dd>The size of the kernel along each axis.</dd>
 <dt><tt>pads</tt> : list of ints</dt>
-<dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.</dd>
+<dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.This attribute cannot be used simultaneously with autopad attribute.</dd>
 <dt><tt>strides</tt> : list of ints</dt>
 <dd>Stride along each axis.</dd>
 </dl>
@@ -476,7 +476,7 @@
 
 <dl>
 <dt><tt>auto_pad</tt> : string</dt>
-<dd>auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input.In case of odd number add the extra padding at the end for SAME_UPPER and at the begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values from the pads attribute.</dd>
+<dd>auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input.In case of odd number add the extra padding at the end for SAME_UPPER and at the begining for SAME_LOWER. VALID mean no padding.</dd>
 <dt><tt>dilations</tt> : list of ints</dt>
 <dd>dilation value along each axis of the filter.</dd>
 <dt><tt>group</tt> : int</dt>
@@ -484,7 +484,7 @@
 <dt><tt>kernel_shape</tt> : list of ints</dt>
 <dd>The shape of the convolution kernel.</dd>
 <dt><tt>pads</tt> : list of ints</dt>
-<dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.</dd>
+<dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.This attribute cannot be used simultaneously with autopad attribute.</dd>
 <dt><tt>strides</tt> : list of ints</dt>
 <dd>stride along each axis.</dd>
 </dl>
@@ -524,7 +524,7 @@
 
 <dl>
 <dt><tt>auto_pad</tt> : string</dt>
-<dd>auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input.In case of odd number add the extra padding at the end for SAME_UPPER and at the begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values from the pads attribute.</dd>
+<dd>auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input.In case of odd number add the extra padding at the end for SAME_UPPER and at the begining for SAME_LOWER. VALID mean no padding.</dd>
 <dt><tt>dilations</tt> : list of ints</dt>
 <dd>dilation value along each axis of the filter.</dd>
 <dt><tt>group</tt> : int</dt>
@@ -534,7 +534,7 @@
 <dt><tt>output_shape</tt> : list of ints</dt>
 <dd>The shape of the output.</dd>
 <dt><tt>pads</tt> : list of ints</dt>
-<dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.</dd>
+<dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.This attribute cannot be used simultaneously with autopad attribute.</dd>
 <dt><tt>strides</tt> : list of ints</dt>
 <dd>stride along each axis.</dd>
 </dl>
@@ -1292,7 +1292,7 @@
 <dt><tt>kernel_shape</tt> : list of ints</dt>
 <dd>The size of the kernel along each axis.</dd>
 <dt><tt>pads</tt> : list of ints</dt>
-<dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.In the event that both pads and auto_pad are specified, pads will take precedence over auto_pad</dd>
+<dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.This attribute cannot be used simultaneously with autopad attribute.</dd>
 <dt><tt>strides</tt> : list of ints</dt>
 <dd>Stride along each axis.</dd>
 </dl>

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -1286,13 +1286,13 @@
 
 <dl>
 <dt><tt>auto_pad</tt> : string</dt>
-<dd>auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input.In case of odd number add the extra padding at the end for SAME_UPPER and at the begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values from the pads attribute.</dd>
+<dd>auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input.In case of odd number add the extra padding at the end for SAME_UPPER and at the begining for SAME_LOWER. VALID mean no padding.</dd>
 <dt><tt>dilations</tt> : list of ints</dt>
 <dd>Dilation along each axis, 1 means no dilation.</dd>
 <dt><tt>kernel_shape</tt> : list of ints</dt>
 <dd>The size of the kernel along each axis.</dd>
 <dt><tt>pads</tt> : list of ints</dt>
-<dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.</dd>
+<dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.In the event that both pads and auto_pad are specified, pads will take precedence over auto_pad</dd>
 <dt><tt>strides</tt> : list of ints</dt>
 <dd>Stride along each axis.</dd>
 </dl>

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -87,15 +87,16 @@ namespace onnx {
                         "auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where "
                         "SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input."
                         "In case of odd number add the extra padding at the end for SAME_UPPER and at the "
-                        "begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values "
-                        "from the pads attribute.",
+                        "begining for SAME_LOWER. VALID mean no padding.",
                         AttrType::STRING);
             schema.Attr("pads",
                         "Padding for lower and upper side along each axis, it can take any value greater "
                         "than or equal to 0. The value represent the number of pixels added to the lower "
                         "and upper part of the corresponding axis. So `pads` will have two values per axis, "
                         "first value corresponding to the number of pixels added to the begining of the axis "
-                        "and the second value corresponding to the number of pixels add at the end of the axis.",
+                        "and the second value corresponding to the number of pixels add at the end of the axis."
+                        "In the event that both pads and auto_pad are specified, pads will take precedence over "
+                        "auto_pad",
                         AttrType::INTS);
             schema.Attr("dilations",
                         "Dilation along each axis, 1 means no dilation.",

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -29,15 +29,15 @@ namespace onnx {
                         "auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where "
                         "SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input."
                         "In case of odd number add the extra padding at the end for SAME_UPPER and at the "
-                        "begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values "
-                        "from the pads attribute.",
+                        "begining for SAME_LOWER. VALID mean no padding.",
                         AttrType::STRING);
             schema.Attr("pads",
                         "Padding for lower and upper side along each axis, it can take any value greater "
                         "than or equal to 0. The value represent the number of pixels added to the lower "
                         "and upper part of the corresponding axis. So `pads` will have two values per axis, "
                         "first value corresponding to the number of pixels added to the begining of the axis "
-                        "and the second value corresponding to the number of pixels add at the end of the axis.",
+                        "and the second value corresponding to the number of pixels add at the end of the axis."
+                        "This attribute cannot be used simultaneously with autopad attribute.",
                         AttrType::INTS);
             schema.Input(0,
                          "X",
@@ -95,8 +95,7 @@ namespace onnx {
                         "and upper part of the corresponding axis. So `pads` will have two values per axis, "
                         "first value corresponding to the number of pixels added to the begining of the axis "
                         "and the second value corresponding to the number of pixels add at the end of the axis."
-                        "In the event that both pads and auto_pad are specified, pads will take precedence over "
-                        "auto_pad",
+                        "This attribute cannot be used simultaneously with autopad attribute.",
                         AttrType::INTS);
             schema.Attr("dilations",
                         "Dilation along each axis, 1 means no dilation.",
@@ -175,15 +174,15 @@ computes the output.)DOC";
                         "auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where "
                         "SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input."
                         "In case of odd number add the extra padding at the end for SAME_UPPER and at the "
-                        "begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values "
-                        "from the pads attribute.",
+                        "begining for SAME_LOWER. VALID mean no padding.",
                         AttrType::STRING);
             schema.Attr("pads",
                         "Padding for lower and upper side along each axis, it can take any value greater "
                         "than or equal to 0. The value represent the number of pixels added to the lower "
                         "and upper part of the corresponding axis. So `pads` will have two values per axis, "
                         "first value corresponding to the number of pixels added to the begining of the axis "
-                        "and the second value corresponding to the number of pixels add at the end of the axis.",
+                        "and the second value corresponding to the number of pixels add at the end of the axis."
+                        "This attribute cannot be used simultaneously with autopad attribute.",
                         AttrType::INTS);
             schema.Attr("group",
                         "number of groups input channels and output channels are divided into",
@@ -247,15 +246,15 @@ and computes the output.)DOC";
                         "auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where "
                         "SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input."
                         "In case of odd number add the extra padding at the end for SAME_UPPER and at the "
-                        "begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values "
-                        "from the pads attribute.",
+                        "begining for SAME_LOWER. VALID mean no padding.",
                         AttrType::STRING);
             schema.Attr("pads",
                         "Padding for lower and upper side along each axis, it can take any value greater "
                         "than or equal to 0. The value represent the number of pixels added to the lower "
                         "and upper part of the corresponding axis. So `pads` will have two values per axis, "
                         "first value corresponding to the number of pixels added to the begining of the axis "
-                        "and the second value corresponding to the number of pixels add at the end of the axis.",
+                        "and the second value corresponding to the number of pixels add at the end of the axis."
+                        "This attribute cannot be used simultaneously with autopad attribute.",
                         AttrType::INTS);
             schema.Attr("group",
                         "number of groups input channels and output channels are divided into",

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -36,8 +36,8 @@ namespace onnx {
                         "than or equal to 0. The value represent the number of pixels added to the lower "
                         "and upper part of the corresponding axis. So `pads` will have two values per axis, "
                         "first value corresponding to the number of pixels added to the begining of the axis "
-                        "and the second value corresponding to the number of pixels add at the end of the axis."
-                        "This attribute cannot be used simultaneously with autopad attribute.",
+                        "and the second value corresponding to the number of pixels add at the end of the axis. "
+                        "This attribute cannot be used simultaneously with auto_pad attribute.",
                         AttrType::INTS);
             schema.Input(0,
                          "X",
@@ -94,8 +94,8 @@ namespace onnx {
                         "than or equal to 0. The value represent the number of pixels added to the lower "
                         "and upper part of the corresponding axis. So `pads` will have two values per axis, "
                         "first value corresponding to the number of pixels added to the begining of the axis "
-                        "and the second value corresponding to the number of pixels add at the end of the axis."
-                        "This attribute cannot be used simultaneously with autopad attribute.",
+                        "and the second value corresponding to the number of pixels add at the end of the axis. "
+                        "This attribute cannot be used simultaneously with auto_pad attribute.",
                         AttrType::INTS);
             schema.Attr("dilations",
                         "Dilation along each axis, 1 means no dilation.",
@@ -181,8 +181,8 @@ computes the output.)DOC";
                         "than or equal to 0. The value represent the number of pixels added to the lower "
                         "and upper part of the corresponding axis. So `pads` will have two values per axis, "
                         "first value corresponding to the number of pixels added to the begining of the axis "
-                        "and the second value corresponding to the number of pixels add at the end of the axis."
-                        "This attribute cannot be used simultaneously with autopad attribute.",
+                        "and the second value corresponding to the number of pixels add at the end of the axis. "
+                        "This attribute cannot be used simultaneously with auto_pad attribute.",
                         AttrType::INTS);
             schema.Attr("group",
                         "number of groups input channels and output channels are divided into",
@@ -253,8 +253,8 @@ and computes the output.)DOC";
                         "than or equal to 0. The value represent the number of pixels added to the lower "
                         "and upper part of the corresponding axis. So `pads` will have two values per axis, "
                         "first value corresponding to the number of pixels added to the begining of the axis "
-                        "and the second value corresponding to the number of pixels add at the end of the axis."
-                        "This attribute cannot be used simultaneously with autopad attribute.",
+                        "and the second value corresponding to the number of pixels add at the end of the axis. "
+                        "This attribute cannot be used simultaneously with auto_pad attribute.",
                         AttrType::INTS);
             schema.Attr("group",
                         "number of groups input channels and output channels are divided into",


### PR DESCRIPTION
> VALID mean no padding, therefore, read the pixel values from the pads attribute.

We cannot make sense of the logical consequence as evinced in the use of `therefore` here. Therefore in this PR we hope to resolve the conflict of auto_pad and pads in a more coherent way.

More specific reason for change, quoted from https://github.com/onnx/onnx/pull/166 

## Current behavior
> If auto_pad = 'VALID' that mean not auto_padding, in this case if pads is specified then use the value in pads attribute, otherwise no padding is applied.
> 
> Here is the logic,
> If auto_pad = SAME_LOWER or SAME_UPPER, then ignore pads attribute.
> If auto_pad = VALID, then check pads attribute. If pads attribute isn't empty, then use it. Otherwise no padding.

## Reason for change

> @ebarsoum This could be very confusing for the Tensorflow world as 'VALID' = no padding as opposed to no **auto** padding. On the other hand, we will try to put aside my presumptions from Tensorflow and explain the scheme that I think is the most intuitive:
> 
> You specify either autopad or pads. When both are specified, we should have a precedence established from discussion and take the one with higher precedence and abandon the one with lower precedence. 
> 
> Your current specification has the following aspects that we cannot understand/ do not feel good about:
> 
> 1. The interaction of auto_pad and pads are asymmetrical. Meaning that in some cases you go down to pads after looking at auto_pad whereas in some other cases you dont. Such asymmetrical behavior will lead to user having a hard time to memorize your specification and results in time wasted in looking up documentation and debugging.
> 
> 2. I do not see why anyone would specify audo_pad to be 'VALID' and then specify pads to be non-empty. Can you give me a specific use case? Why use 'VALID'  and nothing in the pads attribute in any case if you can just leave pads empty? 
> 
> 3. On a conceptually level, VALID is an automatic padding scheme (as manifested by its naming). You seem to take it as a partial padding scheme this is problematic because VALID option currently serves two purposes:
> - specify no padding is needed. (in which case no information is gained by having this 'VALID' paramter since we can leave pads empty).
> - specify users' intent that padding should be done according to the pads attribute (again, no information is gained by having this 'VALID' parameter since it is overiden).
> - So my question is why would we have this 'VALID' option? What information can be gained?
> 
> I hope you can understand our confusion coming from a Tensorflow world.