### PR TITLE
include license info in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include onnx *.h *.cc *.proto
 recursive-include third_party *
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,6 @@ test=pytest
 [tool:pytest]
 addopts = --nbval --current-env --cov=onnx --cov-report term-missing
 testpaths = onnx/test onnx/examples
+
+[metadata]
+license-file = LICENSE


### PR DESCRIPTION
Redistributions of your source code are supposed to include the `LICENSE` text under the terms of your license, but your distributions currently don't – this makes it harder for everyone to follow the license. :)

The `MANIFEST.in` file makes sure that `LICENSE` ends up in the `.tar.gz` source files from `sdist`, and the `setup.cfg` setting tells wheels about it.