### PR TITLE
BatchNormalization docs - add information about 3D support

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -424,7 +424,7 @@ opset_import {
 
 <dl>
 <dt><tt>X</tt> : T</dt>
-<dd>The input 4-dimensional tensor of shape NCHW.</dd>
+<dd>The input 4-dimensional tensor of shape NCHW for 2D BatchNormalization or 5-dimensional tensor of shape NCHWD for 3D BatchNormalization.</dd>
 <dt><tt>scale</tt> : T</dt>
 <dd>The scale as a 1-dimensional tensor of size C to be applied to the output.</dd>
 <dt><tt>B</tt> : T</dt>
@@ -439,7 +439,7 @@ opset_import {
 
 <dl>
 <dt><tt>Y</tt> : T</dt>
-<dd>The output 4-dimensional tensor of the same shape as X.</dd>
+<dd>The output tensor of the same shape as X.</dd>
 <dt><tt>mean</tt> (optional) : T</dt>
 <dd>The running mean after the BatchNormalization operator. Must be in-place with the input mean. Should not be used for testing.</dd>
 <dt><tt>var</tt> (optional) : T</dt>

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -513,7 +513,7 @@ opset_import {
 
 <dl>
 <dt><tt>X</tt> : T</dt>
-<dd>The input 4-dimensional tensor of shape NCHW.</dd>
+<dd>The input 4-dimensional tensor of shape NCHW for 2D BatchNormalization or 5-dimensional tensor of shape NCHWD for 3D BatchNormalization.</dd>
 <dt><tt>scale</tt> : T</dt>
 <dd>The scale as a 1-dimensional tensor of size C to be applied to the output.</dd>
 <dt><tt>B</tt> : T</dt>
@@ -528,7 +528,7 @@ opset_import {
 
 <dl>
 <dt><tt>Y</tt> : T</dt>
-<dd>The output 4-dimensional tensor of the same shape as X.</dd>
+<dd>The output tensor of the same shape as X.</dd>
 <dt><tt>mean</tt> (optional) : T</dt>
 <dd>The running mean after the BatchNormalization operator. Must be in-place with the input mean. Should not be used for testing.</dd>
 <dt><tt>var</tt> (optional) : T</dt>

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -383,7 +383,8 @@ Output case #2: Y (test mode)
         AttributeProto::FLOAT)
     .Input(0,
         "X",
-        "The input 4-dimensional tensor of shape NCHW.", "T")
+        "The input 4-dimensional tensor of shape NCHW for 2D BatchNormalization "
+        "or 5-dimensional tensor of shape NCHWD for 3D BatchNormalization.", "T")
     .Input(1,
         "scale",
         "The scale as a 1-dimensional tensor of size C to be applied to the "
@@ -400,7 +401,7 @@ Output case #2: Y (test mode)
         "var",
         "The running variance (training) or the estimated "
         "variance (testing) as a 1-dimensional tensor of size C.", "T")
-    .Output(0, "Y", "The output 4-dimensional tensor of the same shape as X.", "T")
+    .Output(0, "Y", "The output tensor of the same shape as X.", "T")
     .Output(1,
         "mean",
         "The running mean after the BatchNormalization operator. Must be in-place "


### PR DESCRIPTION
Specify the possibility of using a 5-D input tensor for a 3-D BatchNorm operation.