### PR TITLE
Use op schema.all tensor types in random like definitions

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -3503,7 +3503,7 @@ This version of the operator has been available since version 1 of the default O
 #### Type Constraints
 
 <dl>
-<dt><tt>T1</tt> : tensor(float16), tensor(float), tensor(double), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(bool), tensor(string)</dt>
+<dt><tt>T1</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool)</dt>
 <dd>Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type.</dd>
 <dt><tt>T2</tt> : tensor(float16), tensor(float), tensor(double)</dt>
 <dd>Constrain output types to float tensors.</dd>
@@ -3598,7 +3598,7 @@ This version of the operator has been available since version 1 of the default O
 #### Type Constraints
 
 <dl>
-<dt><tt>T1</tt> : tensor(float16), tensor(float), tensor(double), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(bool), tensor(string)</dt>
+<dt><tt>T1</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool)</dt>
 <dd>Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type.</dd>
 <dt><tt>T2</tt> : tensor(float16), tensor(float), tensor(double)</dt>
 <dd>Constrain output types to float tensors.</dd>

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -5621,7 +5621,7 @@ This version of the operator has been available since version 1 of the default O
 #### Type Constraints
 
 <dl>
-<dt><tt>T1</tt> : tensor(float16), tensor(float), tensor(double), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(bool), tensor(string)</dt>
+<dt><tt>T1</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool)</dt>
 <dd>Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type.</dd>
 <dt><tt>T2</tt> : tensor(float16), tensor(float), tensor(double)</dt>
 <dd>Constrain output types to float tensors.</dd>
@@ -5718,7 +5718,7 @@ This version of the operator has been available since version 1 of the default O
 #### Type Constraints
 
 <dl>
-<dt><tt>T1</tt> : tensor(float16), tensor(float), tensor(double), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(bool), tensor(string)</dt>
+<dt><tt>T1</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool)</dt>
 <dd>Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type.</dd>
 <dt><tt>T2</tt> : tensor(float16), tensor(float), tensor(double)</dt>
 <dd>Constrain output types to float tensors.</dd>

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -139,19 +139,7 @@ TensorProto message and be valid as an output type.
             "Output tensor of random values drawn from uniform distribution", "T2")
     .TypeConstraint(
         "T1",
-        {"tensor(float16)",
-         "tensor(float)",
-         "tensor(double)",
-         "tensor(int8)",
-         "tensor(int16)",
-         "tensor(int32)",
-         "tensor(int64)",
-         "tensor(uint8)",
-         "tensor(uint16)",
-         "tensor(uint32)",
-         "tensor(uint64)",
-         "tensor(bool)",
-         "tensor(string)"},
+        OpSchema::all_tensor_types(),
         "Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type.")
     .TypeConstraint("T2", { "tensor(float16)", "tensor(float)", "tensor(double)" },
         "Constrain output types to float tensors.");
@@ -197,19 +185,7 @@ TensorProto message, and be valid as an output type.
             "Output tensor of random values drawn from normal distribution", "T2")
     .TypeConstraint(
         "T1",
-        {"tensor(float16)",
-         "tensor(float)",
-         "tensor(double)",
-         "tensor(int8)",
-         "tensor(int16)",
-         "tensor(int32)",
-         "tensor(int64)",
-         "tensor(uint8)",
-         "tensor(uint16)",
-         "tensor(uint32)",
-         "tensor(uint64)",
-         "tensor(bool)",
-         "tensor(string)"},
+        OpSchema::all_tensor_types(),
         "Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type.")
     .TypeConstraint("T2", { "tensor(float16)", "tensor(float)", "tensor(double)" },
         "Constrain output types to float tensors.");


### PR DESCRIPTION
Use OpSchema::all_tensor_types() as per https://github.com/onnx/onnx/pull/846 comment
