### PR TITLE
Change API to support specifying "single", "optional" and "variadic" input

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -596,7 +596,7 @@ expect(node, inputs=[x, y], outputs=[x + y],
 #### Inputs (1 - &#8734;)
 
 <dl>
-<dt><tt>inputs</tt> : T</dt>
+<dt><tt>inputs</tt> (variadic) : T</dt>
 <dd>List of tensors for concatenation</dd>
 </dl>
 
@@ -699,7 +699,7 @@ expect(node, inputs=[], outputs=[values],
 <dd>Input data tensor from previous layer; has size (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and width. Note that this is for the 2D image.Otherwise the size is (N x D1 x D2 ... x Dn)</dd>
 <dt><tt>W</tt> : T</dt>
 <dd>The weight tensor that will be used in the convolutions; has size (M x C x kH x kW), where C is the number of channels, and kH and kW are the height and width of the kernel, and M is the number of feature maps. For more than 2 dimensions, the kernel shape will be (M x C x k1 x k2 x ... x kn), where is the dimension of the kernel</dd>
-<dt><tt>B</tt> : T</dt>
+<dt><tt>B</tt> (optional) : T</dt>
 <dd>Optional 1D bias to be added to the convolution, has size of M.</dd>
 </dl>
 
@@ -749,7 +749,7 @@ expect(node, inputs=[], outputs=[values],
 <dd>Input data tensor from previous layer; has size (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and width. Note that this is for the 2D image.Otherwise the size is (N x D1 x D2 ... x Dn)</dd>
 <dt><tt>W</tt> : T</dt>
 <dd>The weight tensor that will be used in the convolutions; has size (C x M x kH x kW), where C is the number of channels, and kH and kW are the height and width of the kernel, and M is the number of feature maps. For more than 2 dimensions, the kernel shape will be (C x M x k1 x k2 x ... x kn), where is the dimension of the kernel</dd>
-<dt><tt>B</tt> : T</dt>
+<dt><tt>B</tt> (optional) : T</dt>
 <dd>Optional 1D bias to be added to the convolution, has size of C.</dd>
 </dl>
 
@@ -2084,7 +2084,7 @@ expect(node, inputs=[a, b], outputs=[c],
 #### Inputs (1 - &#8734;)
 
 <dl>
-<dt><tt>data_0</tt> : T</dt>
+<dt><tt>data_0</tt> (variadic) : T</dt>
 <dd>First of the input tensors.</dd>
 </dl>
 
@@ -2193,7 +2193,7 @@ expect(node, inputs=[a, b], outputs=[c],
 #### Inputs (1 - &#8734;)
 
 <dl>
-<dt><tt>data_0</tt> : T</dt>
+<dt><tt>data_0</tt> (variadic) : T</dt>
 <dd>First of the input tensors.</dd>
 </dl>
 
@@ -2220,7 +2220,7 @@ expect(node, inputs=[a, b], outputs=[c],
 #### Inputs (1 - &#8734;)
 
 <dl>
-<dt><tt>data_0</tt> : T</dt>
+<dt><tt>data_0</tt> (variadic) : T</dt>
 <dd>First of the input tensors.</dd>
 </dl>
 
@@ -3882,7 +3882,7 @@ expect(node, inputs=[x], outputs=[y],
 #### Inputs (1 - &#8734;)
 
 <dl>
-<dt><tt>data_0</tt> : T</dt>
+<dt><tt>data_0</tt> (variadic) : T</dt>
 <dd>First of the input tensors.</dd>
 </dl>
 
@@ -4340,7 +4340,7 @@ expect(node, inputs=[x], outputs=[y],
 #### Inputs (0 - 1)
 
 <dl>
-<dt><tt>shape</tt> : T</dt>
+<dt><tt>shape</tt> (optional) : T</dt>
 <dd>The shape of filled tensor</dd>
 </dl>
 

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -2085,7 +2085,7 @@ expect(node, inputs=[a, b], outputs=[c],
 
 <dl>
 <dt><tt>data_0</tt> (variadic) : T</dt>
-<dd>First of the input tensors.</dd>
+<dd>List of tensors for Max.</dd>
 </dl>
 
 #### Outputs
@@ -2194,7 +2194,7 @@ expect(node, inputs=[a, b], outputs=[c],
 
 <dl>
 <dt><tt>data_0</tt> (variadic) : T</dt>
-<dd>First of the input tensors.</dd>
+<dd>List of tensors for Mean.</dd>
 </dl>
 
 #### Outputs
@@ -2221,7 +2221,7 @@ expect(node, inputs=[a, b], outputs=[c],
 
 <dl>
 <dt><tt>data_0</tt> (variadic) : T</dt>
-<dd>First of the input tensors.</dd>
+<dd>List of tensors for Min</dd>
 </dl>
 
 #### Outputs
@@ -3883,7 +3883,7 @@ expect(node, inputs=[x], outputs=[y],
 
 <dl>
 <dt><tt>data_0</tt> (variadic) : T</dt>
-<dd>First of the input tensors.</dd>
+<dd>List of tensors for Sum.</dd>
 </dl>
 
 #### Outputs

--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -64,7 +64,7 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
       .def_property_readonly(
           "description", &OpSchema::FormalParameter::GetDescription)
       .def_property_readonly(
-          "optional", &OpSchema::FormalParameter::IsOptional);
+          "option", &OpSchema::FormalParameter::GetOption);
 
   py::enum_<OpSchema::AttrType>(op_schema, "AttrType")
       .value("FLOAT", OpSchema::AttrType::FLOAT)

--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -57,6 +57,11 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
           "allowed_type_strs",
           &OpSchema::TypeConstraintParam::allowed_type_strs);
 
+  py::enum_<OpSchema::FormalParameterOption>(op_schema, "FormalParameterOption")
+      .value("Single", OpSchema::Single)
+      .value("Optional", OpSchema::Optional)
+      .value("Variadic", OpSchema::Variadic);
+
   py::class_<OpSchema::FormalParameter>(op_schema, "FormalParameter")
       .def_property_readonly("name", &OpSchema::FormalParameter::GetName)
       .def_property_readonly("types", &OpSchema::FormalParameter::GetTypes)

--- a/onnx/defs/experiments/defs.cc
+++ b/onnx/defs/experiments/defs.cc
@@ -146,7 +146,7 @@ NOTE: Currently, it supports data type of float, int32, int64, and bool.
         "input",
         "Input tensor (optional) to provide shape information.",
         "T1",
-        true)
+        OpSchema::Optional)
     .Output(
         0,
         "output",
@@ -166,7 +166,7 @@ OPERATOR_SCHEMA(GivenTensorFill)
     .SetSupportLevel(SupportType::EXPERIMENTAL)
     .NumInputs(0, 1)
     .NumOutputs(1)
-    .Input(0, "shape", "The shape of filled tensor", "T")
+    .Input(0, "shape", "The shape of filled tensor", "T", OpSchema::Optional)
     .Output(0, "X", "The filled tensor", "T")
     .TypeConstraint(
         "T",

--- a/onnx/defs/gen_doc.py
+++ b/onnx/defs/gen_doc.py
@@ -97,9 +97,9 @@ def main(args):
               s += '<dl>\n'
               for input in schema.inputs:
                   option_str = ""
-                  if 1 == input.option:
+                  if OpSchema.FormalParameterOption.Optional == input.option:
                       option_str = " (optional)"
-                  elif 2 == input.option:
+                  elif OpSchema.FormalParameterOption.Variadic == input.option:
                       option_str = " (variadic)"
                   s += '<dt><tt>{}</tt>{} : {}</dt>\n'.format(input.name, option_str, input.typeStr)
                   s += '<dd>{}</dd>\n'.format(input.description)

--- a/onnx/defs/gen_doc.py
+++ b/onnx/defs/gen_doc.py
@@ -96,7 +96,12 @@ def main(args):
           if schema.inputs:
               s += '<dl>\n'
               for input in schema.inputs:
-                  s += '<dt><tt>{}</tt>{} : {}</dt>\n'.format(input.name, ' (optional)' if input.optional else '', input.typeStr)
+                  option_str = ""
+                  if 1 == input.option:
+                      option_str = " (optional)"
+                  elif 2 == input.option:
+                      option_str = " (variadic)"
+                  s += '<dt><tt>{}</tt>{} : {}</dt>\n'.format(input.name, option_str, input.typeStr)
                   s += '<dd>{}</dd>\n'.format(input.description)
               s += '</dl>\n'
 

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -396,7 +396,7 @@ OPERATOR_SCHEMA(Max)
 Element-wise max of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
 )DOC")
-    .Input(0, "data_0", "First of the input tensors.", "T", OpSchema::Variadic)
+    .Input(0, "data_0", "List of tensors for Max.", "T", OpSchema::Variadic)
     .Output(0, "max", "Output tensor. Same dimension as inputs.", "T")
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
         "Constrain input and output types to float tensors.");
@@ -409,7 +409,7 @@ OPERATOR_SCHEMA(Min)
 Element-wise min of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
 )DOC")
-    .Input(0, "data_0", "First of the input tensors.", "T", OpSchema::Variadic)
+    .Input(0, "data_0", "List of tensors for Min", "T", OpSchema::Variadic)
     .Output(0, "min", "Output tensor. Same dimension as inputs.", "T")
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
         "Constrain input and output types to float tensors.");
@@ -422,7 +422,7 @@ OPERATOR_SCHEMA(Sum)
 Element-wise sum of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
 )DOC")
-    .Input(0, "data_0", "First of the input tensors.", "T", OpSchema::Variadic)
+    .Input(0, "data_0", "List of tensors for Sum.", "T", OpSchema::Variadic)
     .Output(0, "sum", "Output tensor. Same dimension as inputs.", "T")
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
         "Constrain input and output types to float tensors.");
@@ -435,7 +435,7 @@ OPERATOR_SCHEMA(Mean)
 Element-wise mean of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
 )DOC")
-    .Input(0, "data_0", "First of the input tensors.", "T", OpSchema::Variadic)
+    .Input(0, "data_0", "List of tensors for Mean.", "T", OpSchema::Variadic)
     .Output(0, "mean", "Output tensor. Same dimension as inputs.", "T")
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
         "Constrain input and output types to float tensors.");

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -396,7 +396,7 @@ OPERATOR_SCHEMA(Max)
 Element-wise max of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
 )DOC")
-    .Input(0, "data_0", "First of the input tensors.", "T")
+    .Input(0, "data_0", "First of the input tensors.", "T", OpSchema::Variadic)
     .Output(0, "max", "Output tensor. Same dimension as inputs.", "T")
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
         "Constrain input and output types to float tensors.");
@@ -409,7 +409,7 @@ OPERATOR_SCHEMA(Min)
 Element-wise min of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
 )DOC")
-    .Input(0, "data_0", "First of the input tensors.", "T")
+    .Input(0, "data_0", "First of the input tensors.", "T", OpSchema::Variadic)
     .Output(0, "min", "Output tensor. Same dimension as inputs.", "T")
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
         "Constrain input and output types to float tensors.");
