### PR TITLE
Don't include pybind11 if its target is already exported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,11 @@ if (WIN32)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /WX")
     set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /WX")
 endif()
-add_subdirectory(third_party/pybind11)
+
+# ---[ pybind11
+if (NOT TARGET pybind11)
+  add_subdirectory(third_party/pybind11)
+endif()
 
 # Customized version of find Protobuf. We need to avoid situations mentioned
 # in https://github.com/caffe2/caffe2/blob/b7d983f255ef5496474f1ea188edb5e0ac442761/cmake/ProtoBuf.cmake#L82-L92


### PR DESCRIPTION
Since onnx can be used as a submodule, we want to add option to avoid include its own pybind11 dir if the target is already exported in upper level. This can avoid version clashes in submodules. 

@Maratyszcza 