### PR TITLE
Extend optimizer passes to recursively descend on GraphProto attributes

### DIFF
--- a/onnx/optimizer/passes/eliminate_identity.h
+++ b/onnx/optimizer/passes/eliminate_identity.h
@@ -15,6 +15,7 @@ struct EliminateIdentity final : public OptimizePass {
   void eliminate_identity(Graph& graph) {
     for (auto it = graph.begin(); it != graph.end(); ++it) {
       auto* n = *it;
+      DescendOnGraphAttributes(n, [this](Graph& g){eliminate_identity(g);});
       if (n->kind() == kIdentity) {
         n->output()->replaceAllUsesWith(n->input());
         it.destroyCurrent();

--- a/onnx/optimizer/passes/eliminate_nop_transpose.h
+++ b/onnx/optimizer/passes/eliminate_nop_transpose.h
@@ -22,10 +22,10 @@ struct EliminateNopTranspose final : public OptimizePass {
   void eliminate_nop_transpose(Graph& graph) {
     for (auto it = graph.begin(); it != graph.end(); ++it) {
       auto* n = *it;
-
+      DescendOnGraphAttributes(n, [this](Graph& g){eliminate_nop_transpose(g);});
       if (n->kind() == kTranspose && n->hasAttribute(kperm)) {
         if (is_nop_transpose(n->is(kperm))) {
-          n->replaceAllUsesWith(n->input()->node());
+          n->output()->replaceAllUsesWith(n->input());
           it.destroyCurrent();
           continue;
         }

--- a/onnx/optimizer/passes/fuse_add_bias_into_conv.h
+++ b/onnx/optimizer/passes/fuse_add_bias_into_conv.h
@@ -28,6 +28,7 @@ struct FuseAddBiasIntoConv final : public OptimizePass {
     int size_lack_count = 0;
     for (auto it = graph.begin(); it != graph.end(); ++it) {
       auto* n = *it;
+      DescendOnGraphAttributes(n, [this](Graph& g){fuse_add_bias_into_conv(g);});
       if (n->kind() == kAdd && n->inputs()[0]->node()->kind() == kConv
           && n->inputs()[0]->node()->inputs().size() == 2) {
         // due to current broadcasting's constraint, Conv has to be the first oprand

--- a/onnx/optimizer/passes/fuse_consecutive_transposes.h
+++ b/onnx/optimizer/passes/fuse_consecutive_transposes.h
@@ -30,6 +30,7 @@ struct FuseConsecutiveTransposes final : public OptimizePass {
   void fuse_consecutive_transposes(Graph& graph) {
     for (auto it = graph.begin(); it != graph.end(); ++it) {
       auto* n = *it;
+      DescendOnGraphAttributes(n, [this](Graph& g){fuse_consecutive_transposes(g);});
       if (n->kind() == kTranspose && n->input()->node()->kind() == kTranspose) {
         auto origInput = n->input();
         if (!n->hasAttribute(kperm) && !origInput->node()->hasAttribute(kperm)) {

--- a/onnx/optimizer/passes/fuse_transpose_into_gemm.h
+++ b/onnx/optimizer/passes/fuse_transpose_into_gemm.h
@@ -17,6 +17,7 @@ struct FuseTransposeIntoGemm final : public OptimizePass {
 
     for (auto it = graph.begin(); it != graph.end(); ++it) {
       auto* n = *it;
+      DescendOnGraphAttributes(n, [this](Graph& g){fuse_transpose_into_gemm(g);});
 
       if (n->kind() == kGemm) {
         for (size_t i : {0,1}) {

--- a/onnx/optimizer/passes/optimize_pass.h
+++ b/onnx/optimizer/passes/optimize_pass.h
@@ -27,6 +27,20 @@ struct OptimizePass {
 
   virtual void optimize(Graph& /*graph*/) {}
 
+  void DescendOnGraphAttributes(Node * n, std::function<void(Graph&)> fn) {
+    for (auto name : n->attributeNames()) {
+      auto kind = n->kindOf(name);
+      if (kind == AttributeKind::g) {
+        fn(*n->g(name));
+      }
+      if (kind == AttributeKind::gs) {
+        for (auto & g  : n->gs(name)) {
+          fn(*g);
+        }
+      }
+    }
+  }
+
 };
 
 inline OptimizePass::~OptimizePass() noexcept = default;

--- a/onnx/test/optimizer_test.py
+++ b/onnx/test/optimizer_test.py
@@ -19,19 +19,69 @@ class TestOptimizer(unittest.TestCase):
         checker.check_model(optimized_model)
         return optimized_model
 
+    # input_types and output_types are lists of triples of (name, type, shape)
+    def _make_fake_loop_op(self, body_nodes, input_types, output_types):
+        zero = helper.make_tensor("trip_count_value", TensorProto.INT32, (), [10])
+        true = helper.make_tensor("condition", TensorProto.BOOL, (), [True])
+        # lcd is a dummy loop-carried dependency that only exists because
+        # right now the schema checker is broken and assumes a variadic
+        # input needs at least one value.
+        graph_inputs = [helper.make_tensor_value_info("i", TensorProto.INT32, ()),
+                        helper.make_tensor_value_info("cond", TensorProto.BOOL, ())]
+        for type, shape, name in input_types:
+            graph_inputs.append(helper.make_tensor_value_info("_" + name, type, shape))
+        graph_outputs = [helper.make_tensor_value_info("cond", TensorProto.BOOL, ())]
+        for type, shape, name in output_types:
+            graph_outputs.append(helper.make_tensor_value_info("_" + name, type, shape))
+        body_graph = helper.make_graph(body_nodes, "body_graph", graph_inputs,
+                                       graph_outputs)
+        loop_inputs = ["trip_count", "condition"]
+        loop_inputs.extend([name for _, _, name in input_types])
+        loop_outputs = [name for _, _, name in output_types]
+        retval_nodes = [
+            helper.make_node("Constant", [], ["trip_count"], value=zero),
+            helper.make_node("Constant", [], ["condition"], value=true),
+            helper.make_node("Loop", loop_inputs, loop_outputs, body=body_graph)
+        ]
+        return retval_nodes
+
+    # fn is a function that takes a single node as argument
+    def _visit_all_nodes_recursive(self, graph, fn):
+        for node in graph.node:
+            fn(node)
+            for attr in node.attribute:
+                if attr.g is not None:
+                    self._visit_all_nodes_recursive(attr.g, fn)
+                if len(attr.graphs):
+                    for gr in attr.graphs:
+                        self._visit_all_nodes_recursive(gr, fn)
+
     def test_eliminate_identity_single_use(self):
-        identity = helper.make_node("Identity", ["X"], ["Y"])
+        nodes = [helper.make_node("Identity", ["X"], ["Y"])]
+        nodes.extend(self._make_fake_loop_op(
+            [helper.make_node("Identity", ["_Y"], ["_Y2"])],
+            [(TensorProto.FLOAT, (5,), "Y")],
+            [(TensorProto.FLOAT, (5,), "Y2")]))
         graph = helper.make_graph(
-            [identity],
+            nodes,
             "test",
             [helper.make_tensor_value_info("X", TensorProto.FLOAT, (5,))],
-            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, (5,))])
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, (5,)),
+             helper.make_tensor_value_info("Y2", TensorProto.FLOAT, (5,))])
         optimized_model = self._optimized(graph, ["eliminate_identity"])
 
-        for node in optimized_model.graph.node:
+        # All identity nodes should have been eliminated
+        def check_identity(node):
             assert node.op_type != "Identity"
+        self._visit_all_nodes_recursive(optimized_model.graph, check_identity)
+        # Use of the output from the Identity node in the main graph should
+        # have been replaced with the input to the identity node
+        assert len(optimized_model.graph.output) == 2
         assert optimized_model.graph.output[0].name == "X"
-        assert len(optimized_model.graph.node) == 0
+        # Use of the output from the Identity node in the loop graph should
+        # have been replaced with the input to that identity node
+        assert len(optimized_model.graph.node[2].attribute[0].g.output) == 2
+        assert optimized_model.graph.node[2].attribute[0].g.output[1].name == "_Y"
 
     def test_eliminate_identity_multiple_uses(self):
         identity = helper.make_node("Identity", ["X"], ["Y"])
@@ -50,16 +100,30 @@ class TestOptimizer(unittest.TestCase):
         assert len(optimized_model.graph.node) == 2
 
     def test_nop_transpose(self):
-        trans = helper.make_node("Transpose", ["X"], ["Y"], perm=[0, 1])
+        nodes = [helper.make_node("Transpose", ["X"], ["Y"], perm=[0, 1])]
+        nodes.extend(self._make_fake_loop_op(
+            [helper.make_node("Transpose", ["_Y"], ["_Y2"], perm=[0, 1])],
+            [(TensorProto.FLOAT, (2, 3), "Y")],
+            [(TensorProto.FLOAT, (2, 3), "Y2")]))
         graph = helper.make_graph(
-            [trans],
+            nodes,
             "test",
             [helper.make_tensor_value_info("X", TensorProto.FLOAT, (2, 3))],
-            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, (2, 3))])
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, (2, 3)),
+             helper.make_tensor_value_info("Y2", TensorProto.FLOAT, (2, 3))])
         optimized_model = self._optimized(graph, ["eliminate_nop_transpose"])
 
-        for node in optimized_model.graph.node:
+        def check_transpose(node):
             assert node.op_type != "Transpose"
+        self._visit_all_nodes_recursive(optimized_model.graph, check_transpose)
+        # Use of the output from the Transpose node in the main graph should
+        # have been replaced with the input to the identity node
+        assert len(optimized_model.graph.output) == 2
+        assert optimized_model.graph.output[0].name == "X"
+        # Use of the output from the Transpose node in the loop graph should
+        # have been replaced with the input to that identity node
+        assert len(optimized_model.graph.node[2].attribute[0].g.output) == 2
+        assert optimized_model.graph.node[2].attribute[0].g.output[1].name == "_Y"
 
     def test_nop_transpose_default(self):
         trans = helper.make_node("Transpose", ["X"], ["Y"])
@@ -74,17 +138,27 @@ class TestOptimizer(unittest.TestCase):
         assert optimized_model.graph.node[0].op_type == "Transpose"
 
     def test_fuse_transpose(self):
-        trans1 = helper.make_node("Transpose", ["X"], ["Y"], perm=[1, 0, 2])
-        trans2 = helper.make_node("Transpose", ["Y"], ["Z"], perm=[2, 0, 1])
-        trans3 = helper.make_node("Transpose", ["Z"], ["A"], perm=[2, 0, 1])
+        nodes = [helper.make_node("Transpose", ["X"], ["Y"], perm=[1, 0, 2]),
+                 helper.make_node("Transpose", ["Y"], ["Z"], perm=[2, 0, 1]),
+                 helper.make_node("Transpose", ["Z"], ["A"], perm=[2, 0, 1])]
+        nodes.extend(self._make_fake_loop_op(
+            [helper.make_node("Transpose", ["_X"], ["_Y2"], perm=[1, 0, 2]),
+             helper.make_node("Transpose", ["_Y2"], ["_Y3"], perm=[2, 0, 1]),
+             helper.make_node("Transpose", ["_Y3"], ["_Y4"], perm=[2, 0, 1])],
+            [(TensorProto.FLOAT, (2, 3), "X")],
+            [(TensorProto.FLOAT, (2, 3), "Y4")]))
         graph = helper.make_graph(
-            [trans1, trans2, trans3],
+            nodes,
             "test",
             [helper.make_tensor_value_info("X", TensorProto.FLOAT, (2, 3, 4))],
-            [helper.make_tensor_value_info("A", TensorProto.FLOAT, (4, 3, 2))])
+            [helper.make_tensor_value_info("A", TensorProto.FLOAT, (4, 3, 2)),
+             helper.make_tensor_value_info("Y4", TensorProto.FLOAT, (4, 3, 2))])
         optimized_model = self._optimized(graph, ["fuse_consecutive_transposes"])
 
-        assert len(list(optimized_model.graph.node)) == 1
+        # Transpose, Constant (trip count), Constant (cond), Loop
+        assert len(list(optimized_model.graph.node)) == 4
+        # Transpose
+        assert len(optimized_model.graph.node[3].attribute[0].g.node) == 1
 
     def test_fuse_transpose_default(self):
         trans1 = helper.make_node("Transpose", ["X"], ["Y"])
@@ -113,11 +187,19 @@ class TestOptimizer(unittest.TestCase):
             assert node.op_type == "Transpose"
 
     def test_fuse_transpose_into_gemm(self):
-        trans1 = helper.make_node("Transpose", ["X"], ["A"], perm=[1, 0])
-        trans2 = helper.make_node("Transpose", ["Y"], ["B"], perm=[1, 0])
-        gemm = helper.make_node("Gemm", ["A", "B", "C"], ["Z"])
+        nodes = [helper.make_node("Transpose", ["X"], ["A"], perm=[1, 0]),
+                 helper.make_node("Transpose", ["Y"], ["B"], perm=[1, 0]),
+                 helper.make_node("Gemm", ["A", "B", "C"], ["Z"])]
+        nodes.extend(self._make_fake_loop_op(
+            [helper.make_node("Transpose", ["_X"], ["_A"], perm=[1, 0]),
+             helper.make_node("Transpose", ["_Y"], ["_B"], perm=[1, 0]),
+             helper.make_node("Gemm", ["_A", "_B", "_C"], ["_Z2"])],
+            [(TensorProto.FLOAT, (2, 3), "X"),
+             (TensorProto.FLOAT, (5, 2), "Y"),
+             (TensorProto.FLOAT, (3, 5), "C")],
+            [(TensorProto.FLOAT, (2, 3), "Z2")]))
         graph = helper.make_graph(
-            [trans1, trans2, gemm],
+            nodes,
             "test",
             [helper.make_tensor_value_info("X", TensorProto.FLOAT, (2, 3)),
              helper.make_tensor_value_info("Y", TensorProto.FLOAT, (5, 2)),
@@ -125,14 +207,25 @@ class TestOptimizer(unittest.TestCase):
             [helper.make_tensor_value_info("Z", TensorProto.FLOAT, (3, 5))])
         optimized_model = self._optimized(graph, ["fuse_transpose_into_gemm"])
 
-        assert len(list(optimized_model.graph.node)) == 1
+        # Gemm, Constant (trip count), Constant (cond), Loop
+        assert len(list(optimized_model.graph.node)) == 4
         assert optimized_model.graph.node[0].op_type == "Gemm"
+        # Gemm
+        assert len(optimized_model.graph.node[3].attribute[0].g.node) == 1
+        assert optimized_model.graph.node[3].attribute[0].g.node[0].op_type == "Gemm"
 
     def test_fuse_add_bias_into_conv_use_weight_shape(self):
-        conv = helper.make_node("Conv", ["X", "Y"], ["Z"])
-        add = helper.make_node("Add", ["Z", "A"], ["B"], broadcast=1, axis=1)
+        nodes = [helper.make_node("Conv", ["X", "Y"], ["Z"]),
+                 helper.make_node("Add", ["Z", "A"], ["B"], broadcast=1, axis=1)]
+        nodes.extend(self._make_fake_loop_op(
+            [helper.make_node("Conv", ["_X", "_Y"], ["_Z"]),
+             helper.make_node("Add", ["_Z", "_A"], ["_B2"], broadcast=1, axis=1)],
+            [(TensorProto.FLOAT, (1, 5, 3, 3), "X"),
+             (TensorProto.FLOAT, (16, 5, 3, 3), "Y"),
+             (TensorProto.FLOAT, (16,), "A")],
+            [(TensorProto.FLOAT, (1, 16, 3, 3), "B2")]))
         graph = helper.make_graph(
-            [conv, add],
+            nodes,
             "test",
             [helper.make_tensor_value_info("X", TensorProto.FLOAT, (1, 5, 3, 3)),
              helper.make_tensor_value_info("Y", TensorProto.FLOAT, (16, 5, 3, 3)),
@@ -141,9 +234,15 @@ class TestOptimizer(unittest.TestCase):
         )
         optimized_model = self._optimized(graph, ["fuse_add_bias_into_conv"])
 
-        assert len(list(optimized_model.graph.node)) == 1
+        # Conv, Constant (trip count), Constant (condition), Loop
+        assert len(list(optimized_model.graph.node)) == 4
         assert optimized_model.graph.node[0].op_type == 'Conv'
         assert optimized_model.graph.output[0].name == 'Z'
+        # Conv
+        assert len(optimized_model.graph.node[3].attribute[0].g.node) == 1
+        assert optimized_model.graph.node[3].attribute[0].g.node[0].op_type == 'Conv'
+        # Output 1 since 0 is 'cond'
+        assert optimized_model.graph.node[3].attribute[0].g.output[1].name == '_Z'
 
     def test_fuse_add_bias_into_conv_use_weight_shape_with_tile(self):
         conv = helper.make_node("Conv", ["X", "Y"], ["Z"])


### PR DESCRIPTION
This allows us to properly handle optimizing the body of control operators.

For the moment, we've skipped applying this to the `Split` pass. This is because doing so would turn that pass into a true loop-invariant hoisting pass. This introduces issues in that we can no longer assume that the graphs we are splitting are run at least once (as we've assumed for the existing split pass). This can cause operations that can fault to be hoisted out, when in reality they may never have been run under normal conditions.