### PR TITLE
Renumber fields and add a fixed magic field for models

### DIFF
--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -239,6 +239,12 @@ void check_model(const ModelProto& model, int ir_version) {
   if (model.ir_version() > ir_version) {
     fail_check("Your model ir_version is higher than the checker's.");
   }
+  if (!model.has_magic_prefix()) {
+    fail_check("The model does not have a magic_prefix set properly.");
+  }
+  if (model.magic_prefix() != 0x46584E4F) {
+    fail_check("The model does not have a magic_prefix set properly.");
+  }
   check_graph(model.graph(), model.ir_version());
 }
 

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -50,6 +50,7 @@ def make_model(graph, **kwargs):
     model = ModelProto()
     # Touch model.ir_version so it is stored as the version from which it is
     # generated.
+    model.magic_prefix = 0x46584E4F
     model.ir_version = IR_VERSION
     model.graph.CopyFrom(graph)
 
@@ -292,12 +293,9 @@ def printable_graph(graph, prefix=''):
     return '\n'.join(content)
 
 def read_version(val):
-    '''Given an i64 IR version, return a (major,minor,path) tuple.'''
-    sig   = (val & 0x00000000FFFFFFFF)
-    if sig != 0x4F4E5846:
-        raise ValueError('Tag "{:x}" is not a valid tag for version.'.format(sig))
-    patch = (val & 0x0000FFFF00000000) >> 32
-    minor = (val & 0x00FF000000000000) >> 48
-    major = (val & 0xFF00000000000000) >> 56
+    '''Given an i32 IR version, return a (major,minor,path) tuple.'''
+    patch = (val & 0x0000FFFF)
+    minor = (val & 0x00FF0000) >> 16
+    major = (val & 0xFF000000) >> 24
     return (major, minor, patch)
 

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -290,3 +290,14 @@ def printable_graph(graph, prefix=''):
     # closing bracket
     content.append(prefix + '}')
     return '\n'.join(content)
+
+def read_version(val):
+    '''Given an i64 IR version, return a (major,minor,path) tuple.'''
+    sig   = (val & 0x00000000FFFFFFFF)
+    if sig != 0x4F4E5846:
+        raise ValueError('Tag "{:x}" is not a valid tag for version.'.format(sig))
+    patch = (val & 0x0000FFFF00000000) >> 32
+    minor = (val & 0x00FF000000000000) >> 48
+    major = (val & 0xFF00000000000000) >> 56
+    return (major, minor, patch)
+

--- a/onnx/onnx-ml.proto
+++ b/onnx/onnx-ml.proto
@@ -76,7 +76,13 @@ enum Version {
   //    - Added new message OperatorSetIdProto
   //    - Added opset_import in ModelProto
   // - For vendor extensions, added domain in NodeProto
-  IR_VERSION = 0x00000003;
+  IR_VERSION_2017_11_03 = 0x00000003;
+
+  // IR VERSION 0.0.4 published on Nov 8, 2017
+  // - Model file starts with predictable, sniff-able bytes.
+  //    - magic_prefix is field 1
+  //    - ir_version is now field 12
+  IR_VERSION = 0x00000004;
 }
 
 // A named attribute containing either singular float, integer, string
