### PR TITLE
Add ONNX_USE_LITE_PROTO

### DIFF
--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -1,4 +1,5 @@
 #include "onnx/checker.h"
+#include "onnx/proto_utils.h"
 
 #include "onnx/defs/schema.h"
 
@@ -280,7 +281,7 @@ void check_graph(
             "Nodes in a graph must be topologically sorted, however input '",
             input,
             "' of node: \n",
-            node.ShortDebugString(),
+            ProtoDebugString(node),
             "\n is not output of any previous nodes.");
       }
     }
@@ -292,7 +293,7 @@ void check_graph(
     try {
       check_node(node, ctx, lex_ctx);
     } catch (ValidationError& ex) {
-      ex.AppendContext("Bad node spec: " + node.ShortDebugString());
+      ex.AppendContext("Bad node spec: " + ProtoDebugString(node));
       throw ex;
     }
     // check for SSA form

--- a/onnx/proto_utils.h
+++ b/onnx/proto_utils.h
@@ -3,7 +3,25 @@
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 
+#ifdef ONNX_USE_LITE_PROTO
+#include <google/protobuf/message_lite.h>
+#else // ONNX_USE_LITE_PROTO
+#include <google/protobuf/message.h>
+#endif  // !ONNX_USE_LITE_PROTO
+
 namespace ONNX_NAMESPACE {
+
+#ifdef ONNX_USE_LITE_PROTO
+using ::google::protobuf::MessageLite;
+inline std::string ProtoDebugString(const MessageLite& proto) {
+  return proto.SerializeAsString();
+}
+#else
+using ::google::protobuf::Message;
+inline std::string ProtoDebugString(const Message& proto) {
+  return proto.ShortDebugString();
+}
+#endif
 
 template <typename Proto>
 bool ParseProtoFromBytes(Proto* proto, const char* buffer, size_t length) {


### PR DESCRIPTION
It's generally preferable to use libprotobuf_lite on mobile. However, some features in ONNX were not supported by libprotobuf_lite. To make ONNX lite compatible:
- Add flag ONNX_USE_LITE_PROTO
- Use MessageLite.SerializeAsString() in place of Message.ShortDebugString()