### PR TITLE
Delete SparseTensor.

### DIFF
--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -44,11 +44,6 @@ void check_value_info(const ValueInfoProto& value_info, int ir_version) {
       enforce_has_field(type, elem_type);
       enforce_has_field(type, shape);
     } break;
-    case TypeProto::kSparseTensorType: {
-      const auto& type = value_info.type().sparse_tensor_type();
-      enforce_has_field(type, elem_type);
-      enforce_has_field(type, shape);
-    } break;
     default:
       fail_check("Unrecognized type value case: ", value_case);
   }

--- a/onnx/defs/data_type_utils.cc
+++ b/onnx/defs/data_type_utils.cc
@@ -131,11 +131,6 @@ std::string DataTypeUtils::ToString(
       }
     }
 
-    case TypeProto::ValueCase::kSparseTensorType:
-      return left + "sparse(" +
-          ToDataTypeString(type_proto.sparse_tensor_type().elem_type()) + ")" +
-          right;
-
     default:
       assert(false);
       return "";
@@ -155,12 +150,7 @@ void DataTypeUtils::FromString(
     TypeProto& type_proto) {
   StringRange s(type_str);
   type_proto.Clear();
-  if (s.LStrip("sparse")) {
-    s.ParensWhitespaceStrip();
-    TensorProto::DataType e;
-    FromDataTypeString(std::string(s.Data(), s.Size()), e);
-    type_proto.mutable_sparse_tensor_type()->set_elem_type(e);
-  } else if (s.LStrip("tensor")) {
+  if (s.LStrip("tensor")) {
     s.ParensWhitespaceStrip();
     TensorProto::DataType e;
     FromDataTypeString(std::string(s.Data(), s.Size()), e);

--- a/onnx/defs/data_type_utils.h
+++ b/onnx/defs/data_type_utils.h
@@ -22,13 +22,13 @@ namespace Utils {
 // efficiency.
 //
 // Grammar for data type string:
-// <type> ::= <data_type> | tensor(<data_type>) | sparse(<data_type>)
+// <type> ::= <data_type> | tensor(<data_type>) | ...
 // <data_type> :: = float | int32 | string | bool | uint8
 //                | int8 | uint16 | int16 | int64 | float16 | double
 //
 // NOTE: <type> ::= <data_type> means the data is scalar (zero dimension).
 //
-// Example: float, tensor(float), sparse(double), etc.
+// Example: float, tensor(float), etc.
 //
 class DataTypeUtils {
  public:

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -301,7 +301,7 @@ class OpSchema {
   };
 
   // Grammar for type strings used in Input(), Output().
-  // <type> ::= <data_type> | tensor(<data_type>) | sparse(<data_type>) |
+  // <type> ::= <data_type> | tensor(<data_type>) | ...
   // <type_parameter> <data_type> :: = float | int32 | string | bool | uint8
   //                | int8 | uint16 | int16 | int64 | float16 | double
   // <type_parameter> ::= any type parameter, say "T".

--- a/onnx/onnx-ml.proto
+++ b/onnx/onnx-ml.proto
@@ -364,19 +364,6 @@ message TensorProto {
   repeated uint64 uint64_data = 11 [packed = true];
 }
 
-// A sparse tensor must be stored as three dense tensors:
-//  1. dims: The shape of the original dense tensor.
-//  2. indices: A 2-D tensor specifying the indices of the nonzero elements.
-//  3. values: A 1-D tensor containing the values of the nonzero elements.
-message SparseTensorProto {
-  // The dimensions in the tensor.
-  repeated int64 dims = 1;
-  // This field MUST be present this version of the IR.
-  optional TensorProto indices = 2;
-  // This field MUST be present this version of the IR.
-  optional TensorProto values = 3;
-}
-
 // A ValueProto represents a value that may be serialized into a model.
 message ValueProto {
 
@@ -437,9 +424,6 @@ message ValueProto {
     // A dense tensor (or scalar).
     TensorProto dense_tensor = 1;
 
-    // A sparse tensor.
-    SparseTensorProto sparse_tensor = 2;
-
     // A tuple.
     RecordProto record = 3;
 
@@ -473,13 +457,6 @@ message TypeProto {
   }
 
   message TensorTypeProto {
-    // This field MUST NOT have the value of UNDEFINED
-    // This field MUST be present for this version of the IR.
-    optional TensorProto.DataType elem_type = 1;
-    optional TensorShapeProto shape = 2;
-  }
-
-  message SparseTensorTypeProto {
     // This field MUST NOT have the value of UNDEFINED
     // This field MUST be present for this version of the IR.
     optional TensorProto.DataType elem_type = 1;
@@ -524,9 +501,6 @@ message TypeProto {
   oneof value {
     // The type of a tensor.
     TensorTypeProto tensor_type = 1;
-
-    // The type of a sparse tensor.
-    SparseTensorTypeProto sparse_tensor_type = 2;
 
 
     // NOTE:  DNN-only implementations of ONNX MAY elect to not support non-tensor values

--- a/onnx/onnx-ml.proto3
+++ b/onnx/onnx-ml.proto3
@@ -364,19 +364,6 @@ message TensorProto {
   repeated uint64 uint64_data = 11 [packed = true];
 }
 
-// A sparse tensor must be stored as three dense tensors:
-//  1. dims: The shape of the original dense tensor.
-//  2. indices: A 2-D tensor specifying the indices of the nonzero elements.
-//  3. values: A 1-D tensor containing the values of the nonzero elements.
-message SparseTensorProto {
-  // The dimensions in the tensor.
-  repeated int64 dims = 1;
-  // This field MUST be present this version of the IR.
-  TensorProto indices = 2;
-  // This field MUST be present this version of the IR.
-  TensorProto values = 3;
-}
-
 // A ValueProto represents a value that may be serialized into a model.
 message ValueProto {
 
@@ -437,9 +424,6 @@ message ValueProto {
     // A dense tensor (or scalar).
     TensorProto dense_tensor = 1;
 
-    // A sparse tensor.
-    SparseTensorProto sparse_tensor = 2;
-
     // A tuple.
     RecordProto record = 3;
 
@@ -473,13 +457,6 @@ message TypeProto {
   }
 
   message TensorTypeProto {
-    // This field MUST NOT have the value of UNDEFINED
-    // This field MUST be present for this version of the IR.
-    TensorProto.DataType elem_type = 1;
-    TensorShapeProto shape = 2;
-  }
-
-  message SparseTensorTypeProto {
     // This field MUST NOT have the value of UNDEFINED
     // This field MUST be present for this version of the IR.
     TensorProto.DataType elem_type = 1;
@@ -524,9 +501,6 @@ message TypeProto {
   oneof value {
     // The type of a tensor.
     TensorTypeProto tensor_type = 1;
-
-    // The type of a sparse tensor.
-    SparseTensorTypeProto sparse_tensor_type = 2;
 
 
     // NOTE:  DNN-only implementations of ONNX MAY elect to not support non-tensor values

--- a/onnx/onnx.in.proto
+++ b/onnx/onnx.in.proto
@@ -361,19 +361,6 @@ message TensorProto {
   repeated uint64 uint64_data = 11 [packed = true];
 }
 
-// A sparse tensor must be stored as three dense tensors:
-//  1. dims: The shape of the original dense tensor.
-//  2. indices: A 2-D tensor specifying the indices of the nonzero elements.
-//  3. values: A 1-D tensor containing the values of the nonzero elements.
-message SparseTensorProto {
-  // The dimensions in the tensor.
-  repeated int64 dims = 1;
-  // This field MUST be present this version of the IR.
-  optional TensorProto indices = 2;
-  // This field MUST be present this version of the IR.
-  optional TensorProto values = 3;
-}
-
 // #if ONNX-ML
 // A ValueProto represents a value that may be serialized into a model.
 message ValueProto {
@@ -435,9 +422,6 @@ message ValueProto {
     // A dense tensor (or scalar).
     TensorProto dense_tensor = 1;
 
-    // A sparse tensor.
-    SparseTensorProto sparse_tensor = 2;
-
     // A tuple.
     RecordProto record = 3;
 
@@ -472,13 +456,6 @@ message TypeProto {
   }
 
   message TensorTypeProto {
-    // This field MUST NOT have the value of UNDEFINED
-    // This field MUST be present for this version of the IR.
-    optional TensorProto.DataType elem_type = 1;
-    optional TensorShapeProto shape = 2;
-  }
-
-  message SparseTensorTypeProto {
     // This field MUST NOT have the value of UNDEFINED
     // This field MUST be present for this version of the IR.
     optional TensorProto.DataType elem_type = 1;
@@ -525,9 +502,6 @@ message TypeProto {
   oneof value {
     // The type of a tensor.
     TensorTypeProto tensor_type = 1;
-
-    // The type of a sparse tensor.
-    SparseTensorTypeProto sparse_tensor_type = 2;
 
 // #if ONNX-ML
 

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -363,19 +363,6 @@ message TensorProto {
   repeated uint64 uint64_data = 11 [packed = true];
 }
 
-// A sparse tensor must be stored as three dense tensors:
-//  1. dims: The shape of the original dense tensor.
-//  2. indices: A 2-D tensor specifying the indices of the nonzero elements.
-//  3. values: A 1-D tensor containing the values of the nonzero elements.
-message SparseTensorProto {
-  // The dimensions in the tensor.
-  repeated int64 dims = 1;
-  // This field MUST be present this version of the IR.
-  optional TensorProto indices = 2;
-  // This field MUST be present this version of the IR.
-  optional TensorProto values = 3;
-}
-
 
 // Define the types.
 message TypeProto {
@@ -399,20 +386,10 @@ message TypeProto {
     optional TensorShapeProto shape = 2;
   }
 
-  message SparseTensorTypeProto {
-    // This field MUST NOT have the value of UNDEFINED
-    // This field MUST be present for this version of the IR.
-    optional TensorProto.DataType elem_type = 1;
-    optional TensorShapeProto shape = 2;
-  }
-
 
   oneof value {
     // The type of a tensor.
     TensorTypeProto tensor_type = 1;
-
-    // The type of a sparse tensor.
-    SparseTensorTypeProto sparse_tensor_type = 2;
 
   }
 }

--- a/onnx/onnx.proto3
+++ b/onnx/onnx.proto3
@@ -363,19 +363,6 @@ message TensorProto {
   repeated uint64 uint64_data = 11 [packed = true];
 }
 
-// A sparse tensor must be stored as three dense tensors:
-//  1. dims: The shape of the original dense tensor.
-//  2. indices: A 2-D tensor specifying the indices of the nonzero elements.
-//  3. values: A 1-D tensor containing the values of the nonzero elements.
-message SparseTensorProto {
-  // The dimensions in the tensor.
-  repeated int64 dims = 1;
-  // This field MUST be present this version of the IR.
-  TensorProto indices = 2;
-  // This field MUST be present this version of the IR.
-  TensorProto values = 3;
-}
-
 
 // Define the types.
 message TypeProto {
@@ -399,20 +386,10 @@ message TypeProto {
     TensorShapeProto shape = 2;
   }
 
-  message SparseTensorTypeProto {
-    // This field MUST NOT have the value of UNDEFINED
-    // This field MUST be present for this version of the IR.
-    TensorProto.DataType elem_type = 1;
-    TensorShapeProto shape = 2;
-  }
-
 
   oneof value {
     // The type of a tensor.
     TensorTypeProto tensor_type = 1;
-
-    // The type of a sparse tensor.
-    SparseTensorTypeProto sparse_tensor_type = 2;
 
   }
 }


### PR DESCRIPTION
Maybe some day we will add it back, but at the moment no ONNX
implementations support it, so we are not sure it is exactly right.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>