### PR TITLE
Correct Tile operator inputs to use int64 instead of T

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -7380,9 +7380,9 @@ This version of the operator has been available since version 1 of the default O
 <dl>
 <dt><tt>input</tt> : T</dt>
 <dd>Input tensor of any shape.</dd>
-<dt><tt>tiles</tt> : T</dt>
+<dt><tt>tiles</tt> : tensor(int64)</dt>
 <dd>Number of repeated copies to make of the input tensor.</dd>
-<dt><tt>axis</tt> : T</dt>
+<dt><tt>axis</tt> : tensor(int64)</dt>
 <dd>Axis along which to repeat.</dd>
 </dl>
 

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -696,8 +696,8 @@ ONNX_OPERATOR_SCHEMA(Tile)
         1,
         "tiles",
         "Number of repeated copies to make of the input tensor.",
-        "T")
-    .Input(2, "axis", "Axis along which to repeat.", "T")
+        "tensor(int64)")
+    .Input(2, "axis", "Axis along which to repeat.", "tensor(int64)")
     .Output(0, "output", "Output tensor of same shape and type as input.", "T")
     .TypeConstraint(
         "T",


### PR DESCRIPTION
For axis and tiles, only integer values make any sense.