### PR TITLE
Fix ONNX library build for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,11 +170,6 @@ file(GLOB_RECURSE onnx_src
 )
 list(REMOVE_ITEM onnx_src "${ONNX_ROOT}/onnx/cpp2py_export.cc")
 
-if(MSVC)
-    set(DLLEXPORT_OPTION "-DONNX_API=__declspec(dllexport)")
-else()
-    set(DLLEXPORT_OPTION "-DONNX_API=")
-endif()
 
 add_library(onnx_proto ${PROTO_SRCS} ${PROTO_HDRS})
 target_include_directories(onnx_proto PUBLIC "${CMAKE_CURRENT_BINARY_DIR}" "${PROTOBUF_INCLUDE_DIRS}")
@@ -185,7 +180,10 @@ else()
 endif()
 
 if(MSVC)
-    target_compile_options(onnx_proto PRIVATE /WX- ${DLLEXPORT_OPTION})
+  target_compile_options(onnx_proto PRIVATE /WX-)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(onnx_proto PRIVATE "ONNX_API=__declspec(dllexport)")
+  endif()
 endif()
 
 add_library(onnx ${onnx_src})

--- a/onnx/onnx_pb.h
+++ b/onnx/onnx_pb.h
@@ -50,10 +50,12 @@
 // issue, and for anyone dependent on ONNX it will be defined as
 // ONNX_IMPORT.
 // This is a solution from https://github.com/caffe2/caffe2/blob/4f534fad1af9f77d4f0496ecd37dafb382330223/caffe2/core/common.h
+#ifndef ONNX_API
 #ifdef ONNX_BUILD_MAIN_LIB
 #define ONNX_API ONNX_EXPORT
 #else
 #define ONNX_API ONNX_IMPORT
+#endif
 #endif
 
 #ifdef ONNX_ML


### PR DESCRIPTION
- Use `__declspec(dllexport)` only in shared library build
- Use `target_compile_definitions` for macros instead of `target_compile_options`
- Avoid redefining ONNX_API