### PR TITLE
Update return type and documentation on ONNXIFI_BACKEND_DIRECTX_ID

### DIFF
--- a/onnx/onnxifi.h
+++ b/onnx/onnxifi.h
@@ -416,7 +416,10 @@ typedef int32_t onnxBackendInfo;
 /**
  * DirectX ID of the backend device.
  *
- * Value type: GUID (16 bytes).
+ * This is the value that would be returned by ID3D12Device::GetAdapterLuid()
+ * for the hardware device used by the backend.
+ *
+ * Value type: LUID (8 bytes).
  */
 #define ONNXIFI_BACKEND_DIRECTX_ID 43
 


### PR DESCRIPTION
- Change the type to `LUID` instead of generic `GUID`
- Document relation to `ID3D12Device::GetAdapterLuid()`