### PR TITLE
 Fix checker to know about versions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,8 +75,12 @@ compile_commands.json
 
 # generated files
 onnx/version.py
+compile_commands.json
 
 # test generated files
 .cache
 .coverage
 onnx/examples/.coverage.nbval
+
+# autocomplete
+.ycm_extra_conf.py

--- a/onnx/checker.h
+++ b/onnx/checker.h
@@ -28,13 +28,13 @@ class ValidationError : public std::runtime_error {
 #define fail_check(...) \
   throw onnx::checker::ValidationError(onnx::MakeString(__VA_ARGS__));
 
-struct CheckerContext {
+class CheckerContext {
   int ir_version;
   std::unordered_map<std::string, int> opset_imports;
-  int get_ir_version() { return ir_version; }
+public:
+  int get_ir_version() const { return ir_version; }
   void set_ir_version(int v) { ir_version = v; }
-  // NB: Does a copy
-  const std::unordered_map<std::string, int>& get_opset_imports() {
+  const std::unordered_map<std::string, int>& get_opset_imports() const {
     return opset_imports;
   }
   void set_opset_imports(const std::unordered_map<std::string, int>& imps) {

--- a/onnx/checker.h
+++ b/onnx/checker.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdexcept>
+#include <unordered_map>
 #include "onnx/onnx_pb.h"
 #include "onnx/string_utils.h"
 
@@ -27,12 +28,27 @@ class ValidationError : public std::runtime_error {
 #define fail_check(...) \
   throw onnx::checker::ValidationError(onnx::MakeString(__VA_ARGS__));
 
+struct CheckerContext {
+  int ir_version;
+  std::unordered_map<std::string, int> opset_imports;
+  int get_ir_version() { return ir_version; }
+  void set_ir_version(int v) { ir_version = v; }
+  // NB: Does a copy
+  const std::unordered_map<std::string, int>& get_opset_imports() {
+    return opset_imports;
+  }
+  void set_opset_imports(const std::unordered_map<std::string, int>& imps) {
+    opset_imports = imps;
+  }
+  explicit CheckerContext() : ir_version(-1) {}
+};
+
 using IR_VERSION_TYPE = decltype(Version::IR_VERSION);
-void check_value_info(const ValueInfoProto& value_info, int ir_version);
-void check_tensor(const TensorProto& tensor, int ir_version);
-void check_attribute(const AttributeProto& attr, int ir_version);
-void check_node(const NodeProto& node, int ir_version);
-void check_graph(const GraphProto& graph, int ir_version);
-void check_model(const ModelProto& model, int ir_version);
+void check_value_info(const ValueInfoProto& value_info, const CheckerContext&);
+void check_tensor(const TensorProto& tensor, const CheckerContext&);
+void check_attribute(const AttributeProto& attr, const CheckerContext&);
+void check_node(const NodeProto& node, const CheckerContext&);
+void check_graph(const GraphProto& graph, const CheckerContext&);
+void check_model(const ModelProto& model);
 } // namespace checker
 } // namespace onnx

--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -123,47 +123,53 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
   auto checker = onnx_cpp2py_export.def_submodule("checker");
   checker.doc() = "Checker submodule";
 
+  py::class_<checker::CheckerContext> checker_context(checker, "CheckerContext");
+  checker_context
+      .def(py::init<>())
+      .def_property("ir_version", &checker::CheckerContext::get_ir_version, &checker::CheckerContext::set_ir_version)
+      .def_property("opset_imports", &checker::CheckerContext::get_opset_imports, &checker::CheckerContext::set_opset_imports);
+
   py::register_exception<checker::ValidationError>(checker, "ValidationError");
 
   checker.def(
-      "check_value_info", [](const py::bytes& bytes, int ir_version) -> void {
+      "check_value_info", [](const py::bytes& bytes, const checker::CheckerContext& ctx) -> void {
         std::unique_ptr<ValueInfoProto> proto(new ValueInfoProto());
         ParseProtoFromPyBytes(proto.get(), bytes);
-        checker::check_value_info(*proto, ir_version);
+        checker::check_value_info(*proto, ctx);
       });
 
   checker.def(
-      "check_tensor", [](const py::bytes& bytes, int ir_version) -> void {
+      "check_tensor", [](const py::bytes& bytes, const checker::CheckerContext& ctx) -> void {
         std::unique_ptr<TensorProto> proto(new TensorProto());
         ParseProtoFromPyBytes(proto.get(), bytes);
-        checker::check_tensor(*proto, ir_version);
+        checker::check_tensor(*proto, ctx);
       });
 
   checker.def(
-      "check_attribute", [](const py::bytes& bytes, int ir_version) -> void {
+      "check_attribute", [](const py::bytes& bytes, const checker::CheckerContext& ctx) -> void {
         std::unique_ptr<AttributeProto> proto(new AttributeProto());
         ParseProtoFromPyBytes(proto.get(), bytes);
-        checker::check_attribute(*proto, ir_version);
+        checker::check_attribute(*proto, ctx);
       });
 
-  checker.def("check_node", [](const py::bytes& bytes, int ir_version) -> void {
+  checker.def("check_node", [](const py::bytes& bytes, const checker::CheckerContext& ctx) -> void {
     std::unique_ptr<NodeProto> proto(new NodeProto());
     ParseProtoFromPyBytes(proto.get(), bytes);
-    checker::check_node(*proto, ir_version);
+    checker::check_node(*proto, ctx);
   });
 
   checker.def(
-      "check_graph", [](const py::bytes& bytes, int ir_version) -> void {
+      "check_graph", [](const py::bytes& bytes, const checker::CheckerContext& ctx) -> void {
         std::unique_ptr<GraphProto> proto(new GraphProto());
         ParseProtoFromPyBytes(proto.get(), bytes);
-        checker::check_graph(*proto, ir_version);
+        checker::check_graph(*proto, ctx);
       });
 
   checker.def(
-      "check_model", [](const py::bytes& bytes, int ir_version) -> void {
+      "check_model", [](const py::bytes& bytes) -> void {
         std::unique_ptr<ModelProto> proto(new ModelProto());
         ParseProtoFromPyBytes(proto.get(), bytes);
-        checker::check_model(*proto, ir_version);
+        checker::check_model(*proto);
       });
 }
 

--- a/onnx/defs/__init__.py
+++ b/onnx/defs/__init__.py
@@ -6,6 +6,9 @@ from __future__ import unicode_literals
 import onnx.onnx_cpp2py_export.defs as C
 
 
+ONNX_DOMAIN = ""
+
+
 def has(op_type):
     return C.has_schema(op_type)
 
@@ -23,7 +26,7 @@ def get_all_schemas_with_history():
 
 
 def onnx_opset_version():
-    return C.schema_version_map()[""][1]
+    return C.schema_version_map()[ONNX_DOMAIN][1]
 
 
 OpSchema = C.OpSchema

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -54,6 +54,7 @@ OpSchema::FormalParameterOption OpSchema::FormalParameter::GetOption() const {
 }
 
 void OpSchema::Verify(const NodeProto& node) const {
+
   // Check the number of inputs.
   if (node.input_size() < min_input_ || node.input_size() > max_input_) {
     fail_check(
@@ -89,7 +90,7 @@ void OpSchema::Verify(const NodeProto& node) const {
   }
 
   // Check the values of inputs / outputs
-  for (int in_idx = 0; in_idx < node.input_size(); ++in_idx) {
+  for (size_t in_idx = 0; in_idx < static_cast<size_t>(node.input_size()); ++in_idx) {
     if (in_idx >= inputs_.size()) {
       if (inputs_.size() > 0 && Variadic == inputs_.back().GetOption()) {
         // The last input formal parameter should be variadic.
@@ -114,7 +115,7 @@ void OpSchema::Verify(const NodeProto& node) const {
     }
   }
 
-  for (int out_idx = 0; out_idx < node.output_size(); ++out_idx) {
+  for (size_t out_idx = 0; out_idx < static_cast<size_t>(node.output_size()); ++out_idx) {
     if (out_idx >= outputs_.size()) {
         if (outputs_.size() > 0 && Variadic == outputs_.back().GetOption()) {
             // The last output formal parameter should be variadic.
@@ -454,7 +455,7 @@ void OpSchema::Finalize() {
   
   // Flag indicates whether an optional input is trailing one (there's no single or variadic
   // input behind).
-  for (int i = 0; i < (int)(inputs_.size()); ++i) {
+  for (size_t i = 0; i < inputs_.size(); ++i) {
     switch (inputs_[i].GetOption()) {
     case OpSchema::Single:
       ++max_input_;
@@ -473,7 +474,7 @@ void OpSchema::Finalize() {
   }
 
   // Calculate min/max number of outputs.
-  for (int i = 0; i < (int)(outputs_.size()); ++i) {
+  for (size_t i = 0; i < outputs_.size(); ++i) {
     switch (outputs_[i].GetOption()) {
     case OpSchema::Single:
       ++max_output_;

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -7,6 +7,7 @@
 #include "onnx/checker.h"
 
 namespace onnx {
+
 OpSchema::FormalParameter::FormalParameter(
     const std::string& name,
     const DataTypeSet& allowed_type_set,

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -18,6 +18,18 @@ from onnx import mapping
 def make_node(
         op_type, inputs, outputs,
         name=None, doc_string=None, **kwargs):
+    """Construct a NodeProto.
+
+    Arguments:
+        op_type (string): The name of the operator to construct
+        inputs (list of string): list of input names
+        outputs (list of string): list of output names
+        name (string, default None): optional unique identifier for NodeProto
+        doc_string (string, default None): optional documentation string for NodeProto
+        **kwargs (dict): the attributes of the node.  The acceptable values
+            are documented in :func:`make_attribute`.
+    """
+
     node = NodeProto()
     node.op_type = op_type
     node.input.extend(inputs)
@@ -46,7 +58,14 @@ def make_graph(nodes, name, inputs, outputs, initializer=None, doc_string=None):
         graph.doc_string = doc_string
     return graph
 
-# TODO: Provide a way to set ONNX-ML operator set version
+
+def make_opsetid(domain, version):
+    opsetid = OperatorSetIdProto()
+    opsetid.domain = domain
+    opsetid.version = version
+    return opsetid
+
+
 def make_model(graph, **kwargs):
     model = ModelProto()
     # Touch model.ir_version so it is stored as the version from which it is
@@ -54,8 +73,9 @@ def make_model(graph, **kwargs):
     model.ir_version = IR_VERSION
     model.graph.CopyFrom(graph)
 
-    if 'opset_import' in kwargs:
-        model.opset_import.extend(kwargs['opset_import'])
+    opset_imports = kwargs.pop('opset_imports', None)
+    if opset_imports is not None:
+        model.opset_import.extend(opset_imports)
     else:
         # Default import
         imp = model.opset_import.add()

--- a/onnx/test/checker_test.py
+++ b/onnx/test/checker_test.py
@@ -119,6 +119,19 @@ class TestChecker(unittest.TestCase):
 
         checker.check_model(model)
 
+    def test_check_old_model(self):
+        node = helper.make_node(
+            "Pad", ["X"], ["Y"], paddings=(0,0,0,0))
+        graph = helper.make_graph(
+            [node],
+            "test",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 2])],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 2])])
+        onnx_id = helper.make_opsetid("", 1)
+        model = helper.make_model(graph, producer_name='test', opset_imports=[onnx_id])
+
+        checker.check_model(model)
+
     def test_check_tensor(self):
         tensor = self._sample_float_tensor
         checker.check_tensor(tensor)


### PR DESCRIPTION
Now all checker functions take a CheckerContext, which specifies what
the set of in-scope opset imports are.  We use this to decide which
version of a schema to pull out of the schema checker when doing
validation.

Public facing APIs default to the most recent operator set version
we know about.