### PR TITLE
Replace unittest.skip with custom exception

### DIFF
--- a/onnx/backend/test/runner/__init__.py
+++ b/onnx/backend/test/runner/__init__.py
@@ -24,6 +24,10 @@ from ..loader import load_node_tests, load_model_tests
 from .item import TestItem
 
 
+class BackendIsNotSupposedToImplementIt(unittest.SkipTest):
+    pass
+
+
 class Runner(object):
 
     def __init__(self, backend, parent_module=None):
@@ -203,7 +207,13 @@ class Runner(object):
                 "Backend doesn't support device {}".format(device))
             @functools.wraps(test_func)
             def device_test_func(*args, **kwargs):
-                return test_func(*args, device=device, **kwargs)
+                try:
+                    return test_func(*args, device=device, **kwargs)
+                except BackendIsNotSupposedToImplementIt as e:
+                    # hacky verbose reporting
+                    if '-v' in sys.argv or '--verbose' in sys.argv:
+                        print('Test {} is effectively skipped: {}'.format(
+                            device_test_name, e))
 
             self._test_items[category][device_test_name] = TestItem(
                 device_test_func, report_item)

--- a/onnx/test/test_backend_test.py
+++ b/onnx/test/test_backend_test.py
@@ -7,6 +7,7 @@ import os
 import unittest
 import onnx.backend.base
 import onnx.backend.test
+from onnx.backend.test.runner import BackendIsNotSupposedToImplementIt
 
 
 # The following just executes the fake backend through the backend test
@@ -25,13 +26,13 @@ class DummyBackend(onnx.backend.base.Backend):
     @classmethod
     def prepare(cls, model, device='CPU', **kwargs):
         super(DummyBackend, cls).prepare(model, device, **kwargs)
-        raise unittest.SkipTest(
+        raise BackendIsNotSupposedToImplementIt(
             "This is the dummy backend test that doesn't verify the results but does run the checker")
 
     @classmethod
     def run_node(cls, node, inputs, device='CPU', outputs_info=None):
         super(DummyBackend, cls).run_node(node, inputs, device=device, outputs_info=outputs_info)
-        raise unittest.SkipTest(
+        raise BackendIsNotSupposedToImplementIt(
             "This is the dummy backend test that doesn't verify the results but does run the checker")
 
 


### PR DESCRIPTION
So we avoid annoying warnings about skipped tests