### PR TITLE
Try using setup_requires to install protobuf build time dependency

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -49,4 +49,4 @@ pip install -U pip setuptools
 
 pip list --outdated --format=freeze | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip install -U
 
-pip install pytest-cov nbval protobuf
+pip install pytest-cov nbval

--- a/setup.py
+++ b/setup.py
@@ -263,6 +263,7 @@ install_requires.extend([
 ################################################################################
 
 setup_requires.append('pytest-runner')
+setup_requires.append('protobuf')
 tests_require.append('pytest-cov')
 tests_require.append('nbval')
 tests_require.append('tabulate')


### PR DESCRIPTION
This PR is to try out if this would work with pip on CI.

An alternative is: https://github.com/onnx/onnx/pull/782