### PR TITLE
Use cmake3 if it's available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ ONNX_NAMESPACE = os.getenv('ONNX_NAMESPACE', DEFAULT_ONNX_NAMESPACE)
 
 WINDOWS = (os.name == 'nt')
 
-CMAKE = find_executable('cmake')
+CMAKE = find_executable('cmake3') or find_executable('cmake')
 MAKE = find_executable('make')
 
 install_requires = []


### PR DESCRIPTION
on centos7 cmake3 is available as the command "cmake3" instead of "cmake"