@@ -173,9 +179,13 @@ message NodeProto {
 // a parameterized computation graph against a set of named operators that are
 // defined independently from the graph.
 message ModelProto {
+  // 'ONXF' (reversed as 46 58 4E 4F) 0x46584E4F
+  // This field MUST be present.
+  optional fixed32 magic_prefix = 1;
+
   // The version of the IR this model targets. See Version enum above.
   // This field MUST be present.
-  optional int64 ir_version = 1;
+  optional int64 ir_version = 13;
 
   // The OperatorSets this model relies on.
   // All ModelProtos MUST have at least one entry that

--- a/onnx/onnx-ml.proto3
+++ b/onnx/onnx-ml.proto3
@@ -76,7 +76,13 @@ enum Version {
   //    - Added new message OperatorSetIdProto
   //    - Added opset_import in ModelProto
   // - For vendor extensions, added domain in NodeProto
-  IR_VERSION = 0x00000003;
+  IR_VERSION_2017_11_03 = 0x00000003;
+
+  // IR VERSION 0.0.4 published on Nov 8, 2017
+  // - Model file starts with predictable, sniff-able bytes.
+  //    - magic_prefix is field 1
+  //    - ir_version is now field 12
+  IR_VERSION = 0x00000004;
 }
 
 // A named attribute containing either singular float, integer, string
@@ -173,9 +179,13 @@ message NodeProto {
 // a parameterized computation graph against a set of named operators that are
 // defined independently from the graph.
 message ModelProto {
+  // 'ONXF' (reversed as 46 58 4E 4F) 0x46584E4F
+  // This field MUST be present.
+  fixed32 magic_prefix = 1;
+
   // The version of the IR this model targets. See Version enum above.
   // This field MUST be present.
-  int64 ir_version = 1;
+  int64 ir_version = 13;
 
   // The OperatorSets this model relies on.
   // All ModelProtos MUST have at least one entry that

--- a/onnx/onnx.in.proto
+++ b/onnx/onnx.in.proto
@@ -71,7 +71,13 @@ enum Version {
   //    - Added new message OperatorSetIdProto
   //    - Added opset_import in ModelProto
   // - For vendor extensions, added domain in NodeProto
-  IR_VERSION = 0x00000003;
+  IR_VERSION_2017_11_03 = 0x00000003;
+
+  // IR VERSION 0.0.4 published on Nov 8, 2017
+  // - Model file starts with predictable, sniff-able bytes.
+  //    - Note that protobuf steals the MSB, so ASCII is out the window
+  //    - IR version is encoded as XX YY ZZZZ (major/minor/bugfix) 'ONXF' 4F 4E 58 46
+  IR_VERSION = 0x000000044F4E5846;
 }
 
 // A named attribute containing either singular float, integer, string

--- a/onnx/onnx.in.proto
+++ b/onnx/onnx.in.proto
@@ -75,9 +75,9 @@ enum Version {
 
   // IR VERSION 0.0.4 published on Nov 8, 2017
   // - Model file starts with predictable, sniff-able bytes.
-  //    - Note that protobuf steals the MSB, so ASCII is out the window
-  //    - IR version is encoded as XX YY ZZZZ (major/minor/bugfix) 'ONXF' 4F 4E 58 46
-  IR_VERSION = 0x000000044F4E5846;
+  //    - magic_prefix is field 1
+  //    - ir_version is now field 12
+  IR_VERSION = 0x00000004;
 }
 
 // A named attribute containing either singular float, integer, string
@@ -176,9 +176,13 @@ message NodeProto {
 // a parameterized computation graph against a set of named operators that are
 // defined independently from the graph.
 message ModelProto {
+  // 'ONXF' (reversed as 46 58 4E 4F) 0x46584E4F
+  // This field MUST be present.
+  optional fixed32 magic_prefix = 1;
+
   // The version of the IR this model targets. See Version enum above.
   // This field MUST be present.
-  optional int64 ir_version = 1;
+  optional int64 ir_version = 13;
 
   // The OperatorSets this model relies on.
   // All ModelProtos MUST have at least one entry that

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -76,7 +76,13 @@ enum Version {
   //    - Added new message OperatorSetIdProto
   //    - Added opset_import in ModelProto
   // - For vendor extensions, added domain in NodeProto
-  IR_VERSION = 0x00000003;
+  IR_VERSION_2017_11_03 = 0x00000003;
+
+  // IR VERSION 0.0.4 published on Nov 8, 2017
+  // - Model file starts with predictable, sniff-able bytes.
+  //    - magic_prefix is field 1
+  //    - ir_version is now field 12
+  IR_VERSION = 0x00000004;
 }
 
 // A named attribute containing either singular float, integer, string
@@ -172,9 +178,13 @@ message NodeProto {
 // a parameterized computation graph against a set of named operators that are
 // defined independently from the graph.
 message ModelProto {
+  // 'ONXF' (reversed as 46 58 4E 4F) 0x46584E4F
+  // This field MUST be present.
+  optional fixed32 magic_prefix = 1;
+
   // The version of the IR this model targets. See Version enum above.
   // This field MUST be present.
-  optional int64 ir_version = 1;
+  optional int64 ir_version = 13;
 
   // The OperatorSets this model relies on.
   // All ModelProtos MUST have at least one entry that

--- a/onnx/onnx.proto3
+++ b/onnx/onnx.proto3
@@ -76,7 +76,13 @@ enum Version {
   //    - Added new message OperatorSetIdProto
   //    - Added opset_import in ModelProto
   // - For vendor extensions, added domain in NodeProto
-  IR_VERSION = 0x00000003;
+  IR_VERSION_2017_11_03 = 0x00000003;
+
+  // IR VERSION 0.0.4 published on Nov 8, 2017
+  // - Model file starts with predictable, sniff-able bytes.
+  //    - magic_prefix is field 1
+  //    - ir_version is now field 12
+  IR_VERSION = 0x00000004;
 }
 
 // A named attribute containing either singular float, integer, string
@@ -172,9 +178,13 @@ message NodeProto {
 // a parameterized computation graph against a set of named operators that are
 // defined independently from the graph.
 message ModelProto {
+  // 'ONXF' (reversed as 46 58 4E 4F) 0x46584E4F
+  // This field MUST be present.
+  fixed32 magic_prefix = 1;
+
   // The version of the IR this model targets. See Version enum above.
   // This field MUST be present.
-  int64 ir_version = 1;
+  int64 ir_version = 13;
 
   // The OperatorSets this model relies on.
   // All ModelProtos MUST have at least one entry that


### PR DESCRIPTION
Serialized ONNX models are the unit of interchange, and so it's good to make them robust standalone files. This helps recognize an ONNX file by the prefix 0xD 'O' 'N' 'X' 'F'