### PR TITLE
Stripping doc string and better error message for ValidationError

### DIFF
--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -217,8 +217,13 @@ void check_graph(const GraphProto& graph, int ir_version) {
     check_value_info(value_info, ir_version);
   }
   for (const auto& node : graph.node()) {
-    check_node(node, ir_version);
-  }
+    try {
+      check_node(node, ir_version);
+    } catch (ValidationError& ex) {
+      ex.AppendContext("Bad node spec: " + node.ShortDebugString());
+      throw ex;
+    }
+   }
 
   std::unordered_set<std::string> input_names{};
   for (const auto& value_info : graph.input()) {

--- a/onnx/checker.h
+++ b/onnx/checker.h
@@ -9,6 +9,19 @@ namespace checker {
 class ValidationError : public std::runtime_error {
  public:
   using std::runtime_error::runtime_error;
+  const char* what() const noexcept override {
+    if (!expanded_message_.empty()) {
+      return expanded_message_.c_str();
+    }
+    return std::runtime_error::what();
+  }
+  void AppendContext(const std::string& context) {
+    expanded_message_ = onnx::MakeString(
+        std::runtime_error::what(), "\n\n==> Context: ", context);
+  }
+
+ private:
+  std::string expanded_message_;
 };
 
 #define fail_check(...) \


### PR DESCRIPTION
- strip_doc_string is useful for tests in pytorch which puts entire stacktrace into docstring. I think it's quite generally useful
- validation error appends the entire bad node spec if invoked inside check_graph - makes it much easier to spot the problem