### PR TITLE
Add a V1.0 enumeration value to IR version

### DIFF
--- a/onnx/onnx-ml.proto
+++ b/onnx/onnx-ml.proto
@@ -78,7 +78,7 @@ enum Version {
   //    - Added new message OperatorSetIdProto
   //    - Added opset_import in ModelProto
   // - For vendor extensions, added domain in NodeProto
-  IR_VERSION_2017_10_03 = 0x00000003;
+  IR_VERSION_2017_11_03 = 0x00000003;
 
   // IR VERSION 1_0 published on Nov 22, 2017
   IR_VERSION_1_0 = 0x00010000;

--- a/onnx/onnx-ml.proto
+++ b/onnx/onnx-ml.proto
@@ -56,6 +56,8 @@ package onnx;
 // To be compatible with both proto2 and proto3, we will use a version number
 // that is not defined by the default value but an explicit enum number.
 enum Version {
+  option allow_alias = true;
+
   // proto3 requires the first enum value to be zero.
   // We add this just to appease the compiler.
   _START_VERSION = 0;
@@ -76,7 +78,12 @@ enum Version {
   //    - Added new message OperatorSetIdProto
   //    - Added opset_import in ModelProto
   // - For vendor extensions, added domain in NodeProto
-  IR_VERSION = 0x00000003;
+  IR_VERSION_2017_10_03 = 0x00000003;
+
+  // IR VERSION 1_0 published on Nov 22, 2017
+  IR_VERSION_1_0 = 0x00010000;
+
+  IR_VERSION = 0x00010000;
 }
 
 // A named attribute containing either singular float, integer, string

--- a/onnx/onnx-ml.proto3
+++ b/onnx/onnx-ml.proto3
@@ -78,7 +78,7 @@ enum Version {
   //    - Added new message OperatorSetIdProto
   //    - Added opset_import in ModelProto
   // - For vendor extensions, added domain in NodeProto
-  IR_VERSION_2017_10_03 = 0x00000003;
+  IR_VERSION_2017_11_03 = 0x00000003;
 
   // IR VERSION 1_0 published on Nov 22, 2017
   IR_VERSION_1_0 = 0x00010000;

--- a/onnx/onnx-ml.proto3
+++ b/onnx/onnx-ml.proto3
@@ -56,6 +56,8 @@ package onnx;
 // To be compatible with both proto2 and proto3, we will use a version number
 // that is not defined by the default value but an explicit enum number.
 enum Version {
+  option allow_alias = true;
+
   // proto3 requires the first enum value to be zero.
   // We add this just to appease the compiler.
   _START_VERSION = 0;
@@ -76,7 +78,12 @@ enum Version {
   //    - Added new message OperatorSetIdProto
   //    - Added opset_import in ModelProto
   // - For vendor extensions, added domain in NodeProto
-  IR_VERSION = 0x00000003;
+  IR_VERSION_2017_10_03 = 0x00000003;
+
+  // IR VERSION 1_0 published on Nov 22, 2017
+  IR_VERSION_1_0 = 0x00010000;
+
+  IR_VERSION = 0x00010000;
 }
 
 // A named attribute containing either singular float, integer, string

--- a/onnx/onnx.in.proto
+++ b/onnx/onnx.in.proto
@@ -73,7 +73,7 @@ enum Version {
   //    - Added new message OperatorSetIdProto
   //    - Added opset_import in ModelProto
   // - For vendor extensions, added domain in NodeProto
-  IR_VERSION_2017_10_03 = 0x00000003;
+  IR_VERSION_2017_11_03 = 0x00000003;
 
   // IR VERSION 1_0 published on Nov 22, 2017
   IR_VERSION_1_0 = 0x00010000;

--- a/onnx/onnx.in.proto
+++ b/onnx/onnx.in.proto
@@ -51,6 +51,8 @@ package onnx;
 // To be compatible with both proto2 and proto3, we will use a version number
 // that is not defined by the default value but an explicit enum number.
 enum Version {
+  option allow_alias = true;
+
   // proto3 requires the first enum value to be zero.
   // We add this just to appease the compiler.
   _START_VERSION = 0;
@@ -71,7 +73,12 @@ enum Version {
   //    - Added new message OperatorSetIdProto
   //    - Added opset_import in ModelProto
   // - For vendor extensions, added domain in NodeProto
-  IR_VERSION = 0x00000003;
+  IR_VERSION_2017_10_03 = 0x00000003;
+
+  // IR VERSION 1_0 published on Nov 22, 2017
+  IR_VERSION_1_0 = 0x00010000;
+
+  IR_VERSION = 0x00010000;
 }
 
 // A named attribute containing either singular float, integer, string

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -78,7 +78,7 @@ enum Version {
   //    - Added new message OperatorSetIdProto
   //    - Added opset_import in ModelProto
   // - For vendor extensions, added domain in NodeProto
-  IR_VERSION_2017_10_03 = 0x00000003;
+  IR_VERSION_2017_11_03 = 0x00000003;
 
   // IR VERSION 1_0 published on Nov 22, 2017
   IR_VERSION_1_0 = 0x00010000;

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -56,6 +56,8 @@ package onnx;
 // To be compatible with both proto2 and proto3, we will use a version number
 // that is not defined by the default value but an explicit enum number.
 enum Version {
+  option allow_alias = true;
+
   // proto3 requires the first enum value to be zero.
   // We add this just to appease the compiler.
   _START_VERSION = 0;
@@ -76,7 +78,12 @@ enum Version {
   //    - Added new message OperatorSetIdProto
   //    - Added opset_import in ModelProto
   // - For vendor extensions, added domain in NodeProto
-  IR_VERSION = 0x00000003;
+  IR_VERSION_2017_10_03 = 0x00000003;
+
+  // IR VERSION 1_0 published on Nov 22, 2017
+  IR_VERSION_1_0 = 0x00010000;
+
+  IR_VERSION = 0x00010000;
 }
 
 // A named attribute containing either singular float, integer, string

--- a/onnx/onnx.proto3
+++ b/onnx/onnx.proto3
@@ -78,7 +78,7 @@ enum Version {
   //    - Added new message OperatorSetIdProto
   //    - Added opset_import in ModelProto
   // - For vendor extensions, added domain in NodeProto
-  IR_VERSION_2017_10_03 = 0x00000003;
+  IR_VERSION_2017_11_03 = 0x00000003;
 
   // IR VERSION 1_0 published on Nov 22, 2017
   IR_VERSION_1_0 = 0x00010000;

--- a/onnx/onnx.proto3
+++ b/onnx/onnx.proto3
@@ -56,6 +56,8 @@ package onnx;
 // To be compatible with both proto2 and proto3, we will use a version number
 // that is not defined by the default value but an explicit enum number.
 enum Version {
+  option allow_alias = true;
+
   // proto3 requires the first enum value to be zero.
   // We add this just to appease the compiler.
   _START_VERSION = 0;
@@ -76,7 +78,12 @@ enum Version {
   //    - Added new message OperatorSetIdProto
   //    - Added opset_import in ModelProto
   // - For vendor extensions, added domain in NodeProto
-  IR_VERSION = 0x00000003;
+  IR_VERSION_2017_10_03 = 0x00000003;
+
+  // IR VERSION 1_0 published on Nov 22, 2017
+  IR_VERSION_1_0 = 0x00010000;
+
+  IR_VERSION = 0x00010000;
 }
 
 // A named attribute containing either singular float, integer, string


### PR DESCRIPTION
This has been very stable for a while now and we should be able to have this be a stable target. We'll semver this as needed in the future.