### PR TITLE
Remove onnx-caffe2 reference

### DIFF
--- a/docs/ImplementingAnOnnxBackend.md
+++ b/docs/ImplementingAnOnnxBackend.md
@@ -2,7 +2,7 @@
 
 #### What is an ONNX backend
 
-An ONNX backend is a library that can run ONNX models. Since many deep learning frameworks already exist, you likely won't need to create everything from scratch. Rather, you'll likely create a converter that converts ONNX models to the corresponding framework specific representation and then delegate the execution to the framework. For example, [onnx-caffe2](https://github.com/onnx/onnx-caffe2) , [onnx-coreml](https://github.com/onnx/onnx-coreml), and [onnx-tensorflow](https://github.com/onnx/onnx-tensorflow) are all implemented as converters.
+An ONNX backend is a library that can run ONNX models. Since many deep learning frameworks already exist, you likely won't need to create everything from scratch. Rather, you'll likely create a converter that converts ONNX models to the corresponding framework specific representation and then delegate the execution to the framework. For example, [onnx-caffe2 (as part of caffe2)](https://github.com/caffe2/caffe2/tree/master/caffe2/python/onnx) , [onnx-coreml](https://github.com/onnx/onnx-coreml), and [onnx-tensorflow](https://github.com/onnx/onnx-tensorflow) are all implemented as converters.
 
 #### Unified backend interface
 
@@ -28,7 +28,7 @@ ONNX provides a standard backend test suite to assist backend implementation ver
 
 Integrating the ONNX Backend Test suite into your CI is simple. The following are some examples demonstrating how a backend performs the integration:
 
-- [onnx-caffe2 onnx backend test](https://github.com/onnx/onnx-caffe2/blob/master/tests/onnx_backend_test.py)
+- [onnx-caffe2 onnx backend test](https://github.com/caffe2/caffe2/blob/master/caffe2/python/onnx/tests/onnx_backend_test.py)
 
 - [onnx-tensorflow onnx backend test](https://github.com/onnx/onnx-tensorflow/blob/master/test/backend/test_onnx_backend.py)
 


### PR DESCRIPTION
Since we have moved `onnx-caffe2` into `caffe2`. Update the documentation here.