@@ -422,7 +422,7 @@ OPERATOR_SCHEMA(Sum)
 Element-wise sum of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
 )DOC")
-    .Input(0, "data_0", "First of the input tensors.", "T")
+    .Input(0, "data_0", "First of the input tensors.", "T", OpSchema::Variadic)
     .Output(0, "sum", "Output tensor. Same dimension as inputs.", "T")
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
         "Constrain input and output types to float tensors.");
@@ -435,7 +435,7 @@ OPERATOR_SCHEMA(Mean)
 Element-wise mean of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
 )DOC")
-    .Input(0, "data_0", "First of the input tensors.", "T")
+    .Input(0, "data_0", "First of the input tensors.", "T", OpSchema::Variadic)
     .Output(0, "mean", "Output tensor. Same dimension as inputs.", "T")
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
         "Constrain input and output types to float tensors.");

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -199,7 +199,7 @@ computes the output.)DOC";
                          "where is the dimension of the kernel", "T");
             schema.Input(2,
                          "B",
-                         "Optional 1D bias to be added to the convolution, has size of M.", "T");
+                         "Optional 1D bias to be added to the convolution, has size of M.", "T", OpSchema::Optional);
             schema.Output(0,
                           "Y",
                           "Output data tensor that contains the result of the "
@@ -260,7 +260,7 @@ and computes the output.)DOC";
                          "where is the dimension of the kernel", "T");
             schema.Input(2,
                          "B",
-                         "Optional 1D bias to be added to the convolution, has size of C.", "T");
+                         "Optional 1D bias to be added to the convolution, has size of C.", "T", OpSchema::Optional);
             schema.Output(0,
                           "Y",
                           "Output data tensor that contains the result of the convolution. The "

--- a/onnx/defs/rnn/defs.cc
+++ b/onnx/defs/rnn/defs.cc
@@ -37,11 +37,11 @@ std::function<void(OpSchema&)> RNNDocGenerator(const char* name) {
                      "Optional tensor specifying lengths of the sequences in a batch. "
                      "If not specified - assumed all sequences in the batch to have "
                      "length `seq_length`. It has shape `[batch_size]`.", "T1",
-                     true /*optional*/);
+                     OpSchema::Optional /*optional*/);
         schema.Input(5, "initial_h",
                      "Optional initial value of the hidden. If not specified - assumed "
                      "to be 0. It has shape `[num_directions, batch_size, hidden_size]`.",
-                     "T", true /*optional*/);
+                     "T", OpSchema::Optional /*optional*/);
         schema.Output(0, "Y",
                       "A tensor that concats all the intermediate output values of the hidden. "
                       "It has shape `[seq_length, num_directions, batch_size, hidden_size]`. "
@@ -142,7 +142,7 @@ Equations (Default: f=tanh):
            "and `[WBbi, RBbi]` (if bidirectional). The tensor has shape "
            "`[num_directions, 2*hidden_size]`. Optional: If not specified - assumed "
            "to be 0.", "T",
-	   true /*optional*/)
+        OpSchema::Optional /*optional*/)
     .FillUsing(RNNDocGenerator("RNN"));
 
 
