### PR TITLE
Integrate ninja build system into setup.py (Unix only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ build_*
 .eggs
 dist
 onnx.egg-info
+build.ninja
+.ninja_deps
+.ninja_log
 
 # generated files
 onnx/version.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,6 @@ cache:
 env:
   global:
     - PB_VERSION=2.6.1
+  matrix:
+    - USE_NINJA=false
+    - USE_NINJA=true

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -8,7 +8,7 @@ onnx_dir="$PWD"
 # install onnx
 cd $onnx_dir
 ccache -z
-pip install .
+pip install -v .
 ccache -s
 
 # onnx tests
@@ -25,7 +25,7 @@ git diff --exit-code
 # install onnx-ml
 cd $onnx_dir
 ccache -z
-pip install . --install-option="--onnxml=1"
+pip install -v . --install-option="--onnxml=1"
 ccache -s
 
 # run onnx tests again

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -10,3 +10,8 @@ wget -qO- "https://github.com/google/protobuf/releases/download/v$PB_VERSION/pro
 ccache -z
 cd "$pb_dir" && ./configure && make && make check && sudo make install && sudo ldconfig
 ccache -s
+
+
+if [[ $USE_NINJA == true ]]; then
+    pip install ninja
+fi

--- a/onnx/gen_proto.py
+++ b/onnx/gen_proto.py
@@ -4,6 +4,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import argparse
 import io
 import os
 import re
@@ -108,11 +109,14 @@ def convert(stem, do_onnx_ml=False):
                 fout.write(translate(source, proto=3, onnx_ml=True))
 
 def main():
-    convert("onnx", do_onnx_ml=True)
-    convert("onnx-operators", do_onnx_ml=True)
+    parser = argparse.ArgumentParser(
+        description='Generates .proto file variations from .in.proto')
+    parser.add_argument('stems', nargs='+', default=['onnx', 'onnx-operators'],
+                      help='list of .in.proto file stems (default: %(default)s)')
+    args = parser.parse_args()
+
+    for stem in args.stems:
+        convert(stem, do_onnx_ml=True)
 
 if __name__ == '__main__':
-    import argparse
-    parser = argparse.ArgumentParser(description='Generates .proto file variations from ' + os.path.join(os.path.dirname(__file__), "onnx.in.proto"))
-    args = parser.parse_args()
     main()

--- a/onnx/gen_proto.py
+++ b/onnx/gen_proto.py
@@ -111,8 +111,9 @@ def convert(stem, do_onnx_ml=False):
 def main():
     parser = argparse.ArgumentParser(
         description='Generates .proto file variations from .in.proto')
-    parser.add_argument('stems', nargs='+', default=['onnx', 'onnx-operators'],
-                      help='list of .in.proto file stems (default: %(default)s)')
+    parser.add_argument('stems', nargs='*', default=['onnx', 'onnx-operators'],
+                        help='list of .in.proto file stems '
+                        '(default: %(default)s)')
     args = parser.parse_args()
 
     for stem in args.stems:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import setuptools.command.build_py
 import setuptools.command.develop
 import setuptools.command.build_ext
 
-from contextlib import contextmanager, nested
+from contextlib import contextmanager
 import platform
 import fnmatch
 from collections import namedtuple
@@ -288,17 +288,10 @@ class build_ext(setuptools.command.build_ext.build_ext):
                       export_symbols, debug, extra_preargs,
                       extra_postargs, build_temp, target_lang)
 
-        with nested(
-                patch(
-                    distutils.unixccompiler.UnixCCompiler,
-                    '_compile',
-                    _compile),
-                patch(
-                    distutils.unixccompiler.UnixCCompiler,
-                    'link',
-                    link),
-                patch(self, 'force', True)):
-            self._build_default()
+        with patch(distutils.unixccompiler.UnixCCompiler, '_compile', _compile):
+            with patch(distutils.unixccompiler.UnixCCompiler, 'link', link):
+                with patch(self, 'force', True):
+                    self._build_default()
 
 cmdclass = {
     'build_proto': build_proto,


### PR DESCRIPTION
Why do we need this:
- As more and more of our development happens in c++, `distutils`'s default compilation mechanism slows down our development speed (no incremental build, no parallel build).
- With ninja build file, we can generate clang compilation database, which enables us using all kinds of clang tools (e.g. clang static analyser, clang-tidy ...)

As a beginning, we don't by default opt-in users to use ninja, instead it will only be enabled if users have installed ninja in their environment.
In this diff, only support for unix builds are added, mostly because I'm unfamiliar with windows.