### PR TITLE
Fix leakage in proto_util

### DIFF
--- a/onnx/proto_utils.h
+++ b/onnx/proto_utils.h
@@ -9,8 +9,8 @@ template <typename Proto>
 bool ParseProtoFromBytes(Proto* proto, const char* buffer, size_t length) {
   // Total bytes hard limit / warning limit are set to 1GB and 512MB
   // respectively.
-  ::google::protobuf::io::CodedInputStream coded_stream(
-      new google::protobuf::io::ArrayInputStream(buffer, static_cast<int>(length)));
+  ::google::protobuf::io::ArrayInputStream input_stream(buffer, static_cast<int>(length));
+  ::google::protobuf::io::CodedInputStream coded_stream(&input_stream);
   coded_stream.SetTotalBytesLimit(1024LL << 20, 512LL << 20);
   return proto->ParseFromCodedStream(&coded_stream);
 }


### PR DESCRIPTION
Destructor of CodedInputStream will not free the ZeroCopyInputStream, hence previously we have a leak in the code. This PR fixes it. 

https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.io.coded_stream#CodedInputStream