### PR TITLE
Set 2GB protobuf parse limit

### DIFF
--- a/onnx/proto_utils.h
+++ b/onnx/proto_utils.h
@@ -29,7 +29,7 @@ bool ParseProtoFromBytes(Proto* proto, const char* buffer, size_t length) {
   // respectively.
   ::google::protobuf::io::ArrayInputStream input_stream(buffer, static_cast<int>(length));
   ::google::protobuf::io::CodedInputStream coded_stream(&input_stream);
-  coded_stream.SetTotalBytesLimit(1024LL << 20, 512LL << 20);
+  coded_stream.SetTotalBytesLimit((2048LL << 20) - 1, 512LL << 20);
   return proto->ParseFromCodedStream(&coded_stream);
 }
 } // namespace ONNX_NAMESPACE


### PR DESCRIPTION
This sets the protobuf parse limit to 2GB rather than one. This unblocks the use of potentially large models, for example NLP models with embeddings tables.

We plan to come out with a more general solution for handling prohibitively large models in the near future.