### PR TITLE
Fix compilation warning

### DIFF
--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -25,8 +25,8 @@ OpSchema::FormalParameter::FormalParameter(
     const std::string& type_str,
     bool optional)
     : name_(name),
-      description_(description),
       type_str_(type_str),
+      description_(description),
       is_optional_(optional) {}
 
 const std::string& OpSchema::FormalParameter::GetName() const {


### PR DESCRIPTION
```
onnx/defs/schema.cc:28:7: warning: field 'description_' will be initialized after field 'type_str_' [-Wreorder]
         description_(description),
         ^
   1 warning generated.
```