### PR TITLE
Try using pep518 to install the protobuf build dependency

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -49,4 +49,4 @@ pip install -U pip setuptools
 
 pip list --outdated --format=freeze | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip install -U
 
-pip install pytest-cov nbval protobuf
+pip install pytest-cov nbval

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = ["setuptools", "wheel", "protobuf"]


### PR DESCRIPTION
This PR is to try out if this would work with pip on CI.

An alternative is: https://github.com/onnx/onnx/pull/783