### PR TITLE
Proposal: Nested attributes

### DIFF
--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -172,11 +172,13 @@ void check_attribute(
   check_singular_field(s, AttributeProto::STRING);
   check_singular_field(t, AttributeProto::TENSOR);
   check_singular_field(g, AttributeProto::GRAPH);
+  check_singular_field(a, AttributeProto::ATTRIBUTE);
   check_repeated_field(floats, AttributeProto::FLOATS);
   check_repeated_field(ints, AttributeProto::INTS);
   check_repeated_field(strings, AttributeProto::STRINGS);
   check_repeated_field(tensors, AttributeProto::TENSORS);
   check_repeated_field(graphs, AttributeProto::GRAPHS);
+  check_repeated_field(attributes, AttributeProto::ATTRIBUTES);
 
 #undef check_type
 #undef check_singular_field

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -178,6 +178,9 @@ def make_attribute(key, value, doc_string=None):
     elif isinstance(value, GraphProto):
         attr.g.CopyFrom(value)
         attr.type = AttributeProto.GRAPH
+    elif isinstance(value, AttributeProto):
+        attr.a.CopyFrom(value)
+        attr.type = AttributeProto.ATTRIBUTE
     # third, iterable cases
     elif is_iterable:
         byte_array = [_to_bytes_or_false(v) for v in value]
@@ -197,6 +200,9 @@ def make_attribute(key, value, doc_string=None):
         elif all(isinstance(v, GraphProto) for v in value):
             attr.graphs.extend(value)
             attr.type = AttributeProto.GRAPHS
+        elif all(isinstance(v, AttributeProto) for v in value):
+            attr.attributes.extend(value)
+            attr.type = AttributeProto.ATTRIBUTES
         else:
             raise ValueError(
                 "You passed in an iterable attribute but I cannot figure out "

--- a/onnx/onnx.in.proto
+++ b/onnx/onnx.in.proto
@@ -89,12 +89,14 @@ message AttributeProto {
     STRING = 3;
     TENSOR = 4;
     GRAPH = 5;
+    ATTRIBUTE = 11;
 
     FLOATS = 6;
     INTS = 7;
     STRINGS = 8;
     TENSORS = 9;
     GRAPHS = 10;
+    ATTRIBUTES = 12;
   }
 
   // The name field MUST be present for this version of the IR.
@@ -117,14 +119,16 @@ message AttributeProto {
   optional bytes s = 4;               // UTF-8 string
   optional TensorProto t = 5;         // tensor value
   optional GraphProto g = 6;          // graph
+  optional AttributeProto a = 14;     // attribute
   // Do not use field below, it's deprecated.
   // optional ValueProto v = 12;         // value - subsumes everything but graph
 
-  repeated float floats = 7;          // list of floats
-  repeated int64 ints = 8;            // list of ints
-  repeated bytes strings = 9;         // list of UTF-8 strings
-  repeated TensorProto tensors = 10;  // list of tensors
-  repeated GraphProto graphs = 11;    // list of graph
+  repeated float floats = 7;               // list of floats
+  repeated int64 ints = 8;                 // list of ints
+  repeated bytes strings = 9;              // list of UTF-8 strings
+  repeated TensorProto tensors = 10;       // list of tensors
+  repeated GraphProto graphs = 11;         // list of graphs
+  repeated AttributeProto attributes = 15; // list of attributes
 }
 
 // Defines information on value, including the name, the type, and

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -94,12 +94,14 @@ message AttributeProto {
     STRING = 3;
     TENSOR = 4;
     GRAPH = 5;
+    ATTRIBUTE = 11;
 
     FLOATS = 6;
     INTS = 7;
     STRINGS = 8;
     TENSORS = 9;
     GRAPHS = 10;
+    ATTRIBUTES = 12;
   }
 
   // The name field MUST be present for this version of the IR.
@@ -122,14 +124,16 @@ message AttributeProto {
   optional bytes s = 4;               // UTF-8 string
   optional TensorProto t = 5;         // tensor value
   optional GraphProto g = 6;          // graph
+  optional AttributeProto a = 14;     // attribute
   // Do not use field below, it's deprecated.
   // optional ValueProto v = 12;         // value - subsumes everything but graph
 
-  repeated float floats = 7;          // list of floats
-  repeated int64 ints = 8;            // list of ints
-  repeated bytes strings = 9;         // list of UTF-8 strings
-  repeated TensorProto tensors = 10;  // list of tensors
-  repeated GraphProto graphs = 11;    // list of graph
+  repeated float floats = 7;               // list of floats
+  repeated int64 ints = 8;                 // list of ints
+  repeated bytes strings = 9;              // list of UTF-8 strings
+  repeated TensorProto tensors = 10;       // list of tensors
+  repeated GraphProto graphs = 11;         // list of graphs
+  repeated AttributeProto attributes = 15; // list of attributes
 }
 
 // Defines information on value, including the name, the type, and

--- a/onnx/onnx.proto3
+++ b/onnx/onnx.proto3
@@ -94,12 +94,14 @@ message AttributeProto {
     STRING = 3;
     TENSOR = 4;
     GRAPH = 5;
+    ATTRIBUTE = 11;
 
     FLOATS = 6;
     INTS = 7;
     STRINGS = 8;
     TENSORS = 9;
     GRAPHS = 10;
+    ATTRIBUTES = 12;
   }
 
   // The name field MUST be present for this version of the IR.
@@ -122,14 +124,16 @@ message AttributeProto {
   bytes s = 4;               // UTF-8 string
   TensorProto t = 5;         // tensor value
   GraphProto g = 6;          // graph
+  AttributeProto a = 14;     // attribute
   // Do not use field below, it's deprecated.
   // optional ValueProto v = 12;         // value - subsumes everything but graph
 
-  repeated float floats = 7;          // list of floats
-  repeated int64 ints = 8;            // list of ints
-  repeated bytes strings = 9;         // list of UTF-8 strings
-  repeated TensorProto tensors = 10;  // list of tensors
-  repeated GraphProto graphs = 11;    // list of graph
+  repeated float floats = 7;               // list of floats
+  repeated int64 ints = 8;                 // list of ints
+  repeated bytes strings = 9;              // list of UTF-8 strings
+  repeated TensorProto tensors = 10;       // list of tensors
+  repeated GraphProto graphs = 11;         // list of graphs
+  repeated AttributeProto attributes = 15; // list of attributes
 }
 
 // Defines information on value, including the name, the type, and

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -74,6 +74,16 @@ class TestHelperAttributeFunctions(unittest.TestCase):
         self.assertEqual(attr.s, b"test")
         checker.check_attribute(attr)
 
+    def test_attr_attribute(self):
+        # nested attribute
+        nested_attr = helper.make_attribute("str", "test")
+        attr = helper.make_attribute("attr", nested_attr)
+
+        self.assertEqual(attr.name, "attr")
+        self.assertEqual(attr.a.name, "str")
+        self.assertEqual(attr.a.s, b"test")
+        checker.check_attribute(attr)
+
     def test_attr_repeated_float(self):
         attr = helper.make_attribute("floats", [1.0, 2.0])
         self.assertEqual(attr.name, "floats")
@@ -118,6 +128,16 @@ class TestHelperAttributeFunctions(unittest.TestCase):
         attr = helper.make_attribute("graphs", graphs)
         self.assertEqual(attr.name, "graphs")
         self.assertEqual(list(attr.graphs), graphs)
+        checker.check_attribute(attr)
+
+    def test_attr_repeated_attribute_proto(self):
+        # nested attributes
+        attributes = [helper.make_attribute("str1", "test1"),
+                      helper.make_attribute("str2", "test2")]
+
+        attr = helper.make_attribute("attributes", attributes)
+        self.assertEqual(attr.name, "attributes")
+        self.assertEqual(list(attr.attributes), attributes)
         checker.check_attribute(attr)
 
     def test_is_attr_legal(self):


### PR DESCRIPTION
There are scenarios where a custom `Node` can contain a complex set of Attributes. We propose an extension of ONNX `AttributeProto` to allow attribute nesting.

For example, if we wanted to implement a `Node`, which fuses convolution and pooling, we would need to store attributes such as `kernel_shape` for both operations. Using nested attributes we could store these attributes in nested groups as follows:

```
op_type: "com.acme.ConvPool"
attribute {
  name: "conv"
  attributes {
    name: "strides"
    ints: 1
    ints: 1
    type: INTS
  }
  attributes {
    name: "kernel_shape"
    ints: 3
    ints: 3
    type: INTS
  }
  type: ATTRIBUTES
}
attribute {
  name: "pool"
  attributes {
    name: "strides"
    ints: 1
    ints: 1
    type: INTS
  }
  attributes {
    name: "kernel_shape"
    ints: 8
    ints: 8
    type: INTS
  }
  type: ATTRIBUTES
}
```