### PR TITLE
add axis attribute to Gather

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -1207,11 +1207,11 @@ expect(node, inputs=[], outputs=[values],
 ### <a name="Gather"></a><a name="gather">**Gather**</a>
 
   Given `data` tensor of rank r >= 1, and `indices` tensor of rank q, gather
-  entries of the outer-most dimension of `data` indexed by `indices`, and concatenate
+  entries of the axis dimension of `data` (usually outer-most one as axis=0) indexed by `indices`, and concatenates
   them in an output tensor of rank q + (r - 1).
   
-  Example:
-    data  = [
+  Example 1:
+    data  =
         [1.0, 1.2],
         [2.3, 3.4],
         [4.5, 5.7],
@@ -1230,13 +1230,37 @@ expect(node, inputs=[], outputs=[values],
             [4.5, 5.7],
         ],
     ]
+  
+  Example 2:
+    data  =
+        [1.0, 1.2, 1.9],
+        [2.3, 3.4, 3.9],
+        [4.5, 5.7, 5.9],
+    ]
+    indices = [0, 2],
+    ]
+    axis = 1,
+    output = [
+        [
+            [1.0, 1.9],
+            [2.3, 3.9],
+            [4.5, 5.9],
+        ],
+    ]
+
+#### Attributes
+
+<dl>
+<dt><tt>axis</tt> : int</dt>
+<dd>Which axis to gather on, defaults to 0</dd>
+</dl>
 
 #### Inputs
 
 <dl>
 <dt><tt>data</tt> : T</dt>
 <dd>Tensor of rank r >= 1.</dd>
-<dt><tt>indices</tt> : T</dt>
+<dt><tt>indices</tt> : Tind</dt>
 <dd>Tensor of int32/int64 indices, of any rank q.</dd>
 </dl>
 
