### PR TITLE
remove unnecessary experimental Embedding op

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1105,52 +1105,6 @@ opset_import {
 <dd>Constrain input and output types to float tensors.</dd>
 </dl>
 
-### <a name="Embedding-1"></a>**Embedding-1**</a>
-
-  Turns positive integers (indexes) into dense vectors of fixed size.
-
-#### Versioning
-
-This operator is used if you are using version 1 of the default ONNX operator set until the next BC-breaking change to this operator; e.g., it will be used if your protobuf has:
-
-~~~~
-opset_import {
-  version = 1
-}
-~~~~
-
-#### Attributes
-
-<dl>
-<dt><tt>input_dim</tt> : int</dt>
-<dd>Size of the input vocabulary.</dd>
-<dt><tt>output_dim</tt> : int</dt>
-<dd>Dimension of the embedding output vectors.</dd>
-<dt><tt>weights</tt> : tensor</dt>
-<dd>2-D tensor of weights [O,I].</dd>
-</dl>
-
-#### Inputs
-
-<dl>
-<dt><tt>input</tt> : tensor(int64)</dt>
-<dd>1-D tensor of integers representing indices in the embedding dictionary with length [N] and values [0, input_dim -1]</dd>
-</dl>
-
-#### Outputs
-
-<dl>
-<dt><tt>output</tt> : T</dt>
-<dd>Output tensor of computed features [N, O].</dd>
-</dl>
-
-#### Type Constraints
-
-<dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain output types to float tensors.</dd>
-</dl>
-
 ### <a name="Equal-1"></a>**Equal-1**</a>
 
   Returns the tensor resulted from performing the `equal` logical operation

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -95,7 +95,6 @@
   * <sub>experimental</sub> <a href="#Affine">Affine</a>
   * <sub>experimental</sub> <a href="#ConstantFill">ConstantFill</a>
   * <sub>experimental</sub> <a href="#Crop">Crop</a>
-  * <sub>experimental</sub> <a href="#Embedding">Embedding</a>
   * <sub>experimental</sub> <a href="#FC">FC</a>
   * <sub>experimental</sub> <a href="#GRUUnit">GRUUnit</a>
   * <sub>experimental</sub> <a href="#GivenTensorFill">GivenTensorFill</a>
@@ -5288,53 +5287,6 @@ opset_import {
 <dl>
 <dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
 <dd>Constrain input and output types to float tensors.</dd>
-</dl>
-
-
-### <sub>experimental</sub> <a name="Embedding"></a><a name="embedding">**Embedding**</a>
-
-  Turns positive integers (indexes) into dense vectors of fixed size.
-
-#### Versioning
-
-This operator is used if you are using version 1 of the default ONNX operator set until the next BC-breaking change to this operator; e.g., it will be used if your protobuf has:
-
-~~~~
-opset_import {
-  version = 1
-}
-~~~~
-
-#### Attributes
-
-<dl>
-<dt><tt>input_dim</tt> : int</dt>
-<dd>Size of the input vocabulary.</dd>
-<dt><tt>output_dim</tt> : int</dt>
-<dd>Dimension of the embedding output vectors.</dd>
-<dt><tt>weights</tt> : tensor</dt>
-<dd>2-D tensor of weights [O,I].</dd>
-</dl>
-
-#### Inputs
-
-<dl>
-<dt><tt>input</tt> : tensor(int64)</dt>
-<dd>1-D tensor of integers representing indices in the embedding dictionary with length [N] and values [0, input_dim -1]</dd>
-</dl>
-
-#### Outputs
-
-<dl>
-<dt><tt>output</tt> : T</dt>
-<dd>Output tensor of computed features [N, O].</dd>
-</dl>
-
-#### Type Constraints
-
-<dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain output types to float tensors.</dd>
 </dl>
 
 

--- a/onnx/defs/experiments/defs.cc
+++ b/onnx/defs/experiments/defs.cc
@@ -330,25 +330,6 @@ If scale is not provided, crop the borders as provided.)DOC")
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.");
 
-OPERATOR_SCHEMA(Embedding)
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .AllowConsumed({{0, 0}})
-    .SetDoc(R"DOC(Turns positive integers (indexes) into dense vectors of fixed size.)DOC")
-    .Attr("input_dim", "Size of the input vocabulary.", AttributeProto::INT, OPTIONAL)
-    .Attr("output_dim", "Dimension of the embedding output vectors.", AttributeProto::INT, OPTIONAL)
-    .Attr("weights", "2-D tensor of weights [O,I].", AttributeProto::TENSOR, OPTIONAL)
-    .Input(0,
-           "input",
-           "1-D tensor of integers representing indices in the embedding dictionary "
-           "with length [N] and values [0, input_dim -1]", "tensor(int64)")
-    .Output(0,
-            "output",
-            "Output tensor of computed features [N, O].", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain output types to float tensors.");
-
 OPERATOR_SCHEMA(Upsample)
     .SetSupportLevel(SupportType::EXPERIMENTAL)
     .Attr(


### PR DESCRIPTION
Based on discussions, Gather can be used in place of Embedding. Gather is a supported operator whereas Embedding is an experimental operator so remove to avoid any confusion.