### PR TITLE
Add preprocessor flag to strip docs from ONNX schema

### DIFF
--- a/onnx/defs/logical/defs.cc
+++ b/onnx/defs/logical/defs.cc
@@ -9,6 +9,7 @@ namespace ONNX_NAMESPACE {
 
 std::function<void(OpSchema&)> BinaryLogicDocGenerator(const char* name) {
     return [=](OpSchema& schema) {
+#ifndef ONNX_STRIP_DOCS
         std::string doc = R"DOC(
 Returns the tensor resulted from performing the `{name}` logical operation
 elementwise on the input tensors `A` and `B`.
@@ -18,6 +19,9 @@ to match the shape of left-hand-side argument. See the doc of `Add` for a
 detailed description of the broadcasting rules.
 )DOC";
         ReplaceAll(doc, "{name}", name);
+#else
+        std::string doc = "";
+#endif
         schema.SetDoc(doc.c_str());
         schema.Attr("broadcast", "Enable broadcasting", AttributeProto::INT, static_cast<int64_t>(0));
         schema.Attr("axis", "If set, defines the broadcast dimensions.",

--- a/onnx/defs/logical/defs.cc
+++ b/onnx/defs/logical/defs.cc
@@ -18,7 +18,7 @@ to match the shape of left-hand-side argument. See the doc of `Add` for a
 detailed description of the broadcasting rules.
 )DOC";
         ReplaceAll(doc, "{name}", name);
-        schema.SetDoc(doc);
+        schema.SetDoc(doc.c_str());
         schema.Attr("broadcast", "Enable broadcasting", AttributeProto::INT, static_cast<int64_t>(0));
         schema.Attr("axis", "If set, defines the broadcast dimensions.",
                     AttributeProto::INT,

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -8,6 +8,7 @@ using namespace ONNX_NAMESPACE;
 
 namespace ONNX_NAMESPACE {
 
+#ifndef ONNX_STRIP_DOCS
 const char* kBroadcastDoc = R"DOC(
 If necessary the right-hand-side argument will be broadcasted to match the
 shape of left-hand-side argument. When broadcasting is specified, the second
@@ -26,14 +27,21 @@ For example, the following tensor shapes are supported (with broadcast=1):
 
 Attribute `broadcast=1` needs to be passed to enable broadcasting.
 )DOC";
+#else
+const char* kBroadcastDoc = "";
+#endif
 
 std::function<void(OpSchema&)> MathDocGenerator(const char* name) {
   return [=](OpSchema& schema) {
+#ifndef ONNX_STRIP_DOCS
     std::string doc = R"DOC(
 Performs element-wise binary {name} (with limited broadcast support).
 {broadcast_doc})DOC";
     ReplaceAll(doc, "{name}", name);
     ReplaceAll(doc, "{broadcast_doc}", kBroadcastDoc);
+#else
+    std::string doc = "";
+#endif
     schema.SetDoc(doc.c_str());
     schema.Attr("broadcast",
                 "Pass 1 to enable broadcasting",
@@ -60,6 +68,7 @@ Performs element-wise binary {name} (with limited broadcast support).
 
 std::function<void(OpSchema&)> SoftmaxFamilyDocGenerator(const char* name, const char* description) {
   return [=](OpSchema& schema) {
+#ifndef ONNX_STRIP_DOCS
     std::string doc = R"DOC(
 The operator computes the {name} ({description}) values for each layer in the batch
  of the given input. The input is a 2-D tensor (Tensor<float>) of size
@@ -79,6 +88,9 @@ will throw errors.
 )DOC";
     ReplaceAll(doc, "{name}", name);
     ReplaceAll(doc, "{description}", description);
+#else
+    std::string doc = "";
+#endif
     schema.SetDoc(doc.c_str());
     schema.Attr("axis",
         "(int) default to 1; describes the axis of the inputs when coerced "
@@ -291,11 +303,15 @@ Calculates the hyperbolic tangent of the given input tensor element-wise.
         "Constrain input and output types to float tensors.");
 
 std::string &getPowDoc() {
+#ifndef ONNX_STRIP_DOCS
   static std::string powDoc = R"DOC(
 Pow takes input data (Tensor<T>) and exponent Tensor, and
 produces one output data (Tensor<T>) where the function `f(x) = x^exponent`,
 is applied to the data tensor elementwise.
 )DOC" + std::string(kBroadcastDoc);
+#else
+  static std::string powDoc = "";
+#endif
   return powDoc;
 }
 

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -34,7 +34,7 @@ Performs element-wise binary {name} (with limited broadcast support).
 {broadcast_doc})DOC";
     ReplaceAll(doc, "{name}", name);
     ReplaceAll(doc, "{broadcast_doc}", kBroadcastDoc);
-    schema.SetDoc(doc);
+    schema.SetDoc(doc.c_str());
     schema.Attr("broadcast",
                 "Pass 1 to enable broadcasting",
                 AttributeProto::INT,
@@ -79,7 +79,7 @@ will throw errors.
 )DOC";
     ReplaceAll(doc, "{name}", name);
     ReplaceAll(doc, "{description}", description);
-    schema.SetDoc(doc);
+    schema.SetDoc(doc.c_str());
     schema.Attr("axis",
         "(int) default to 1; describes the axis of the inputs when coerced "
         "to 2D; defaults to one because the 0th axis most likely describes "
@@ -290,12 +290,17 @@ Calculates the hyperbolic tangent of the given input tensor element-wise.
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
         "Constrain input and output types to float tensors.");
 
-ONNX_OPERATOR_SCHEMA(Pow)
-    .SetDoc(R"DOC(
+std::string &getPowDoc() {
+  static std::string powDoc = R"DOC(
 Pow takes input data (Tensor<T>) and exponent Tensor, and
 produces one output data (Tensor<T>) where the function `f(x) = x^exponent`,
 is applied to the data tensor elementwise.
-)DOC" + std::string(kBroadcastDoc))
+)DOC" + std::string(kBroadcastDoc);
+  return powDoc;
+}
+
+ONNX_OPERATOR_SCHEMA(Pow)
+    .SetDoc(getPowDoc().c_str())
     .Input(0, "X", "Input tensor of any shape, base of the exponent.", "T")
     .Input(1, "Y", "Input tensor of any shape broadcastable to X shape, "
                    "the exponent component.", "T")

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -31,7 +31,7 @@ namespace ONNX_NAMESPACE {
  data into the output tensor Y for further processing.)DOC";
             ReplaceAll(doc, "{name}", name);
             ReplaceAll(doc, "{opName}", opName);
-            schema.SetDoc(doc);
+            schema.SetDoc(doc.c_str());
             schema.Attr("kernel_shape",
                         "The size of the kernel along each axis.",
                         AttributeProto::INTS);
@@ -84,7 +84,7 @@ namespace ONNX_NAMESPACE {
  of the input tensor according to the kernel size and downsampling the
  data into the output tensor Y for further processing.)DOC";
             ReplaceAll(doc, "{name}", name);
-            schema.SetDoc(doc);
+            schema.SetDoc(doc.c_str());
             schema.SinceVersion(2);
             schema.Attr("kernel_shape",
                         "The size of the kernel along each axis.",
@@ -135,7 +135,7 @@ namespace ONNX_NAMESPACE {
  apply {name} pooling across each RoI, to produce output 4-D tensor of shape
  (num_rois, channels, pooled_shape[0], pooled_shape[1]).)DOC";
             ReplaceAll(doc, "{name}", name);
-            schema.SetDoc(doc);
+            schema.SetDoc(doc.c_str());
             schema.Attr("pooled_shape",
                         "ROI pool output shape (height, width).",
                         AttributeProto::INTS);
@@ -173,7 +173,7 @@ namespace ONNX_NAMESPACE {
 The convolution operator consumes an input tensor and {filter_desc}, and
 computes the output.)DOC";
             ReplaceAll(doc, "{filter_desc}", filter_desc);
-            schema.SetDoc(doc);
+            schema.SetDoc(doc.c_str());
             schema.Input(0,
                          "X",
                          "Input data tensor from previous layer; "
@@ -234,7 +234,7 @@ namespace ONNX_NAMESPACE {
 The convolution transpose operator consumes an input tensor and {filter_desc},
 and computes the output.)DOC";
             ReplaceAll(doc, "{filter_desc}", filter_desc);
-            schema.SetDoc(doc);
+            schema.SetDoc(doc.c_str());
             schema.Input(0,
                          "X",
                          "Input data tensor from previous layer; has size (N x C x H x W)"
@@ -306,7 +306,7 @@ namespace ONNX_NAMESPACE {
  equal to the spatial dimension of input tensor.)DOC";
             ReplaceAll(doc, "{op_type}", op_type);
             ReplaceAll(doc, "{op}", op);
-            schema.SetDoc(doc);
+            schema.SetDoc(doc.c_str());
             schema.Input(0,
                          "X",
                          "Input data tensor from the previous operator; "
@@ -322,7 +322,7 @@ namespace ONNX_NAMESPACE {
                           "tensor. Dimensions will be N x C x 1 x 1", "T");
             schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
                 "Constrain input and output types to float tensors.");
-            schema.SetDoc(doc);
+            schema.SetDoc(doc.c_str());
         };
     }
   ONNX_OPERATOR_SCHEMA(GlobalAveragePool)
@@ -340,7 +340,7 @@ namespace ONNX_NAMESPACE {
  equal to the spatial dimension of input tensor.)DOC";
             ReplaceAll(doc, "{op_type}", op_type);
             ReplaceAll(doc, "{op}", op);
-            schema.SetDoc(doc);
+            schema.SetDoc(doc.c_str());
             schema.SinceVersion(2);
             schema.Attr("p",
                         "p value of the Lp norm used to pool over the input data, default is 2.",
@@ -361,7 +361,7 @@ namespace ONNX_NAMESPACE {
                           "tensor. Dimensions will be N x C x 1 x 1", "T");
             schema.TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
                 "Constrain input and output types to float tensors.");
-            schema.SetDoc(doc);
+            schema.SetDoc(doc.c_str());
         };
     }
 

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -5,6 +5,7 @@
 using namespace ONNX_NAMESPACE;
 
 namespace ONNX_NAMESPACE {
+#ifndef ONNX_STRIP_DOCS
     static std::string pads_doc = "Padding for the beginning and ending along each axis, it can take any value greater "
                                   "than or equal to 0. The value represent the number of pixels added to the beginning "
                                   "and end part of the corresponding axis. `pads` format should be as follow "
@@ -18,11 +19,16 @@ namespace ONNX_NAMESPACE {
                                       "beginning for SAME_LOWER. VALID mean no padding. DEPRECATION NOTE: auto_pad is "
                                       "only intended to support legacy uses, and for framework authors, one is explicitly "
                                       "encouraged to use explicit padding specified in the pads attribute.";
+#else
+    static std::string pads_doc = "";
+    static std::string auto_pad_doc = "";
+#endif
 }
 
 namespace ONNX_NAMESPACE {
     std::function<void(OpSchema&)> PoolOpSchemaGenerator(const char* name, const char* opName) {
         return [=](OpSchema& schema) {
+#ifndef ONNX_STRIP_DOCS
             std::string doc = R"DOC(
  {name} consumes an input tensor X and applies {opName} pooling across the
  the tensor according to kernel sizes, stride sizes, and pad lengths.
@@ -31,6 +37,9 @@ namespace ONNX_NAMESPACE {
  data into the output tensor Y for further processing.)DOC";
             ReplaceAll(doc, "{name}", name);
             ReplaceAll(doc, "{opName}", opName);
+#else
+            std::string doc = "";
+#endif
             schema.SetDoc(doc.c_str());
             schema.Attr("kernel_shape",
                         "The size of the kernel along each axis.",
@@ -77,6 +86,7 @@ namespace ONNX_NAMESPACE {
 namespace ONNX_NAMESPACE {
     std::function<void(OpSchema&)> LpPoolOpSchemaGenerator(const char* name) {
         return [=](OpSchema& schema) {
+#ifndef ONNX_STRIP_DOCS
             std::string doc = R"DOC(
  {name} consumes an input tensor X and applies Lp pooling across the
  the tensor according to kernel sizes, stride sizes, and pad lengths.
@@ -84,6 +94,9 @@ namespace ONNX_NAMESPACE {
  of the input tensor according to the kernel size and downsampling the
  data into the output tensor Y for further processing.)DOC";
             ReplaceAll(doc, "{name}", name);
+#else
+            std::string doc = "";
+#endif
             schema.SetDoc(doc.c_str());
             schema.SinceVersion(2);
             schema.Attr("kernel_shape",
@@ -130,11 +143,15 @@ namespace ONNX_NAMESPACE {
 namespace ONNX_NAMESPACE {
     std::function<void(OpSchema&)> RoiPoolOpSchemaGenerator(const char* name) {
         return [=](OpSchema& schema) {
+#ifndef ONNX_STRIP_DOCS
             std::string doc = R"DOC(
  ROI {name} pool consumes an input tensor X and region of interests (RoIs) to
  apply {name} pooling across each RoI, to produce output 4-D tensor of shape
  (num_rois, channels, pooled_shape[0], pooled_shape[1]).)DOC";
             ReplaceAll(doc, "{name}", name);
+#else
+            std::string doc = "";
+#endif
             schema.SetDoc(doc.c_str());
             schema.Attr("pooled_shape",
                         "ROI pool output shape (height, width).",
@@ -169,10 +186,14 @@ namespace ONNX_NAMESPACE {
 namespace ONNX_NAMESPACE {
     std::function<void(OpSchema&)> ConvOpSchemaGenerator(const char* filter_desc) {
         return [=](OpSchema& schema) {
+#ifndef ONNX_STRIP_DOCS
             std::string doc = R"DOC(
 The convolution operator consumes an input tensor and {filter_desc}, and
 computes the output.)DOC";
             ReplaceAll(doc, "{filter_desc}", filter_desc);
+#else
+            std::string doc = "";
+#endif
             schema.SetDoc(doc.c_str());
             schema.Input(0,
                          "X",
@@ -230,10 +251,14 @@ computes the output.)DOC";
 namespace ONNX_NAMESPACE {
     std::function<void(OpSchema&)> ConvTransposeOpSchemaGenerator(const char* filter_desc) {
         return [=](OpSchema& schema) {
+#ifndef ONNX_STRIP_DOCS
             std::string doc = R"DOC(
 The convolution transpose operator consumes an input tensor and {filter_desc},
 and computes the output.)DOC";
             ReplaceAll(doc, "{filter_desc}", filter_desc);
+#else
+            std::string doc = "";
+#endif
             schema.SetDoc(doc.c_str());
             schema.Input(0,
                          "X",
@@ -300,12 +325,16 @@ and computes the output.)DOC";
 namespace ONNX_NAMESPACE {
   std::function<void(OpSchema&)> GlobalPoolingOpSchemaGenerator(const char* op_type, const char* op) {
         return [=](OpSchema& schema) {
+#ifndef ONNX_STRIP_DOCS
             std::string doc = R"DOC(
  Global{op_type} consumes an input tensor X and applies {op} pooling across the
  the values in the same channel. This is equivalent to {op_type} with kernel size
  equal to the spatial dimension of input tensor.)DOC";
             ReplaceAll(doc, "{op_type}", op_type);
             ReplaceAll(doc, "{op}", op);
+#else
+            std::string doc = "";
+#endif
             schema.SetDoc(doc.c_str());
             schema.Input(0,
                          "X",
@@ -334,12 +363,16 @@ namespace ONNX_NAMESPACE {
 namespace ONNX_NAMESPACE {
   std::function<void(OpSchema&)> GlobalLpPoolingOpSchemaGenerator(const char* op_type, const char* op) {
         return [=](OpSchema& schema) {
+#ifndef ONNX_STRIP_DOCS
             std::string doc = R"DOC(
  Global{op_type} consumes an input tensor X and applies {op} pooling across the
  the values in the same channel. This is equivalent to {op_type} with kernel size
  equal to the spatial dimension of input tensor.)DOC";
             ReplaceAll(doc, "{op_type}", op_type);
             ReplaceAll(doc, "{op}", op);
+#else
+            std::string doc = "";
+#endif
             schema.SetDoc(doc.c_str());
             schema.SinceVersion(2);
             schema.Attr("p",

--- a/onnx/defs/reduction/defs.cc
+++ b/onnx/defs/reduction/defs.cc
@@ -16,7 +16,7 @@ the resulted tensor have the reduced dimension pruned.
 The above behavior is similar to numpy, with the exception that numpy default keepdims to
 False instead of True.)DOC";
         ReplaceAll(doc, "{name}", name);
-        schema.SetDoc(doc);
+        schema.SetDoc(doc.c_str());
         schema.Attr("axes",
                     "A list of integers, along which to reduce.",
                     AttributeProto::INTS,
@@ -31,7 +31,7 @@ False instead of True.)DOC";
             "Constrain input and output types to float tensors.");
     };
 }
-  
+
 ONNX_OPERATOR_SCHEMA(ReduceMax)
     .FillUsing(ReduceDocGenerator("max"));
 
@@ -70,12 +70,12 @@ namespace ONNX_NAMESPACE {
 std::function<void(OpSchema&)> ArgReduceDocGenerator(const char* name) {
     return [=](OpSchema& schema) {
         std::string doc = R"DOC(
-Computes the indices of the {name} elements of the input tensor's element along the 
+Computes the indices of the {name} elements of the input tensor's element along the
 provided axis. The resulted tensor has the same rank as the input if keepdims equal 1.
-If keepdims equal 0, then the resulted tensor have the reduced dimension pruned. 
+If keepdims equal 0, then the resulted tensor have the reduced dimension pruned.
 The type of the output tensor is integer.)DOC";
         ReplaceAll(doc, "{name}", name);
-        schema.SetDoc(doc);
+        schema.SetDoc(doc.c_str());
         schema.Attr("axis",
                     "The axis in which to compute the arg indices",
                     AttributeProto::INT,

--- a/onnx/defs/reduction/defs.cc
+++ b/onnx/defs/reduction/defs.cc
@@ -8,6 +8,7 @@ namespace ONNX_NAMESPACE {
 
 std::function<void(OpSchema&)> ReduceDocGenerator(const char* name) {
     return [=](OpSchema& schema) {
+#ifndef ONNX_STRIP_DOCS
         std::string doc = R"DOC(
 Computes the {name} of the input tensor's element along the provided axes. The resulted
 tensor has the same rank as the input if keepdims equal 1. If keepdims equal 0, then
@@ -16,6 +17,9 @@ the resulted tensor have the reduced dimension pruned.
 The above behavior is similar to numpy, with the exception that numpy default keepdims to
 False instead of True.)DOC";
         ReplaceAll(doc, "{name}", name);
+#else
+        std::string doc = "";
+#endif
         schema.SetDoc(doc.c_str());
         schema.Attr("axes",
                     "A list of integers, along which to reduce.",
@@ -69,12 +73,16 @@ namespace ONNX_NAMESPACE {
 
 std::function<void(OpSchema&)> ArgReduceDocGenerator(const char* name) {
     return [=](OpSchema& schema) {
+#ifndef ONNX_STRIP_DOCS
         std::string doc = R"DOC(
-Computes the indices of the {name} elements of the input tensor's element along the
+Computes the indices of the {name} elements of the input tensor's element along the 
 provided axis. The resulted tensor has the same rank as the input if keepdims equal 1.
-If keepdims equal 0, then the resulted tensor have the reduced dimension pruned.
+If keepdims equal 0, then the resulted tensor have the reduced dimension pruned. 
 The type of the output tensor is integer.)DOC";
         ReplaceAll(doc, "{name}", name);
+#else
+        std::string doc = "";
+#endif
         schema.SetDoc(doc.c_str());
         schema.Attr("axis",
                     "The axis in which to compute the arg indices",

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -354,6 +354,7 @@ OpSchema& OpSchema::SetSupportLevel(SupportType support) {
   support_ = support;
   return *this;
 }
+
 OpSchema& OpSchema::SetDoc(const char* doc) {
 #ifndef ONNX_STRIP_DOCS
   doc_ = doc;

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -236,7 +236,7 @@ class OpSchema {
           description(description_),
 #else
           description(""),
-#endif ONNX_STRIP_DOCS
+#endif
           type(type_),
           required(required_) {}
 

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -72,12 +72,12 @@ class OpSchema {
         const std::string& name,
         const DataTypeSet& type_set,
         const std::string& type_str,
-        const std::string& description,
+        const char* description,
         FormalParameterOption param_option = Single);
 
     explicit FormalParameter(
         const std::string& name,
-        const std::string& description,
+        const char* description,
         const std::string& type_str,
         FormalParameterOption param_option = Single);
 
@@ -91,7 +91,7 @@ class OpSchema {
     const std::string& GetTypeStr() const;
 
     // Get formal parameter description.
-    const std::string& GetDescription() const;
+    const char* GetDescription() const;
 
     // Get the parameter option, it could be Single, Optional or Variadic.
     FormalParameterOption GetOption() const;
@@ -114,7 +114,9 @@ class OpSchema {
     std::string type_str_;
 
     // Formal parameter description.
-    std::string description_;
+#ifndef ONNX_STRIP_DOCS
+    const char* description_;
+#endif
 
     // Formal parameter option.
     FormalParameterOption param_option_;
@@ -209,7 +211,7 @@ class OpSchema {
   OpSchema& SetSupportLevel(SupportType supportType);
 
   // Functions to do documentation for the operator schema.
-  OpSchema& SetDoc(const std::string& doc);
+  OpSchema& SetDoc(const char* doc);
 
   // Functions to specify domain for the operator schema.
   // Default domain value (ONNX_DOMAIN) means it's ONNX domain.
@@ -226,26 +228,34 @@ class OpSchema {
   struct Attribute {
     Attribute(
         const std::string& name_,
-        const std::string& description_,
+        const char* description_,
         AttributeProto::AttributeType type_,
         bool required_)
         : name(name_),
+#ifndef ONNX_STRIP_DOCS
           description(description_),
+#else
+          description(""),
+#endif ONNX_STRIP_DOCS
           type(type_),
           required(required_) {}
 
     Attribute(
         const std::string& name_,
-        const std::string& description_,
+        const char* description_,
         AttributeProto default_value_)
         : name(name_),
+#ifndef ONNX_STRIP_DOCS
           description(description_),
+#else
+          description(""),
+#endif
           type(default_value_.type()),
           required(false),
           default_value(default_value_) {}
 
     const std::string name;
-    const std::string description;
+    const char* description;
     AttributeProto::AttributeType type;
     bool required;
     AttributeProto default_value;
@@ -257,12 +267,12 @@ class OpSchema {
 #define ATTR_SETTER_WITH_DEFAULT_VALUE(TypeName) \
   OpSchema& Attr(                                \
       const std::string& name,                   \
-      const std::string& description,            \
+      const char* description,                   \
       AttributeProto::AttributeType type,        \
       const TypeName& defaultValue);             \
   OpSchema& Attr(                                \
       const std::string& name,                   \
-      const std::string& description,            \
+      const char* description,                   \
       AttributeProto::AttributeType type,        \
       const std::vector<TypeName>& defaultValue);
 
@@ -275,7 +285,7 @@ class OpSchema {
   // Register "required" attribute without default value.
   OpSchema& Attr(
       const std::string& name,
-      const std::string& description,
+      const char* description,
       AttributeProto::AttributeType type,
       bool required = true);
   OpSchema& AllowUncheckedAttributes();
@@ -285,18 +295,22 @@ class OpSchema {
     TypeConstraintParam(
         const std::string& type_param_str_,
         const std::vector<std::string>& allowed_type_strs_,
-        const std::string& description_)
+        const char* description_)
         : type_param_str(type_param_str_),
-          allowed_type_strs(allowed_type_strs_),
-          description(description_) {}
+#ifndef ONNX_STRIP_DOCS
+          description(description_),
+#else
+          description(""),
+#endif
+          allowed_type_strs(allowed_type_strs_) {}
 
     // Type parameter string, for example, "T", "T1", etc.
     std::string type_param_str;
+    // Type parameter description.
+    const char* description;
     // Allowed type strings for <*this> type parameter, for example,
     // "tensor(float)".
     std::vector<std::string> allowed_type_strs;
-    // Type parameter description.
-    std::string description;
   };
 
   // Grammar for type strings used in Input(), Output().
@@ -328,19 +342,19 @@ class OpSchema {
   OpSchema& Input(
       const int n,
       const std::string& name,
-      const std::string& description,
+      const char* description,
       const std::string& type_str,
       FormalParameterOption param_option = Single);
   OpSchema& Output(
       const int n,
       const std::string& name,
-      const std::string& description,
+      const char* description,
       const std::string& type_str,
       FormalParameterOption param_option = Single);
   OpSchema& TypeConstraint(
       const std::string& type_str,
       const std::vector<std::string>& constraints,
-      const std::string& description);
+      const char* description);
 
   // Convenience members for types
   static const std::vector<std::string>& all_integral_types() {


### PR DESCRIPTION
Human-readable doc strings occupy binary space, and this can become problematic in memory-constrained cases where they are not needed, such as mobile deployments. This PR adds a preprocessor flag, `ONNX_STRIP_DOCS`, which will elide uses of documentation string literals, allowing a link-time optimization pass to eliminate them

cc @Maratyszcza please try this out and tell me if this has a considerable effect on binary size

== Preliminary results ==
Building ONNX with `-O3 -flto -DONNX_STRIP_DOCS` I look at the generated `onnx_cpp2py_export.cpython-36m-darwin.so` on my Mac. I extract the strings from that SO and compare sizes with and without having the strip flag set:

```
-rw-r--r--  1 jamesreed  1876110778    22K Mar 17 12:06 /Users/jamesreed/strings_stripped.txt
-rw-r--r--  1 jamesreed  1876110778    75K Mar 17 12:07 /Users/jamesreed/strings_unstripped.txt
```

Note that `-flto` is required for the toolchain to remove string literals from the compiled binary in this case