@@ -243,7 +243,7 @@ Equations (Default: f=sigmoid, g=tanh):
            "`[WBb[zrh], RBb[zrh]]` (if bidirectional) along dimension 0. This tensor "
            "has shape `[num_directions, 6*hidden_size]`. Optional: If not specified "
            "- assumed to be 0", "T",
-	   true /*optional*/)
+        OpSchema::Optional /*optional*/)
     .FillUsing(RNNDocGenerator("GRU"));
 
 
@@ -356,17 +356,17 @@ Equations (Default: f=sigmoid, g=tanh, h=tanh):
 	   "and `[WBb[iofc], RBb[iofc]]` (if bidirectional) along dimension 0. This "
            "tensor has shape `[num_directions, 8*hidden_size]`. Optional: If not "
 	   "specified - assumed to be 0.", "T",
-	   true /*optional*/)
+       OpSchema::Optional /*optional*/)
     .Input(6, "initial_c",
            "Optional initial value of the cell. If not specified - assumed "
 	   "to be 0. It has shape `[num_directions, batch_size, hidden_size]`.",
-	   "T", true /*optional*/)
+	   "T", OpSchema::Optional /*optional*/)
     .Input(7, "P",
 	   "The weight tensor for peepholes. Concatenation of `P[iof]` and "
 	   "`PB[iof]` (if bidirectional) along dimension 0. It has shape "
 	   "`[num_directions, 3*hidde_size]`. Optional: If not specified - "
 	   "assumed to be 0.", "T",
-	   true /*optional*/)
+       OpSchema::Optional /*optional*/)
     .FillUsing(RNNDocGenerator("LSTM"));
 
 }  // namespace onnx    

