### PR TITLE
Add 8bit quantization support

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -75,8 +75,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Add-1"></a>**Add-1**</a>
@@ -138,8 +138,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Affine-1"></a>**Affine-1**</a>
@@ -284,8 +284,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="ArgMin-1"></a>**ArgMin-1**</a>
@@ -331,8 +331,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="AveragePool-1"></a>**AveragePool-1**</a>
@@ -383,8 +383,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="BatchNormalization-1"></a>**BatchNormalization-1**</a>
@@ -454,7 +454,7 @@ opset_import {
 
 <dl>
 <dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Cast-1"></a>**Cast-1**</a>
@@ -539,8 +539,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Clip-1"></a>**Clip-1**</a>
@@ -585,8 +585,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Concat-1"></a>**Concat-1**</a>
@@ -777,7 +777,7 @@ opset_import {
 <dd>Input data tensor from previous layer; has size (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and width. Note that this is for the 2D image.Otherwise the size is (N x D1 x D2 ... x Dn)</dd>
 <dt><tt>W</tt> : T</dt>
 <dd>The weight tensor that will be used in the convolutions; has size (M x C x kH x kW), where C is the number of channels, and kH and kW are the height and width of the kernel, and M is the number of feature maps. For more than 2 dimensions, the kernel shape will be (M x C x k1 x k2 x ... x kn), where is the dimension of the kernel</dd>
-<dt><tt>B</tt> (optional) : T</dt>
+<dt><tt>B</tt> (optional) : Tb</dt>
 <dd>Optional 1D bias to be added to the convolution, has size of M.</dd>
 </dl>
 
@@ -791,8 +791,10 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input, weights, and output types to float or uint8 tensors.</dd>
+<dt><tt>Tb</tt> : tensor(float16), tensor(float), tensor(double), tensor(int32)</dt>
+<dd>Constrain bias types to float or int32 tensors.</dd>
 </dl>
 
 ### <a name="ConvTranspose-1"></a>**ConvTranspose-1**</a>
@@ -838,7 +840,7 @@ opset_import {
 <dd>Input data tensor from previous layer; has size (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and width. Note that this is for the 2D image.Otherwise the size is (N x D1 x D2 ... x Dn)</dd>
 <dt><tt>W</tt> : T</dt>
 <dd>The weight tensor that will be used in the convolutions; has size (C x M x kH x kW), where C is the number of channels, and kH and kW are the height and width of the kernel, and M is the number of feature maps. For more than 2 dimensions, the kernel shape will be (C x M x k1 x k2 x ... x kn), where is the dimension of the kernel</dd>
-<dt><tt>B</tt> (optional) : T</dt>
+<dt><tt>B</tt> (optional) : Tb</dt>
 <dd>Optional 1D bias to be added to the convolution, has size of C.</dd>
 </dl>
 
@@ -852,8 +854,10 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input, weights, and output types to float or uint8 tensors.</dd>
+<dt><tt>Tb</tt> : tensor(float16), tensor(float), tensor(double), tensor(int32)</dt>
+<dd>Constrain bias types to float or int32 tensors.</dd>
 </dl>
 
 ### <a name="Crop-1"></a>**Crop-1**</a>
@@ -943,8 +947,45 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input types to float or uint8 tensors.</dd>
+</dl>
+
+### <a name="Dequantize-1"></a>**Dequantize-1**</a>
+
+  Dequantize a uint8 quantized tensor into a float tensor
+
+#### Versioning
+
+This operator is used if you are using version 1 of the default ONNX operator set until the next BC-breaking change to this operator; e.g., it will be used if your protobuf has:
+
+~~~~
+opset_import {
+  version = 1
+}
+~~~~
+
+#### Inputs
+
+<dl>
+<dt><tt>input</tt> : T0</dt>
+<dd>Input tensor of any shape.</dd>
+</dl>
+
+#### Outputs
+
+<dl>
+<dt><tt>output</tt> : T1</dt>
+<dd>Output tensor of same shape and type as input.</dd>
+</dl>
+
+#### Type Constraints
+
+<dl>
+<dt><tt>T0</tt> : tensor(uint8)</dt>
+<dd>Constrain input types to uint8 tensors.</dd>
+<dt><tt>T1</tt> : tensor(float16), tensor(float), tensor(double)</dt>
+<dd>Constrain output types to float tensors.</dd>
 </dl>
 
 ### <a name="Div-1"></a>**Div-1**</a>
@@ -1006,8 +1047,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Dropout-1"></a>**Dropout-1**</a>
@@ -1056,8 +1097,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Elu-1"></a>**Elu-1**</a>
@@ -1101,8 +1142,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Equal-1"></a>**Equal-1**</a>
@@ -1189,8 +1230,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="FC-1"></a>**FC-1**</a>
@@ -1297,8 +1338,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Floor-1"></a>**Floor-1**</a>
@@ -1334,8 +1375,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="GRU-1"></a>**GRU-1**</a>
@@ -1613,8 +1654,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 <dt><tt>Tind</tt> : tensor(int32), tensor(int64)</dt>
 <dd>Constrain indices to integer types</dd>
 </dl>
@@ -1676,8 +1717,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="GivenTensorFill-1"></a>**GivenTensorFill-1**</a>
@@ -1759,8 +1800,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="GlobalLpPool-1"></a>**GlobalLpPool-1**</a>
@@ -1840,8 +1881,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Greater-1"></a>**Greater-1**</a>
@@ -1939,8 +1980,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Hardmax-1"></a>**Hardmax-1**</a>
@@ -1995,8 +2036,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Identity-1"></a>**Identity-1**</a>
@@ -2172,8 +2213,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="LRN-1"></a>**LRN-1**</a>
@@ -2222,8 +2263,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output  types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output  types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="LSTM-1"></a>**LSTM-1**</a>
@@ -2421,8 +2462,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Less-1"></a>**Less-1**</a>
@@ -2509,8 +2550,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="LogSoftmax-1"></a>**LogSoftmax-1**</a>
@@ -2565,8 +2606,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Loop-1"></a>**Loop-1**</a>
@@ -2824,7 +2865,7 @@ opset_import {
 
 <dl>
 <dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="LpPool-1"></a>**LpPool-1**</a>
@@ -2914,8 +2955,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Max-1"></a>**Max-1**</a>
@@ -2950,8 +2991,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="MaxPool-1"></a>**MaxPool-1**</a>
@@ -3002,8 +3043,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="MaxRoiPool-1"></a>**MaxRoiPool-1**</a>
@@ -3050,8 +3091,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Mean-1"></a>**Mean-1**</a>
@@ -3086,8 +3127,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="MeanVarianceNormalization-1"></a>**MeanVarianceNormalization-1**</a>
@@ -3166,8 +3207,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Mul-1"></a>**Mul-1**</a>
@@ -3229,8 +3270,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Neg-1"></a>**Neg-1**</a>
@@ -3266,8 +3307,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Not-1"></a>**Not-1**</a>
@@ -3394,8 +3435,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Pad-1"></a>**Pad-1**</a>
@@ -3569,8 +3610,45 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
+</dl>
+
+### <a name="Quantize-1"></a>**Quantize-1**</a>
+
+  Quantize a float tensor into a uint8 quantized tensor
+
+#### Versioning
+
+This operator is used if you are using version 1 of the default ONNX operator set until the next BC-breaking change to this operator; e.g., it will be used if your protobuf has:
+
+~~~~
+opset_import {
+  version = 1
+}
+~~~~
+
+#### Inputs
+
+<dl>
+<dt><tt>input</tt> : T0</dt>
+<dd>Input tensor of any shape.</dd>
+</dl>
+
+#### Outputs
+
+<dl>
+<dt><tt>output</tt> : T1</dt>
+<dd>Output tensor of same shape and type as input.</dd>
+</dl>
+
+#### Type Constraints
+
+<dl>
+<dt><tt>T0</tt> : tensor(float16), tensor(float), tensor(double)</dt>
+<dd>Constrain input types to float tensors.</dd>
+<dt><tt>T1</tt> : tensor(uint8)</dt>
+<dd>Constrain output types to uint8 tensors.</dd>
 </dl>
 
 ### <a name="RNN-1"></a>**RNN-1**</a>
@@ -3943,8 +4021,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="ReduceL1-1"></a>**ReduceL1-1**</a>
@@ -3992,8 +4070,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="ReduceL2-1"></a>**ReduceL2-1**</a>
@@ -4041,8 +4119,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="ReduceLogSum-1"></a>**ReduceLogSum-1**</a>
@@ -4090,8 +4168,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="ReduceLogSumExp-1"></a>**ReduceLogSumExp-1**</a>
@@ -4139,8 +4217,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="ReduceMax-1"></a>**ReduceMax-1**</a>
@@ -4188,8 +4266,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="ReduceMean-1"></a>**ReduceMean-1**</a>
@@ -4237,8 +4315,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="ReduceMin-1"></a>**ReduceMin-1**</a>
@@ -4286,8 +4364,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="ReduceProd-1"></a>**ReduceProd-1**</a>
@@ -4335,8 +4413,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="ReduceSum-1"></a>**ReduceSum-1**</a>
@@ -4384,8 +4462,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="ReduceSumSquare-1"></a>**ReduceSumSquare-1**</a>
@@ -4433,8 +4511,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Relu-1"></a>**Relu-1**</a>
@@ -4470,8 +4548,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Reshape-1"></a>**Reshape-1**</a>
@@ -4519,8 +4597,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Scale-1"></a>**Scale-1**</a>
@@ -4656,8 +4734,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Shape-1"></a>**Shape-1**</a>
@@ -4730,8 +4808,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Size-1"></a>**Size-1**</a>
@@ -4852,8 +4930,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Softmax-1"></a>**Softmax-1**</a>
@@ -4908,8 +4986,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Softplus-1"></a>**Softplus-1**</a>
@@ -4945,8 +5023,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Softsign-1"></a>**Softsign-1**</a>
@@ -4980,8 +5058,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="SpaceToDepth-1"></a>**SpaceToDepth-1**</a>
@@ -5024,8 +5102,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Split-1"></a>**Split-1**</a>
@@ -5110,8 +5188,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Squeeze-1"></a>**Squeeze-1**</a>
@@ -5153,8 +5231,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Sub-1"></a>**Sub-1**</a>
@@ -5216,8 +5294,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Sum-1"></a>**Sum-1**</a>
@@ -5252,8 +5330,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Tanh-1"></a>**Tanh-1**</a>
@@ -5287,8 +5365,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="ThresholdedRelu-1"></a>**ThresholdedRelu-1**</a>
@@ -5370,8 +5448,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="TopK-1"></a>**TopK-1**</a>
@@ -5426,7 +5504,7 @@ opset_import {
 
 <dl>
 <dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 <dt><tt>I</tt> : tensor(int64), tensor(int32)</dt>
 <dd>Constrain index tensor to integral types</dd>
 </dl>
@@ -5471,8 +5549,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Unsqueeze-1"></a>**Unsqueeze-1**</a>
@@ -5519,8 +5597,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Upsample-1"></a>**Upsample-1**</a>
@@ -5685,8 +5763,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="LpPool-2"></a>**LpPool-2**</a>
@@ -5739,8 +5817,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Pad-2"></a>**Pad-2**</a>
@@ -5803,8 +5881,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 ### <a name="Split-2"></a>**Split-2**</a>
@@ -5849,8 +5927,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input types to float or uint8 tensors.</dd>
 </dl>
 
 ## Version 3 of the default ONNX operator set
@@ -6034,7 +6112,7 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain output types to float or uint8 tensors.</dd>
 </dl>
 

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -19,6 +19,7 @@
   * <a href="#Conv">Conv</a>
   * <a href="#ConvTranspose">ConvTranspose</a>
   * <a href="#DepthToSpace">DepthToSpace</a>
+  * <a href="#Dequantize">Dequantize</a>
   * <a href="#Div">Div</a>
   * <a href="#Dropout">Dropout</a>
   * <a href="#Elu">Elu</a>
@@ -57,6 +58,7 @@
   * <a href="#PRelu">PRelu</a>
   * <a href="#Pad">Pad</a>
   * <a href="#Pow">Pow</a>
+  * <a href="#Quantize">Quantize</a>
   * <a href="#RNN">RNN</a>
   * <a href="#RandomNormal">RandomNormal</a>
   * <a href="#RandomNormalLike">RandomNormalLike</a>
@@ -148,8 +150,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -233,8 +235,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -515,8 +517,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -563,8 +565,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -616,8 +618,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -688,7 +690,7 @@ opset_import {
 
 <dl>
 <dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -808,8 +810,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -881,8 +883,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -984,8 +986,8 @@ Other versions of this operator: <a href="Changelog.md#Concat-1">Concat-1</a>
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -1126,7 +1128,7 @@ opset_import {
 <dd>Input data tensor from previous layer; has size (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and width. Note that this is for the 2D image.Otherwise the size is (N x D1 x D2 ... x Dn)</dd>
 <dt><tt>W</tt> : T</dt>
 <dd>The weight tensor that will be used in the convolutions; has size (M x C x kH x kW), where C is the number of channels, and kH and kW are the height and width of the kernel, and M is the number of feature maps. For more than 2 dimensions, the kernel shape will be (M x C x k1 x k2 x ... x kn), where is the dimension of the kernel</dd>
-<dt><tt>B</tt> (optional) : T</dt>
+<dt><tt>B</tt> (optional) : Tb</dt>
 <dd>Optional 1D bias to be added to the convolution, has size of M.</dd>
 </dl>
 
@@ -1140,8 +1142,10 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input, weights, and output types to float or uint8 tensors.</dd>
+<dt><tt>Tb</tt> : tensor(float16), tensor(float), tensor(double), tensor(int32)</dt>
+<dd>Constrain bias types to float or int32 tensors.</dd>
 </dl>
 
 
@@ -1305,7 +1309,7 @@ opset_import {
 <dd>Input data tensor from previous layer; has size (N x C x H x W), where N is the batch size, C is the number of channels, and H and W are the height and width. Note that this is for the 2D image.Otherwise the size is (N x D1 x D2 ... x Dn)</dd>
 <dt><tt>W</tt> : T</dt>
 <dd>The weight tensor that will be used in the convolutions; has size (C x M x kH x kW), where C is the number of channels, and kH and kW are the height and width of the kernel, and M is the number of feature maps. For more than 2 dimensions, the kernel shape will be (C x M x k1 x k2 x ... x kn), where is the dimension of the kernel</dd>
-<dt><tt>B</tt> (optional) : T</dt>
+<dt><tt>B</tt> (optional) : Tb</dt>
 <dd>Optional 1D bias to be added to the convolution, has size of C.</dd>
 </dl>
 
@@ -1319,8 +1323,10 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input, weights, and output types to float or uint8 tensors.</dd>
+<dt><tt>Tb</tt> : tensor(float16), tensor(float), tensor(double), tensor(int32)</dt>
+<dd>Constrain bias types to float or int32 tensors.</dd>
 </dl>
 
 
@@ -1365,8 +1371,46 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input types to float or uint8 tensors.</dd>
+</dl>
+
+
+### <a name="Dequantize"></a><a name="dequantize">**Dequantize**</a>
+
+  Dequantize a uint8 quantized tensor into a float tensor
+
+#### Versioning
+
+This operator is used if you are using version 1 of the default ONNX operator set until the next BC-breaking change to this operator; e.g., it will be used if your protobuf has:
+
+~~~~
+opset_import {
+  version = 1
+}
+~~~~
+
+#### Inputs
+
+<dl>
+<dt><tt>input</tt> : T0</dt>
+<dd>Input tensor of any shape.</dd>
+</dl>
+
+#### Outputs
+
+<dl>
+<dt><tt>output</tt> : T1</dt>
+<dd>Output tensor of same shape and type as input.</dd>
+</dl>
+
+#### Type Constraints
+
+<dl>
+<dt><tt>T0</tt> : tensor(uint8)</dt>
+<dd>Constrain input types to uint8 tensors.</dd>
+<dt><tt>T1</tt> : tensor(float16), tensor(float), tensor(double)</dt>
+<dd>Constrain output types to float tensors.</dd>
 </dl>
 
 
@@ -1429,8 +1473,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -1529,8 +1573,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -1575,8 +1619,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -1755,8 +1799,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -1826,8 +1870,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -1911,8 +1955,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -2167,8 +2211,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 <dt><tt>Tind</tt> : tensor(int32), tensor(int64)</dt>
 <dd>Constrain indices to integer types</dd>
 </dl>
@@ -2275,8 +2319,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -2313,8 +2357,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -2404,8 +2448,8 @@ Other versions of this operator: <a href="Changelog.md#GlobalLpPool-1">GlobalLpP
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -2442,8 +2486,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -2631,8 +2675,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -2736,8 +2780,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -2866,8 +2910,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -2917,8 +2961,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output  types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output  types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -3118,8 +3162,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -3298,8 +3342,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -3381,8 +3425,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -3513,7 +3557,7 @@ opset_import {
 
 <dl>
 <dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -3569,8 +3613,8 @@ Other versions of this operator: <a href="Changelog.md#LpPool-1">LpPool-1</a>
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -3607,8 +3651,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -3681,8 +3725,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -3773,8 +3817,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -3822,8 +3866,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -3859,8 +3903,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -3935,8 +3979,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -4038,8 +4082,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -4125,8 +4169,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -4452,8 +4496,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -4519,8 +4563,8 @@ Other versions of this operator: <a href="Changelog.md#Pad-1">Pad-1</a>
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -4640,8 +4684,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -4705,6 +4749,44 @@ expect(node, inputs=[x, y], outputs=[z],
 ```
 
 </details>
+
+
+### <a name="Quantize"></a><a name="quantize">**Quantize**</a>
+
+  Quantize a float tensor into a uint8 quantized tensor
+
+#### Versioning
+
+This operator is used if you are using version 1 of the default ONNX operator set until the next BC-breaking change to this operator; e.g., it will be used if your protobuf has:
+
+~~~~
+opset_import {
+  version = 1
+}
+~~~~
+
+#### Inputs
+
+<dl>
+<dt><tt>input</tt> : T0</dt>
+<dd>Input tensor of any shape.</dd>
+</dl>
+
+#### Outputs
+
+<dl>
+<dt><tt>output</tt> : T1</dt>
+<dd>Output tensor of same shape and type as input.</dd>
+</dl>
+
+#### Type Constraints
+
+<dl>
+<dt><tt>T0</tt> : tensor(float16), tensor(float), tensor(double)</dt>
+<dd>Constrain input types to float tensors.</dd>
+<dt><tt>T1</tt> : tensor(uint8)</dt>
+<dd>Constrain output types to uint8 tensors.</dd>
+</dl>
 
 
 ### <a name="RNN"></a><a name="rnn">**RNN**</a>
@@ -5082,8 +5164,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -5158,8 +5240,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -5208,8 +5290,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -5258,8 +5340,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -5308,8 +5390,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -5358,8 +5440,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -5408,8 +5490,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -5458,8 +5540,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -5508,8 +5590,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -5558,8 +5640,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -5608,8 +5690,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -5646,8 +5728,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -5717,8 +5799,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -5797,8 +5879,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -5955,8 +6037,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -6136,8 +6218,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -6309,8 +6391,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -6434,8 +6516,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -6496,8 +6578,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -6567,8 +6649,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -6616,8 +6698,8 @@ Other versions of this operator: <a href="Changelog.md#Split-1">Split-1</a>
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -6654,8 +6736,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -6724,8 +6806,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -6810,8 +6892,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -6896,8 +6978,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -6971,8 +7053,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -7037,8 +7119,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -7094,7 +7176,7 @@ opset_import {
 
 <dl>
 <dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 <dt><tt>I</tt> : tensor(int64), tensor(int32)</dt>
 <dd>Constrain index tensor to integral types</dd>
 </dl>
@@ -7175,8 +7257,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 
@@ -7270,8 +7352,8 @@ opset_import {
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double), tensor(uint8)</dt>
+<dd>Constrain input and output types to float or uint8 tensors.</dd>
 </dl>
 
 

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -53,8 +53,8 @@ Performs element-wise binary {name} (with limited broadcast support).
         "Second operand. With broadcasting can be of smaller size than A. "
         "If broadcasting is disabled it should be of the same size.", "T");
     schema.Output(0, "C", "Result, has same dimensions and type as A", "T");
-    schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
   };
 }
 
@@ -91,8 +91,8 @@ will throw errors.
          "as described above.", "T");
     schema.Output(0, "output", "The output values with the same "
           "shape as input tensor.", "T");
-    schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
   };
 }
 
@@ -122,8 +122,8 @@ the tensor elementwise.
 )DOC")
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Abs)
     .AllowConsumed({{0, 0}})
@@ -134,8 +134,8 @@ the tensor elementwise.
 )DOC")
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Reciprocal)
     .AllowConsumed({{0, 0}})
@@ -146,8 +146,8 @@ the tensor elementwise.
 )DOC")
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Floor)
     .AllowConsumed({{0, 0}})
@@ -158,8 +158,8 @@ the tensor elementwise.
 )DOC")
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Ceil)
     .AllowConsumed({{0, 0}})
@@ -170,8 +170,8 @@ the tensor elementwise.
 )DOC")
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Sqrt)
     .AllowConsumed({{0, 0}})
@@ -182,8 +182,8 @@ the tensor elementwise. If x is negative, then it will return NaN.
 )DOC")
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Relu)
   .AllowConsumed({{0, 0}})
@@ -194,8 +194,8 @@ the tensor elementwise.
 )DOC")
   .Input(0, "X", "Input tensor", "T")
   .Output(0, "Y", "Output tensor", "T")
-  .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+  .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(LeakyRelu)
     .Attr("alpha",
@@ -210,8 +210,8 @@ output data (Tensor<T>) where the function `f(x) = alpha * x for x < 0`,
 )DOC")
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Selu)
     .AllowConsumed({{0, 0}})
@@ -231,8 +231,8 @@ is applied to the tensor elementwise.
 )DOC")
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Elu)
     .AllowConsumed({{0, 0}})
@@ -248,8 +248,8 @@ Elu takes one input data (Tensor<T>) and produces one output data
 )DOC")
     .Input(0, "X", "1D input tensor", "T")
     .Output(0, "Y", "1D input tensor", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Exp)
     .AllowConsumed({{0, 0}})
@@ -262,8 +262,8 @@ Calculates the exponential of the given input tensor, element-wise.
         "output",
         "The exponential of the input tensor computed "
         "element-wise", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Log)
     .AllowConsumed({{0, 0}})
@@ -276,8 +276,8 @@ Calculates the natural log of the given input tensor, element-wise.
         "output",
         "The natural log of the input tensor computed "
         "element-wise", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Tanh)
   .AllowConsumed({{0, 0}})
@@ -287,8 +287,8 @@ Calculates the hyperbolic tangent of the given input tensor element-wise.
     .Input(0, "input", "1-D input tensor", "T")
     .Output(0, "output", "The hyperbolic tangent values of the input tensor "
                "computed element-wise", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Pow)
     .SetDoc(R"DOC(
@@ -308,8 +308,8 @@ is applied to the data tensor elementwise.
           AttributeProto::INT,
           OPTIONAL)
     .Output(0, "Z", "Output tensor (same size as X)", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(PRelu)
     .AllowConsumed({{0, 0}})
@@ -327,8 +327,8 @@ output data (Tensor<T>) where the function `f(x) = slope * x for x < 0`,
         "Slope tensor. If `Slope` is of size 1, the value is shared"
         "across different channels", "T")
     .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Sigmoid)
   .AllowConsumed({{0, 0}})
@@ -339,8 +339,8 @@ tensor elementwise.
 )DOC")
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(HardSigmoid)
   .AllowConsumed({{0, 0}})
@@ -359,8 +359,8 @@ is applied to the tensor elementwise.
 )DOC")
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Max)
     .AllowConsumed({{0, 0}})
@@ -370,8 +370,8 @@ have the same shape and data type.
 )DOC")
     .Input(0, "data_0", "List of tensors for Max.", "T", OpSchema::Variadic)
     .Output(0, "max", "Output tensor. Same dimension as inputs.", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Min)
     .AllowConsumed({{0, 0}})
@@ -381,8 +381,8 @@ have the same shape and data type.
 )DOC")
     .Input(0, "data_0", "List of tensors for Min", "T", OpSchema::Variadic)
     .Output(0, "min", "Output tensor. Same dimension as inputs.", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Sum)
     .AllowConsumed({{0, 0}})
@@ -392,8 +392,8 @@ have the same shape and data type.
 )DOC")
     .Input(0, "data_0", "List of tensors for Sum.", "T", OpSchema::Variadic)
     .Output(0, "sum", "Output tensor. Same dimension as inputs.", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Mean)
     .AllowConsumed({{0, 0}})
@@ -403,8 +403,8 @@ have the same shape and data type.
 )DOC")
     .Input(0, "data_0", "List of tensors for Mean.", "T", OpSchema::Variadic)
     .Output(0, "mean", "Output tensor. Same dimension as inputs.", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Clip)
     .AllowConsumed({{0, 0}})
@@ -421,8 +421,8 @@ numeric_limits::lowest() and numeric_limits::max() respectively.
           OPTIONAL)
     .Input(0, "input", "Input tensor whose elements to be clipped", "T")
     .Output(0, "output", "Output tensor with clipped input elements", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Softmax)
     .FillUsing(SoftmaxFamilyDocGenerator("softmax", "normalized exponential"));
@@ -443,8 +443,8 @@ Calculates the softsign (x/(1+|x|)) of the given input tensor element-wise.
         "output",
         "The softsign (x/(1+|x|)) values of the input tensor computed element-wise",
         "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Softplus)
     .SetDoc(R"DOC(
@@ -454,8 +454,8 @@ the tensor elementwise.
 )DOC")
     .Input(0, "X", "1D input tensor", "T")
     .Output(0, "Y", "1D input tensor", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Gemm)
     .SetDoc(R"DOC(General Matrix multiplication:
@@ -472,8 +472,8 @@ if attribute transA is non-zero, same for B and transB.
     .Input(2, "C", "Input tensor C, can be inplace.", "T")
     .AllowConsumed({{2, 0}})
     .Output(0, "Y", "Output tensor.", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.")
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.")
     .Attr("transA",
           "Whether A should be transposed",
           AttributeProto::INT,
@@ -500,8 +500,8 @@ ONNX_OPERATOR_SCHEMA(MatMul)
     .Input(0, "A", "N-dimensional matrix A", "T")
     .Input(1, "B", "N-dimensional matrix B", "T")
     .Output(0, "Y", "Matrix multiply results from A * B", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.")
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.")
     .SetDoc(R"DOC(
 Matrix product that behaves like numpy.matmul: https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.matmul.html
 )DOC");
@@ -536,7 +536,7 @@ Given two equivalent values, this operator uses the indices along the axis  as
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
+        "Constrain input and output types to float or uint8 tensors.")
     .TypeConstraint(
         "I",
         {"tensor(int64)", "tensor(int32)"},

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -61,8 +61,8 @@ namespace ONNX_NAMESPACE {
                           "the input tensor. Dimensions will vary based "
                           "on various kernel, stride, and pad sizes. Floor value of "
                           "the dimension is used", "T");
-            schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-                "Constrain input and output types to float tensors.");
+            schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+                "Constrain input and output types to float or uint8 tensors.");
         };
     }
 
@@ -117,8 +117,8 @@ namespace ONNX_NAMESPACE {
                           "Output data tensor from Lp pooling across the input "
                           "tensor. Dimensions will vary based on various kernel, stride, and pad "
                           "sizes.", "T");
-            schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-                "Constrain input and output types to float tensors.");
+            schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+                "Constrain input and output types to float or uint8 tensors.");
         };
     }
 
@@ -157,8 +157,8 @@ namespace ONNX_NAMESPACE {
             schema.Output(0,
                           "Y",
                           "RoI pooled output 4-D tensor of shape (num_rois, channels, pooled_shape[0], pooled_shape[1]).", "T");
-            schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-                "Constrain input and output types to float tensors.");
+            schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+                "Constrain input and output types to float or uint8 tensors.");
         };
     }
 
@@ -192,14 +192,16 @@ computes the output.)DOC";
                          "where is the dimension of the kernel", "T");
             schema.Input(2,
                          "B",
-                         "Optional 1D bias to be added to the convolution, has size of M.", "T", OpSchema::Optional);
+                         "Optional 1D bias to be added to the convolution, has size of M.", "Tb", OpSchema::Optional);
             schema.Output(0,
                           "Y",
                           "Output data tensor that contains the result of the "
                           "convolution. The output dimensions are functions "
                           "of the kernel size, stride size, and pad lengths.", "T");
-            schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-                "Constrain input and output types to float tensors.");
+            schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+                "Constrain input, weights, and output types to float or uint8 tensors.");
+            schema.TypeConstraint("Tb", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(int32)" },
+                "Constrain bias types to float or int32 tensors.");
             schema.Attr("kernel_shape",
                         "The shape of the convolution kernel. If not present, should be inferred from input W.",
                          AttributeProto::INTS, OPTIONAL);
@@ -252,14 +254,16 @@ and computes the output.)DOC";
                          "where is the dimension of the kernel", "T");
             schema.Input(2,
                          "B",
-                         "Optional 1D bias to be added to the convolution, has size of C.", "T", OpSchema::Optional);
+                         "Optional 1D bias to be added to the convolution, has size of C.", "Tb", OpSchema::Optional);
             schema.Output(0,
                           "Y",
                           "Output data tensor that contains the result of the convolution. The "
                           "output dimensions are functions of the kernel size, stride size, "
                           "and pad lengths.", "T");
-            schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-                "Constrain input and output types to float tensors.");
+            schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+                "Constrain input, weights, and output types to float or uint8 tensors.");
+            schema.TypeConstraint("Tb", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(int32)" },
+                "Constrain bias types to float or int32 tensors.");
             schema.Attr("kernel_shape",
                         "The shape of the convolution kernel. If not present, should be inferred from input W.",
                          AttributeProto::INTS, OPTIONAL);
@@ -320,8 +324,8 @@ namespace ONNX_NAMESPACE {
                           "Y",
                           "Output data tensor from pooling across the input "
                           "tensor. Dimensions will be N x C x 1 x 1", "T");
-            schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-                "Constrain input and output types to float tensors.");
+            schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+                "Constrain input and output types to float or uint8 tensors.");
             schema.SetDoc(doc);
         };
     }
@@ -359,8 +363,8 @@ namespace ONNX_NAMESPACE {
                           "Y",
                           "Output data tensor from pooling across the input "
                           "tensor. Dimensions will be N x C x 1 x 1", "T");
-            schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-                "Constrain input and output types to float tensors.");
+            schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+                "Constrain input and output types to float or uint8 tensors.");
             schema.SetDoc(doc);
         };
     }
@@ -436,7 +440,7 @@ Output case #2: Y (test mode)
         "Saved variance used during training to speed up "
         "gradient computation. Should not be used for testing.", "T", OpSchema::Optional)
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(InstanceNormalization)
     .AllowConsumed({{0, 0}})
@@ -464,8 +468,8 @@ where mean and variance are computed per instance per channel.
     .Output(0,
         "output",
         "The output 4-dimensional tensor of the same shape as input.", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(LpNormalization)
     .Input(0, "input", "Input matrix", "T")
@@ -473,7 +477,7 @@ ONNX_OPERATOR_SCHEMA(LpNormalization)
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
+        "Constrain input and output types to float or uint8 tensors.")
     .SetDoc(R"DOC(
 Given a matrix, apply Lp-normalization along the provided axis.
 )DOC")
@@ -502,8 +506,8 @@ the training phase, so during testing nothing needs to be done.
     .Output(0, "output", "The output.", "T")
     .Output(1, "mask",
                "The output mask. If is_test is nonzero, this output is not filled.", "T", OpSchema::Optional)
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.");
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Flatten)
     .SetDoc(R"DOC(
@@ -519,8 +523,8 @@ Flattens the input tensor into a 2D matrix. If input tensor has shape
         "with input dimensions up to axis flattened to the outer dimension "
         "of the output and remaining input dimensions flattened into the inner "
         "dimension of the output.", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.")
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+        "Constrain input and output types to float or uint8 tensors.")
     .Attr(
         "axis",
         "(Default to 1) Indicate up to which input dimensions "
@@ -538,8 +542,8 @@ ONNX_OPERATOR_SCHEMA(LRN)
     .Attr("bias", "Default to 1.f", AttributeProto::FLOAT, 1.0f)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" }, "Constrain input and output "
-        " types to float tensors.")
+    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" }, "Constrain input and output "
+        " types to float or uint8 tensors.")
     .SetDoc(R"DOC(
 Local Response Normalization. It normalizes over local input regions.
 Each input value is divided by

--- a/onnx/defs/quantization/defs.cc
+++ b/onnx/defs/quantization/defs.cc
@@ -3,6 +3,7 @@
 
 #include "onnx/defs/schema.h"
 
+namespace ONNX_NAMESPACE {
 ONNX_OPERATOR_SCHEMA(Quantize)
     .SetDoc(R"DOC(Quantize a float tensor into a uint8 quantized tensor)DOC")
     .Input(0, "input", "Input tensor of any shape.", "T0")
@@ -28,3 +29,4 @@ ONNX_OPERATOR_SCHEMA(Dequantize)
         "T1",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain output types to float tensors.");                
+}

--- a/onnx/defs/quantization/defs.cc
+++ b/onnx/defs/quantization/defs.cc
@@ -1,0 +1,30 @@
+// Copyright (c) Facebook Inc. and Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "onnx/defs/schema.h"
+
+ONNX_OPERATOR_SCHEMA(Quantize)
+    .SetDoc(R"DOC(Quantize a float tensor into a uint8 quantized tensor)DOC")
+    .Input(0, "input", "Input tensor of any shape.", "T0")
+    .Output(0, "output", "Output tensor of same shape and type as input.", "T1")
+    .TypeConstraint(
+        "T0",
+        {"tensor(float16)", "tensor(float)", "tensor(double)"},
+        "Constrain input types to float tensors.")
+    .TypeConstraint(
+        "T1",
+        {"tensor(uint8)"},
+        "Constrain output types to uint8 tensors."); 
+
+ONNX_OPERATOR_SCHEMA(Dequantize)
+    .SetDoc(R"DOC(Dequantize a uint8 quantized tensor into a float tensor)DOC")
+    .Input(0, "input", "Input tensor of any shape.", "T0")
+    .Output(0, "output", "Output tensor of same shape and type as input.", "T1")
+    .TypeConstraint(
+        "T0",
+        {"tensor(uint8)"},
+        "Constrain input types to uint8 tensors.")
+    .TypeConstraint(
+        "T1",
+        {"tensor(float16)", "tensor(float)", "tensor(double)"},
+        "Constrain output types to float tensors.");                

--- a/onnx/defs/reduction/defs.cc
+++ b/onnx/defs/reduction/defs.cc
@@ -27,8 +27,8 @@ False instead of True.)DOC";
                     static_cast<int64_t>(1));
         schema.Input(0, "data", "An input tensor.", "T");
         schema.Output(0, "reduced", "Reduced output tensor.", "T");
-        schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-            "Constrain input and output types to float tensors.");
+        schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" },
+            "Constrain input and output types to float or uint8 tensors.");
     };
 }
   
@@ -86,7 +86,8 @@ The type of the output tensor is integer.)DOC";
                     static_cast<int64_t>(1));
         schema.Input(0, "data", "An input tensor.", "T");
         schema.Output(0, "reduced", "Reduced output tensor with integer data type.", "tensor(int32)");
-        schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" }, "Constrain input and output types to float tensors.");
+        schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)" }, 
+            "Constrain input and output types to float or uint8 tensors.");
     };
 }
 

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -73,8 +73,8 @@ from the input tensor).)DOC")
     .Output(0, "reshaped", "Reshaped data.", "T")
     .TypeConstraint(
         "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)"},
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Shape)
     .SetDoc(R"DOC(
@@ -134,8 +134,8 @@ ONNX_OPERATOR_SCHEMA(Concat)
     .Output(0, "concat_result", "Concatenated tensor", "T")
     .TypeConstraint(
         "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain output types to float tensors.");
+        {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)"},
+        "Constrain output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Split)
     .SinceVersion(2)
@@ -148,8 +148,8 @@ ONNX_OPERATOR_SCHEMA(Split)
         OpSchema::Variadic)
     .TypeConstraint(
         "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input types to float tensors.")
+        {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)"},
+        "Constrain input types to float or uint8 tensors.")
     .Attr("axis", "Which axis to split on", AttributeProto::INT, OPTIONAL)
     .Attr("split", "length of each output", AttributeProto::INTS, OPTIONAL)
     .SetDoc(R"DOC(Split a tensor into a list of tensors, along the specified
@@ -219,8 +219,8 @@ Example 2:
     .Output(0, "output", "Sliced data tensor.", "T")
     .TypeConstraint(
         "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)"},
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Transpose)
     .SetDoc(R"DOC(
@@ -238,8 +238,8 @@ will be (2, 1, 3).
     .Output(0, "transposed", "Transposed output.", "T")
     .TypeConstraint(
         "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)"},
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Gather)
     .SetDoc(R"DOC(
@@ -301,8 +301,8 @@ Example 2:
     .Output(0, "output", "Tensor of rank q + (r - 1).", "T")
     .TypeConstraint(
         "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
+        {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)"},
+        "Constrain input and output types to float or uint8 tensors.")
     .TypeConstraint(
         "Tind",
         {"tensor(int32)", "tensor(int64)"},
@@ -321,8 +321,8 @@ Takes a  parameter `axes` with a list of axes to squeeze.
     .Output(0, "squeezed", "Reshaped tensor with same data as input.", "T")
     .TypeConstraint(
         "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)"},
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Unsqueeze)
     .Attr(
@@ -342,8 +342,8 @@ Dimension indices in `axes` are as seen in the output tensor. For example:
     .Output(0, "expanded", "Reshaped tensor with same data as input.", "T")
     .TypeConstraint(
         "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)"},
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Pad)
     .SinceVersion(2)
@@ -391,8 +391,8 @@ Example:
     .Output(0, "output", "Tensor after padding.", "T")
     .TypeConstraint(
         "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)"},
+        "Constrain input and output types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(SpaceToDepth)
     .Attr(
@@ -418,8 +418,8 @@ are moved to the depth dimension.
         "T")
     .TypeConstraint(
         "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input types to float tensors.");
+        {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)"},
+        "Constrain input types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(DepthToSpace)
     .Attr(
@@ -446,8 +446,8 @@ and width dimensions.
         "T")
     .TypeConstraint(
         "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input types to float tensors.");
+        {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)"},
+        "Constrain input types to float or uint8 tensors.");
 
 ONNX_OPERATOR_SCHEMA(Tile)
     .SetDoc(R"DOC(Repeat the elements of a tensor along an axis.)DOC")
@@ -461,5 +461,5 @@ ONNX_OPERATOR_SCHEMA(Tile)
     .Output(0, "output", "Output tensor of same shape and type as input.", "T")
     .TypeConstraint(
         "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input types to float tensors.");
+        {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(uint8)"},
+        "Constrain input types to float or uint8 tensors.");

--- a/onnx/onnx.in.proto
+++ b/onnx/onnx.in.proto
@@ -136,6 +136,10 @@ message ValueInfoProto {
   optional TypeProto type = 2;
   // A human-readable documentation for this value. Markdown is allowed.
   optional string doc_string = 3;
+  // scale for 8bit quantized tensor
+  optional float scale = 4;
+  // zero_point for 8bit quantized tensor
+  optional int32 zero_point = 5;
 }
 
 // NodeProto stores a node that is similar to the notion of "layer"

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -141,6 +141,10 @@ message ValueInfoProto {
   optional TypeProto type = 2;
   // A human-readable documentation for this value. Markdown is allowed.
   optional string doc_string = 3;
+  // scale for 8bit quantized tensor
+  optional float scale = 4;
+  // zero_point for 8bit quantized tensor
+  optional int32 zero_point = 5;
 }
 
 // NodeProto stores a node that is similar to the notion of "layer"

--- a/onnx/onnx.proto3
+++ b/onnx/onnx.proto3
@@ -141,6 +141,10 @@ message ValueInfoProto {
   TypeProto type = 2;
   // A human-readable documentation for this value. Markdown is allowed.
   string doc_string = 3;
+  // scale for 8bit quantized tensor
+  float scale = 4;
+  // zero_point for 8bit quantized tensor
+  int32 zero_point = 5;
 }
 
 // NodeProto stores a node that is similar to the notion of "layer"


### PR DESCRIPTION
Add scale/zero_point to ValueInfoProto
Add schemas for Quantize/Dequantize
Add tensor(uint8) to TypeConstraint to operators in math, nn, reduction, and tensor
Note the bias type is int32 for Conv and ConvTranspose when the input and weight are uint8
