### PR TITLE
Fix Attribute default value pybind11 binding

### DIFF
--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -47,7 +47,11 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
       .def_readonly("name", &OpSchema::Attribute::name)
       .def_readonly("description", &OpSchema::Attribute::description)
       .def_readonly("type", &OpSchema::Attribute::type)
-      .def_readonly("default_value", &OpSchema::Attribute::default_value)
+      .def_property_readonly("_default_value", [](OpSchema::Attribute* attr) -> py::bytes {
+          std::string out;
+          attr->default_value.SerializeToString(&out);
+          return out;
+      })
       .def_readonly("required", &OpSchema::Attribute::required);
 
   py::class_<OpSchema::TypeConstraintParam>(op_schema, "TypeConstraintParam")

--- a/onnx/defs/__init__.py
+++ b/onnx/defs/__init__.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import onnx
 import onnx.onnx_cpp2py_export.defs as C
 
 
@@ -30,3 +31,12 @@ def onnx_opset_version():
 
 
 OpSchema = C.OpSchema
+
+
+@property
+def _Attribute_default_value(self):
+    attr = onnx.AttributeProto()
+    attr.ParseFromString(self._default_value)
+    return attr
+
+OpSchema.Attribute.default_value = _Attribute_default_value

--- a/onnx/defs/__init__.py
+++ b/onnx/defs/__init__.py
@@ -39,4 +39,5 @@ def _Attribute_default_value(self):
     attr.ParseFromString(self._default_value)
     return attr
 
+
 OpSchema.Attribute.default_value = _Attribute_default_value

--- a/onnx/test/schema_test.py
+++ b/onnx/test/schema_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from onnx import defs
+from onnx import defs, AttributeProto
 
 
 class TestSchema(unittest.TestCase):
@@ -10,6 +10,11 @@ class TestSchema(unittest.TestCase):
 
     def test_typecheck(self):
         defs.get_schema("Conv")
+
+    def test_attr_default_value(self):
+        v = defs.get_schema("BatchNormalization").attributes['epsilon'].default_value
+        self.assertEqual(type(v), AttributeProto)
+        self.assertEqual(v.type, AttributeProto.FLOAT)
 
 
 if __name__ == '__main__':

--- a/onnx/test/schema_test.py
+++ b/onnx/test/schema_test.py
@@ -12,7 +12,8 @@ class TestSchema(unittest.TestCase):
         defs.get_schema("Conv")
 
     def test_attr_default_value(self):
-        v = defs.get_schema("BatchNormalization").attributes['epsilon'].default_value
+        v = defs.get_schema(
+            "BatchNormalization").attributes['epsilon'].default_value
         self.assertEqual(type(v), AttributeProto)
         self.assertEqual(v.type, AttributeProto.FLOAT)
 


### PR DESCRIPTION
```
In [1]: from onnx import defs

In [2]: s = defs.get_schema('BatchNormalization')

In [3]: s.attributes['epsilon'].default_value
Out[3]:
name: "epsilon"
f: 9.999999747378752e-06
type: FLOAT

In [4]: type(s.attributes['epsilon'].default_value)
Out[4]: onnx_pb2.AttributeProto
```