### PR TITLE
fix issue so that we could handle many versions of one op

### DIFF
--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -562,9 +562,11 @@ class OpSchemaRegistry {
   }
 };
 
-#define OPERATOR_SCHEMA(name)                          \
-  static onnx::OpSchemaRegistry::OpSchemaRegisterOnce( \
-      op_schema_register_once##name) = OpSchema(#name, __FILE__, __LINE__)
+#define OPERATOR_SCHEMA(name)   OPERATOR_SCHEMA_UNIQ_HELPER(__COUNTER__, name)
+#define OPERATOR_SCHEMA_UNIQ_HELPER(Counter, name) OPERATOR_SCHEMA_UNIQ(Counter, name)
+#define OPERATOR_SCHEMA_UNIQ(Counter, name)                                         \
+  static onnx::OpSchemaRegistry::OpSchemaRegisterOnce(                              \
+      op_schema_register_once##name##Counter) = OpSchema(#name, __FILE__, __LINE__)
 
 // Helper function
 size_t ReplaceAll(std::string& s, const char* from, const char* to);


### PR DESCRIPTION
I used to use "opname" as the static op registry field name, which is not good given we now having many versions with the same op.