### PR TITLE
Tile - align with numpy

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -4877,7 +4877,9 @@ This version of the operator has been available since version 1 of the default O
 
 ### <a name="Tile-1"></a>**Tile-1**</a>
 
-  Repeat the elements of a tensor along an axis.
+  Constructs a tensor by tiling a given tensor.
+  This is the same as function `tile` in Numpy, but no broadcast.
+  For example A = [[1, 2], [3, 4]], B = [1, 2], tile(A, B) = [[1, 2, 1, 2], [3, 4, 3, 4]]
 
 #### Version
 
@@ -4888,24 +4890,24 @@ This version of the operator has been available since version 1 of the default O
 <dl>
 <dt><tt>input</tt> : T</dt>
 <dd>Input tensor of any shape.</dd>
-<dt><tt>tiles</tt> : T</dt>
-<dd>Number of repeated copies to make of the input tensor.</dd>
-<dt><tt>axis</tt> : T</dt>
-<dd>Axis along which to repeat.</dd>
+<dt><tt>repeats</tt> : T1</dt>
+<dd>1D int64 tensor of the same length as input's dimension number, includes numbers of repeated copies along input's dimensions.</dd>
 </dl>
 
 #### Outputs
 
 <dl>
 <dt><tt>output</tt> : T</dt>
-<dd>Output tensor of same shape and type as input.</dd>
+<dd>Output tensor of the same dimension and type as tensor input. output_dim[i] = input_dim[i] * repeats[i]</dd>
 </dl>
 
 #### Type Constraints
 
 <dl>
 <dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input types to float tensors.</dd>
+<dd>Constrain input and output's types to float tensors.</dd>
+<dt><tt>T1</tt> : tensor(int64)</dt>
+<dd>Constrain repeat's type to int64 tensors.</dd>
 </dl>
 
 ### <a name="TopK-1"></a>**TopK-1**</a>

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -7369,7 +7369,9 @@ expect(node, inputs=[x], outputs=[y],
 
 ### <a name="Tile"></a><a name="tile">**Tile**</a>
 
-  Repeat the elements of a tensor along an axis.
+  Constructs a tensor by tiling a given tensor.
+  This is the same as function `tile` in Numpy, but no broadcast.
+  For example A = [[1, 2], [3, 4]], B = [1, 2], tile(A, B) = [[1, 2, 1, 2], [3, 4, 3, 4]]
 
 #### Version
 
@@ -7380,24 +7382,24 @@ This version of the operator has been available since version 1 of the default O
 <dl>
 <dt><tt>input</tt> : T</dt>
 <dd>Input tensor of any shape.</dd>
-<dt><tt>tiles</tt> : T</dt>
-<dd>Number of repeated copies to make of the input tensor.</dd>
-<dt><tt>axis</tt> : T</dt>
-<dd>Axis along which to repeat.</dd>
+<dt><tt>repeats</tt> : T1</dt>
+<dd>1D int64 tensor of the same length as input's dimension number, includes numbers of repeated copies along input's dimensions.</dd>
 </dl>
 
 #### Outputs
 
 <dl>
 <dt><tt>output</tt> : T</dt>
-<dd>Output tensor of same shape and type as input.</dd>
+<dd>Output tensor of the same dimension and type as tensor input. output_dim[i] = input_dim[i] * repeats[i]</dd>
 </dl>
 
 #### Type Constraints
 
 <dl>
 <dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input types to float tensors.</dd>
+<dd>Constrain input and output's types to float tensors.</dd>
+<dt><tt>T1</tt> : tensor(int64)</dt>
+<dd>Constrain repeat's type to int64 tensors.</dd>
 </dl>
 
 

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -690,16 +690,32 @@ and width dimensions.
         "Constrain input types to float tensors.");
 
 ONNX_OPERATOR_SCHEMA(Tile)
