### PR TITLE
Prettify printer: show initializers, types, etc

### DIFF
--- a/onnx/examples/Protobufs.ipynb
+++ b/onnx/examples/Protobufs.ipynb
@@ -2,8 +2,10 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from onnx import *"
@@ -11,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -37,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -48,7 +50,7 @@
       "Float attribute:\n",
       "\n",
       "name: \"this_is_a_float\"\n",
-      "f: 3.14\n",
+      "f: 3.1400001049\n",
       "type: FLOAT\n",
       "\n"
      ]
@@ -64,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -90,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -119,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -146,7 +148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -201,7 +203,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -313,77 +315,17 @@
       "\n",
       "More Readable GraphProto:\n",
       "\n",
-      "graph MLP (%name: \"X\"\n",
-      "type {\n",
-      "  tensor_type {\n",
-      "    elem_type: FLOAT\n",
-      "    shape {\n",
-      "      dim {\n",
-      "        dim_value: 1\n",
-      "      }\n",
-      "    }\n",
-      "  }\n",
-      "}\n",
-      ", %name: \"W1\"\n",
-      "type {\n",
-      "  tensor_type {\n",
-      "    elem_type: FLOAT\n",
-      "    shape {\n",
-      "      dim {\n",
-      "        dim_value: 1\n",
-      "      }\n",
-      "    }\n",
-      "  }\n",
-      "}\n",
-      ", %name: \"B1\"\n",
-      "type {\n",
-      "  tensor_type {\n",
-      "    elem_type: FLOAT\n",
-      "    shape {\n",
-      "      dim {\n",
-      "        dim_value: 1\n",
-      "      }\n",
-      "    }\n",
-      "  }\n",
-      "}\n",
-      ", %name: \"W2\"\n",
-      "type {\n",
-      "  tensor_type {\n",
-      "    elem_type: FLOAT\n",
-      "    shape {\n",
-      "      dim {\n",
-      "        dim_value: 1\n",
-      "      }\n",
-      "    }\n",
-      "  }\n",
-      "}\n",
-      ", %name: \"B2\"\n",
-      "type {\n",
-      "  tensor_type {\n",
-      "    elem_type: FLOAT\n",
-      "    shape {\n",
-      "      dim {\n",
-      "        dim_value: 1\n",
-      "      }\n",
-      "    }\n",
-      "  }\n",
-      "}\n",
+      "graph MLP (\n",
+      "  %X[FLOAT, 1]\n",
+      "  %W1[FLOAT, 1]\n",
+      "  %B1[FLOAT, 1]\n",
+      "  %W2[FLOAT, 1]\n",
+      "  %B2[FLOAT, 1]\n",
       ") {\n",
       "  %H1 = FC(%X, %W1, %B1)\n",
       "  %R1 = Relu(%H1)\n",
       "  %Y = FC(%R1, %W2, %B2)\n",
-      "  return %name: \"Y\"\n",
-      "type {\n",
-      "  tensor_type {\n",
-      "    elem_type: FLOAT\n",
-      "    shape {\n",
-      "      dim {\n",
-      "        dim_value: 1\n",
-      "      }\n",
-      "    }\n",
-      "  }\n",
-      "}\n",
-      "\n",
+      "  return %Y\n",
       "}\n"
      ]
     }
@@ -418,7 +360,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -578,10 +520,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
    "file_extension": ".py",
    "mimetype": "text/x-python",
-   "name": "python"
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
   }
  },
  "nbformat": 4,

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 test=pytest
 
 [tool:pytest]
-addopts = --nbval --cov=onnx --cov-report term-missing
+addopts = --nbval --current-env --cov=onnx --cov-report term-missing
 testpaths = onnx/test onnx/examples


### PR DESCRIPTION
Example output: git push --set-upstream origin dzhulgakov/update-printer

For future work, would be nice to rewrite it using something like https://github.com/caffe2/caffe2/blob/master/caffe2/python/net_printer.py