### PR TITLE
Check that the entire protobuf is deserialized

### DIFF
--- a/onnx/__init__.py
+++ b/onnx/__init__.py
@@ -11,7 +11,8 @@ import onnx.helper  # noqa
 import onnx.checker  # noqa
 import onnx.defs  # noqa
 
-import sys
+import google.protobuf.message
+
 
 def load(obj):
     '''
@@ -24,8 +25,13 @@ def load(obj):
     '''
     model = ModelProto()
     if hasattr(obj, 'read') and callable(obj.read):
-        model.ParseFromString(obj.read())
+        s = obj.read()
     else:
         with open(obj, 'rb') as f:
-            model.ParseFromString(f.read())
+            s = f.read()
+    decoded = model.ParseFromString(s)
+    if decoded != len(s):
+        raise google.protobuf.message.DecodeError(
+            "Protobuf decoding consumed too few bytes: {} out of {}".format(
+                decoded, len(s)))
     return model


### PR DESCRIPTION
Specified the wrong model file and onnx.load silently ate it while producing an empty result struct, which is not cool