### PR TITLE
Make proto_utils compatible for old version of protobuf

### DIFF
--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -22,9 +22,7 @@ inline bool getRepeatedAttribute(InferenceContext& ctx,
                                  std::vector<T>& values) {
   const auto* attr = ctx.getAttribute(attr_name);
   if (attr) {
-    for (const auto& value : RetrieveValues<T>(*attr)) {
-      values.push_back(value);
-    }
+    values = RetrieveValues<T>(*attr);
     return true;
   } else {
     return false;

--- a/onnx/proto_utils.h
+++ b/onnx/proto_utils.h
@@ -33,7 +33,9 @@ bool ParseProtoFromBytes(Proto* proto, const char* buffer, size_t length) {
   return proto->ParseFromCodedStream(&coded_stream);
 }
 
-template<typename T> inline google::protobuf::RepeatedField<T> RetrieveValues(const AttributeProto& attr);
-template<> inline google::protobuf::RepeatedField<int64_t> RetrieveValues(const AttributeProto& attr) { return attr.ints(); }
+template<typename T> inline std::vector<T> RetrieveValues(const AttributeProto& attr);
+template<> inline std::vector<int64_t> RetrieveValues(const AttributeProto& attr) {
+    return {attr.ints().begin(), attr.ints().end()};
+}
 
 } // namespace ONNX_NAMESPACE


### PR DESCRIPTION
old version protobuf uses `long long` as int64 type, new version uses `int64_t` and `RepeatedField<long long>` can not be converted to `RepeatedField<int64_t>`