### PR TITLE
Deduplicate initializers in split graphs

### DIFF
--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -818,6 +818,9 @@ public:
     initializers_.push_back(std::move(initializer));
     initializer_names_.push_back(std::move(name));
   }
+  void clearInitializers() {
+    initializers_.clear();
+  }
   const std::vector<Tensor>& initializers() {
     return initializers_;
   }

--- a/onnx/optimizer/passes/split.h
+++ b/onnx/optimizer/passes/split.h
@@ -156,6 +156,9 @@ static void split_init_and_predict(Graph& graph, bool init, bool predict) {
         graph.eraseInput(i);
       }
     }
+
+    // Remove all initializers, they are already in the init net.
+    graph.clearInitializers();
   }
 }
 


### PR DESCRIPTION
when we split a graph, all initializers go to the init net