@@ -1252,6 +1276,8 @@ expect(node, inputs=[], outputs=[values],
 <dl>
 <dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
 <dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>Tind</tt> : tensor(int32), tensor(int64)</dt>
+<dd>Constrain indices to integer types</dd>
 </dl>
 
 

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -1207,11 +1207,11 @@ expect(node, inputs=[], outputs=[values],
 ### <a name="Gather"></a><a name="gather">**Gather**</a>
 
   Given `data` tensor of rank r >= 1, and `indices` tensor of rank q, gather
-  entries of the axis dimension of `data` (usually outer-most one as axis=0) indexed by `indices`, and concatenates
+  entries of the axis dimension of `data` (by default outer-most one as axis=0) indexed by `indices`, and concatenates
   them in an output tensor of rank q + (r - 1).
   
   Example 1:
-    data  =
+    data = [
         [1.0, 1.2],
         [2.3, 3.4],
         [4.5, 5.7],
@@ -1232,7 +1232,7 @@ expect(node, inputs=[], outputs=[values],
     ]
   
   Example 2:
-    data  =
+    data = [
         [1.0, 1.2, 1.9],
         [2.3, 3.4, 3.9],
         [4.5, 5.7, 5.9],
@@ -1252,7 +1252,7 @@ expect(node, inputs=[], outputs=[values],
 
 <dl>
 <dt><tt>axis</tt> : int</dt>
-<dd>Which axis to gather on, defaults to 0</dd>
+<dd>Which axis to gather on, defaults to 0. Negative value means counting dimensions from the back. Accepted range in [-r, r-1]</dd>
 </dl>
 
 #### Inputs

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -170,11 +170,11 @@ OPERATOR_SCHEMA(Gather)
     .NumOutputs(1)
     .SetDoc(R"DOC(
 Given `data` tensor of rank r >= 1, and `indices` tensor of rank q, gather
-entries of the outer-most dimension of `data` indexed by `indices`, and concatenate
+entries of the axis dimension of `data` (usually outer-most one as axis=0) indexed by `indices`, and concatenates
 them in an output tensor of rank q + (r - 1).
 
-Example:
-  data  = [
+Example 1:
+  data  =
       [1.0, 1.2],
       [2.3, 3.4],
       [4.5, 5.7],
@@ -193,12 +193,32 @@ Example:
           [4.5, 5.7],
       ],
   ]
+
+Example 2:
+  data  =
+      [1.0, 1.2, 1.9],
+      [2.3, 3.4, 3.9],
+      [4.5, 5.7, 5.9],
+  ]
+  indices = [0, 2],
+  ]
+  axis = 1,
+  output = [
+      [
+          [1.0, 1.9],
+          [2.3, 3.9],
+          [4.5, 5.9],
+      ],
+  ]
 )DOC")
+    .Attr("axis", "Which axis to gather on, defaults to 0", AttrType::INT)
     .Input(0, "data", "Tensor of rank r >= 1.", "T")
-    .Input(1, "indices", "Tensor of int32/int64 indices, of any rank q.", "T")
+    .Input(1, "indices", "Tensor of int32/int64 indices, of any rank q.", "Tind")
     .Output(0, "output", "Tensor of rank q + (r - 1).", "T")
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-            "Constrain input and output types to float tensors.");
+            "Constrain input and output types to float tensors.")
+    .TypeConstraint("Tind", { "tensor(int32)", "tensor(int64)" },
+            "Constrain indices to integer types");
 
 OPERATOR_SCHEMA(Squeeze)
     .NumInputs(1)

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -170,11 +170,11 @@ OPERATOR_SCHEMA(Gather)
     .NumOutputs(1)
     .SetDoc(R"DOC(
 Given `data` tensor of rank r >= 1, and `indices` tensor of rank q, gather
-entries of the axis dimension of `data` (usually outer-most one as axis=0) indexed by `indices`, and concatenates
+entries of the axis dimension of `data` (by default outer-most one as axis=0) indexed by `indices`, and concatenates
 them in an output tensor of rank q + (r - 1).
 
 Example 1:
-  data  =
+  data = [
       [1.0, 1.2],
       [2.3, 3.4],
       [4.5, 5.7],
@@ -195,7 +195,7 @@ Example 1:
   ]
 
 Example 2:
-  data  =
+  data = [
       [1.0, 1.2, 1.9],
       [2.3, 3.4, 3.9],
       [4.5, 5.7, 5.9],
@@ -211,14 +211,26 @@ Example 2:
       ],
   ]
 )DOC")
-    .Attr("axis", "Which axis to gather on, defaults to 0", AttrType::INT)
+    .Attr(
+        "axis",
+        "Which axis to gather on, defaults to 0. Negative value means "
+        "counting dimensions from the back. Accepted range in [-r, r-1]",
+        AttrType::INT)
     .Input(0, "data", "Tensor of rank r >= 1.", "T")
-    .Input(1, "indices", "Tensor of int32/int64 indices, of any rank q.", "Tind")
+    .Input(
+        1,
+        "indices",
+        "Tensor of int32/int64 indices, of any rank q.",
+        "Tind")
     .Output(0, "output", "Tensor of rank q + (r - 1).", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-            "Constrain input and output types to float tensors.")
-    .TypeConstraint("Tind", { "tensor(int32)", "tensor(int64)" },
-            "Constrain indices to integer types");
+    .TypeConstraint(
+        "T",
+        {"tensor(float16)", "tensor(float)", "tensor(double)"},
+        "Constrain input and output types to float tensors.")
+    .TypeConstraint(
+        "Tind",
+        {"tensor(int32)", "tensor(int64)"},
+        "Constrain indices to integer types");
 
 OPERATOR_SCHEMA(Squeeze)
     .NumInputs(1)
@@ -340,4 +352,3 @@ OPERATOR_SCHEMA(Tile)
             "Output tensor of same shape and type as input.", "T")
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
             "Constrain input types to float tensors.");
-


### PR DESCRIPTION
Addresses #296 - it's generally useful. For example Caffe2 has Gather (axis=0) and BatchGather (axis=1). I haven't added tests because we want to fix backends first probably.