### PR TITLE
add max inclusive version to defs.get_schema function

### DIFF
--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -99,8 +99,9 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
       []() -> std::unordered_map<std::string, std::pair<int, int>> {
         return OpSchemaRegistry::DomainToVersionRange::Instance().Map();
       });
-  defs.def("get_schema", [](const std::string& op_type) -> OpSchema {
-    const auto* schema = OpSchemaRegistry::Schema(op_type);
+  defs.def("get_schema", [](const std::string& op_type,
+                            const int& maxInclusiveVersion) -> OpSchema {
+    const auto* schema = OpSchemaRegistry::Schema(op_type, maxInclusiveVersion);
     if (!schema) {
       throw std::runtime_error("No schema registered for '" + op_type + "'!");
     }

--- a/onnx/defs/__init__.py
+++ b/onnx/defs/__init__.py
@@ -14,8 +14,12 @@ def has(op_type):
     return C.has_schema(op_type)
 
 
-def get_schema(op_type):
-    return C.get_schema(op_type)
+def onnx_opset_version():
+    return C.schema_version_map()[ONNX_DOMAIN][1]
+
+
+def get_schema(op_type, max_inclusive_version=onnx_opset_version()):
+    return C.get_schema(op_type, max_inclusive_version)
 
 
 def get_all_schemas():
@@ -24,10 +28,6 @@ def get_all_schemas():
 
 def get_all_schemas_with_history():
     return C.get_all_schemas_with_history()
-
-
-def onnx_opset_version():
-    return C.schema_version_map()[ONNX_DOMAIN][1]
 
 
 OpSchema = C.OpSchema


### PR DESCRIPTION
Return the schema with biggest version, which is not greater than specified maxInclusiveVersion.
Make get_schema function easier to use.