### PR TITLE
Split docs - remove mention of optional second input blob

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -5381,9 +5381,8 @@ opset_import {
 ### <a name="Split-2"></a>**Split-2**</a>
 
   Split a tensor into a list of tensors, along the specified
-  'axis'. The lengths of the split can be specified using argument 'axis' or
-  optional second input blob to the operator. Otherwise, the tensor is split
-  to equal sized parts.
+  'axis'. Lengths of the parts can be specified using argument 'split'.
+  Otherwise, the tensor is split to equal sized parts.
 
 #### Versioning
 

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -4511,9 +4511,8 @@ opset_import {
 ### <a name="Split"></a><a name="split">**Split**</a>
 
   Split a tensor into a list of tensors, along the specified
-  'axis'. The lengths of the split can be specified using argument 'axis' or
-  optional second input blob to the operator. Otherwise, the tensor is split
-  to equal sized parts.
+  'axis'. Lengths of the parts can be specified using argument 'split'.
+  Otherwise, the tensor is split to equal sized parts.
 
 #### Versioning
 

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -75,9 +75,8 @@ OPERATOR_SCHEMA(Split)
           "length of each output",
           AttrType::INTS)
     .SetDoc(R"DOC(Split a tensor into a list of tensors, along the specified
-'axis'. The lengths of the split can be specified using argument 'axis' or
-optional second input blob to the operator. Otherwise, the tensor is split
-to equal sized parts.
+'axis'. Lengths of the parts can be specified using argument 'split'.
+Otherwise, the tensor is split to equal sized parts.
 )DOC");
 
 OPERATOR_SCHEMA(Slice)


### PR DESCRIPTION
Some updates to the `Split` operation docs are needed:

* remove mention of optional second input blob
* update Argument name `axis` to `split`