### PR TITLE
to_string for Android

### DIFF
--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -228,7 +228,7 @@ void check_node(
   if (!schema) {
     fail_check(
         "No Schema registered for " + node.op_type() +
-        " with domain_version of " + std::to_string(domain_version));
+        " with domain_version of " + ONNX_NAMESPACE::to_string(domain_version));
   }
   schema->Verify(node);
 }

--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -15,6 +15,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "onnx/string_utils.h"
 #include "onnx/common/array_ref.h"
 #include "onnx/common/assertions.h"
 #include "onnx/common/interned_strings.h"
@@ -320,7 +321,7 @@ public:
   std::string uniqueName() const {
     if(has_unique_name())
       return unique_name_;
-    return std::to_string(unique());
+    return ONNX_NAMESPACE::to_string(unique());
   }
   Value* setUniqueName(const std::string & name) {
     has_unique_name_ = true;

--- a/onnx/string_utils.h
+++ b/onnx/string_utils.h
@@ -4,6 +4,18 @@
 #include <string>
 
 namespace ONNX_NAMESPACE {
+
+#if defined(__ANDROID__)
+template <typename T>
+std::string to_string(T value) {
+  std::ostringstream os;
+  os << value;
+  return os.str();
+}
+#else
+using std::to_string;
+#endif // defined(__ANDROID__)
+
 inline void MakeStringInternal(std::stringstream& /*ss*/) {}
 
 template <typename T>


### PR DESCRIPTION
Android doesn't have `std::to_string` and we need to in order to build with Caffe2 in Android. 

Code copied from https://github.com/caffe2/caffe2/blob/4f534fad1af9f77d4f0496ecd37dafb382330223/caffe2/core/common.h#L198-L206