-    .SetDoc(R"DOC(Repeat the elements of a tensor along an axis.)DOC")
-    .Input(0, "input", "Input tensor of any shape.", "T")
+    .SetDoc(R"DOC(Constructs a tensor by tiling a given tensor.
+This is the same as function `tile` in Numpy, but no broadcast.
+For example A = [[1, 2], [3, 4]], B = [1, 2], tile(A, B) = [[1, 2, 1, 2], [3, 4, 3, 4]]
+)DOC")
+    .Input(
+        0,
+        "input",
+        "Input tensor of any shape.",
+        "T")
     .Input(
         1,
-        "tiles",
-        "Number of repeated copies to make of the input tensor.",
+        "repeats",
+        "1D int64 tensor of the same length as input's dimension number, "
+        "includes numbers of repeated copies along input's dimensions.",
+        "T1")
+    .Output(
+        0,
+        "output",
+        "Output tensor of the same dimension and type as tensor input. "
+        "output_dim[i] = input_dim[i] * repeats[i]",
         "T")
-    .Input(2, "axis", "Axis along which to repeat.", "T")
-    .Output(0, "output", "Output tensor of same shape and type as input.", "T")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input types to float tensors.");
+        "Constrain input and output's types to float tensors.")
+    .TypeConstraint(
+        "T1",
+        {"tensor(int64)"},
+        "Constrain repeat's type to int64 tensors.");

--- a/onnx/optimizer/passes/fuse_add_bias_into_conv.h
+++ b/onnx/optimizer/passes/fuse_add_bias_into_conv.h
@@ -85,20 +85,9 @@ struct FuseAddBiasIntoConv final : public OptimizePass {
             constant1->output()->setSizes(s1);
             constant1->output()->setElemType(TensorProto_DataType_INT64);
             constant1->insertBefore(orig_conv->node());
-            Node* constant2 = graph.create(kConstant, 1);
-            Tensor t2;
-            t2.sizes().push_back(static_cast<int64_t>(1));
-            t2.int64s().push_back(0);
-            t2.elem_type() = TensorProto_DataType_INT64;
-            constant2->t_(sym, t2);
-            std::vector<Dimension> s2 = {1};
-            constant2->output()->setSizes(s2);
-            constant2->output()->setElemType(TensorProto_DataType_INT64);
-            constant2->insertBefore(orig_conv->node());
             Node* tile = graph.create(kTile, 1);
             tile->addInput(orig_bias);
             tile->addInput(constant1->output());
-            tile->addInput(constant2->output());
             tile->insertBefore(orig_conv->node());
             orig_conv->node()->addInput(tile->output());
           } else if (bias_shape[0].dim == M &&

--- a/onnx/test/optimizer_test.py
+++ b/onnx/test/optimizer_test.py
@@ -257,16 +257,13 @@ class TestOptimizer(unittest.TestCase):
         )
         optimized_model = self._optimized(graph, ["fuse_add_bias_into_conv"])
 
-        assert len(list(optimized_model.graph.node)) == 4
-        assert len(optimized_model.graph.value_info) == 2
+        assert len(list(optimized_model.graph.node)) == 3
+        assert len(optimized_model.graph.value_info) == 1
         assert optimized_model.graph.value_info[0].type.tensor_type.elem_type == TensorProto.INT64
-        assert optimized_model.graph.value_info[1].type.tensor_type.elem_type == TensorProto.INT64
         assert len(optimized_model.graph.value_info[0].type.tensor_type.shape.dim) == 1
-        assert len(optimized_model.graph.value_info[1].type.tensor_type.shape.dim) == 1
         assert optimized_model.graph.node[0].op_type == 'Constant'
-        assert optimized_model.graph.node[1].op_type == 'Constant'
-        assert optimized_model.graph.node[2].op_type == 'Tile'
-        assert optimized_model.graph.node[3].op_type == 'Conv'
+        assert optimized_model.graph.node[1].op_type == 'Tile'
+        assert optimized_model.graph.node[2].op_type == 'Conv'
         assert optimized_model.graph.output[0].name == 'Z'
 
     def test_fuse_add_bias_into_conv_use_conv_shape(self):


### PR DESCRIPTION
~~Change the type and description of 2nd and 3rd inputs.~~

With more investigation, most existing frameworks aligned with numpy. So I aligned our spec with numpy, too. Numpy strongly suggests not using broadcast in tile. In our spec, broadcast is not supported.