### PR TITLE
Update RNN Activation Funcs

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1423,35 +1423,31 @@ opset_import {
   
   Activation functions:
   
-    relu(x)                - max(0, x)
+    Relu(x)                - max(0, x)
   
-    tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
+    Tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
   
-    sigmoid(x)             - 1/(1 + e^{-x})
+    Sigmoid(x)             - 1/(1 + e^{-x})
   
     (NOTE: Below are optional)
   
-    linear(x)              - alpha*x + beta
+    Affine(x)              - alpha*x + beta
   
-    leakyRelu(x)           - x if x >= 0 else alpha * x
+    LeakyRelu(x)           - x if x >= 0 else alpha * x
   
-    thresholdedRelu(x)     - x if x >= alpha else 0
+    ThresholdedRelu(x)     - x if x >= alpha else 0
   
-    pRelu(xi)              - xi if xi >= 0 else alpha[i]* xi over dim 0
+    ScaledTanh(x)          - alpha*Tanh(beta*x)
   
-    scaledTanh(x)          - alpha*tanh(beta*x)
+    HardSigmoid(x)         - min(max(alpha*x + beta, 0), 1)
   
-    sigmoidHard(x)         - min(max(alpha*x + beta, 0), 1)
+    Elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
   
-    elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
+    Softsign(x)            - x/(1 + |x|)
   
-    softsign(x)            - x/(1 + |x|)
+    Softplus(x)            - log(1 + e^x)
   
-    softplus(x)            - log(1 + e^x)
-  
-    parametricSoftplus(xi) - alpha[i]*log(1 + e^{beta[i]* xi}) over dim 0
-  
-  Equations (Default: f=sigmoid, g=tanh):
+  Equations (Default: f=Sigmoid, g=Tanh):
   
     - zt = f(Xt*(Wz^T) + Ht-1*Rz + Wbz + Rbz)
   
@@ -2270,35 +2266,31 @@ opset_import {
   
   Activation functions:
   
-    relu(x)                - max(0, x)
+    Relu(x)                - max(0, x)
   
-    tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
+    Tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
   
-    sigmoid(x)             - 1/(1 + e^{-x})
+    Sigmoid(x)             - 1/(1 + e^{-x})
   
     (NOTE: Below are optional)
   
-    linear(x)              - alpha*x + beta
+    Affine(x)              - alpha*x + beta
   
-    leakyRelu(x)           - x if x >= 0 else alpha * x
+    LeakyRelu(x)           - x if x >= 0 else alpha * x
   
-    thresholdedRelu(x)     - x if x >= alpha else 0
+    ThresholdedRelu(x)     - x if x >= alpha else 0
   
-    pRelu(xi)              - xi if xi >= 0 else alpha[i]* xi over dim 0
+    ScaledTanh(x)          - alpha*Tanh(beta*x)
   
-    scaledTanh(x)          - alpha*tanh(beta*x)
+    HardSigmoid(x)         - min(max(alpha*x + beta, 0), 1)
   
-    sigmoidHard(x)         - min(max(alpha*x + beta, 0), 1)
+    Elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
   
-    elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
+    Softsign(x)            - x/(1 + |x|)
   
-    softsign(x)            - x/(1 + |x|)
+    Softplus(x)            - log(1 + e^x)
   
-    softplus(x)            - log(1 + e^x)
-  
-    parametricSoftplus(xi) - alpha[i]*log(1 + e^{beta[i]* xi}) over dim 0
-  
-  Equations (Default: f=sigmoid, g=tanh, h=tanh):
+  Equations (Default: f=Sigmoid, g=Tanh, h=Tanh):
   
     - it = f(Xt*(Wi^T) + Ht-1*Ri + Pi (.) Ct-1 + Wbi + Rbi)
   
@@ -3369,35 +3361,31 @@ opset_import {
   
   Activation functions:
   
-    relu(x)                - max(0, x)
+    Relu(x)                - max(0, x)
   
-    tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
+    Tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
   
-    sigmoid(x)             - 1/(1 + e^{-x})
+    Sigmoid(x)             - 1/(1 + e^{-x})
   
     (NOTE: Below are optional)
   
-    linear(x)              - alpha*x + beta
+    Affine(x)              - alpha*x + beta
   
-    leakyRelu(x)           - x if x >= 0 else alpha * x
+    LeakyRelu(x)           - x if x >= 0 else alpha * x
   
-    thresholdedRelu(x)     - x if x >= alpha else 0
+    ThresholdedRelu(x)     - x if x >= alpha else 0
   
-    pRelu(xi)              - xi if xi >= 0 else alpha[i]* xi over dim 0
+    ScaledTanh(x)          - alpha*Tanh(beta*x)
   
-    scaledTanh(x)          - alpha*tanh(beta*x)
+    HardSigmoid(x)         - min(max(alpha*x + beta, 0), 1)
   
-    sigmoidHard(x)         - min(max(alpha*x + beta, 0), 1)
+    Elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
   
-    elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
+    Softsign(x)            - x/(1 + |x|)
   
-    softsign(x)            - x/(1 + |x|)
+    Softplus(x)            - log(1 + e^x)
   
-    softplus(x)            - log(1 + e^x)
-  
-    parametricSoftplus(xi) - alpha[i]*log(1 + e^{beta[i]* xi}) over dim 0
-  
-  Equations (Default: f=tanh):
+  Equations (Default: f=Tanh):
   
     - Ht = f(Xt*(Wi^T) + Ht-1*Ri + Wbi + Rbi)
 
@@ -3419,7 +3407,7 @@ opset_import {
 <dt><tt>activation_beta</tt> : list of floats</dt>
 <dd>Optional scaling values used by some activation functions. The values are consumed in the order of activation functions, for example (f, g, h) in LSTM.</dd>
 <dt><tt>activations</tt> : list of strings</dt>
-<dd>One (or two if bidirectional) activation function for input gate. The activation function must be one of the activation functions specified above. Optional: Default `tanh` if not specified.</dd>
+<dd>One (or two if bidirectional) activation function for input gate. The activation function must be one of the activation functions specified above. Optional: Default `Tanh` if not specified.</dd>
 <dt><tt>clip</tt> : float</dt>
 <dd>Cell clip threshold. Clipping bounds the elements of a tensor in the range of [-threshold, +threshold] and is applied to the input of activations. No clip if not specified.</dd>
 <dt><tt>direction</tt> : string</dt>

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -339,7 +339,7 @@ opset_import {
 
   AveragePool consumes an input tensor X and applies average pooling across the
    the tensor according to kernel sizes, stride sizes, and pad lengths.
-   average pooling consisting of computing the average on all values of a 
+   average pooling consisting of computing the average on all values of a
    subset of the input tensor according to the kernel size and downsampling the
    data into the output tensor Y for further processing.
 
@@ -2123,10 +2123,10 @@ opset_import {
 ### <a name="InstanceNormalization-1"></a>**InstanceNormalization-1**</a>
 
   Carries out instance normalization as described in the paper
-  https://arxiv.org/abs/1607.08022. 
+  https://arxiv.org/abs/1607.08022.
   
-  y = scale * (x - mean) / sqrt(variance + epsilon) + B, 
-  where mean and B are computed per instance per channel. 
+  y = scale * (x - mean) / sqrt(variance + epsilon) + B,
+  where mean and B are computed per instance per channel.
   
 
 #### Versioning
@@ -2737,7 +2737,7 @@ opset_import {
 
   MaxPool consumes an input tensor X and applies max pooling across the
    the tensor according to kernel sizes, stride sizes, and pad lengths.
-   max pooling consisting of computing the max on all values of a 
+   max pooling consisting of computing the max on all values of a
    subset of the input tensor according to the kernel size and downsampling the
    data into the output tensor Y for further processing.
 
@@ -2787,8 +2787,8 @@ opset_import {
 
 ### <a name="MaxRoiPool-1"></a>**MaxRoiPool-1**</a>
 
-  ROI max pool consumes an input tensor X and region of interests (RoIs) to 
-   apply max pooling across each RoI, to produce output 4-D tensor of shape 
+  ROI max pool consumes an input tensor X and region of interests (RoIs) to
+   apply max pooling across each RoI, to produce output 4-D tensor of shape
    (num_rois, channels, pooled_shape[0], pooled_shape[1]).
 
 #### Versioning
@@ -5264,7 +5264,7 @@ opset_import {
 
   LpPool consumes an input tensor X and applies Lp pooling across the
    the tensor according to kernel sizes, stride sizes, and pad lengths.
-   Lp pooling consisting of computing the Lp norm on all values of a subset 
+   Lp pooling consisting of computing the Lp norm on all values of a subset
    of the input tensor according to the kernel size and downsampling the
    data into the output tensor Y for further processing.
 

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -1329,35 +1329,31 @@ opset_import {
   
   Activation functions:
   
-    relu(x)                - max(0, x)
+    Relu(x)                - max(0, x)
   
-    tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
+    Tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
   
-    sigmoid(x)             - 1/(1 + e^{-x})
+    Sigmoid(x)             - 1/(1 + e^{-x})
   
     (NOTE: Below are optional)
   
-    linear(x)              - alpha*x + beta
+    Affine(x)              - alpha*x + beta
   
-    leakyRelu(x)           - x if x >= 0 else alpha * x
+    LeakyRelu(x)           - x if x >= 0 else alpha * x
   
-    thresholdedRelu(x)     - x if x >= alpha else 0
+    ThresholdedRelu(x)     - x if x >= alpha else 0
   
-    pRelu(xi)              - xi if xi >= 0 else alpha[i]* xi over dim 0
+    ScaledTanh(x)          - alpha*Tanh(beta*x)
   
-    scaledTanh(x)          - alpha*tanh(beta*x)
+    HardSigmoid(x)         - min(max(alpha*x + beta, 0), 1)
   
-    sigmoidHard(x)         - min(max(alpha*x + beta, 0), 1)
+    Elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
   
-    elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
+    Softsign(x)            - x/(1 + |x|)
   
-    softsign(x)            - x/(1 + |x|)
+    Softplus(x)            - log(1 + e^x)
   
-    softplus(x)            - log(1 + e^x)
-  
-    parametricSoftplus(xi) - alpha[i]*log(1 + e^{beta[i]* xi}) over dim 0
-  
-  Equations (Default: f=sigmoid, g=tanh):
+  Equations (Default: f=Sigmoid, g=Tanh):
   
     - zt = f(Xt*(Wz^T) + Ht-1*Rz + Wbz + Rbz)
   
@@ -2010,35 +2006,31 @@ opset_import {
   
   Activation functions:
   
-    relu(x)                - max(0, x)
+    Relu(x)                - max(0, x)
   
-    tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
+    Tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
   
-    sigmoid(x)             - 1/(1 + e^{-x})
+    Sigmoid(x)             - 1/(1 + e^{-x})
   
     (NOTE: Below are optional)
   
-    linear(x)              - alpha*x + beta
+    Affine(x)              - alpha*x + beta
   
-    leakyRelu(x)           - x if x >= 0 else alpha * x
+    LeakyRelu(x)           - x if x >= 0 else alpha * x
   
-    thresholdedRelu(x)     - x if x >= alpha else 0
+    ThresholdedRelu(x)     - x if x >= alpha else 0
   
-    pRelu(xi)              - xi if xi >= 0 else alpha[i]* xi over dim 0
+    ScaledTanh(x)          - alpha*Tanh(beta*x)
   
-    scaledTanh(x)          - alpha*tanh(beta*x)
+    HardSigmoid(x)         - min(max(alpha*x + beta, 0), 1)
   
-    sigmoidHard(x)         - min(max(alpha*x + beta, 0), 1)
+    Elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
   
-    elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
+    Softsign(x)            - x/(1 + |x|)
   
-    softsign(x)            - x/(1 + |x|)
+    Softplus(x)            - log(1 + e^x)
   
-    softplus(x)            - log(1 + e^x)
-  
-    parametricSoftplus(xi) - alpha[i]*log(1 + e^{beta[i]* xi}) over dim 0
-  
-  Equations (Default: f=sigmoid, g=tanh, h=tanh):
+  Equations (Default: f=Sigmoid, g=Tanh, h=Tanh):
   
     - it = f(Xt*(Wi^T) + Ht-1*Ri + Pi (.) Ct-1 + Wbi + Rbi)
   
@@ -3135,35 +3127,31 @@ opset_import {
   
   Activation functions:
   
-    relu(x)                - max(0, x)
+    Relu(x)                - max(0, x)
   
-    tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
+    Tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
   
-    sigmoid(x)             - 1/(1 + e^{-x})
+    Sigmoid(x)             - 1/(1 + e^{-x})
   
     (NOTE: Below are optional)
   
-    linear(x)              - alpha*x + beta
+    Affine(x)              - alpha*x + beta
   
-    leakyRelu(x)           - x if x >= 0 else alpha * x
+    LeakyRelu(x)           - x if x >= 0 else alpha * x
   
-    thresholdedRelu(x)     - x if x >= alpha else 0
+    ThresholdedRelu(x)     - x if x >= alpha else 0
   
-    pRelu(xi)              - xi if xi >= 0 else alpha[i]* xi over dim 0
+    ScaledTanh(x)          - alpha*Tanh(beta*x)
   
-    scaledTanh(x)          - alpha*tanh(beta*x)
+    HardSigmoid(x)         - min(max(alpha*x + beta, 0), 1)
   
-    sigmoidHard(x)         - min(max(alpha*x + beta, 0), 1)
+    Elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
   
-    elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
+    Softsign(x)            - x/(1 + |x|)
   
-    softsign(x)            - x/(1 + |x|)
+    Softplus(x)            - log(1 + e^x)
   
-    softplus(x)            - log(1 + e^x)
-  
-    parametricSoftplus(xi) - alpha[i]*log(1 + e^{beta[i]* xi}) over dim 0
-  
-  Equations (Default: f=tanh):
+  Equations (Default: f=Tanh):
   
     - Ht = f(Xt*(Wi^T) + Ht-1*Ri + Wbi + Rbi)
 
@@ -3185,7 +3173,7 @@ opset_import {
 <dt><tt>activation_beta</tt> : list of floats</dt>
 <dd>Optional scaling values used by some activation functions. The values are consumed in the order of activation functions, for example (f, g, h) in LSTM.</dd>
 <dt><tt>activations</tt> : list of strings</dt>
-<dd>One (or two if bidirectional) activation function for input gate. The activation function must be one of the activation functions specified above. Optional: Default `tanh` if not specified.</dd>
+<dd>One (or two if bidirectional) activation function for input gate. The activation function must be one of the activation functions specified above. Optional: Default `Tanh` if not specified.</dd>
 <dt><tt>clip</tt> : float</dt>
 <dd>Cell clip threshold. Clipping bounds the elements of a tensor in the range of [-threshold, +threshold] and is applied to the input of activations. No clip if not specified.</dd>
 <dt><tt>direction</tt> : string</dt>

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -427,7 +427,7 @@ opset_import {
 
   AveragePool consumes an input tensor X and applies average pooling across the
    the tensor according to kernel sizes, stride sizes, and pad lengths.
-   average pooling consisting of computing the average on all values of a 
+   average pooling consisting of computing the average on all values of a
    subset of the input tensor according to the kernel size and downsampling the
    data into the output tensor Y for further processing.
 
@@ -1861,10 +1861,10 @@ opset_import {
 ### <a name="InstanceNormalization"></a><a name="instancenormalization">**InstanceNormalization**</a>
 
   Carries out instance normalization as described in the paper
-  https://arxiv.org/abs/1607.08022. 
+  https://arxiv.org/abs/1607.08022.
   
-  y = scale * (x - mean) / sqrt(variance + epsilon) + B, 
-  where mean and B are computed per instance per channel. 
+  y = scale * (x - mean) / sqrt(variance + epsilon) + B,
+  where mean and B are computed per instance per channel.
   
 
 #### Versioning
@@ -2356,7 +2356,7 @@ opset_import {
 
   LpPool consumes an input tensor X and applies Lp pooling across the
    the tensor according to kernel sizes, stride sizes, and pad lengths.
-   Lp pooling consisting of computing the Lp norm on all values of a subset 
+   Lp pooling consisting of computing the Lp norm on all values of a subset
    of the input tensor according to the kernel size and downsampling the
    data into the output tensor Y for further processing.
 
@@ -2525,7 +2525,7 @@ opset_import {
 
   MaxPool consumes an input tensor X and applies max pooling across the
    the tensor according to kernel sizes, stride sizes, and pad lengths.
-   max pooling consisting of computing the max on all values of a 
+   max pooling consisting of computing the max on all values of a
    subset of the input tensor according to the kernel size and downsampling the
    data into the output tensor Y for further processing.
 
@@ -2576,8 +2576,8 @@ opset_import {
 
 ### <a name="MaxRoiPool"></a><a name="maxroipool">**MaxRoiPool**</a>
 
-  ROI max pool consumes an input tensor X and region of interests (RoIs) to 
-   apply max pooling across each RoI, to produce output 4-D tensor of shape 
+  ROI max pool consumes an input tensor X and region of interests (RoIs) to
+   apply max pooling across each RoI, to produce output 4-D tensor of shape
    (num_rois, channels, pooled_shape[0], pooled_shape[1]).
 
 #### Versioning

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -4,7 +4,6 @@
 #include "onnx/defs/schema.h"
 using namespace onnx;
 
-
 namespace onnx {
     static std::string pads_doc = "Padding for the begining and ending along each axis, it can take any value greater "
                                   "than or equal to 0. The value represent the number of pixels added to the begining "

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -4,6 +4,7 @@
 #include "onnx/defs/schema.h"
 using namespace onnx;
 
+
 namespace onnx {
     static std::string pads_doc = "Padding for the begining and ending along each axis, it can take any value greater "
                                   "than or equal to 0. The value represent the number of pixels added to the begining "
@@ -26,11 +27,11 @@ namespace onnx {
             std::string doc = R"DOC(
  {name} consumes an input tensor X and applies {opName} pooling across the
  the tensor according to kernel sizes, stride sizes, and pad lengths.
- {opName} pooling consisting of computing the {opName} on all values of a 
+ {opName} pooling consisting of computing the {opName} on all values of a
  subset of the input tensor according to the kernel size and downsampling the
  data into the output tensor Y for further processing.)DOC";
             ReplaceAll(doc, "{name}", name);
-            ReplaceAll(doc, "{opName}", opName);            
+            ReplaceAll(doc, "{opName}", opName);
             schema.SetDoc(doc);
             schema.Attr("kernel_shape",
                         "The size of the kernel along each axis.",
@@ -69,7 +70,7 @@ namespace onnx {
 
     OPERATOR_SCHEMA(MaxPool)
         .FillUsing(PoolOpSchemaGenerator("MaxPool", "max"));
-        
+
 } // namespace onnx
 
 namespace onnx {
@@ -78,7 +79,7 @@ namespace onnx {
             std::string doc = R"DOC(
  {name} consumes an input tensor X and applies Lp pooling across the
  the tensor according to kernel sizes, stride sizes, and pad lengths.
- Lp pooling consisting of computing the Lp norm on all values of a subset 
+ Lp pooling consisting of computing the Lp norm on all values of a subset
  of the input tensor according to the kernel size and downsampling the
  data into the output tensor Y for further processing.)DOC";
             ReplaceAll(doc, "{name}", name);
@@ -128,8 +129,8 @@ namespace onnx {
     std::function<void(OpSchema&)> RoiPoolOpSchemaGenerator(const char* name) {
         return [=](OpSchema& schema) {
             std::string doc = R"DOC(
- ROI {name} pool consumes an input tensor X and region of interests (RoIs) to 
- apply {name} pooling across each RoI, to produce output 4-D tensor of shape 
+ ROI {name} pool consumes an input tensor X and region of interests (RoIs) to
+ apply {name} pooling across each RoI, to produce output 4-D tensor of shape
  (num_rois, channels, pooled_shape[0], pooled_shape[1]).)DOC";
             ReplaceAll(doc, "{name}", name);
             schema.SetDoc(doc);
@@ -424,10 +425,10 @@ OPERATOR_SCHEMA(InstanceNormalization)
     .AllowConsumed({{0, 0}})
     .SetDoc(R"DOC(
 Carries out instance normalization as described in the paper
-https://arxiv.org/abs/1607.08022. 
+https://arxiv.org/abs/1607.08022.
 
-y = scale * (x - mean) / sqrt(variance + epsilon) + B, 
-where mean and B are computed per instance per channel. 
+y = scale * (x - mean) / sqrt(variance + epsilon) + B,
+where mean and B are computed per instance per channel.
 
 )DOC")
     .Attr("epsilon",

--- a/onnx/defs/rnn/defs.cc
+++ b/onnx/defs/rnn/defs.cc
@@ -346,7 +346,7 @@ Equations (Default: f=Sigmoid, g=Tanh, h=Tanh):
 	   "The weight tensor for peepholes. Concatenation of `P[iof]` and "
 	   "`PB[iof]` (if bidirectional) along dimension 0. It has shape "
 	   "`[num_directions, 3*hidde_size]`. Optional: If not specified - "
-	   "assumed to be 0.", "T",
+	   "assumed to be 0. ", "T",
        OpSchema::Optional)
     .FillUsing(RNNDocGenerator("LSTM"));
 

--- a/onnx/defs/rnn/defs.cc
+++ b/onnx/defs/rnn/defs.cc
@@ -346,7 +346,7 @@ Equations (Default: f=Sigmoid, g=Tanh, h=Tanh):
 	   "The weight tensor for peepholes. Concatenation of `P[iof]` and "
 	   "`PB[iof]` (if bidirectional) along dimension 0. It has shape "
 	   "`[num_directions, 3*hidde_size]`. Optional: If not specified - "
-	   "assumed to be 0. ", "T",
+	   "assumed to be 0.", "T",
        OpSchema::Optional)
     .FillUsing(RNNDocGenerator("LSTM"));
 

--- a/onnx/defs/rnn/defs.cc
+++ b/onnx/defs/rnn/defs.cc
@@ -90,41 +90,37 @@ Notations:
 
 Activation functions:
 
-  relu(x)                - max(0, x)
+  Relu(x)                - max(0, x)
 
-  tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
+  Tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
 
-  sigmoid(x)             - 1/(1 + e^{-x})
+  Sigmoid(x)             - 1/(1 + e^{-x})
 
   (NOTE: Below are optional)
 
-  linear(x)              - alpha*x + beta
+  Affine(x)              - alpha*x + beta
 
-  leakyRelu(x)           - x if x >= 0 else alpha * x
+  LeakyRelu(x)           - x if x >= 0 else alpha * x
 
-  thresholdedRelu(x)     - x if x >= alpha else 0
+  ThresholdedRelu(x)     - x if x >= alpha else 0
 
-  pRelu(xi)              - xi if xi >= 0 else alpha[i]* xi over dim 0
+  ScaledTanh(x)          - alpha*Tanh(beta*x)
 
-  scaledTanh(x)          - alpha*tanh(beta*x)
+  HardSigmoid(x)         - min(max(alpha*x + beta, 0), 1)
 
-  sigmoidHard(x)         - min(max(alpha*x + beta, 0), 1)
+  Elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
 
-  elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
+  Softsign(x)            - x/(1 + |x|)
 
-  softsign(x)            - x/(1 + |x|)
+  Softplus(x)            - log(1 + e^x)
 
-  softplus(x)            - log(1 + e^x)
-
-  parametricSoftplus(xi) - alpha[i]*log(1 + e^{beta[i]* xi}) over dim 0
-
-Equations (Default: f=tanh):
+Equations (Default: f=Tanh):
 
   - Ht = f(Xt*(Wi^T) + Ht-1*Ri + Wbi + Rbi)
 )DOC")
     .Attr("activations", "One (or two if bidirectional) activation function for "
           "input gate. The activation function must be one of the activation "
-          "functions specified above. Optional: Default `tanh` if not specified.",
+          "functions specified above. Optional: Default `Tanh` if not specified.",
           AttributeProto::STRINGS)
     .Input(1, "W",
 	   "The weight tensor for input gate. Concatenation of `Wi` and `WBi` "
@@ -182,35 +178,31 @@ Notations:
 
 Activation functions:
 
-  relu(x)                - max(0, x)
+  Relu(x)                - max(0, x)
 
-  tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
+  Tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
 
-  sigmoid(x)             - 1/(1 + e^{-x})
+  Sigmoid(x)             - 1/(1 + e^{-x})
 
   (NOTE: Below are optional)
 
-  linear(x)              - alpha*x + beta
+  Affine(x)              - alpha*x + beta
 
-  leakyRelu(x)           - x if x >= 0 else alpha * x
+  LeakyRelu(x)           - x if x >= 0 else alpha * x
 
-  thresholdedRelu(x)     - x if x >= alpha else 0
+  ThresholdedRelu(x)     - x if x >= alpha else 0
 
-  pRelu(xi)              - xi if xi >= 0 else alpha[i]* xi over dim 0
+  ScaledTanh(x)          - alpha*Tanh(beta*x)
 
-  scaledTanh(x)          - alpha*tanh(beta*x)
+  HardSigmoid(x)         - min(max(alpha*x + beta, 0), 1)
 
-  sigmoidHard(x)         - min(max(alpha*x + beta, 0), 1)
+  Elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
 
-  elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
+  Softsign(x)            - x/(1 + |x|)
 
-  softsign(x)            - x/(1 + |x|)
+  Softplus(x)            - log(1 + e^x)
 
-  softplus(x)            - log(1 + e^x)
-
-  parametricSoftplus(xi) - alpha[i]*log(1 + e^{beta[i]* xi}) over dim 0
-
-Equations (Default: f=sigmoid, g=tanh):
+Equations (Default: f=Sigmoid, g=Tanh):
 
   - zt = f(Xt*(Wz^T) + Ht-1*Rz + Wbz + Rbz)
 
@@ -287,35 +279,31 @@ Notations:
 
 Activation functions:
 
-  relu(x)                - max(0, x)
+  Relu(x)                - max(0, x)
 
-  tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
+  Tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
 
-  sigmoid(x)             - 1/(1 + e^{-x})
+  Sigmoid(x)             - 1/(1 + e^{-x})
 
   (NOTE: Below are optional)
 
-  linear(x)              - alpha*x + beta
+  Affine(x)              - alpha*x + beta
 
-  leakyRelu(x)           - x if x >= 0 else alpha * x
+  LeakyRelu(x)           - x if x >= 0 else alpha * x
 
-  thresholdedRelu(x)     - x if x >= alpha else 0
+  ThresholdedRelu(x)     - x if x >= alpha else 0
 
-  pRelu(xi)              - xi if xi >= 0 else alpha[i]* xi over dim 0
+  ScaledTanh(x)          - alpha*Tanh(beta*x)
 
-  scaledTanh(x)          - alpha*tanh(beta*x)
+  HardSigmoid(x)         - min(max(alpha*x + beta, 0), 1)
 
-  sigmoidHard(x)         - min(max(alpha*x + beta, 0), 1)
+  Elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
 
-  elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
+  Softsign(x)            - x/(1 + |x|)
 
-  softsign(x)            - x/(1 + |x|)
+  Softplus(x)            - log(1 + e^x)
 
-  softplus(x)            - log(1 + e^x)
-
-  parametricSoftplus(xi) - alpha[i]*log(1 + e^{beta[i]* xi}) over dim 0
-
-Equations (Default: f=sigmoid, g=tanh, h=tanh):
+Equations (Default: f=Sigmoid, g=Tanh, h=Tanh):
 
   - it = f(Xt*(Wi^T) + Ht-1*Ri + Pi (.) Ct-1 + Wbi + Rbi)
 
@@ -335,7 +323,7 @@ Equations (Default: f=sigmoid, g=tanh, h=tanh):
           "for default if not specified.",
           AttributeProto::STRINGS)
     .Attr("input_forget", "Couple the input and forget gates if 1, default 0.",
-          AttributeProto::INT)	  
+          AttributeProto::INT)
     .Input(1, "W",
 	   "The weight tensor for the gates. Concatenation of `W[iofc]` and "
            "`WB[iofc]` (if bidirectional) along dimension 0. The tensor has shape "
@@ -362,4 +350,4 @@ Equations (Default: f=sigmoid, g=tanh, h=tanh):
        OpSchema::Optional)
     .FillUsing(RNNDocGenerator("LSTM"));
 
-}  // namespace onnx    
+}  // namespace onnx


### PR DESCRIPTION
1. Rename activation function to follow the Op Name
   - e.g. linear -> Affine, sigmoidhard -> HardSigmoid

2. Remove PRelu and ParametricSoftPlus


Only description change. 
