### PR TITLE
BatchNormalization docs - change input tensor shape description

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -412,7 +412,7 @@ opset_import {
 
 <dl>
 <dt><tt>X</tt> : T</dt>
-<dd>The input 4-dimensional tensor of shape NCHW or NHWC depending on the order parameter.</dd>
+<dd>The input 4-dimensional tensor of shape NCHW.</dd>
 <dt><tt>scale</tt> : T</dt>
 <dd>The scale as a 1-dimensional tensor of size C to be applied to the output.</dd>
 <dt><tt>B</tt> : T</dt>

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -513,7 +513,7 @@ opset_import {
 
 <dl>
 <dt><tt>X</tt> : T</dt>
-<dd>The input 4-dimensional tensor of shape NCHW or NHWC depending on the order parameter.</dd>
+<dd>The input 4-dimensional tensor of shape NCHW.</dd>
 <dt><tt>scale</tt> : T</dt>
 <dd>The scale as a 1-dimensional tensor of size C to be applied to the output.</dd>
 <dt><tt>B</tt> : T</dt>

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -385,8 +385,7 @@ Output case #2: Y (test mode)
         AttrType::FLOAT)
     .Input(0,
         "X",
-        "The input 4-dimensional tensor of shape NCHW or NHWC depending "
-        "on the order parameter.", "T")
+        "The input 4-dimensional tensor of shape NCHW.", "T")
     .Input(1,
         "scale",
         "The scale as a 1-dimensional tensor of size C to be applied to the "


### PR DESCRIPTION
I think the input tensor shape description for BatchNormalization may be outdated. ONNX `BatchNormalization` Op does not have an `order` attribute, so I believe the axes order should just be `NCHW`.