--- a/onnx/defs/rnn/defs.cc
+++ b/onnx/defs/rnn/defs.cc
@@ -37,11 +37,11 @@ std::function<void(OpSchema&)> RNNDocGenerator(const char* name) {
                      "Optional tensor specifying lengths of the sequences in a batch. "
                      "If not specified - assumed all sequences in the batch to have "
                      "length `seq_length`. It has shape `[batch_size]`.", "T1",
-                     OpSchema::Optional /*optional*/);
+                     OpSchema::Optional);
         schema.Input(5, "initial_h",
                      "Optional initial value of the hidden. If not specified - assumed "
                      "to be 0. It has shape `[num_directions, batch_size, hidden_size]`.",
-                     "T", OpSchema::Optional /*optional*/);
+                     "T", OpSchema::Optional);
         schema.Output(0, "Y",
                       "A tensor that concats all the intermediate output values of the hidden. "
                       "It has shape `[seq_length, num_directions, batch_size, hidden_size]`. "
@@ -142,7 +142,7 @@ Equations (Default: f=tanh):
            "and `[WBbi, RBbi]` (if bidirectional). The tensor has shape "
            "`[num_directions, 2*hidden_size]`. Optional: If not specified - assumed "
            "to be 0.", "T",
-        OpSchema::Optional /*optional*/)
+        OpSchema::Optional)
     .FillUsing(RNNDocGenerator("RNN"));
 
 
