### PR TITLE
Op signature consistency updates: attribute names

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -1288,7 +1288,7 @@ expect(node, inputs=[], outputs=[values],
 #### Attributes
 
 <dl>
-<dt><tt>p</tt> : float</dt>
+<dt><tt>P</tt> : float</dt>
 <dd>p value of the Lp norm used to pool over the input data, default is 2.0.</dd>
 </dl>
 
@@ -1808,12 +1808,12 @@ expect(node, inputs=[], outputs=[values],
 #### Attributes
 
 <dl>
+<dt><tt>P</tt> : float</dt>
+<dd>p value of the Lp norm used to pool over the input data, default is 2.0.</dd>
 <dt><tt>auto_pad</tt> : string</dt>
 <dd>auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where SAME_UPPER or SAME_LOWER mean pad the input so that the ouput size match the input.In case of odd number add the extra padding at the end for SAME_UPPER and at the begining for SAME_LOWER. VALID mean no padding, therefore, read the pixel values from the pads attribute.</dd>
 <dt><tt>kernel_shape</tt> : list of ints</dt>
 <dd>The size of the kernel along each axis.</dd>
-<dt><tt>p</tt> : float</dt>
-<dd>p value of the Lp norm used to pool over the input data, default is 2.0.</dd>
 <dt><tt>pads</tt> : list of ints</dt>
 <dd>Padding for lower and upper side along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the lower and upper part of the corresponding axis. So `pads` will have two values per axis, first value corresponding to the number of pixels added to the begining of the axis and the second value corresponding to the number of pixels add at the end of the axis.</dd>
 <dt><tt>strides</tt> : list of ints</dt>
@@ -4223,10 +4223,10 @@ expect(node, inputs=[x], outputs=[y],
 #### Attributes
 
 <dl>
+<dt><tt>P</tt> : float</dt>
+<dd>(float, default 2.0) the order of the normalization, only 2.0 is supported.</dd>
 <dt><tt>axis</tt> : int</dt>
 <dd>(int64, default -1) the axis on which to apply normalization, -1 mean last axis.</dd>
-<dt><tt>p</tt> : float</dt>
-<dd>(float, default 2.0) the order of the normalization, only 2.0 is supported.</dd>
 </dl>
 
 #### Inputs

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -3988,12 +3988,12 @@ expect(node, inputs=[x], outputs=[y],
 #### Attributes
 
 <dl>
+<dt><tt>W</tt> : tensor</dt>
+<dd>2-D tensor of weights [O,I].</dd>
 <dt><tt>input_dim</tt> : int</dt>
 <dd>Size of the input vocabulary.</dd>
 <dt><tt>output_dim</tt> : int</dt>
 <dd>Dimension of the embedding output vectors.</dd>
-<dt><tt>weights</tt> : tensor</dt>
-<dd>2-D tensor of weights [O,I].</dd>
 </dl>
 
 #### Inputs

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -1121,7 +1121,7 @@ expect(node, inputs=[], outputs=[values],
 <dd>The weight tensor for the gates. Concatenation of `W[zrh]` and `WB[zrh]` (if bidirectional) along dimension 0. This tensor has shape `[num_directions, 3*hidden_size, input_size]`.</dd>
 <dt><tt>R</tt> : T</dt>
 <dd>The recurrence weight tensor. Concatenation of `R[zrh]` and `RB[zrh]` (if bidirectional) along dimension 0. This tensor has shape `[num_directions, 3*hidden_size, hidden_size]`.</dd>
-<dt><tt>B</tt> (optional) : T</dt>
+<dt><tt>bias</tt> (optional) : T</dt>
 <dd>The bias tensor for the gates. Concatenation of `[Wb[zrh], Rb[zrh]]` and `[WBb[zrh], RBb[zrh]]` (if bidirectional) along dimension 0. This tensor has shape `[num_directions, 6*hidden_size]`. Optional: If not specified - assumed to be 0</dd>
 <dt><tt>sequence_lens</tt> (optional) : T1</dt>
 <dd>Optional tensor specifying lengths of the sequences in a batch. If not specified - assumed all sequences in the batch to have length `seq_length`. It has shape `[batch_size]`.</dd>
@@ -1150,21 +1150,21 @@ expect(node, inputs=[], outputs=[values],
 
 ### <a name="Gather"></a><a name="gather">**Gather**</a>
 
-  Given DATA tensor of rank r >= 1, and INDICES tensor of rank q, gather
-  entries of the outer-most dimension of DATA indexed by INDICES, and concatenate
+  Given `data` tensor of rank r >= 1, and `indices` tensor of rank q, gather
+  entries of the outer-most dimension of `data` indexed by `indices`, and concatenate
   them in an output tensor of rank q + (r - 1).
   
   Example:
-    DATA  = [
+    data  = [
         [1.0, 1.2],
         [2.3, 3.4],
         [4.5, 5.7],
     ]
-    INDICES = [
+    indices = [
         [0, 1],
         [1, 2],
     ]
-    OUTPUT = [
+    output = [
         [
             [1.0, 1.2],
             [2.3, 3.4],
@@ -1178,16 +1178,16 @@ expect(node, inputs=[], outputs=[values],
 #### Inputs
 
 <dl>
-<dt><tt>DATA</tt> : T</dt>
+<dt><tt>data</tt> : T</dt>
 <dd>Tensor of rank r >= 1.</dd>
-<dt><tt>INDICES</tt> : T</dt>
+<dt><tt>indices</tt> : T</dt>
 <dd>Tensor of int32/int64 indices, of any rank q.</dd>
 </dl>
 
 #### Outputs
 
 <dl>
-<dt><tt>OUTPUT</tt> : T</dt>
+<dt><tt>output</tt> : T</dt>
 <dd>Tensor of rank q + (r - 1).</dd>
 </dl>
 
@@ -1612,7 +1612,7 @@ expect(node, inputs=[], outputs=[values],
 <dd>The weight tensor for the gates. Concatenation of `W[iofc]` and `WB[iofc]` (if bidirectional) along dimension 0. The tensor has shape `[num_directions, 4*hidden_size, input_size]`.</dd>
 <dt><tt>R</tt> : T</dt>
 <dd>The recurrence weight tensor. Concatenation of `R[iofc]` and `RB[iofc]` (if bidirectional) along dimension 0. This tensor has shape `[num_directions, 4*hidden_size, hidden_size]`.</dd>
-<dt><tt>B</tt> (optional) : T</dt>
+<dt><tt>bias</tt> (optional) : T</dt>
 <dd>The bias tensor for input gate. Concatenation of `[Wb[iofc], Rb[iofc]]`, and `[WBb[iofc], RBb[iofc]]` (if bidirectional) along dimension 0. This tensor has shape `[num_directions, 8*hidden_size]`. Optional: If not specified - assumed to be 0.</dd>
 <dt><tt>sequence_lens</tt> (optional) : T1</dt>
 <dd>Optional tensor specifying lengths of the sequences in a batch. If not specified - assumed all sequences in the batch to have length `seq_length`. It has shape `[batch_size]`.</dd>
@@ -2240,7 +2240,7 @@ expect(node, inputs=[a, b], outputs=[c],
 <dl>
 <dt><tt>X</tt> : T</dt>
 <dd>Input tensor</dd>
-<dt><tt>Slope</tt> : T</dt>
+<dt><tt>slope</tt> : T</dt>
 <dd>Slope tensor. If `Slope` is of size 1, the value is sharedacross different channels</dd>
 </dl>
 
@@ -2261,19 +2261,19 @@ expect(node, inputs=[a, b], outputs=[c],
 
 ### <a name="Pad"></a><a name="pad">**Pad**</a>
 
-  Given DATA tensor, paddings, mode, and value.
+  Given `data` tensor, paddings, mode, and value.
   
   Example:
     Insert 0 paddings to the beginning of the second dimension.
   
-    DATA  = [
+    data = [
         [1.0, 1.2],
         [2.3, 3.4],
         [4.5, 5.7],
     ]
     paddings = [0, 0, 2, 0]
   
-    OUTPUT = [
+    output = [
         [
             [0.0, 0.0, 1.0, 1.2],
             [0.0, 0.0, 2.3, 3.4],
@@ -2295,14 +2295,14 @@ expect(node, inputs=[a, b], outputs=[c],
 #### Inputs
 
 <dl>
-<dt><tt>DATA</tt> : T</dt>
+<dt><tt>data</tt> : T</dt>
 <dd>Input tensor.</dd>
 </dl>
 
 #### Outputs
 
 <dl>
-<dt><tt>OUTPUT</tt> : T</dt>
+<dt><tt>output</tt> : T</dt>
 <dd>Tensor after padding.</dd>
 </dl>
 
@@ -2444,7 +2444,7 @@ for mode in ['edge', 'reflect']:
 <dd>The weight tensor for input gate. Concatenation of `Wi` and `WBi` (if bidirectional). The tensor has shape `[num_directions, hidden_size, input_size]`.</dd>
 <dt><tt>R</tt> : T</dt>
 <dd>The recurrence weight tensor. Concatenation of `Ri` and `RBi` (if bidirectional). The tensor has shape `[num_directions, hidden_size, hidden_size]`.</dd>
-<dt><tt>B</tt> (optional) : T</dt>
+<dt><tt>bias</tt> (optional) : T</dt>
 <dd>The bias tensor for input gate. Concatenation of `[Wbi, Rbi]` and `[WBbi, RBbi]` (if bidirectional). The tensor has shape `[num_directions, 2*hidden_size]`, Optional: If not specified - assumed to be 0.</dd>
 <dt><tt>sequence_lens</tt> (optional) : T1</dt>
 <dd>Optional tensor specifying lengths of the sequences in a batch. If not specified - assumed all sequences in the batch to have length `seq_length`. It has shape `[batch_size]`.</dd>
@@ -4054,7 +4054,7 @@ expect(node, inputs=[x], outputs=[y],
 <dd>input tensor that's coerced into a 2D matrix of size (MxK) as described above</dd>
 <dt><tt>W</tt> : T</dt>
 <dd>2D blob of size (KxN) containing fully connected weight matrix</dd>
-<dt><tt>b</tt> : T</dt>
+<dt><tt>bias</tt> : T</dt>
 <dd>1D blob containing bias vector</dd>
 </dl>
 

--- a/onnx/defs/experiments/defs.cc
+++ b/onnx/defs/experiments/defs.cc
@@ -368,7 +368,7 @@ OPERATOR_SCHEMA(Embedding)
     .SetDoc(R"DOC(Turns positive integers (indexes) into dense vectors of fixed size.)DOC")
     .Attr("input_dim", "Size of the input vocabulary.", AttrType::INT)
     .Attr("output_dim", "Dimension of the embedding output vectors.", AttrType::INT)
-    .Attr("weights", "2-D tensor of weights [O,I].", AttrType::TENSOR)    
+    .Attr("W", "2-D tensor of weights [O,I].", AttrType::TENSOR)    
     .Input(0, 
            "input", 
            "1-D tensor of integers representing indices in the embedding dictionary "

--- a/onnx/defs/experiments/defs.cc
+++ b/onnx/defs/experiments/defs.cc
@@ -226,7 +226,7 @@ will throw errors.
         "2D blob of size (KxN) containing fully connected weight "
         "matrix",
         "T")
-    .Input(2, "b", "1D blob containing bias vector", "T")
+    .Input(2, "bias", "1D blob containing bias vector", "T")
     .Output(0, "Y", "2D output tensor", "T")
     .TypeConstraint(
         "T",

--- a/onnx/defs/experiments/defs.cc
+++ b/onnx/defs/experiments/defs.cc
@@ -247,7 +247,7 @@ OPERATOR_SCHEMA(LpNormalization)
 Given a matrix, apply Lp-normalization along the provided axis.
 )DOC")
     .Attr("axis", "(int64, default -1) the axis on which to apply normalization, -1 mean last axis.", AttrType::INT)
-    .Attr("p", "(float, default 2.0) the order of the normalization, only 2.0 is supported.", AttrType::FLOAT);
+    .Attr("P", "(float, default 2.0) the order of the normalization, only 2.0 is supported.", AttrType::FLOAT);
 
 OPERATOR_SCHEMA(Scale)
     .SetSupportLevel(SupportType::EXPERIMENTAL)

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -353,7 +353,7 @@ output data (Tensor<T>) where the function `f(x) = slope * x for x < 0`,
     .Input(0, "X", "Input tensor", "T")
     .Input(
         1,
-        "Slope",
+        "slope",
         "Slope tensor. If `Slope` is of size 1, the value is shared"
         "across different channels", "T")
     .Output(0, "Y", "Output tensor", "T")

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -101,7 +101,7 @@ namespace onnx {
                         "first value corresponding to the number of pixels added to the begining of the axis "
                         "and the second value corresponding to the number of pixels add at the end of the axis.",
                         AttrType::INTS);
-            schema.Attr("p",
+            schema.Attr("P",
                         "p value of the Lp norm used to pool over the input data, default is 2.0.",
                         AttrType::FLOAT);
             schema.Input(0,
@@ -362,7 +362,7 @@ namespace onnx {
             schema.SetDoc(doc);
             schema.NumInputs(1);
             schema.NumOutputs(1);
-            schema.Attr("p",
+            schema.Attr("P",
                         "p value of the Lp norm used to pool over the input data, default is 2.0.",
                         AttrType::FLOAT);
             schema.Input(0,

--- a/onnx/defs/rnn/defs.cc
+++ b/onnx/defs/rnn/defs.cc
@@ -75,7 +75,7 @@ Equations:
 	   "The recurrence weight tensor. Concatenation of `Ri` and `RBi` "
            "(if bidirectional). The tensor has shape "
 	   "`[num_directions, hidden_size, hidden_size]`.", "T")
-    .Input(3, "B",
+    .Input(3, "bias",
 	   "The bias tensor for input gate. Concatenation of `[Wbi, Rbi]` "
            "and `[WBbi, RBbi]` (if bidirectional). The tensor has shape "
            "`[num_directions, 2*hidden_size]`, Optional: If not specified - assumed "
@@ -128,7 +128,7 @@ Equations (GRU with default activations):
 	   "The recurrence weight tensor. Concatenation of `R[zrh]` and `RB[zrh]` "
 	   "(if bidirectional) along dimension 0. This tensor has shape "
 	   "`[num_directions, 3*hidden_size, hidden_size]`.", "T")
-    .Input(3, "B",
+    .Input(3, "bias",
 	   "The bias tensor for the gates. Concatenation of `[Wb[zrh], Rb[zrh]]` and "
            "`[WBb[zrh], RBb[zrh]]` (if bidirectional) along dimension 0. This tensor "
            "has shape `[num_directions, 6*hidden_size]`. Optional: If not specified "
@@ -192,7 +192,7 @@ Equations (forward LSTM with default activations and peepholes):
 	   "The recurrence weight tensor. Concatenation of `R[iofc]` and "
 	   "`RB[iofc]` (if bidirectional) along dimension 0. This tensor has shape "
            "`[num_directions, 4*hidden_size, hidden_size]`.", "T")
-    .Input(3, "B",
+    .Input(3, "bias",
 	   "The bias tensor for input gate. Concatenation of `[Wb[iofc], Rb[iofc]]`, "
 	   "and `[WBb[iofc], RBb[iofc]]` (if bidirectional) along dimension 0. This "
            "tensor has shape `[num_directions, 8*hidden_size]`. Optional: If not "

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -169,21 +169,21 @@ OPERATOR_SCHEMA(Gather)
     .NumInputs(2)
     .NumOutputs(1)
     .SetDoc(R"DOC(
-Given DATA tensor of rank r >= 1, and INDICES tensor of rank q, gather
-entries of the outer-most dimension of DATA indexed by INDICES, and concatenate
+Given `data` tensor of rank r >= 1, and `indices` tensor of rank q, gather
+entries of the outer-most dimension of `data` indexed by `indices`, and concatenate
 them in an output tensor of rank q + (r - 1).
 
 Example:
-  DATA  = [
+  data  = [
       [1.0, 1.2],
       [2.3, 3.4],
       [4.5, 5.7],
   ]
-  INDICES = [
+  indices = [
       [0, 1],
       [1, 2],
   ]
-  OUTPUT = [
+  output = [
       [
           [1.0, 1.2],
           [2.3, 3.4],
@@ -194,9 +194,9 @@ Example:
       ],
   ]
 )DOC")
-    .Input(0, "DATA", "Tensor of rank r >= 1.", "T")
-    .Input(1, "INDICES", "Tensor of int32/int64 indices, of any rank q.", "T")
-    .Output(0, "OUTPUT", "Tensor of rank q + (r - 1).", "T")
+    .Input(0, "data", "Tensor of rank r >= 1.", "T")
+    .Input(1, "indices", "Tensor of int32/int64 indices, of any rank q.", "T")
+    .Output(0, "output", "Tensor of rank q + (r - 1).", "T")
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
             "Constrain input and output types to float tensors.");
 
@@ -233,19 +233,19 @@ OPERATOR_SCHEMA(Pad)
           "One float, indicates the value to be filled, default is 0",
           AttrType::FLOAT)
     .SetDoc(R"DOC(
-Given DATA tensor, paddings, mode, and value.
+Given `data` tensor, paddings, mode, and value.
 
 Example:
   Insert 0 paddings to the beginning of the second dimension.
 
-  DATA  = [
+  data = [
       [1.0, 1.2],
       [2.3, 3.4],
       [4.5, 5.7],
   ]
   paddings = [0, 0, 2, 0]
 
-  OUTPUT = [
+  output = [
       [
           [0.0, 0.0, 1.0, 1.2],
           [0.0, 0.0, 2.3, 3.4],
@@ -253,8 +253,8 @@ Example:
       ],
   ]
 )DOC")
-    .Input(0, "DATA", "Input tensor.", "T")
-    .Output(0, "OUTPUT", "Tensor after padding.", "T")
+    .Input(0, "data", "Input tensor.", "T")
+    .Output(0, "output", "Tensor after padding.", "T")
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
             "Constrain input and output types to float tensors.");
 


### PR DESCRIPTION
Any variable represented by a single letter is capitalized (i.e. X)
Any variable that represents a weight tensor will utilize the name “W”

This is a breaking change since it impacts attribute names