### PR TITLE
Pass to lift captured values as inputs to control nodes

### DIFF
--- a/onnx/common/interned_strings.h
+++ b/onnx/common/interned_strings.h
@@ -128,7 +128,14 @@ _(trunc) \
 _(zeros) \
 _(exponent) \
 _(device) \
-_(Identity)
+_(Identity) \
+_(Loop) \
+_(If) \
+_(body) \
+_(then_branch) \
+_(else_branch) \
+_(Captured) \
+_(__num_control_inputs)
 
 enum BuiltinSymbol {
   #define DEFINE_SYMBOL(s) \

--- a/onnx/common/interned_strings.h
+++ b/onnx/common/interned_strings.h
@@ -135,7 +135,7 @@ _(body) \
 _(then_branch) \
 _(else_branch) \
 _(Captured) \
-_(__num_control_inputs)
+_(__control_inputs)
 
 enum BuiltinSymbol {
   #define DEFINE_SYMBOL(s) \

--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -1074,4 +1074,5 @@ inline const_graph_node_list_iterator Node::reverseIterator() const {
   return iterator().reverse();
 }
 
+
 } // namespace ONNX_NAMESPACE

--- a/onnx/common/ir_pb_converter.cc
+++ b/onnx/common/ir_pb_converter.cc
@@ -6,7 +6,7 @@
 namespace ONNX_NAMESPACE {
 
 // Part 1: convert ONNX Protobuf to IR
-std::unique_ptr<Graph> graphProtoToGraph(const ONNX_NAMESPACE::GraphProto& gp);
+std::unique_ptr<Graph> graphProtoToGraph(const ONNX_NAMESPACE::GraphProto& gp, bool nested=false);
 
 Tensor tensorProtoToTensor(const ONNX_NAMESPACE::TensorProto & tp) {
   Tensor ret;
@@ -140,13 +140,13 @@ void convertAttribute(const ONNX_NAMESPACE::AttributeProto & ap, Node * n) {
     break;
   }
   case ONNX_NAMESPACE::AttributeProto_AttributeType_GRAPH:
-    n->g_(sym, graphProtoToGraph(ap.g()));
+    n->g_(sym, graphProtoToGraph(ap.g(), true));
     break;
   case ONNX_NAMESPACE::AttributeProto_AttributeType_GRAPHS: {
     std::vector<std::shared_ptr<Graph>> graphs;
     graphs.reserve(ap.graphs_size());
     for (int i = 0; i < ap.graphs_size(); i++) {
-      graphs.push_back(graphProtoToGraph(ap.graphs(i)));
+      graphs.push_back(graphProtoToGraph(ap.graphs(i), true));
     }
     n->gs_(sym, std::move(graphs));
     break;
@@ -176,7 +176,7 @@ std::vector<Dimension> tensorShapeProtoToDimensions(const ONNX_NAMESPACE::Tensor
   return dims;
 }
 
-std::unique_ptr<Graph> graphProtoToGraph(const ONNX_NAMESPACE::GraphProto& gp) {
+std::unique_ptr<Graph> graphProtoToGraph(const ONNX_NAMESPACE::GraphProto& gp, bool nested) {
   std::unique_ptr<Graph> g(new Graph());
 
   if (gp.has_name()) {
@@ -260,7 +260,16 @@ std::unique_ptr<Graph> graphProtoToGraph(const ONNX_NAMESPACE::GraphProto& gp) {
       continue;
     }
     for (auto input : search->second) {
-      n->addInput(value_by_name_of[input]);
+      if (!value_by_name_of.count(input) && nested) {
+        // Undefined reference to an input in a nested block. This may be a
+        // captured value. Create a dummy node that we ignore later.
+        auto * undef = g->create(kCaptured, 1);
+        g->appendNode(undef);
+        undef->outputs()[0]->setUniqueName(input);
+        value_by_name_of[input] = undef->outputs()[0];
+      }
+
+      n->addInput(value_by_name_of.at(input));
     }
   }
 
@@ -472,7 +481,7 @@ void encodeGraph(ONNX_NAMESPACE::GraphProto * p_g, const std::shared_ptr<Graph> 
   std::unordered_set<Value*> graph_outputs(g->outputs().begin(), g->outputs().end());
 
   for (auto node : g->nodes()) {
-    if (node->kind() == kUndefined) {
+    if (node->kind() == kUndefined || node->kind() == kCaptured) {
       // Undefined nodes are used to represent optional inputs that are not provided.
       continue;
     }

--- a/onnx/common/ir_pb_converter.cc
+++ b/onnx/common/ir_pb_converter.cc
@@ -6,7 +6,7 @@
 namespace ONNX_NAMESPACE {
 
 // Part 1: convert ONNX Protobuf to IR
-std::unique_ptr<Graph> graphProtoToGraph(const ONNX_NAMESPACE::GraphProto& gp, bool nested=false);
+std::unique_ptr<Graph> graphProtoToGraph(const ONNX_NAMESPACE::GraphProto& gp, bool nested);
 
 Tensor tensorProtoToTensor(const ONNX_NAMESPACE::TensorProto & tp) {
   Tensor ret;
@@ -299,7 +299,7 @@ std::unique_ptr<Graph> ImportModelProto(const ONNX_NAMESPACE::ModelProto& mp) {
     return nullptr;
   }
 
-  return graphProtoToGraph(mp.graph());
+  return graphProtoToGraph(mp.graph(), false);
 }
 
 

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -142,6 +142,11 @@ void OpSchema::Verify(const NodeProto& node) const {
     }
   }
 
+  auto isInternalSymbol = [](const std::string& sym) -> bool {
+    if (sym.length() >= 2 && sym[0] == '_' && sym[1] == '_') return true;
+    return false;
+  };
+
   // Check attributes
   std::unordered_set<std::string> seen_attr_names{};
   for (const auto& attr_proto : node.attribute()) {
@@ -155,7 +160,7 @@ void OpSchema::Verify(const NodeProto& node) const {
     AttributeProto::AttributeType expected_type;
     if (search != attributes_.end()) {
       expected_type = search->second.type;
-    } else if (allows_unchecked_attributes_) {
+    } else if (allows_unchecked_attributes_ || isInternalSymbol(name)) {
       continue;
     } else {
       fail_check("Unrecognized attribute: ", name);

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -142,9 +142,11 @@ void OpSchema::Verify(const NodeProto& node) const {
     }
   }
 
+  // An internal symbol is defined as starting with two underscores. Attributes
+  // with names meeting this condition are considered implementation details
+  // and should be ignored for the purpose of schema checking.
   auto isInternalSymbol = [](const std::string& sym) -> bool {
-    if (sym.length() >= 2 && sym[0] == '_' && sym[1] == '_') return true;
-    return false;
+    return sym.length() >= 2 && sym[0] == '_' && sym[1] == '_';
   };
 
   // Check attributes

--- a/onnx/optimizer/optimize.h
+++ b/onnx/optimizer/optimize.h
@@ -11,6 +11,7 @@
 #include "onnx/optimizer/passes/fuse_consecutive_transposes.h"
 #include "onnx/optimizer/passes/fuse_add_bias_into_conv.h"
 #include "onnx/optimizer/passes/fuse_transpose_into_gemm.h"
+#include "onnx/optimizer/passes/lift_lexical_references.h"
 #include "onnx/optimizer/passes/nop.h"
 #include "onnx/optimizer/passes/split.h"
 #include "onnx/proto_utils.h"
@@ -32,6 +33,7 @@ struct Optimizer {
     _registerOptimizer<Nop>();
     _registerOptimizer<SplitInit>();
     _registerOptimizer<SplitPredict>();
+    _registerOptimizer<LiftLexicalReferences>();
   }
 
   virtual ~Optimizer() = default;

--- a/onnx/optimizer/passes/lift_lexical_references.h
+++ b/onnx/optimizer/passes/lift_lexical_references.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include "onnx/optimizer/passes/optimize_pass.h"
+
+namespace ONNX_NAMESPACE { namespace optimization {
+
+// Lift lexically-scoped references within control operators to be inputs of the
+// ops themselves. This transformation yields a graph that does not conform to
+// the ONNX spec.
+//
+// The purpose of this pass is to expose the data dependencies within control
+// blocks for frameworks that use those dependencies to schedule parallel
+// execution. e.g. caffe2 graph execution.
+//
+// The algorithm is roughly:
+//  symbol_table_stack = empty stack of symbol tables
+//
+//  liftreferences(graph)
+//      -> a set of unresolved reference strings:
+//    unresolved_references = {}
+//
+//    symbol_table_stack.push(new symbol table containing inputs for this sub-graph)
+//    for each node in the graph:
+//      for input in node.inputs:
+//        if input is not in this frame:
+//          unresolved_references.insert(input)
+//      if node is a control flow operator:
+//        for each sub-graph g:
+//          refs = liftreferences(g)
+//          for each ref in refs:
+//            if ref is in this frame:
+//              insert ref as an input to node
+//            else:
+//              unresolved_references.insert(ref)
+//        for output in node.outputs:
+//          symbol_table_stack.top()[output] = Value*
+//    return unresolved_references
+struct LiftLexicalReferences : public OptimizePass {
+  explicit LiftLexicalReferences()
+    : OptimizePass("lift_lexical_references", API_TYPE::IR) {
+  }
+
+  using ValueTable = std::unordered_map<std::string, Value*>;
+  using EnvStack = std::vector<ValueTable>;
+
+  std::unordered_set<std::string> liftReferences(Graph* g, EnvStack *es) {
+    std::unordered_set<std::string> unresolved_references;
+    es->push_back(ValueTable());
+    for (auto &inp : g->inputs()) {
+      es->back()[inp->uniqueName()] = inp;
+    }
+
+    for (auto *n : g->nodes()) {
+      // Skip optional input/captured value node.
+      if (n->kind() == ONNX_NAMESPACE::kUndefined ||
+            n->kind() == ONNX_NAMESPACE::kCaptured) {
+        continue;
+      }
+      for (auto *inp : n->inputs()) {
+        if (!es->back().count(inp->uniqueName())) {
+          unresolved_references.insert(inp->uniqueName());
+        }
+      }
+
+      std::unordered_set<std::string> local_unresolved;
+      if (n->kind() == ONNX_NAMESPACE::kLoop) {
+        auto *body_graph = n->g(ONNX_NAMESPACE::kbody).get();
+        local_unresolved = liftReferences(body_graph, es);
+      } else if (n->kind() == ONNX_NAMESPACE::kIf) {
+        auto *then_graph = n->g(ONNX_NAMESPACE::kthen_branch).get();
+        auto then_unresolved = liftReferences(then_graph, es);
+        local_unresolved.insert(then_unresolved.begin(), then_unresolved.end());
+        auto *else_graph = n->g(ONNX_NAMESPACE::kelse_branch).get();
+        auto else_unresolved = liftReferences(else_graph, es);
+        local_unresolved.insert(else_unresolved.begin(), else_unresolved.end());
+      }
+
+      size_t num_control_inputs = 0;
+      for (auto &unresolved : local_unresolved) {
+        if (es->back().count(unresolved)) {
+          n->addInput(es->back()[unresolved]);
+          num_control_inputs++;
+        } else {
+          unresolved_references.insert(unresolved);
+        }
+      }
+
+      // Create this attribute so the backend knows how many of these inputs
+      // are simply there for control dependencies
+      n->i_(ONNX_NAMESPACE::k__num_control_inputs, num_control_inputs);
+
+      for (auto *out : n->outputs()) {
+        es->back()[out->uniqueName()] = out;
+      }
+    }
+
+    es->pop_back();
+    return unresolved_references;
+  }
+
+
+  void optimize(Graph& graph) override {
+    EnvStack es;
+    auto unresolved = liftReferences(&graph, &es);
+
+    if (unresolved.size()) {
+      std::string errmsg = "Unresolved value references: ";
+      for (auto& ref : unresolved) {
+        errmsg += ref;
+      }
+      throw std::runtime_error(errmsg);
+    }
+  }
+};
+
+}} // namespace ONNX_NAMESPACE::optimization

--- a/onnx/optimizer/passes/lift_lexical_references.h
+++ b/onnx/optimizer/passes/lift_lexical_references.h
@@ -43,8 +43,8 @@ struct LiftLexicalReferences : public OptimizePass {
   using ValueTable = std::unordered_map<std::string, Value*>;
   using EnvStack = std::vector<ValueTable>;
 
-  std::unordered_set<std::string> liftReferences(Graph* g, EnvStack *es) {
-    std::unordered_set<std::string> unresolved_references;
+  std::set<std::string> liftReferences(Graph* g, EnvStack *es) {
+    std::set<std::string> unresolved_references;
     es->push_back(ValueTable());
     for (auto &inp : g->inputs()) {
       es->back()[inp->uniqueName()] = inp;
@@ -62,7 +62,7 @@ struct LiftLexicalReferences : public OptimizePass {
         }
       }
 
-      std::unordered_set<std::string> local_unresolved;
+      std::set<std::string> local_unresolved;
       if (n->kind() == ONNX_NAMESPACE::kLoop) {
         auto *body_graph = n->g(ONNX_NAMESPACE::kbody).get();
         local_unresolved = liftReferences(body_graph, es);

--- a/onnx/test/optimizer_test.py
+++ b/onnx/test/optimizer_test.py
@@ -456,8 +456,8 @@ class TestOptimizer(unittest.TestCase):
         optimized_model = self._optimized(graph, ["lift_lexical_references"])
         assert len(optimized_model.graph.node) == 4
         assert len(optimized_model.graph.node[3].input) == 4
-        assert optimized_model.graph.node[3].input[2] == "Y"
-        assert optimized_model.graph.node[3].input[3] == "X"
+        assert optimized_model.graph.node[3].input[2] == "X"
+        assert optimized_model.graph.node[3].input[3] == "Y"
 
     def test_lift_lex_if(self):
         nodes = [helper.make_node("Identity", ["X"], ["Y"])]


### PR DESCRIPTION
Lift lexically-scoped references within control operators to be inputs of the
ops themselves. This transformation yields a graph that does not conform to
the ONNX spec.
The purpose of this pass is to expose the data dependencies within control
blocks for frameworks that use those dependencies to schedule parallel
execution. e.g. caffe2 graph execution.

There are a few edits here and there to allow for this transformation, but nothing earth-shattering.