### PR TITLE
Bare minimum to get SinceVersion running

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -3724,13 +3724,11 @@ expect(node, inputs=[x], outputs=[y],
 <dd>length of each output</dd>
 </dl>
 
-#### Inputs (1 - 2)
+#### Inputs
 
 <dl>
 <dt><tt>input</tt> : T</dt>
 <dd>The tensor to split</dd>
-<dt><tt>split</tt> : T</dt>
-<dd>Optional list of output lengths (see also arg 'split')</dd>
 </dl>
 
 #### Outputs (1 - &#8734;)

--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -100,7 +100,7 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
   defs.def(
       "get_all_schemas",
       []() -> const std::unordered_map<std::string, OpSchema> {
-        return OpSchemaRegistry::registered_schemas();
+        return OpSchemaRegistry::latest_registered_schemas();
       });
 
   // Submodule `checker`

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -261,6 +261,11 @@ OpSchema& OpSchema::NumInputs(int min, int max) {
   return *this;
 }
 
+OpSchema& OpSchema::SinceVersion(OperatorSetVersion v) {
+  since_version_ = v;
+  return *this;
+}
+
 OpSchema& OpSchema::NumInputs(int n) {
   return NumInputs(n, n);
 }
@@ -559,8 +564,8 @@ std::ostream& operator<<(std::ostream& out, const OpSchema& schema) {
   return out;
 }
 
-std::unordered_map<std::string, OpSchema>& OpSchemaRegistry::map() {
-  static std::unordered_map<std::string, OpSchema> map;
+std::unordered_map<std::string, std::map<OperatorSetVersion, OpSchema>>& OpSchemaRegistry::map() {
+  static std::unordered_map<std::string, std::map<OperatorSetVersion, OpSchema>> map;
   return map;
 }
 

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -69,10 +69,9 @@ OPERATOR_SCHEMA(Concat)
         "Constrain output types to float tensors.");
 
 OPERATOR_SCHEMA(Split)
-    .NumInputs(1, 2)
+    .NumInputs(1)
     .NumOutputs(1, INT_MAX)
     .Input(0, "input", "The tensor to split", "T")
-    .Input(1, "split", "Optional list of output lengths (see also arg 'split')", "T")
     .Output(0, "outputs...", "One or more outputs forming list of tensors after splitting", "T")
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
             "Constrain input types to float tensors.")

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -69,6 +69,7 @@ OPERATOR_SCHEMA(Concat)
         "Constrain output types to float tensors.");
 
 OPERATOR_SCHEMA(Split)
+    .SinceVersion(2)
     .NumInputs(1)
     .NumOutputs(1, INT_MAX)
     .Input(0, "input", "The tensor to split", "T")
@@ -316,4 +317,4 @@ OPERATOR_SCHEMA(Tile)
             "Output tensor of same shape and type as input.", "T")
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
             "Constrain input types to float tensors.");
-        
+

--- a/onnx/defs/tensor/old.cc
+++ b/onnx/defs/tensor/old.cc
@@ -1,0 +1,28 @@
+// Copyright (c) Facebook Inc. and Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "onnx/defs/schema.h"
+
+using AttrType = onnx::OpSchema::AttrType;
+using namespace onnx;
+
+OPERATOR_SCHEMA(Split)
+    .SinceVersion(1)
+    .NumInputs(1, 2)
+    .NumOutputs(1, INT_MAX)
+    .Input(0, "input", "The tensor to split", "T")
+    .Input(1, "split", "Optional list of output lengths (see also arg 'split')", "T")
+    .Output(0, "outputs...", "One or more outputs forming list of tensors after splitting", "T")
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
+            "Constrain input types to float tensors.")
+    .Attr("axis",
+          "Which axis to split on",
+          AttrType::INT)
+    .Attr("split",
+          "length of each output",
+          AttrType::INTS)
+    .SetDoc(R"DOC(Split a tensor into a list of tensors, along the specified
+'axis'. The lengths of the split can be specified using argument 'axis' or
+optional second input blob to the operator. Otherwise, the tensor is split
+to equal sized parts.
+)DOC");


### PR DESCRIPTION
This is on top of https://github.com/onnx/onnx/pull/235 to demonstrate the bare minimum necessary to get the SinceVersion machinery working, with multiple versions of operators. It moves the old 'split' operator (modified in a BC-breaking way by Emad) into an old.cc file, sets up OpSchema to record multiple versions of an operator, but then has the public Python interface only return the latest versions.

I think the next thing to do is build a changelog rendererer, which shows a chronological listing of operator definitions as they change over operator definitions.