### PR TITLE
Move docker links to Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,19 +54,6 @@ A binary build of ONNX is available from [Conda](https://conda.io), in [conda-fo
 conda install -c conda-forge onnx
 ```
 
-## Docker
-
-Docker images (CPU-only and GPU versions) with ONNX, PyTorch, and Caffe2 are availiable for quickly trying [tutorials that use ONNX](http://pytorch.org/tutorials/advanced/super_resolution_with_caffe2.html). To quickly try CPU-only version, simply run:
-
-```
-docker run -it --rm onnx/onnx-docker:cpu /bin/bash
-```
-
-To run the version with GPU support, [nvidia-docker](https://github.com/NVIDIA/nvidia-docker) is needed. Execute:
-```
-nvidia-docker run -it --rm onnx/onnx-docker:gpu /bin/bash
-```
-
 ## Source
 
 You will need an install of protobuf and numpy to build ONNX.  One easy


### PR DESCRIPTION
Docker image is specific to the tutorials, so move there