### PR TITLE
Change the return type for the zipmap operator to match the description in the spec.

### DIFF
--- a/docs/Changelog-ml.md
+++ b/docs/Changelog-ml.md
@@ -881,7 +881,7 @@ This version of the operator has been available since version 1 of the 'ai.onnx.
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : map(string, float), map(int64, float)</dt>
+<dt><tt>T</tt> : seq(map(string, float)), seq(map(int64, float))</dt>
 <dd> allowed types.</dd>
 </dl>
 

--- a/docs/Operators-ml.md
+++ b/docs/Operators-ml.md
@@ -917,7 +917,7 @@ This version of the operator has been available since version 1 of the 'ai.onnx.
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : map(string, float), map(int64, float)</dt>
+<dt><tt>T</tt> : seq(map(string, float)), seq(map(int64, float))</dt>
 <dd> allowed types.</dd>
 </dl>
 

--- a/onnx/defs/traditionalml/defs.cc
+++ b/onnx/defs/traditionalml/defs.cc
@@ -747,7 +747,7 @@ ONNX_OPERATOR_SCHEMA(ZipMap)
     .Output(0, "Z", "The output map", "T")
     .TypeConstraint(
         "T",
-        {"map(string, float)", "map(int64, float)"},
+        {"seq(map(string, float))", "seq(map(int64, float))"},
         " allowed types.")
     .Attr(
         "classlabels_strings",


### PR DESCRIPTION
Change the return type for the zipmap operator to match the description in the spec.