### PR TITLE
Add adjs attribute to ConvTranspose

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -823,8 +823,10 @@ opset_import {
 <dd>number of groups input channels and output channels are divided into</dd>
 <dt><tt>kernel_shape</tt> : list of ints</dt>
 <dd>The shape of the convolution kernel.</dd>
+<dt><tt>output_padding</tt> : list of ints</dt>
+<dd>The zero-padding added to one side of the output. This is also called adjs/adjustment in some frameworks. If output_shape is set, this attribute will be ignored.</dd>
 <dt><tt>output_shape</tt> : list of ints</dt>
-<dd>The shape of the output.</dd>
+<dd>The shape of the output. output_shape[i] = stride[i] * (input_size[i] - 1) + output_padding[i] + kernel_shape[i] - pads[start_i] - pads[end_i]</dd>
 <dt><tt>pads</tt> : list of ints</dt>
 <dd>Padding for the beginning and ending along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the beginning and end part of the corresponding axis. `pads` format should be as follow [x1_begin, x2_begin...x1_end, x2_end,...], where xi_begin the number of pixels added at the beginning of axis `i` and xi_end, the number of pixels added at the end of axis `i`. This attribute cannot be used simultaneously with auto_pad attribute.</dd>
 <dt><tt>strides</tt> : list of ints</dt>

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -876,8 +876,10 @@ opset_import {
 <dd>number of groups input channels and output channels are divided into</dd>
 <dt><tt>kernel_shape</tt> : list of ints</dt>
 <dd>The shape of the convolution kernel.</dd>
+<dt><tt>output_padding</tt> : list of ints</dt>
+<dd>The zero-padding added to one side of the output. This is also called adjs/adjustment in some frameworks. If output_shape is set, this attribute will be ignored.</dd>
 <dt><tt>output_shape</tt> : list of ints</dt>
-<dd>The shape of the output.</dd>
+<dd>The shape of the output. output_shape[i] = stride[i] * (input_size[i] - 1) + output_padding[i] + kernel_shape[i] - pads[start_i] - pads[end_i]</dd>
 <dt><tt>pads</tt> : list of ints</dt>
 <dd>Padding for the beginning and ending along each axis, it can take any value greater than or equal to 0. The value represent the number of pixels added to the beginning and end part of the corresponding axis. `pads` format should be as follow [x1_begin, x2_begin...x1_end, x2_end,...], where xi_begin the number of pixels added at the beginning of axis `i` and xi_end, the number of pixels added at the end of axis `i`. This attribute cannot be used simultaneously with auto_pad attribute.</dd>
 <dt><tt>strides</tt> : list of ints</dt>

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -264,7 +264,14 @@ and computes the output.)DOC";
                         "The shape of the convolution kernel.",
                          AttributeProto::INTS, OPTIONAL);
             schema.Attr("output_shape",
-                        "The shape of the output.",
+                        "The shape of the output."
+                        " output_shape[i] = stride[i] * (input_size[i] - 1) + output_padding[i] +"
+                        " kernel_shape[i] - pads[start_i] - pads[end_i]",
+                        AttributeProto::INTS, OPTIONAL);
+            schema.Attr("output_padding",
+                        "The zero-padding added to one side of the output."
+                        " This is also called adjs/adjustment in some frameworks."
+                        " If output_shape is set, this attribute will be ignored.",
                         AttributeProto::INTS, OPTIONAL);
             schema.Attr("dilations",
                         "dilation value along each axis of the filter.",

--- a/onnx/defs/nn/old.cc
+++ b/onnx/defs/nn/old.cc
@@ -90,5 +90,5 @@ OPERATOR_SCHEMA(GlobalLpPool)
             "Y",
             "Output data tensor from pooling across the input "
             "tensor. Dimensions will be N x C x 1 x 1", "T")
-.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-                "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
+                    "Constrain input and output types to float tensors.");


### PR DESCRIPTION
There are a couple of requests for this feature from PyTorch side https://github.com/pytorch/pytorch/issues/3826. So I think we should add adjs attribute into ConvTranspose. Actually, this PR chooses the second solution in https://github.com/onnx/onnx/issues/102, which enables both output_shape and adj. Adjs will be ignored if output_shape exists, so it won't break any existing models.