### PR TITLE
Change get_all_schemas to return a vector rather than map.

### DIFF
--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -27,6 +27,7 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
           "doc", &OpSchema::doc, py::return_value_policy::reference)
       .def_property_readonly("since_version", &OpSchema::since_version)
       .def_property_readonly("domain", &OpSchema::domain)
+      .def_property_readonly("name", &OpSchema::Name)
       .def_property_readonly("min_input", &OpSchema::min_input)
       .def_property_readonly("max_input", &OpSchema::max_input)
       .def_property_readonly("min_output", &OpSchema::min_output)
@@ -100,8 +101,14 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
 
   defs.def(
       "get_all_schemas",
-      []() -> const std::unordered_map<std::string, OpSchema> {
-        return OpSchemaRegistry::latest_registered_schemas();
+      []() -> const std::vector<OpSchema> {
+        return OpSchemaRegistry::get_all_schemas();
+      });
+
+  defs.def(
+      "get_all_schemas_with_history",
+      []() -> const std::vector<OpSchema> {
+        return OpSchemaRegistry::get_all_schemas_with_history();
       });
 
   // Submodule `checker`

--- a/onnx/defs/gen_doc.py
+++ b/onnx/defs/gen_doc.py
@@ -46,8 +46,8 @@ def main(args):
           "            Do not modify directly and instead edit operator definitions.*\n")
 
       sorted_ops = sorted(
-          (schema.domain, int(schema.support_level), op_type, schema)
-          for (op_type, schema) in defs.get_all_schemas().items())
+          (schema.domain, int(schema.support_level), schema.name, schema)
+          for schema in defs.get_all_schemas())
 
       fout.write('\n')
 

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -582,20 +582,27 @@ class OpSchemaRegistry {
   static OpName_Domain_Version_Schema_Map& map();
 
  public:
-  static const OpName_Domain_Version_Schema_Map& registered_schemas() {
-    return map();
-  }
-
-  static const std::unordered_map<std::string, OpSchema>
-  latest_registered_schemas() {
-    // TODO: Do this better with C++11
-    std::unordered_map<std::string, OpSchema> latest_map;
-    for (auto kv : map()) {
-      for (auto domain_ops : kv.second) {
-        latest_map.emplace(kv.first, domain_ops.second.rbegin()->second);
+  static const std::vector<OpSchema> get_all_schemas_with_history() {
+    std::vector<OpSchema> r;
+    for (auto x : map()) {
+      for (auto y : x.second) {
+        for (auto z : y.second) {
+          r.emplace_back(z.second);
+        }
       }
     }
-    return latest_map;
+    return r;
+  }
+
+  static const std::vector<OpSchema> get_all_schemas() {
+    std::vector<OpSchema> r;
+    for (auto x : map()) {
+      for (auto y : x.second) {
+        auto& version2schema = y.second;
+        r.emplace_back(version2schema.rbegin()->second);
+      }
+    }
+    return r;
   }
 };
 


### PR DESCRIPTION
Now the API accurately reflects how we use it.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>