### PR TITLE
Make the coefficient non optional for LinearClassifier

### DIFF
--- a/docs/Changelog-ml.md
+++ b/docs/Changelog-ml.md
@@ -363,7 +363,7 @@ This version of the operator has been available since version 1 of the 'ai.onnx.
 <dd>class labels if using int labels</dd>
 <dt><tt>classlabels_strings</tt> : list of strings</dt>
 <dd>class labels if using string labels</dd>
-<dt><tt>coefficients</tt> : list of floats</dt>
+<dt><tt>coefficients</tt> : list of floats (required)</dt>
 <dd>weights of the model(s)</dd>
 <dt><tt>intercepts</tt> : list of floats</dt>
 <dd>weights of the intercepts (if used)</dd>

--- a/docs/Operators-ml.md
+++ b/docs/Operators-ml.md
@@ -390,7 +390,7 @@ This version of the operator has been available since version 1 of the 'ai.onnx.
 <dd>class labels if using int labels</dd>
 <dt><tt>classlabels_strings</tt> : list of strings</dt>
 <dd>class labels if using string labels</dd>
-<dt><tt>coefficients</tt> : list of floats</dt>
+<dt><tt>coefficients</tt> : list of floats (required)</dt>
 <dd>weights of the model(s)</dd>
 <dt><tt>intercepts</tt> : list of floats</dt>
 <dd>weights of the intercepts (if used)</dd>

--- a/onnx/defs/traditionalml/defs.cc
+++ b/onnx/defs/traditionalml/defs.cc
@@ -254,8 +254,7 @@ ONNX_OPERATOR_SCHEMA(LinearClassifier)
     .Attr(
         "coefficients",
         "weights of the model(s)",
-        AttributeProto::FLOATS,
-        OPTIONAL)
+        AttributeProto::FLOATS)
     .Attr(
         "intercepts",
         "weights of the intercepts (if used)",


### PR DESCRIPTION
Coefficients represent the model for LinearClassifier. Having it as OPTIONAL makes the implementation to assume defaults and could lead to different results. So this change is to make it non optional.