### PR TITLE
Use ONNX_NAMESPACE::to_string instead of std::to_string

### DIFF
--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -1,6 +1,6 @@
 #include "onnx/checker.h"
 #include "onnx/proto_utils.h"
-
+#include "onnx/string_utils.h"
 #include "onnx/defs/schema.h"
 
 #include <unordered_set>

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -2,6 +2,7 @@
 
 #include "onnx/defs/data_type_utils.h"
 #include "onnx/proto_utils.h"
+#include "onnx/string_utils.h"
 
 namespace ONNX_NAMESPACE {
 
@@ -102,7 +103,7 @@ inline void propagateShapeFromInputToOutput(
       TypeProto::kTensorType != output_type->value_case()) {
     throw std::runtime_error(
         "zhangke: " +
-        std::to_string(
+        ONNX_NAMESPACE::to_string(
             ctx.getInputType(inputIndex)->tensor_type().shape().dim_size()));
     return;
   }

--- a/onnx/shape_inference/implementation.h
+++ b/onnx/shape_inference/implementation.h
@@ -2,6 +2,7 @@
 
 #include "onnx/defs/schema.h"
 #include "onnx/proto_utils.h"
+#include "onnx/string_utils.h"
 
 namespace ONNX_NAMESPACE {
 namespace shape_inference {


### PR DESCRIPTION
caffe2_benchmark.cc build is failing on android because of use of std::to_string. This PR fixes it