### PR TITLE
Add option to use customized protoc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ cmake_minimum_required(VERSION 3.1)
 # Project
 project(onnx C CXX)
 
+option(BUILD_PYTHON "Build Python binaries" ON)
+
 # Set C++11 as standard for the whole project
 set(CMAKE_CXX_STANDARD 11)
 
@@ -12,8 +14,16 @@ set(ONNX_ROOT ${PROJECT_SOURCE_DIR})
 set(CMAKE_MODULE_PATH "")
 list(APPEND CMAKE_MODULE_PATH ${ONNX_ROOT}/cmake/Modules)
 
-if(TARGET protobuf::protoc)
-  set(PROTOBUF_PROTOC_EXECUTABLE $<TARGET_FILE:protobuf::protoc>)
+if(TARGET protobuf::libprotobuf)
+  # Sometimes we need to use protoc compiled for host architecture while
+  # linking libprotobuf against target architecture. See
+  # https://github.com/caffe2/caffe2/blob/96f35ad75480b25c1a23d6e9e97bccae9f7a7f9c/cmake/ProtoBuf.cmake#L92-L99
+  if(EXISTS "${ONNX_CUSTOM_PROTOC_EXECUTABLE}")
+    message(STATUS "Using custom protoc executable")
+    set(ONNX_PROTOC_EXECUTABLE ${ONNX_CUSTOM_PROTOC_EXECUTABLE})
+  else()
+    set(ONNX_PROTOC_EXECUTABLE $<TARGET_FILE:protobuf::protoc>)
+  endif()
 else()
   # Customized version of find Protobuf. We need to avoid situations mentioned
   # in https://github.com/caffe2/caffe2/blob/b7d983f255ef5496474f1ea188edb5e0ac442761/cmake/ProtoBuf.cmake#L82-L92
@@ -26,6 +36,7 @@ else()
   # We assume that protoc is installed at PREFIX/bin.
   # We use get_filename_component to resolve PREFIX.
   if(PROTOBUF_PROTOC_EXECUTABLE)
+    set(ONNX_PROTOC_EXECUTABLE ${PROTOBUF_PROTOC_EXECUTABLE})
     get_filename_component(
       _PROTOBUF_INSTALL_PREFIX
       ${PROTOBUF_PROTOC_EXECUTABLE}
@@ -128,7 +139,7 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP SRCS HDRS ROOT_DIR)
     add_custom_command (
       OUTPUT "${OUTPUT_PB_SRC}"
              "${OUTPUT_PB_HEADER}"
-      COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
+      COMMAND ${ONNX_PROTOC_EXECUTABLE}
       ARGS --cpp_out ${DLLEXPORT_STR}${OUTPUT_PROTO_DIR} ${GENERATED_PROTO} -I ${OUTPUT_PROTO_DIR}
       DEPENDS ${GENERATED_PROTO}
       COMMENT "Running C++ protocol buffer compiler on ${GENERATED_PROTO}"
@@ -181,20 +192,30 @@ add_library(onnx ${onnx_src})
 target_include_directories(onnx PUBLIC ${ONNX_ROOT} "${CMAKE_CURRENT_BINARY_DIR}")
 target_link_libraries(onnx PUBLIC onnx_proto)
 
-add_library(onnx_pybind MODULE "${ONNX_ROOT}/onnx/cpp2py_export.cc")
-target_include_directories(onnx_pybind PRIVATE "${CMAKE_CURRENT_BINARY_DIR}" "${PROTOBUF_INCLUDE_DIRS}" "${PYTHON_INCLUDE_DIR}")
+if(BUILD_PYTHON)
+  add_library(onnx_pybind MODULE "${ONNX_ROOT}/onnx/cpp2py_export.cc")
+  target_include_directories(onnx_pybind PRIVATE "${CMAKE_CURRENT_BINARY_DIR}" "${PROTOBUF_INCLUDE_DIRS}" "${PYTHON_INCLUDE_DIR}")
 
-# pybind11 is a header only lib
-find_package(pybind11)
-if(pybind11_FOUND)
-  target_include_directories(onnx_pybind PRIVATE ${pybind11_INCLUDE_DIRS})
-else()
-  target_include_directories(onnx_pybind PRIVATE ${ONNX_ROOT}/third_party/pybind11/include)
-endif()
-target_link_libraries(onnx_pybind PRIVATE onnx_proto onnx)
-if (APPLE)
-  set_target_properties(onnx_pybind PROPERTIES SUFFIX ".so")
-  set_target_properties(onnx_pybind PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+  # pybind11 is a header only lib
+  find_package(pybind11)
+  if(pybind11_FOUND)
+    target_include_directories(onnx_pybind PRIVATE ${pybind11_INCLUDE_DIRS})
+  else()
+    target_include_directories(onnx_pybind PRIVATE ${ONNX_ROOT}/third_party/pybind11/include)
+  endif()
+  target_link_libraries(onnx_pybind PRIVATE onnx_proto onnx)
+  if(WIN32)
+    target_compile_options(onnx_pybind PRIVATE
+        /MP
+        /MX
+        /wd4800 # disable warning type' : forcing value to bool 'true' or 'false' (performance warning)
+        /wd4503 # identifier' : decorated name length exceeded, name was truncated
+    )
+  endif()
+  if(APPLE)
+    set_target_properties(onnx_pybind PROPERTIES SUFFIX ".so")
+    set_target_properties(onnx_pybind PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+  endif()
 endif()
 
 # Export include directories
@@ -207,12 +228,6 @@ if (WIN32)
         /MX
     )
     target_compile_options(onnx PRIVATE
-        /MP
-        /MX
-        /wd4800 # disable warning type' : forcing value to bool 'true' or 'false' (performance warning)
-        /wd4503 # identifier' : decorated name length exceeded, name was truncated
-    )
-    target_compile_options(onnx_pybind PRIVATE
         /MP
         /MX
         /wd4800 # disable warning type' : forcing value to bool 'true' or 'false' (performance warning)


### PR DESCRIPTION
Sometimes we need to use protoc compiled for host architecture while linking libprotobuf against target architecture (iOS and Android). See https://github.com/caffe2/caffe2/blob/96f35ad75480b25c1a23d6e9e97bccae9f7a7f9c/cmake/ProtoBuf.cmake#L92-L99

This PR provides such an option to do so. In addition, it makes compiling of python binding optional as on some of the platform, there might not be `Python.h`. 