### PR TITLE
dimension denotation

### DIFF
--- a/onnx/onnx-ml.proto
+++ b/onnx/onnx-ml.proto
@@ -384,6 +384,7 @@ message TensorShapeProto {
       int64 dim_value = 1;
       string dim_param = 2;   // namespace Shape
     };
+    optional string standard_denotation = 3;
   };
   repeated Dimension dim = 1;
 }

--- a/onnx/onnx-ml.proto3
+++ b/onnx/onnx-ml.proto3
@@ -384,6 +384,7 @@ message TensorShapeProto {
       int64 dim_value = 1;
       string dim_param = 2;   // namespace Shape
     };
+    string standard_denotation = 3;
   };
   repeated Dimension dim = 1;
 }

--- a/onnx/onnx.in.proto
+++ b/onnx/onnx.in.proto
@@ -379,6 +379,7 @@ message TensorShapeProto {
       int64 dim_value = 1;
       string dim_param = 2;   // namespace Shape
     };
+    optional string standard_denotation = 3;
   };
   repeated Dimension dim = 1;
 }

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -384,6 +384,7 @@ message TensorShapeProto {
       int64 dim_value = 1;
       string dim_param = 2;   // namespace Shape
     };
+    optional string standard_denotation = 3;
   };
   repeated Dimension dim = 1;
 }

--- a/onnx/onnx.proto3
+++ b/onnx/onnx.proto3
@@ -384,6 +384,7 @@ message TensorShapeProto {
       int64 dim_value = 1;
       string dim_param = 2;   // namespace Shape
     };
+    string standard_denotation = 3;
   };
   repeated Dimension dim = 1;
 }

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -248,6 +248,19 @@ class TestHelperNodeFunctions(unittest.TestCase):
         dupe.value = 'Other'
         self.assertRaises(checker.ValidationError, checker.check_model, model_def)
 
+    def test_shape_denotation(self):
+        shape_denotation = [helper.StandardDenotation.DATA_BATCH,
+                            helper.StandardDenotation.DATA_CHANNEL,
+                            helper.StandardDenotation.DATA_SPATIAL,
+                            helper.StandardDenotation.DATA_SPATIAL]
+        tensor = helper.make_tensor_value_info("X",
+                                                TensorProto.FLOAT,
+                                                [2, 2, 2, 2],
+                                                shape_denotation=shape_denotation)
+
+        for i, d in enumerate(tensor.type.tensor_type.shape.dim):
+            self.assertEqual(d.standard_denotation, shape_denotation[i])
+
 class TestHelperTensorFunctions(unittest.TestCase):
 
     def test_make_tensor(self):


### PR DESCRIPTION
As per https://github.com/onnx/onnx/issues/406

I settled on the word standard_denotation b/c denotation seems to imply "direct meaning". This helps to convey the idea that such denotation is for the algorithms not for some programmer's high level perception.

I hope that people don't confuse these two as this could happen if someone wants to do channel pooling on data tensor of size [N, C, W] by transpose the data tensor into [N, W, C] and then do spatial pool on [N, W, C]; in such case one should still annotate the tensor as [data_batch, data_channel, data_spatial]. But, people doing such hacky implementation should be aware of the potential consequence anyways...