### PR TITLE
Fix a typo in InstanceNormalization doc.

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2126,7 +2126,7 @@ opset_import {
   https://arxiv.org/abs/1607.08022.
   
   y = scale * (x - mean) / sqrt(variance + epsilon) + B,
-  where mean and B are computed per instance per channel.
+  where mean and variance are computed per instance per channel.
   
 
 #### Versioning

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -1864,7 +1864,7 @@ opset_import {
   https://arxiv.org/abs/1607.08022.
   
   y = scale * (x - mean) / sqrt(variance + epsilon) + B,
-  where mean and B are computed per instance per channel.
+  where mean and variance are computed per instance per channel.
   
 
 #### Versioning

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -437,7 +437,7 @@ Carries out instance normalization as described in the paper
 https://arxiv.org/abs/1607.08022.
 
 y = scale * (x - mean) / sqrt(variance + epsilon) + B,
-where mean and B are computed per instance per channel.
+where mean and variance are computed per instance per channel.
 
 )DOC")
     .Attr("epsilon",


### PR DESCRIPTION
In `InstanceNormalization`, the `variance` rather than input `B` are computed per instance per channel.