### PR TITLE
Introduce shape inference

### DIFF
--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -8,6 +8,7 @@
 #include "onnx/defs/schema.h"
 #include "onnx/optimizer/optimize.h"
 #include "onnx/py_utils.h"
+#include "onnx/shape_inference/shape_inference.h"
 
 namespace ONNX_NAMESPACE {
 
@@ -198,6 +199,21 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
         result.SerializeToString(&out);
         return py::bytes(out);
       });
+
+  // Submodule `shape_inference`
+  auto shape_inference = onnx_cpp2py_export.def_submodule("shape_inference");
+  shape_inference.doc() = "Shape Inference submodule";
+
+  shape_inference.def(
+    "infer_shapes",
+    [](const py::bytes& bytes) {
+      ModelProto proto{};
+      ParseProtoFromPyBytes(&proto, bytes);
+      shape_inference::InferShapes(proto);
+      std::string out;
+      proto.SerializeToString(&out);
+      return py::bytes(out);
+    });
 }
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -342,6 +342,11 @@ OpSchema& OpSchema::EnforceOneToOneConsumed() {
   return EnforceConsumed([](int i) { return std::make_pair(true, i); });
 }
 
+OpSchema& OpSchema::ShapeInferenceFunction(InferenceFunction inferenceFunction) {
+  tensor_inference_function_ = inferenceFunction;
+  return *this;
+}
+
 OpSchema& OpSchema::SetSupportLevel(SupportType support) {
   support_ = support;
   return *this;

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -240,7 +240,39 @@ will be (2, 1, 3).
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors.")
+    .ShapeInferenceFunction([](InferenceContext& ctx) {
+        if (ctx.getNumInputTypes() != 1) {
+          return;
+        }
+        std::vector<int64_t> perm;
+        {
+          auto perm_attr = ctx.getAttribute("perm");
+          if (perm_attr) {
+            for (auto dim : perm_attr->ints()) {
+              perm.push_back(dim);
+            }
+          } else {
+            int ndims = ctx.getInputType(0)->shape().dim_size();
+            for (int i = 0; i < ndims; i++) {
+              perm.push_back(ndims - i - 1);
+            }
+          }
+        }
+
+        TypeProto_Tensor tt;
+        {
+          tt.set_elem_type(ctx.getInputType(0)->elem_type());
+          auto shape = tt.mutable_shape();
+
+          for (size_t i = 0; i < perm.size(); i++) {
+            auto dim = shape->add_dim();
+            *dim = ctx.getInputType(0)->shape().dim(perm[i]);
+          }
+        }
+
+        *ctx.getOutputType(0) = tt;
+      });
 
 ONNX_OPERATOR_SCHEMA(Gather)
     .SetDoc(R"DOC(

--- a/onnx/shape_inference.py
+++ b/onnx/shape_inference.py
@@ -1,0 +1,23 @@
+"""onnx shape inference. Shape inference is not guaranteed to be
+complete.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import onnx.onnx_cpp2py_export.shape_inference as C
+
+"""Apply shape inference to the provided ModelProto.
+
+Inferred shapes are added to the value_info field of the graph.
+
+If the inferred values conflict with values already provided in the
+graph, that means that the provided values are invalid (or there is a
+bug in shape inference), and the result is unspecified.
+
+Arguments:
+    input (string): serialized ModelProto
+"""
+infer_shapes = C.infer_shapes

--- a/onnx/shape_inference/shape_inference.h
+++ b/onnx/shape_inference/shape_inference.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include "onnx/proto_utils.h"
+#include "onnx/defs/schema.h"
+
+namespace ONNX_NAMESPACE { namespace shape_inference {
+
+struct InferenceContextImpl : public InferenceContext {
+  virtual const AttributeProto* getAttribute(const std::string& name) const {
+    auto iter = attributesByName_.find(name);
+    if (iter == attributesByName_.end()) {
+      return nullptr;
+    } else {
+      return iter->second;
+    }
+  }
+  virtual size_t getNumInputTypes() const {
+    return allInputTypes_.size();
+  }
+  virtual const TypeProto_Tensor* getInputType(size_t index) const {
+    return allInputTypes_[index];
+  }
+  virtual size_t getNumOutputTypes() const {
+    return allOutputTypes_.size();
+  }
+  virtual TypeProto_Tensor* getOutputType(size_t index) {
+    return &allOutputTypes_[index];
+  }
+  std::unordered_map<std::string, const AttributeProto *> attributesByName_;
+  std::vector<const TypeProto_Tensor*> allInputTypes_;
+  std::vector<TypeProto_Tensor> allOutputTypes_;
+};
+
+void InferShapes(ONNX_NAMESPACE::ModelProto& m) {
+  auto g = m.mutable_graph();
+
+  std::unordered_map<std::string, TypeProto_Tensor> valueTypesByName;
+  for (auto vi : g->value_info()) {
+    valueTypesByName[vi.name()] = vi.type().tensor_type();
+  }
+  for (auto vi : g->input()) {
+    valueTypesByName[vi.name()] = vi.type().tensor_type();
+  }
+  for (auto vi : g->output()) {
+    valueTypesByName[vi.name()] = vi.type().tensor_type();
+  }
+
+  for (auto n : g->node()) {
+    auto schema = OpSchemaRegistry::Schema(n.op_type());
+    if (schema) {
+      InferenceContextImpl ctx;
+
+      {
+        std::unordered_map<std::string, const AttributeProto *> attributesByName;
+        for (auto& attr : n.attribute()) {
+          attributesByName[attr.name()] = &attr;
+        }
+        ctx.attributesByName_ = std::move(attributesByName);
+      }
+
+      {
+        std::vector<const TypeProto_Tensor *> allInputTypes;
+
+        for (auto input : n.input()) {
+          auto iter = valueTypesByName.find(input);
+          if (iter != valueTypesByName.end()) {
+            allInputTypes.push_back(&iter->second);
+          } else {
+            allInputTypes.push_back(nullptr);
+          }
+        }
+
+        ctx.allInputTypes_ = std::move(allInputTypes);
+      }
+
+      for (auto i = 0; i < n.output_size(); i++) {
+        ctx.allOutputTypes_.emplace_back();
+      }
+
+      schema->GetShapeInferenceFunction()(ctx);
+
+      // TODO: this handles the simple case of adding value_infos when
+      // there were none before. It should be enhanced to refine
+      // partially-specified types as well.
+
+      for (int i = 0; i < n.output_size(); i++) {
+        auto output = n.output(i);
+        if (ctx.getOutputType(i)->elem_type() == TensorProto::UNDEFINED) {
+          continue;
+        }
+
+        if (valueTypesByName.find(output) == valueTypesByName.end()) {
+          valueTypesByName[output] = *ctx.getOutputType(i);
+          auto vi = g->add_value_info();
+          vi->set_name(output);
+          *vi->mutable_type()->mutable_tensor_type() = *ctx.getOutputType(i);
+        }
+      }
+    }
+  }
+}
+
+}}

--- a/onnx/test/backend_shape_inference_test.py
+++ b/onnx/test/backend_shape_inference_test.py
@@ -1,0 +1,54 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os
+import unittest
+import onnx.backend.base
+import onnx.backend.test
+
+import onnx
+from onnx import helper, ModelProto
+from onnx.mapping import NP_TYPE_TO_TENSOR_TYPE
+import onnx.shape_inference
+
+
+class DummyBackend(onnx.backend.base.Backend):
+    @classmethod
+    def prepare(cls, model, device='CPU', **kwargs):
+        super(DummyBackend, cls).prepare(model, device, **kwargs)
+        raise unittest.SkipTest("This is the dummy backend test that doesn't verify the results but does run the checker")
+
+    @classmethod
+    def run_node(cls, node, inputs, device='CPU', outputs_info=None):
+        inputs_info = [(x.dtype, x.shape) for x in inputs]
+        input_value_infos = [helper.make_tensor_value_info(x, NP_TYPE_TO_TENSOR_TYPE[t], shape)
+                              for x, (t, shape) in zip(node.input, inputs_info)]
+        output_value_infos = [helper.make_tensor_value_info(x, NP_TYPE_TO_TENSOR_TYPE[t], shape)
+                               for x, (t, shape) in zip(node.output, outputs_info)]
+        if outputs_info:
+            graph = helper.make_graph([node], "test", input_value_infos, [])
+            orig_model = helper.make_model(graph, producer_name='onnx-test')
+            orig_model_str = orig_model.SerializeToString()
+            inferred_model_str = onnx.shape_inference.infer_shapes(orig_model_str)
+            inferred_model = ModelProto()
+            inferred_model.ParseFromString(inferred_model_str)
+
+            # Allow shape inference to not return anything, but if it
+            # does then check that it's correct
+            if inferred_model.graph.value_info:
+                assert(list(inferred_model.graph.value_info) == output_value_infos)
+        raise unittest.SkipTest("This is the dummy backend test that doesn't verify the results but does run the checker")
+
+
+backend_test = onnx.backend.test.BackendTest(DummyBackend, __name__)
+if os.getenv('APPVEYOR'):
+    backend_test.exclude(r'(test_vgg19|test_vgg16)')
+
+# import all test cases at global scope to make them visible to python.unittest
+globals().update(backend_test
+                 .test_cases)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -1,0 +1,102 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from onnx import checker, helper, ModelProto, TensorProto
+
+import onnx.shape_inference
+import unittest
+
+
+class TestShapeInference(unittest.TestCase):
+
+    def _inferred(self, graph):
+        orig_model = helper.make_model(graph, producer_name='onnx-test')
+        orig_model_str = orig_model.SerializeToString()
+        inferred_model_str = onnx.shape_inference.infer_shapes(orig_model_str)
+        inferred_model = ModelProto()
+        inferred_model.ParseFromString(inferred_model_str)
+        checker.check_model(inferred_model)
+        return inferred_model
+
+    def test_transpose(self):
+        trans = helper.make_node("Transpose", ["X"], ["Y"], perm=[1, 0, 2])
+        graph = helper.make_graph(
+            [trans],
+            "test",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (2, 3, 4))],
+            [])
+
+        inferred_model = self._inferred(graph)
+
+        vis_expected = [
+            helper.make_tensor_value_info("Y", TensorProto.FLOAT, (3, 2, 4))
+        ]
+
+        assert list(inferred_model.graph.value_info) == vis_expected, \
+            inferred_model.graph.value_info
+
+    def test_transpose_preexisting(self):
+        trans = helper.make_node("Transpose", ["X"], ["Y"], perm=[1, 0, 2])
+        graph = helper.make_graph(
+            [trans],
+            "test",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (2, 3, 4))],
+            [])
+        graph.value_info.extend([
+            helper.make_tensor_value_info("Y", TensorProto.FLOAT, ())
+        ])
+
+        inferred_model = self._inferred(graph)
+
+        vis_expected = [
+            helper.make_tensor_value_info("Y", TensorProto.FLOAT, ())
+        ]
+
+        assert list(inferred_model.graph.value_info) == vis_expected, \
+            inferred_model.graph.value_info
+
+    def test_transpose_preexisting_incorrect_shape(self):
+        trans = helper.make_node("Transpose", ["X"], ["Y"], perm=[1, 0, 2])
+        graph = helper.make_graph(
+            [trans],
+            "test",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (2, 3, 4))],
+            [])
+        graph.value_info.extend([
+            helper.make_tensor_value_info("Y", TensorProto.FLOAT, (5, 5, 5))
+        ])
+
+        inferred_model = self._inferred(graph)
+
+        vis_expected = [
+            helper.make_tensor_value_info("Y", TensorProto.FLOAT, (5, 5, 5))
+        ]
+
+        assert list(inferred_model.graph.value_info) == vis_expected, \
+            inferred_model.graph.value_info
+
+    def test_transpose_preexisting_incorrect_type(self):
+        trans = helper.make_node("Transpose", ["X"], ["Y"], perm=[1, 0, 2])
+        graph = helper.make_graph(
+            [trans],
+            "test",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (2, 3, 4))],
+            [])
+        graph.value_info.extend([
+            helper.make_tensor_value_info("Y", TensorProto.STRING, (3, 2, 5))
+        ])
+
+        inferred_model = self._inferred(graph)
+
+        vis_expected = [
+            helper.make_tensor_value_info("Y", TensorProto.STRING, (3, 2, 5))
+        ]
+
+        assert list(inferred_model.graph.value_info) == vis_expected, \
+            inferred_model.graph.value_info
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
as an optimizer pass, and a proof-of-concept shape inference
implementation for Transpose.

The way that we define the actual shape-inference logic is subject to
change, but the way in which it's tied into the optimizer is pretty
straightforward and probably won't need a big overhaul.