### PR TITLE
Skip bvlc_alexnet_cuda on AppVeyor for memory error 

### DIFF
--- a/onnx/test/test_backend_test.py
+++ b/onnx/test/test_backend_test.py
@@ -38,7 +38,7 @@ class DummyBackend(onnx.backend.base.Backend):
 
 backend_test = onnx.backend.test.BackendTest(DummyBackend, __name__)
 if os.getenv('APPVEYOR'):
-    backend_test.exclude(r'(test_vgg19|test_vgg16)')
+    backend_test.exclude(r'(test_vgg19|test_vgg16|test_bvlc_alexnet_cuda)')
 
 # import all test cases at global scope to make them visible to python.unittest
 globals().update(backend_test


### PR DESCRIPTION
Resolve MemoryError in AppVeyor for now.
See [related issue](https://github.com/onnx/onnx/issues/698) for using CUDA in AppVeyor