### PR TITLE
Add default constructors for TypeConstraintParam and Attribute and re…

### DIFF
--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -225,6 +225,10 @@ class OpSchema {
   };
 
   struct Attribute {
+    Attribute()
+        : name("unknown"),
+          description("unknown") {}
+
     Attribute(
         const std::string& name_,
         const std::string& description_,
@@ -245,8 +249,8 @@ class OpSchema {
         required(false),
         default_value(default_value_) {}
 
-    const std::string name;
-    const std::string description;
+    std::string name;
+    std::string description;
     AttributeProto::AttributeType type;
     bool required;
     AttributeProto default_value;
@@ -281,6 +285,9 @@ class OpSchema {
 
   // Type constraint.
   struct TypeConstraintParam {
+    TypeConstraintParam()
+        : description("unknown") {}
+
     TypeConstraintParam(
         const std::string& type_param_str_,
         const std::vector<std::string>& allowed_type_strs_,


### PR DESCRIPTION
…move const from string members to prevent implicit function deletion.

This brings things in line with OpSchema (default constructor) and TypeConstraintParam (no const on members).

The motivation here is that I'm working on a Java binding for ONNX using JavaCPP Presets and it was causing a couple of errors:
```
jnionnx.cpp:33190:36: error: use of deleted function ‘onnx::OpSchema::Attribute& onnx::OpSchema::Attribute::operator=(const onnx::OpSchema::Attribute&)’
```
and 
```
tuple:1172:70: error: no matching function for call to ‘onnx::OpSchema::Attribute::Attribute()’
         second(std::forward<_Args2>(std::get<_Indexes2>(__tuple2))...)
```
and another that I don't have on hand for TypeConstraintParam.

Related JavaCPP issue here: https://github.com/bytedeco/javacpp/issues/223

Thanks!