@@ -243,7 +243,7 @@ Equations (Default: f=sigmoid, g=tanh):
            "`[WBb[zrh], RBb[zrh]]` (if bidirectional) along dimension 0. This tensor "
            "has shape `[num_directions, 6*hidden_size]`. Optional: If not specified "
            "- assumed to be 0", "T",
-        OpSchema::Optional /*optional*/)
+        OpSchema::Optional)
     .FillUsing(RNNDocGenerator("GRU"));
 
 
@@ -356,17 +356,17 @@ Equations (Default: f=sigmoid, g=tanh, h=tanh):
 	   "and `[WBb[iofc], RBb[iofc]]` (if bidirectional) along dimension 0. This "
            "tensor has shape `[num_directions, 8*hidden_size]`. Optional: If not "
 	   "specified - assumed to be 0.", "T",
-       OpSchema::Optional /*optional*/)
+       OpSchema::Optional)
     .Input(6, "initial_c",
            "Optional initial value of the cell. If not specified - assumed "
 	   "to be 0. It has shape `[num_directions, batch_size, hidden_size]`.",
-	   "T", OpSchema::Optional /*optional*/)
+	   "T", OpSchema::Optional)
     .Input(7, "P",
 	   "The weight tensor for peepholes. Concatenation of `P[iof]` and "
 	   "`PB[iof]` (if bidirectional) along dimension 0. It has shape "
 	   "`[num_directions, 3*hidde_size]`. Optional: If not specified - "
 	   "assumed to be 0.", "T",
-       OpSchema::Optional /*optional*/)
+       OpSchema::Optional)
     .FillUsing(RNNDocGenerator("LSTM"));
 
 }  // namespace onnx    

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -110,6 +110,22 @@ void OpSchema::Verify(const NodeProto& node) const {
 
   // Check the values of inputs / outputs
   for (int in_idx = 0; in_idx < node.input_size(); ++in_idx) {
+    if (in_idx >= inputs_.size()) {
+      if (Variadic == inputs_.back().GetOption()) {
+        // The last input formal parameter should be variadic.
+        break;
+      }
+      else {
+        fail_check(
+            "Node (",
+            node.name(),
+            ") has more inputs (",
+            node.input_size(),
+            ") than declared (",
+            inputs_.size(),
+            ") in op definition.");
+      }
+    }
     if (node.input(in_idx).empty() && (Single == inputs_[in_idx].GetOption())) {
       fail_check(
           "Input ",

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -49,6 +49,19 @@ constexpr int kCannotComputeNumOutputs = -1;
  */
 class OpSchema {
  public:
+  // Formal parameter options.
+  enum FormalParameterOption {
+    // The input formal parameter is single and not optional.
+    // Number of this input is 1.
+    Single = 0,
+    // The input formal parameter is single and optional.
+    // Number of this input is 0 or 1.
+    Optional = 1,
+    // The input formal parameter is variadic.
+    // Number of this input is [0, n].
+    Variadic = 2,
+  };
+
   // Formal parameter represenation, including input/output name, typeStr,
   // description, and type constraints.
   class FormalParameter {
@@ -61,13 +74,13 @@ class OpSchema {
         const DataTypeSet& type_set,
         const std::string& type_str,
         const std::string& description,
-        bool is_optional = false);
+        FormalParameterOption param_option = Single);
 
     explicit FormalParameter(
         const std::string& name,
         const std::string& description,
         const std::string& type_str,
-        bool is_optional = false);
+        FormalParameterOption param_option = Single);
 
     // Get formal parameter name.
     const std::string& GetName() const;
@@ -81,9 +94,8 @@ class OpSchema {
     // Get formal parameter description.
     const std::string& GetDescription() const;
 
-    // Indicates whether this formal parameter is optional or not.
-    // It's applicable for input formal parameter only.
-    bool IsOptional() const;
+    // Get the parameter option, it could be Single, Optional or Variadic.
+    FormalParameterOption GetOption() const;
 
    private:
     friend class OpSchema;
@@ -105,8 +117,8 @@ class OpSchema {
     // Formal parameter description.
     std::string description_;
 
-    // Flag indicates whether this formal parameter is optional or not.
-    bool is_optional_;
+    // Formal parameter option.
+    FormalParameterOption param_option_;
   };
 
   enum class SupportType {
@@ -347,7 +359,7 @@ class OpSchema {
       const std::string& name,
       const std::string& description,
       const std::string& type_str,
-      bool optinal = false);
+      FormalParameterOption param_option = Single);
   OpSchema& Output(
       const int n,
       const std::string& name,

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -63,7 +63,7 @@ OPERATOR_SCHEMA(Concat)
     "Which axis to concat on",
     AttrType::INT)
     .SetDoc("Concatenate a list of tensors into a single tensor")
-    .Input(0, "inputs", "List of tensors for concatenation", "T")
+    .Input(0, "inputs", "List of tensors for concatenation", "T", OpSchema::Variadic)
     .Output(0, "concat_result", "Concatenated tensor", "T")
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
         "Constrain output types to float tensors.");

--- a/onnx/defs/tensor/old.cc
+++ b/onnx/defs/tensor/old.cc
@@ -11,7 +11,7 @@ OPERATOR_SCHEMA(Split)
     .NumInputs(1, 2)
     .NumOutputs(1, INT_MAX)
     .Input(0, "input", "The tensor to split", "T")
-    .Input(1, "split", "Optional list of output lengths (see also arg 'split')", "T")
+    .Input(1, "split", "Optional list of output lengths (see also arg 'split')", "T", OpSchema::Optional)
     .Output(0, "outputs...", "One or more outputs forming list of tensors after splitting", "T")
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
             "Constrain input types to float tensors.")

--- a/onnx/defs/traditionalml/defs.cc
+++ b/onnx/defs/traditionalml/defs.cc
@@ -622,7 +622,7 @@ OPERATOR_SCHEMA(FeatureVectorizer)
     All inputs are tensors of float.  Any feature that is not a tensor of float should
     be converted using either Cast or CastMap.
 )DOC")
-.Input(0, "X", "ordered input tensors", "T")
+.Input(0, "X", "ordered input tensors", "T", OpSchema::Variadic)
 .Output(0, "Y", "Full output array, in order assigned in the inputlist, as floats", "T")
 .TypeConstraint("T", { "tensor(float)" }, " allowed types.")
 .Attr("inputdimensions", "the size of each input in the input list", AttrType::INT);


### PR DESCRIPTION
This is a follow-up of https://github.com/onnx/onnx/issues/285.

More thoughts and open questions:
1. Remove all "NumInputs", "NumOutputs" API, which seem to be not needed now given we have "optional", "variadic" types specified clearly.
2. Do we need to support "optional" and "variadic" outputs? for example, operator "Split". How do we hook up the outputs of "Split" with another node (op)?