### PR TITLE
PyPi install fails when git is not installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ tests_require = []
 try:
     git_version = subprocess.check_output(['git', 'rev-parse', 'HEAD'],
                                           cwd=TOP_DIR).decode('ascii').strip()
-except subprocess.CalledProcessError:
+except (OSError, subprocess.CalledProcessError):
     git_version = None
 
 with open(os.path.join(TOP_DIR, 'VERSION_NUMBER')) as version_file:


### PR DESCRIPTION
setup.py is looking for git, and when git is not installed it fails the setup.
Updating error handling to gracefully handle the case where git is not installed.