### PR TITLE
Enable non-static schema registration

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -5611,7 +5611,6 @@ This version of the operator has been available since version 6 of the default O
   
   Output case #1: Y, mean, var, saved_mean, saved_var (training mode)
   Output case #2: Y (test mode)
-      
 
 #### Version
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -6374,7 +6374,6 @@ This version of the operator has been available since version 6 of the default O
   PRelu takes input data (Tensor<T>) and slope tensor as input, and produces one
   output data (Tensor<T>) where the function `f(x) = slope * x for x < 0`,
   `f(x) = x for x >= 0`., is applied to the data tensor elementwise.
-  
   This operator supports **unidirectional broadcasting** (tensor slope should be unidirectional broadcastable to input tensor X); for more details please check [the doc](Broadcasting.md).
 
 #### Version
@@ -7221,7 +7220,6 @@ This version of the operator has been available since version 7 of the default O
     - ht = g(Xt*(Wh^T) + (rt (.) (Ht-1*Rh + Rbh) + Wbh) # when linear_before_reset != 0
   
     - Ht = (1 - zt) (.) ht + zt (.) Ht-1
-  
   This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted.
 
 #### Version
@@ -7295,7 +7293,6 @@ This version of the operator has been available since version 7 of the default O
   input tensor B has shape (K, N) or (N, K), input tensor C is broadcastable to shape (M, N),
   and output tensor Y has shape (M, N). A will be transposed before doing the
   computation if attribute transA is non-zero, same for B and transB.
-  
   This operator supports **unidirectional broadcasting** (tensor C should be unidirectional broadcastable to tensor A * B); for more details please check [the doc](Broadcasting.md).
 
 #### Version
@@ -7458,7 +7455,6 @@ This version of the operator has been available since version 7 of the default O
     - ot = f(Xt*(Wo^T) + Ht-1*Ro + Po (.) Ct + Wbo + Rbo)
   
     - Ht = ot (.) h(Ct)
-  
   This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted.
 
 #### Version
@@ -7678,7 +7674,6 @@ This version of the operator has been available since version 7 of the default O
   Pow takes input data (Tensor<T>) and exponent Tensor, and
   produces one output data (Tensor<T>) where the function `f(x) = x^exponent`,
   is applied to the data tensor elementwise.
-  
   This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
 #### Version
@@ -7770,7 +7765,6 @@ This version of the operator has been available since version 7 of the default O
   Equations (Default: f=Tanh):
   
     - Ht = f(Xt*(Wi^T) + Ht-1*Ri + Wbi + Rbi)
-  
   This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted.
 
 #### Version

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -2429,7 +2429,6 @@ expect(node, inputs=[x], outputs=[y],
     - ht = g(Xt*(Wh^T) + (rt (.) (Ht-1*Rh + Rbh) + Wbh) # when linear_before_reset != 0
   
     - Ht = (1 - zt) (.) ht + zt (.) Ht-1
-  
   This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted.
 
 #### Version
@@ -2730,7 +2729,6 @@ expect(node, inputs=[data, indices.astype(np.int64)], outputs=[y],
   input tensor B has shape (K, N) or (N, K), input tensor C is broadcastable to shape (M, N),
   and output tensor Y has shape (M, N). A will be transposed before doing the
   computation if attribute transA is non-zero, same for B and transB.
-  
   This operator supports **unidirectional broadcasting** (tensor C should be unidirectional broadcastable to tensor A * B); for more details please check [the doc](Broadcasting.md).
 
 #### Version
@@ -3557,7 +3555,6 @@ This version of the operator has been available since version 1 of the default O
     - ot = f(Xt*(Wo^T) + Ht-1*Ro + Po (.) Ct + Wbo + Rbo)
   
     - Ht = ot (.) h(Ct)
-  
   This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted.
 
 #### Version
@@ -5281,7 +5278,6 @@ expect(node, inputs=[x, y], outputs=[z],
   PRelu takes input data (Tensor<T>) and slope tensor as input, and produces one
   output data (Tensor<T>) where the function `f(x) = slope * x for x < 0`,
   `f(x) = x for x >= 0`., is applied to the data tensor elementwise.
-  
   This operator supports **unidirectional broadcasting** (tensor slope should be unidirectional broadcastable to input tensor X); for more details please check [the doc](Broadcasting.md).
 
 #### Version
@@ -5476,7 +5472,6 @@ for mode in ['edge', 'reflect']:
   Pow takes input data (Tensor<T>) and exponent Tensor, and
   produces one output data (Tensor<T>) where the function `f(x) = x^exponent`,
   is applied to the data tensor elementwise.
-  
   This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
 #### Version
@@ -5631,7 +5626,6 @@ expect(node, inputs=[x, y], outputs=[z],
   Equations (Default: f=Tanh):
   
     - Ht = f(Xt*(Wi^T) + Ht-1*Ri + Wbi + Rbi)
-  
   This operator has **optional** inputs/outputs. See [the doc](IR.md) for more details about the representation of optional arguments. An empty string may be used in the place of an actual argument's name to indicate a missing argument. Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted.
 
 #### Version

--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -1,5 +1,5 @@
-#include "onnx/checker.h"
 #include "onnx/defs/schema.h"
+#include "onnx/checker.h"
 #include "onnx/proto_utils.h"
 #include "onnx/string_utils.h"
 
@@ -271,8 +271,7 @@ void check_node(
     check_attribute(attr, ctx, lex_ctx);
   }
 
-  const auto* schema =
-      OpSchemaRegistry::Schema(node.op_type(), domain_version, node.domain());
+  const auto* schema = ctx.get_schema_registry()->GetSchema(node.op_type(), domain_version, node.domain());
   if (!schema) {
     fail_check(
         "No Schema registered for " + node.op_type() +

--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -1,5 +1,5 @@
-#include "onnx/defs/schema.h"
 #include "onnx/checker.h"
+#include "onnx/defs/schema.h"
 #include "onnx/proto_utils.h"
 #include "onnx/string_utils.h"
 
@@ -271,7 +271,8 @@ void check_node(
     check_attribute(attr, ctx, lex_ctx);
   }
 
-  const auto* schema = ctx.get_schema_registry()->GetSchema(node.op_type(), domain_version, node.domain());
+  const auto* schema = ctx.get_schema_registry()->GetSchema(
+      node.op_type(), domain_version, node.domain());
   if (!schema) {
     fail_check(
         "No Schema registered for " + node.op_type() +

--- a/onnx/checker.h
+++ b/onnx/checker.h
@@ -6,6 +6,7 @@
 #include "onnx/onnx_pb.h"
 #include "onnx/onnx-operators_pb.h"
 #include "onnx/string_utils.h"
+#include "onnx/defs/schema.h"
 
 namespace ONNX_NAMESPACE {
 namespace checker {
@@ -52,12 +53,21 @@ class CheckerContext final {
     is_main_graph_ = is_main_graph;
   }
 
+  void set_schema_registry(const ISchemaRegistry *schema_registry) {
+    schema_registry_ = schema_registry;
+  }
+
+  const ISchemaRegistry * get_schema_registry() const {
+    return schema_registry_;
+  }
+
   explicit CheckerContext() : ir_version_(-1) {}
 
  private:
   int ir_version_;
   std::unordered_map<std::string, int> opset_imports_;
   bool is_main_graph_ = true;
+  const ISchemaRegistry *schema_registry_ = OpSchemaRegistry::Instance();
 };
 
 struct LexicalScopeContext final {

--- a/onnx/checker.h
+++ b/onnx/checker.h
@@ -3,10 +3,10 @@
 #include <stdexcept>
 #include <unordered_map>
 #include <unordered_set>
-#include "onnx/onnx_pb.h"
-#include "onnx/onnx-operators_pb.h"
-#include "onnx/string_utils.h"
 #include "onnx/defs/schema.h"
+#include "onnx/onnx-operators_pb.h"
+#include "onnx/onnx_pb.h"
+#include "onnx/string_utils.h"
 
 namespace ONNX_NAMESPACE {
 namespace checker {
@@ -53,11 +53,11 @@ class CheckerContext final {
     is_main_graph_ = is_main_graph;
   }
 
-  void set_schema_registry(const ISchemaRegistry *schema_registry) {
+  void set_schema_registry(const ISchemaRegistry* schema_registry) {
     schema_registry_ = schema_registry;
   }
 
-  const ISchemaRegistry * get_schema_registry() const {
+  const ISchemaRegistry* get_schema_registry() const {
     return schema_registry_;
   }
 
@@ -67,7 +67,7 @@ class CheckerContext final {
   int ir_version_;
   std::unordered_map<std::string, int> opset_imports_;
   bool is_main_graph_ = true;
-  const ISchemaRegistry *schema_registry_ = OpSchemaRegistry::Instance();
+  const ISchemaRegistry* schema_registry_ = OpSchemaRegistry::Instance();
 };
 
 struct LexicalScopeContext final {

--- a/onnx/common/assertions.h
+++ b/onnx/common/assertions.h
@@ -32,10 +32,14 @@ void barf(const char *fmt, ...);
     ::ONNX_NAMESPACE::barf("%s:%u: %s: Assertion `%s` failed.", __FILE__, __LINE__, __func__, #cond); \
   }
 
+// The following is used to prevent MSVC from passing the whole __VA_ARGS__ list as the first
+// parameter value to a macro call.
+#define ONNX_EXPAND(x) x
+
 // The trailing ' ' argument is a hack to deal with the extra comma when ... is empty.
 // Another way to solve this is ##__VA_ARGS__ in _ONNX_ASSERTM, but this is a non-portable
 // extension we shouldn't use.
-#define ONNX_ASSERTM(...) _ONNX_ASSERTM(__VA_ARGS__, " ")
+#define ONNX_ASSERTM(...) ONNX_EXPAND(_ONNX_ASSERTM(__VA_ARGS__, " "))
 
 // Note: msg must be a string literal
 #define _ONNX_ASSERTM(cond, msg, ...) \
@@ -43,7 +47,7 @@ void barf(const char *fmt, ...);
     ::ONNX_NAMESPACE::barf("%s:%u: %s: Assertion `%s` failed: " msg, __FILE__, __LINE__, __func__, #cond, __VA_ARGS__); \
   }
 
-#define ONNX_EXPECTM(...) _ONNX_EXPECTM(__VA_ARGS__, " ")
+#define ONNX_EXPECTM(...) ONNX_EXPAND(_ONNX_EXPECTM(__VA_ARGS__, " "))
 
 // Note: msg must be a string literal
 #define _ONNX_EXPECTM(cond, msg, ...) \

--- a/onnx/common/assertions.h
+++ b/onnx/common/assertions.h
@@ -32,8 +32,8 @@ void barf(const char *fmt, ...);
     ::ONNX_NAMESPACE::barf("%s:%u: %s: Assertion `%s` failed.", __FILE__, __LINE__, __func__, #cond); \
   }
 
-// The following is used to prevent MSVC from passing the whole __VA_ARGS__ list as the first
-// parameter value to a macro call.
+// The following is used to prevent MSVC from passing the whole __VA_ARGS__ list
+// as the first parameter value to a macro call.
 #define ONNX_EXPAND(x) x
 
 // The trailing ' ' argument is a hack to deal with the extra comma when ... is empty.

--- a/onnx/common/ir_pb_converter.cc
+++ b/onnx/common/ir_pb_converter.cc
@@ -70,7 +70,7 @@ Tensor tensorProtoToTensor(const ONNX_NAMESPACE::TensorProto & tp) {
     break;
   }
   case ONNX_NAMESPACE::TensorProto_DataType_UNDEFINED:
-    abort();
+    fail_convert("Unknown tensor data type");
   }
 
   // The only way to know if we should be using raw_data or
@@ -152,7 +152,7 @@ void convertAttribute(const ONNX_NAMESPACE::AttributeProto & ap, Node * n) {
     break;
   }
   case ONNX_NAMESPACE::AttributeProto_AttributeType_UNDEFINED:
-    abort();
+    fail_convert("Unknown tensor data type");
     break;
   }
 }
@@ -371,7 +371,7 @@ void encodeTensor(ONNX_NAMESPACE::TensorProto * p, const Tensor & tensor) {
     break;
   }
   case ONNX_NAMESPACE::TensorProto_DataType_UNDEFINED:
-    abort();
+    fail_convert("Unknown tensor data type");
   }
   if (!tensor.raw().empty()) {
     p->set_raw_data(tensor.raw());

--- a/onnx/common/ir_pb_converter.h
+++ b/onnx/common/ir_pb_converter.h
@@ -9,30 +9,29 @@
 namespace ONNX_NAMESPACE {
 
 class ConvertError final : public std::runtime_error {
-public:
-	using std::runtime_error::runtime_error;
+ public:
+  using std::runtime_error::runtime_error;
 
-	ConvertError(const std::string& message) : std::runtime_error(message) {}
+  ConvertError(const std::string& message) : std::runtime_error(message) {}
 
-	const char* what() const noexcept override {
-		if (!expanded_message_.empty()) {
-			return expanded_message_.c_str();
-		}
-		return std::runtime_error::what();
-	}
+  const char* what() const noexcept override {
+    if (!expanded_message_.empty()) {
+      return expanded_message_.c_str();
+    }
+    return std::runtime_error::what();
+  }
 
-	void AppendContext(const std::string& context) {
-		expanded_message_ = ONNX_NAMESPACE::MakeString(
-			std::runtime_error::what(), "\n\n==> Context: ", context);
-	}
+  void AppendContext(const std::string& context) {
+    expanded_message_ = ONNX_NAMESPACE::MakeString(
+        std::runtime_error::what(), "\n\n==> Context: ", context);
+  }
 
-private:
-	std::string expanded_message_;
+ private:
+  std::string expanded_message_;
 };
 
-#define fail_convert(...)                         \
-  throw ONNX_NAMESPACE::ConvertError(             \
-      ONNX_NAMESPACE::MakeString(__VA_ARGS__));
+#define fail_convert(...) \
+  throw ONNX_NAMESPACE::ConvertError(ONNX_NAMESPACE::MakeString(__VA_ARGS__));
 
 void ExportModelProto(ONNX_NAMESPACE::ModelProto* p_m, const std::shared_ptr<Graph>& g);
 

--- a/onnx/common/ir_pb_converter.h
+++ b/onnx/common/ir_pb_converter.h
@@ -8,7 +8,34 @@
 
 namespace ONNX_NAMESPACE {
 
+class ConvertError final : public std::runtime_error {
+public:
+	using std::runtime_error::runtime_error;
+
+	ConvertError(const std::string& message) : std::runtime_error(message) {}
+
+	const char* what() const noexcept override {
+		if (!expanded_message_.empty()) {
+			return expanded_message_.c_str();
+		}
+		return std::runtime_error::what();
+	}
+
+	void AppendContext(const std::string& context) {
+		expanded_message_ = ONNX_NAMESPACE::MakeString(
+			std::runtime_error::what(), "\n\n==> Context: ", context);
+	}
+
+private:
+	std::string expanded_message_;
+};
+
+#define fail_convert(...)                         \
+  throw ONNX_NAMESPACE::ConvertError(             \
+      ONNX_NAMESPACE::MakeString(__VA_ARGS__));
+
 void ExportModelProto(ONNX_NAMESPACE::ModelProto* p_m, const std::shared_ptr<Graph>& g);
+
 std::unique_ptr<Graph> ImportModelProto(const ONNX_NAMESPACE::ModelProto& mp);
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -4,8 +4,8 @@
 #include <limits>
 #include <unordered_map>
 
-#include "onnx/defs/schema.h"
 #include "onnx/checker.h"
+#include "onnx/defs/schema.h"
 #include "onnx/optimizer/optimize.h"
 #include "onnx/py_utils.h"
 #include "onnx/shape_inference/implementation.h"

--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -4,8 +4,8 @@
 #include <limits>
 #include <unordered_map>
 
-#include "onnx/checker.h"
 #include "onnx/defs/schema.h"
+#include "onnx/checker.h"
 #include "onnx/optimizer/optimize.h"
 #include "onnx/py_utils.h"
 #include "onnx/shape_inference/implementation.h"

--- a/onnx/defs/controlflow/defs.cc
+++ b/onnx/defs/controlflow/defs.cc
@@ -2,38 +2,40 @@
 // Licensed under the MIT license.
 
 #include "onnx/defs/schema.h"
-namespace ONNX_NAMESPACE
-{
-  using SupportType = OpSchema::SupportType;
+namespace ONNX_NAMESPACE {
+using SupportType = OpSchema::SupportType;
 
-ONNX_OPERATOR_SET_SCHEMA(If, 1, OpSchema()
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .SetDoc("If conditional")
-    .Input(0, "cond", "Condition for the if", "B")
-    .Output(
-        0,
-        "outputs",
-        "Values that are live-out to the enclosing scope.",
-        "V",
-        OpSchema::Variadic)
-    .Attr(
-        "then_branch",
-        "Graph to run if condition is true. Has N outputs: values you wish to "
-        "be live-out to the enclosing scope. The number of outputs must match"
-        " the number of outputs in the else_branch.",
-        AttributeProto::GRAPH,
-        true)
-    .Attr(
-        "else_branch",
-        "Graph to run if condition is false. Has N outputs: values you wish to"
-        " be live-out to the enclosing scope. The number of outputs must match"
-        " the number of outputs in the then_branch.",
-        AttributeProto::GRAPH,
-        true)
-    .TypeConstraint("V", OpSchema::all_tensor_types(), "All Tensor types")
-    .TypeConstraint("B", {"tensor(bool)"}, "Only bool"));
+ONNX_OPERATOR_SET_SCHEMA(
+    If,
+    1,
+    OpSchema()
+        .SetSupportLevel(SupportType::EXPERIMENTAL)
+        .SetDoc("If conditional")
+        .Input(0, "cond", "Condition for the if", "B")
+        .Output(
+            0,
+            "outputs",
+            "Values that are live-out to the enclosing scope.",
+            "V",
+            OpSchema::Variadic)
+        .Attr(
+            "then_branch",
+            "Graph to run if condition is true. Has N outputs: values you wish to "
+            "be live-out to the enclosing scope. The number of outputs must match"
+            " the number of outputs in the else_branch.",
+            AttributeProto::GRAPH,
+            true)
+        .Attr(
+            "else_branch",
+            "Graph to run if condition is false. Has N outputs: values you wish to"
+            " be live-out to the enclosing scope. The number of outputs must match"
+            " the number of outputs in the then_branch.",
+            AttributeProto::GRAPH,
+            true)
+        .TypeConstraint("V", OpSchema::all_tensor_types(), "All Tensor types")
+        .TypeConstraint("B", {"tensor(bool)"}, "Only bool"));
 
-static const char * Loop_ver1_doc = R"DOC(
+static const char* Loop_ver1_doc = R"DOC(
 Generic Looping construct. This loop has multiple termination conditions:
 
 1) Trip count. Iteration count specified at runtime. Set by
@@ -155,64 +157,74 @@ pipelined/"wavefront" fashion.
 
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Loop, 1, OpSchema()
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .SetDoc(Loop_ver1_doc)
-    .Input(
-        0,
-        "M",
-        "A maximum trip-count for the loop specified at runtime. Optional."
-        " pass empty string to skip.",
-        "I")
-    .Input(
-        1,
-        "cond",
-        "A boolean termination condition. Pass empty string to skip.",
-        "B")
-    .Input(
-        2,
-        "v_initial",
-        "The initial values of any loop-carried dependencies (values that "
-        "change across loop iterations)",
-        "V",
-        OpSchema::Variadic)
-    .Output(
-        0,
-        "v_final_and_scan_outputs",
-        "Final N loop carried dependency values then K scan_outputs",
-        "V",
-        OpSchema::Variadic)
-    .Attr(
-        "body",
-        "The graph run each iteration. It has 2+N inputs: (iteration_num, "
-        "condition, loop carried dependencies...). It has 1+N+K outputs: "
-        "(condition, loop carried dependencies..., scan_outputs...). Each "
-        "scan_output is created by concatenating the value of the specified "
-        "output value at the end of each iteration of the loop. It is an error"
-        " if the dimensions of these values change across loop iterations.",
-        AttributeProto::GRAPH,
-        true)
-    .TypeConstraint("V", OpSchema::all_tensor_types(), "All Tensor types")
-    .TypeConstraint("I", {"int64"}, "Only int64")
-    .TypeConstraint("B", {"bool"}, "Only bool"));
+ONNX_OPERATOR_SET_SCHEMA(
+    Loop,
+    1,
+    OpSchema()
+        .SetSupportLevel(SupportType::EXPERIMENTAL)
+        .SetDoc(Loop_ver1_doc)
+        .Input(
+            0,
+            "M",
+            "A maximum trip-count for the loop specified at runtime. Optional."
+            " pass empty string to skip.",
+            "I")
+        .Input(
+            1,
+            "cond",
+            "A boolean termination condition. Pass empty string to skip.",
+            "B")
+        .Input(
+            2,
+            "v_initial",
+            "The initial values of any loop-carried dependencies (values that "
+            "change across loop iterations)",
+            "V",
+            OpSchema::Variadic)
+        .Output(
+            0,
+            "v_final_and_scan_outputs",
+            "Final N loop carried dependency values then K scan_outputs",
+            "V",
+            OpSchema::Variadic)
+        .Attr(
+            "body",
+            "The graph run each iteration. It has 2+N inputs: (iteration_num, "
+            "condition, loop carried dependencies...). It has 1+N+K outputs: "
+            "(condition, loop carried dependencies..., scan_outputs...). Each "
+            "scan_output is created by concatenating the value of the specified "
+            "output value at the end of each iteration of the loop. It is an error"
+            " if the dimensions of these values change across loop iterations.",
+            AttributeProto::GRAPH,
+            true)
+        .TypeConstraint("V", OpSchema::all_tensor_types(), "All Tensor types")
+        .TypeConstraint("I", {"int64"}, "Only int64")
+        .TypeConstraint("B", {"bool"}, "Only bool"));
 
-ONNX_OPERATOR_SET_SCHEMA(LoopIndexTensor, 1, OpSchema()
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .SetDoc(
-        "This is a special operator only valid inside the loop that supports "
-        "the common case behavior of accessing the correct element of the input"
-        " sequence in an RNN. This operator MUST be directly given the passed-"
-        "in iteration number to the body of a Loop graph. This signals to back-"
-        "ends that this is a direct indexing operation, with no transforms "
-        "applied to the index.")
-    .Input(0, "T", "Tensor to be indexed (has N dimensions)", "T")
-    .Input(1, "loop_idx", "Loop index provided as input to the body graph", "I")
-    .Attr(
-        "axis",
-        "Axis on which to index",
-        AttributeProto::INT,
-        static_cast<int64_t>(0))
-    .Output(0, "O", "Tensor of N - 1 dims that is a sub tensor of T", "T")
-    .TypeConstraint("T", OpSchema::all_tensor_types(), "All Tensor types")
-    .TypeConstraint("I", {"int32"}, "Indices"));
-}
+ONNX_OPERATOR_SET_SCHEMA(
+    LoopIndexTensor,
+    1,
+    OpSchema()
+        .SetSupportLevel(SupportType::EXPERIMENTAL)
+        .SetDoc(
+            "This is a special operator only valid inside the loop that supports "
+            "the common case behavior of accessing the correct element of the input"
+            " sequence in an RNN. This operator MUST be directly given the passed-"
+            "in iteration number to the body of a Loop graph. This signals to back-"
+            "ends that this is a direct indexing operation, with no transforms "
+            "applied to the index.")
+        .Input(0, "T", "Tensor to be indexed (has N dimensions)", "T")
+        .Input(
+            1,
+            "loop_idx",
+            "Loop index provided as input to the body graph",
+            "I")
+        .Attr(
+            "axis",
+            "Axis on which to index",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Output(0, "O", "Tensor of N - 1 dims that is a sub tensor of T", "T")
+        .TypeConstraint("T", OpSchema::all_tensor_types(), "All Tensor types")
+        .TypeConstraint("I", {"int32"}, "Indices"));
+} // namespace ONNX_NAMESPACE

--- a/onnx/defs/controlflow/defs.cc
+++ b/onnx/defs/controlflow/defs.cc
@@ -2,11 +2,11 @@
 // Licensed under the MIT license.
 
 #include "onnx/defs/schema.h"
-using namespace ONNX_NAMESPACE;
+namespace ONNX_NAMESPACE
+{
+  using SupportType = OpSchema::SupportType;
 
-using SupportType = ONNX_NAMESPACE::OpSchema::SupportType;
-
-ONNX_OPERATOR_SCHEMA(If)
+ONNX_OPERATOR_SET_SCHEMA(If, 1, OpSchema()
     .SetSupportLevel(SupportType::EXPERIMENTAL)
     .SetDoc("If conditional")
     .Input(0, "cond", "Condition for the if", "B")
@@ -31,11 +31,9 @@ ONNX_OPERATOR_SCHEMA(If)
         AttributeProto::GRAPH,
         true)
     .TypeConstraint("V", OpSchema::all_tensor_types(), "All Tensor types")
-    .TypeConstraint("B", {"tensor(bool)"}, "Only bool");
+    .TypeConstraint("B", {"tensor(bool)"}, "Only bool"));
 
-ONNX_OPERATOR_SCHEMA(Loop)
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .SetDoc(R"DOC(
+static const char * Loop_ver1_doc = R"DOC(
 Generic Looping construct. This loop has multiple termination conditions:
 
 1) Trip count. Iteration count specified at runtime. Set by
@@ -155,7 +153,11 @@ necessarily a loop-carried dependency. Backends can recognize this pattern and
 are permitted to schedule the execution of the multi-layer network in a
 pipelined/"wavefront" fashion.
 
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Loop, 1, OpSchema()
+    .SetSupportLevel(SupportType::EXPERIMENTAL)
+    .SetDoc(Loop_ver1_doc)
     .Input(
         0,
         "M",
@@ -192,9 +194,9 @@ pipelined/"wavefront" fashion.
         true)
     .TypeConstraint("V", OpSchema::all_tensor_types(), "All Tensor types")
     .TypeConstraint("I", {"int64"}, "Only int64")
-    .TypeConstraint("B", {"bool"}, "Only bool");
+    .TypeConstraint("B", {"bool"}, "Only bool"));
 
-ONNX_OPERATOR_SCHEMA(LoopIndexTensor)
+ONNX_OPERATOR_SET_SCHEMA(LoopIndexTensor, 1, OpSchema()
     .SetSupportLevel(SupportType::EXPERIMENTAL)
     .SetDoc(
         "This is a special operator only valid inside the loop that supports "
@@ -212,4 +214,5 @@ ONNX_OPERATOR_SCHEMA(LoopIndexTensor)
         static_cast<int64_t>(0))
     .Output(0, "O", "Tensor of N - 1 dims that is a sub tensor of T", "T")
     .TypeConstraint("T", OpSchema::all_tensor_types(), "All Tensor types")
-    .TypeConstraint("I", {"int32"}, "Indices");
+    .TypeConstraint("I", {"int32"}, "Indices"));
+}

--- a/onnx/defs/experiments/defs.cc
+++ b/onnx/defs/experiments/defs.cc
@@ -2,33 +2,38 @@
 // Licensed under the MIT license.
 
 #include "onnx/defs/schema.h"
-using namespace ONNX_NAMESPACE;
+namespace ONNX_NAMESPACE
+{
+  using SupportType = OpSchema::SupportType;
 
 using SupportType = ONNX_NAMESPACE::OpSchema::SupportType;
 
-ONNX_OPERATOR_SCHEMA(Affine)
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .SetDoc(R"DOC(
+static const char * Affine_ver1_doc = R"DOC(
 Affine takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the affine function, y = alpha * x + beta,
 is applied to the tensor elementwise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Affine, 1, OpSchema()
+    .SetSupportLevel(SupportType::EXPERIMENTAL)
+    .SetDoc(Affine_ver1_doc)
     .Attr("alpha", "Value of alpha", AttributeProto::FLOAT, 1.0f)
     .Attr("beta" , "Value of beta", AttributeProto::FLOAT, 0.0f)
     .Input(0, "X", "1D input tensor", "T")
     .Output(0, "Y", "1D output tensor", "T")
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-
-ONNX_OPERATOR_SCHEMA(ThresholdedRelu)
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .SetDoc(R"DOC(
+static const char * ThresholdedRelu_ver1_doc = R"DOC(
 ThresholdedRelu takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the rectified linear function, y = x for x > alpha, y = 0 otherwise,
 is applied to the tensor elementwise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(ThresholdedRelu, 1, OpSchema()
+    .SetSupportLevel(SupportType::EXPERIMENTAL)
+    .SetDoc(ThresholdedRelu_ver1_doc)
     .Attr("alpha",
           "Threshold value",
           AttributeProto::FLOAT,
@@ -37,15 +42,17 @@ is applied to the tensor elementwise.
     .Output(0, "Y", "Output tensor", "T")
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(ScaledTanh)
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .SetDoc(R"DOC(
+static const char * ScaledTanh_ver1_doc = R"DOC(
 Calculates the scaled hyperbolic tangent of the given input tensor element-wise,
 alpha * tanh(beta * x). This operation can be done in an in-place fashion too,
 by providing the same input and output blobs.
-    )DOC")
+    )DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(ScaledTanh, 1, OpSchema()
+    .SetSupportLevel(SupportType::EXPERIMENTAL)
+    .SetDoc(ScaledTanh_ver1_doc)
     .Attr("alpha", "Scaling value", AttributeProto::FLOAT, OPTIONAL)
     .Attr("beta", "Scaling value", AttributeProto::FLOAT, OPTIONAL)
     .Input(0, "input", "Input tensor", "T")
@@ -53,26 +60,26 @@ by providing the same input and output blobs.
         "computed element-wise", "T")
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(ParametricSoftplus)
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .SetDoc(R"DOC(
+static const char * ParametricSoftplus_ver1_doc = R"DOC(
 ParametricSoftplus takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the softplus function, y = alpha * ln(exp(beta * x) + 1), is applied to
 the tensor elementwise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(ParametricSoftplus, 1, OpSchema()
+    .SetSupportLevel(SupportType::EXPERIMENTAL)
+    .SetDoc(ParametricSoftplus_ver1_doc)
     .Attr("alpha", "Value of alpha", AttributeProto::FLOAT, OPTIONAL)
     .Attr("beta", "Value of beta", AttributeProto::FLOAT, OPTIONAL)
     .Input(0, "X", "1D input tensor", "T")
     .Output(0, "Y", "1D input tensor", "T")
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(ConstantFill)
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .SetDoc(R"DOC(
+static const char * ConstantFill_ver1_doc = R"DOC(
 The operator fills the elements of the output tensor with a constant value
 specified by the 'value' attribute.
 
@@ -91,7 +98,11 @@ containing the desired output shape (the dimensions specified in extra_shape
 will also be appended)
 
 NOTE: Currently, it supports data type of float, int32, int64, and bool.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(ConstantFill, 1, OpSchema()
+    .SetSupportLevel(SupportType::EXPERIMENTAL)
+    .SetDoc(ConstantFill_ver1_doc)
     .Attr(
         "value",
         "The value for the elements of the output tensor. Default is 0.",
@@ -161,9 +172,9 @@ NOTE: Currently, it supports data type of float, int32, int64, and bool.
             }
             updateOutputShape(ctx, 0, shape);
         }
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(GivenTensorFill)
+ONNX_OPERATOR_SET_SCHEMA(GivenTensorFill, 1, OpSchema()
 .SetSupportLevel(SupportType::EXPERIMENTAL)
 .Input(0, "shape", "The shape of filled tensor", "T", OpSchema::Optional)
 .Output(0, "X", "The filled tensor", "T")
@@ -196,10 +207,14 @@ ONNX_OPERATOR_SCHEMA(GivenTensorFill)
             }
             updateOutputShape(ctx, 0, shape);
         }
-    });
+    }));
 
+static const char * Scale_ver1_doc = R"DOC(
+Scale takes one input data (Tensor<float>) and produces one output data
+(Tensor<float>) whose value is the input data tensor scaled element-wise.
+)DOC";
 
-ONNX_OPERATOR_SCHEMA(Scale)
+ONNX_OPERATOR_SET_SCHEMA(Scale, 1, OpSchema()
     .SetSupportLevel(SupportType::EXPERIMENTAL)
     .Input(0, "input", "Input data to be scaled", "T")
     .Output(0, "output", "Output data after scaling", "T")
@@ -207,23 +222,22 @@ ONNX_OPERATOR_SCHEMA(Scale)
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .SetDoc(R"DOC(
-Scale takes one input data (Tensor<float>) and produces one output data
-(Tensor<float>) whose value is the input data tensor scaled element-wise.
-)DOC")
+    .SetDoc(Scale_ver1_doc)
     .Attr("scale", "(float, default 1.0) the scale to apply.", AttributeProto::FLOAT, 1.0f)
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(GRUUnit)
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .SetDoc(R"DOC(
+static const char * GRUUnit_ver1_doc = R"DOC(
 GRUUnit computes the activations of a standard GRU,
 in a sequence-length aware fashion.
 Concretely, given the (fused) inputs X (TxNxD), the previous hidden
 state (NxD), and the sequence lengths (N), computes the GRU
 activations, avoiding computation if the input is invalid (as in, the
 value at X[t][n] >= seqLengths[n].
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(GRUUnit, 1, OpSchema()
+    .SetSupportLevel(SupportType::EXPERIMENTAL)
+    .SetDoc(GRUUnit_ver1_doc)
     .Attr(
         "drop_states",
         "Bool to determine if hidden state is zeroes or passed "
@@ -248,26 +262,30 @@ value at X[t][n] >= seqLengths[n].
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(ATen)
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .AllowUncheckedAttributes()
-    .SetDoc(R"DOC(
+static const char * ATen_ver1_doc = R"DOC(
 Experimental allowing ATen operations to be accessed directly from Caffe2
 to allow for quick prototyping when ONNX is missing standard versions of
-and op)DOC")
+and op)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(ATen, 1, OpSchema()
+    .SetSupportLevel(SupportType::EXPERIMENTAL)
+    .AllowUncheckedAttributes()
+    .SetDoc(ATen_ver1_doc)
     .Input(0, "input", "Arbitrary input", "T", OpSchema::Variadic)
     .Output(0, "output", "Arbitrary output", "T", OpSchema::Variadic)
     .TypeConstraint("T",
         { "tensor(bool)", "tensor(int32)", "tensor(int64)",
         "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain output types to bool, int32, int64, float16, float, double tensors.");
+        "Constrain output types to bool, int32, int64, float16, float, double tensors."));
 
-ONNX_OPERATOR_SCHEMA(ImageScaler)
+static const char * ImageScaler_ver1_doc = R"DOC(Scale and bias the input image. Bias values are stored in
+the same ordering as the image pixel format.)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(ImageScaler, 1, OpSchema()
     .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .SetDoc(R"DOC(Scale and bias the input image. Bias values are stored in
-the same ordering as the image pixel format.)DOC")
+    .SetDoc(ImageScaler_ver1_doc)
     .Attr("bias", "Bias applied to each channel, same size as C.", AttributeProto::FLOATS, OPTIONAL)
     .Attr("scale", "(float, default 1.0) the scale to apply.", AttributeProto::FLOAT, 1.0f)
     .Input(0, "input", "Input tensor of shape [N,C,H,W]", "T")
@@ -276,11 +294,13 @@ the same ordering as the image pixel format.)DOC")
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(MeanVarianceNormalization)
+static const char * MeanVarianceNormalization_ver1_doc = R"DOC(Perform mean variance normalization.)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(MeanVarianceNormalization, 1, OpSchema()
     .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .SetDoc(R"DOC(Perform mean variance normalization.)DOC")
+    .SetDoc(MeanVarianceNormalization_ver1_doc)
     .Attr("across_channels", "If 1, mean and variance are computed across channels. Default is 0.", AttributeProto::INT, static_cast<int64_t>(0))
     .Attr("normalize_variance", "If 0, normalize the mean only.  Default is 1.", AttributeProto::INT, static_cast<int64_t>(1))
     .Input(0, "input", "Input tensor of shape [N,C,H,W]", "T")
@@ -289,13 +309,15 @@ ONNX_OPERATOR_SCHEMA(MeanVarianceNormalization)
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Crop)
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .SetDoc(R"DOC(Crop and image to the specified spatial dimensions. If scale is given,
+static const char * Crop_ver1_doc = R"DOC(Crop and image to the specified spatial dimensions. If scale is given,
 then optionally start the crop offset by the left/top border amounts.
-If scale is not provided, crop the borders as provided.)DOC")
+If scale is not provided, crop the borders as provided.)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Crop, 1, OpSchema()
+    .SetSupportLevel(SupportType::EXPERIMENTAL)
+    .SetDoc(Crop_ver1_doc)
     .Attr("border", "A 1-D values of (leftBorder, topBorder, rightBorder, bottomBorder).", AttributeProto::INTS, OPTIONAL)
     .Attr("scale", "A 1-D values of (height, width).", AttributeProto::INTS, OPTIONAL)
     .Input(0, "input", "Input tensor of shape [N,C,H,W]", "T")
@@ -303,4 +325,5 @@ If scale is not provided, crop the borders as provided.)DOC")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
+}

--- a/onnx/defs/experiments/defs.cc
+++ b/onnx/defs/experiments/defs.cc
@@ -2,84 +2,104 @@
 // Licensed under the MIT license.
 
 #include "onnx/defs/schema.h"
-namespace ONNX_NAMESPACE
-{
-  using SupportType = OpSchema::SupportType;
+namespace ONNX_NAMESPACE {
+using SupportType = OpSchema::SupportType;
 
 using SupportType = ONNX_NAMESPACE::OpSchema::SupportType;
 
-static const char * Affine_ver1_doc = R"DOC(
+static const char* Affine_ver1_doc = R"DOC(
 Affine takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the affine function, y = alpha * x + beta,
 is applied to the tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Affine, 1, OpSchema()
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .SetDoc(Affine_ver1_doc)
-    .Attr("alpha", "Value of alpha", AttributeProto::FLOAT, 1.0f)
-    .Attr("beta" , "Value of beta", AttributeProto::FLOAT, 0.0f)
-    .Input(0, "X", "1D input tensor", "T")
-    .Output(0, "Y", "1D output tensor", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Affine,
+    1,
+    OpSchema()
+        .SetSupportLevel(SupportType::EXPERIMENTAL)
+        .SetDoc(Affine_ver1_doc)
+        .Attr("alpha", "Value of alpha", AttributeProto::FLOAT, 1.0f)
+        .Attr("beta", "Value of beta", AttributeProto::FLOAT, 0.0f)
+        .Input(0, "X", "1D input tensor", "T")
+        .Output(0, "Y", "1D output tensor", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * ThresholdedRelu_ver1_doc = R"DOC(
+static const char* ThresholdedRelu_ver1_doc = R"DOC(
 ThresholdedRelu takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the rectified linear function, y = x for x > alpha, y = 0 otherwise,
 is applied to the tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(ThresholdedRelu, 1, OpSchema()
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .SetDoc(ThresholdedRelu_ver1_doc)
-    .Attr("alpha",
-          "Threshold value",
-          AttributeProto::FLOAT,
-          1.0f)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    ThresholdedRelu,
+    1,
+    OpSchema()
+        .SetSupportLevel(SupportType::EXPERIMENTAL)
+        .SetDoc(ThresholdedRelu_ver1_doc)
+        .Attr("alpha", "Threshold value", AttributeProto::FLOAT, 1.0f)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * ScaledTanh_ver1_doc = R"DOC(
+static const char* ScaledTanh_ver1_doc = R"DOC(
 Calculates the scaled hyperbolic tangent of the given input tensor element-wise,
 alpha * tanh(beta * x). This operation can be done in an in-place fashion too,
 by providing the same input and output blobs.
     )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(ScaledTanh, 1, OpSchema()
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .SetDoc(ScaledTanh_ver1_doc)
-    .Attr("alpha", "Scaling value", AttributeProto::FLOAT, OPTIONAL)
-    .Attr("beta", "Scaling value", AttributeProto::FLOAT, OPTIONAL)
-    .Input(0, "input", "Input tensor", "T")
-    .Output(0, "output", "The scaled hyperbolic tangent values of the input tensor "
-        "computed element-wise", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    ScaledTanh,
+    1,
+    OpSchema()
+        .SetSupportLevel(SupportType::EXPERIMENTAL)
+        .SetDoc(ScaledTanh_ver1_doc)
+        .Attr("alpha", "Scaling value", AttributeProto::FLOAT, OPTIONAL)
+        .Attr("beta", "Scaling value", AttributeProto::FLOAT, OPTIONAL)
+        .Input(0, "input", "Input tensor", "T")
+        .Output(
+            0,
+            "output",
+            "The scaled hyperbolic tangent values of the input tensor "
+            "computed element-wise",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * ParametricSoftplus_ver1_doc = R"DOC(
+static const char* ParametricSoftplus_ver1_doc = R"DOC(
 ParametricSoftplus takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the softplus function, y = alpha * ln(exp(beta * x) + 1), is applied to
 the tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(ParametricSoftplus, 1, OpSchema()
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .SetDoc(ParametricSoftplus_ver1_doc)
-    .Attr("alpha", "Value of alpha", AttributeProto::FLOAT, OPTIONAL)
-    .Attr("beta", "Value of beta", AttributeProto::FLOAT, OPTIONAL)
-    .Input(0, "X", "1D input tensor", "T")
-    .Output(0, "Y", "1D input tensor", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    ParametricSoftplus,
+    1,
+    OpSchema()
+        .SetSupportLevel(SupportType::EXPERIMENTAL)
+        .SetDoc(ParametricSoftplus_ver1_doc)
+        .Attr("alpha", "Value of alpha", AttributeProto::FLOAT, OPTIONAL)
+        .Attr("beta", "Value of beta", AttributeProto::FLOAT, OPTIONAL)
+        .Input(0, "X", "1D input tensor", "T")
+        .Output(0, "Y", "1D input tensor", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * ConstantFill_ver1_doc = R"DOC(
+static const char* ConstantFill_ver1_doc = R"DOC(
 The operator fills the elements of the output tensor with a constant value
 specified by the 'value' attribute.
 
@@ -100,133 +120,154 @@ will also be appended)
 NOTE: Currently, it supports data type of float, int32, int64, and bool.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(ConstantFill, 1, OpSchema()
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .SetDoc(ConstantFill_ver1_doc)
-    .Attr(
-        "value",
-        "The value for the elements of the output tensor. Default is 0.",
-        AttributeProto::FLOAT,
-        0.0f)
-    .Attr(
-        "dtype",
-        "The data type for the elements of the output tensor."
-        "Strictly must be one of the types from DataType enum in TensorProto.",
-        AttributeProto::INT,
-        static_cast<int64_t>(TensorProto::FLOAT))
-    .Attr(
-        "shape",
-        "The shape of the output tensor. "
-        "Cannot set the shape argument and pass in an input at the same time.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "extra_shape",
-        "The additional dimensions appended at the end of the shape indicated"
-        "by the input blob."
-        "Cannot set the extra_shape argument when there is no input blob.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "input_as_shape",
-        "1D tensor containing the desired output shape.  First input must be in "
-        "CPU context.",
-        AttributeProto::INT,
-        OPTIONAL)
-    .Input(
-        0,
-        "input",
-        "Input tensor (optional) to provide shape information.",
-        "T1",
-        OpSchema::Optional)
-    .Output(
-        0,
-        "output",
-        "Output tensor of constant values specified by 'value'"
-        "argument and its type is specified by the 'dtype' argument",
-        "T2")
-    .TypeConstraint(
-        "T1",
-        {"tensor(float)", "tensor(int32)", "tensor(int64)", "tensor(bool)"},
-        "Constrain input types to float, int32, int64, bool tensors.")
-    .TypeConstraint(
-        "T2",
-        {"tensor(float)", "tensor(int32)", "tensor(int64)", "tensor(bool)"},
-        "Constrain output types to float, int32, int64, bool tensors.")
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-        propagateElemTypeFromAttributeToOutput(ctx, "dtype", 0, TensorProto::FLOAT);
-        if (ctx.getAttribute("shape") != nullptr) {
+ONNX_OPERATOR_SET_SCHEMA(
+    ConstantFill,
+    1,
+    OpSchema()
+        .SetSupportLevel(SupportType::EXPERIMENTAL)
+        .SetDoc(ConstantFill_ver1_doc)
+        .Attr(
+            "value",
+            "The value for the elements of the output tensor. Default is 0.",
+            AttributeProto::FLOAT,
+            0.0f)
+        .Attr(
+            "dtype",
+            "The data type for the elements of the output tensor."
+            "Strictly must be one of the types from DataType enum in TensorProto.",
+            AttributeProto::INT,
+            static_cast<int64_t>(TensorProto::FLOAT))
+        .Attr(
+            "shape",
+            "The shape of the output tensor. "
+            "Cannot set the shape argument and pass in an input at the same time.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "extra_shape",
+            "The additional dimensions appended at the end of the shape indicated"
+            "by the input blob."
+            "Cannot set the extra_shape argument when there is no input blob.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "input_as_shape",
+            "1D tensor containing the desired output shape.  First input must be in "
+            "CPU context.",
+            AttributeProto::INT,
+            OPTIONAL)
+        .Input(
+            0,
+            "input",
+            "Input tensor (optional) to provide shape information.",
+            "T1",
+            OpSchema::Optional)
+        .Output(
+            0,
+            "output",
+            "Output tensor of constant values specified by 'value'"
+            "argument and its type is specified by the 'dtype' argument",
+            "T2")
+        .TypeConstraint(
+            "T1",
+            {"tensor(float)", "tensor(int32)", "tensor(int64)", "tensor(bool)"},
+            "Constrain input types to float, int32, int64, bool tensors.")
+        .TypeConstraint(
+            "T2",
+            {"tensor(float)", "tensor(int32)", "tensor(int64)", "tensor(bool)"},
+            "Constrain output types to float, int32, int64, bool tensors.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateElemTypeFromAttributeToOutput(
+              ctx, "dtype", 0, TensorProto::FLOAT);
+          if (ctx.getAttribute("shape") != nullptr) {
             propagateShapeFromAttributeToOutput(ctx, "shape", 0);
             return;
-        }
-        if (getAttribute(ctx, "input_as_shape", 0) != 0) // dynamic shape
+          }
+          if (getAttribute(ctx, "input_as_shape", 0) != 0) // dynamic shape
             return;
-        std::vector<int64_t> extra_shape;
-        getRepeatedAttribute(ctx, "extra_shape", extra_shape);
-        if (hasInputShape(ctx, 0)) {
+          std::vector<int64_t> extra_shape;
+          getRepeatedAttribute(ctx, "extra_shape", extra_shape);
+          if (hasInputShape(ctx, 0)) {
             TensorShapeProto shape = ctx.getInputType(0)->tensor_type().shape();
             for (auto extra_dim_val : extra_shape) {
-                if (extra_dim_val < 0)
-                    fail_shape_inference("Negative values are not allowed in a shape specification");
-                shape.add_dim()->set_dim_value(extra_dim_val);
+              if (extra_dim_val < 0)
+                fail_shape_inference(
+                    "Negative values are not allowed in a shape specification");
+              shape.add_dim()->set_dim_value(extra_dim_val);
             }
             updateOutputShape(ctx, 0, shape);
-        }
-    }));
+          }
+        }));
 
-ONNX_OPERATOR_SET_SCHEMA(GivenTensorFill, 1, OpSchema()
-.SetSupportLevel(SupportType::EXPERIMENTAL)
-.Input(0, "shape", "The shape of filled tensor", "T", OpSchema::Optional)
-.Output(0, "X", "The filled tensor", "T")
-.TypeConstraint(
-    "T",
-    { "tensor(float16)", "tensor(float)", "tensor(double)" },
-    "Constrain input and output types to float tensors.")
-    .Attr("values", "", AttributeProto::FLOATS, OPTIONAL)
-    .Attr("shape", "", AttributeProto::INTS, OPTIONAL)
-    .Attr("input_as_shape", "", AttributeProto::INT, OPTIONAL)
-    .Attr("extra_shape", "", AttributeProto::INTS, OPTIONAL)
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-        propagateElemTypeFromInputToOutput(ctx, 0, 0);
-        if (ctx.getAttribute("shape") != nullptr) {
+ONNX_OPERATOR_SET_SCHEMA(
+    GivenTensorFill,
+    1,
+    OpSchema()
+        .SetSupportLevel(SupportType::EXPERIMENTAL)
+        .Input(
+            0,
+            "shape",
+            "The shape of filled tensor",
+            "T",
+            OpSchema::Optional)
+        .Output(0, "X", "The filled tensor", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .Attr("values", "", AttributeProto::FLOATS, OPTIONAL)
+        .Attr("shape", "", AttributeProto::INTS, OPTIONAL)
+        .Attr("input_as_shape", "", AttributeProto::INT, OPTIONAL)
+        .Attr("extra_shape", "", AttributeProto::INTS, OPTIONAL)
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          if (ctx.getAttribute("shape") != nullptr) {
             propagateShapeFromAttributeToOutput(ctx, "shape", 0);
             return;
-        }
-        // The type constraints above do not allow for input_as_shape
-        // and may need to be fixed.
-        if (getAttribute(ctx, "input_as_shape", 0) != 0) // dynamic shape
+          }
+          // The type constraints above do not allow for input_as_shape
+          // and may need to be fixed.
+          if (getAttribute(ctx, "input_as_shape", 0) != 0) // dynamic shape
             return;
-        std::vector<int64_t> extra_shape;
-        getRepeatedAttribute(ctx, "extra_shape", extra_shape);
-        if (hasInputShape(ctx, 0)) {
+          std::vector<int64_t> extra_shape;
+          getRepeatedAttribute(ctx, "extra_shape", extra_shape);
+          if (hasInputShape(ctx, 0)) {
             TensorShapeProto shape = ctx.getInputType(0)->tensor_type().shape();
             for (auto extra_dim_val : extra_shape) {
-                if (extra_dim_val < 0)
-                    fail_shape_inference("Negative values are not allowed in a shape specification");
-                shape.add_dim()->set_dim_value(extra_dim_val);
+              if (extra_dim_val < 0)
+                fail_shape_inference(
+                    "Negative values are not allowed in a shape specification");
+              shape.add_dim()->set_dim_value(extra_dim_val);
             }
             updateOutputShape(ctx, 0, shape);
-        }
-    }));
+          }
+        }));
 
-static const char * Scale_ver1_doc = R"DOC(
+static const char* Scale_ver1_doc = R"DOC(
 Scale takes one input data (Tensor<float>) and produces one output data
 (Tensor<float>) whose value is the input data tensor scaled element-wise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Scale, 1, OpSchema()
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .Input(0, "input", "Input data to be scaled", "T")
-    .Output(0, "output", "Output data after scaling", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .SetDoc(Scale_ver1_doc)
-    .Attr("scale", "(float, default 1.0) the scale to apply.", AttributeProto::FLOAT, 1.0f)
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Scale,
+    1,
+    OpSchema()
+        .SetSupportLevel(SupportType::EXPERIMENTAL)
+        .Input(0, "input", "Input data to be scaled", "T")
+        .Output(0, "output", "Output data after scaling", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .SetDoc(Scale_ver1_doc)
+        .Attr(
+            "scale",
+            "(float, default 1.0) the scale to apply.",
+            AttributeProto::FLOAT,
+            1.0f)
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * GRUUnit_ver1_doc = R"DOC(
+static const char* GRUUnit_ver1_doc = R"DOC(
 GRUUnit computes the activations of a standard GRU,
 in a sequence-length aware fashion.
 Concretely, given the (fused) inputs X (TxNxD), the previous hidden
@@ -235,95 +276,150 @@ activations, avoiding computation if the input is invalid (as in, the
 value at X[t][n] >= seqLengths[n].
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(GRUUnit, 1, OpSchema()
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .SetDoc(GRUUnit_ver1_doc)
-    .Attr(
-        "drop_states",
-        "Bool to determine if hidden state is zeroes or passed "
-        "along for timesteps past the given sequence_length.",
-        AttributeProto::INT,
-        OPTIONAL)
-    .Input(0, "hidden_prev", "The previous GRU hidden state.", "T")
-    .Input(
-        1,
-        "gates",
-        "Unactivated gate outputs from forget, update, "
-        "and output gates, pre-activation.",
-        "T")
-    .Input(
-        2,
-        "seq_lengths",
-        "Array of sequence lengths.  "
-        "len(seq_lengths) should equal batch size N.",
-        "T")
-    .Input(3, "t", "The timestep for this operation.", "T")
-    .Output(0, "hidden", "The new GRU hidden state calculated by this op.", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    GRUUnit,
+    1,
+    OpSchema()
+        .SetSupportLevel(SupportType::EXPERIMENTAL)
+        .SetDoc(GRUUnit_ver1_doc)
+        .Attr(
+            "drop_states",
+            "Bool to determine if hidden state is zeroes or passed "
+            "along for timesteps past the given sequence_length.",
+            AttributeProto::INT,
+            OPTIONAL)
+        .Input(0, "hidden_prev", "The previous GRU hidden state.", "T")
+        .Input(
+            1,
+            "gates",
+            "Unactivated gate outputs from forget, update, "
+            "and output gates, pre-activation.",
+            "T")
+        .Input(
+            2,
+            "seq_lengths",
+            "Array of sequence lengths.  "
+            "len(seq_lengths) should equal batch size N.",
+            "T")
+        .Input(3, "t", "The timestep for this operation.", "T")
+        .Output(
+            0,
+            "hidden",
+            "The new GRU hidden state calculated by this op.",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * ATen_ver1_doc = R"DOC(
+static const char* ATen_ver1_doc = R"DOC(
 Experimental allowing ATen operations to be accessed directly from Caffe2
 to allow for quick prototyping when ONNX is missing standard versions of
 and op)DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(ATen, 1, OpSchema()
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .AllowUncheckedAttributes()
-    .SetDoc(ATen_ver1_doc)
-    .Input(0, "input", "Arbitrary input", "T", OpSchema::Variadic)
-    .Output(0, "output", "Arbitrary output", "T", OpSchema::Variadic)
-    .TypeConstraint("T",
-        { "tensor(bool)", "tensor(int32)", "tensor(int64)",
-        "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain output types to bool, int32, int64, float16, float, double tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    ATen,
+    1,
+    OpSchema()
+        .SetSupportLevel(SupportType::EXPERIMENTAL)
+        .AllowUncheckedAttributes()
+        .SetDoc(ATen_ver1_doc)
+        .Input(0, "input", "Arbitrary input", "T", OpSchema::Variadic)
+        .Output(0, "output", "Arbitrary output", "T", OpSchema::Variadic)
+        .TypeConstraint(
+            "T",
+            {"tensor(bool)",
+             "tensor(int32)",
+             "tensor(int64)",
+             "tensor(float16)",
+             "tensor(float)",
+             "tensor(double)"},
+            "Constrain output types to bool, int32, int64, float16, float, double tensors."));
 
-static const char * ImageScaler_ver1_doc = R"DOC(Scale and bias the input image. Bias values are stored in
+static const char* ImageScaler_ver1_doc =
+    R"DOC(Scale and bias the input image. Bias values are stored in
 the same ordering as the image pixel format.)DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(ImageScaler, 1, OpSchema()
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .SetDoc(ImageScaler_ver1_doc)
-    .Attr("bias", "Bias applied to each channel, same size as C.", AttributeProto::FLOATS, OPTIONAL)
-    .Attr("scale", "(float, default 1.0) the scale to apply.", AttributeProto::FLOAT, 1.0f)
-    .Input(0, "input", "Input tensor of shape [N,C,H,W]", "T")
-    .Output(0, "output", "Result, has same shape and type as input", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    ImageScaler,
+    1,
+    OpSchema()
+        .SetSupportLevel(SupportType::EXPERIMENTAL)
+        .SetDoc(ImageScaler_ver1_doc)
+        .Attr(
+            "bias",
+            "Bias applied to each channel, same size as C.",
+            AttributeProto::FLOATS,
+            OPTIONAL)
+        .Attr(
+            "scale",
+            "(float, default 1.0) the scale to apply.",
+            AttributeProto::FLOAT,
+            1.0f)
+        .Input(0, "input", "Input tensor of shape [N,C,H,W]", "T")
+        .Output(0, "output", "Result, has same shape and type as input", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * MeanVarianceNormalization_ver1_doc = R"DOC(Perform mean variance normalization.)DOC";
+static const char* MeanVarianceNormalization_ver1_doc =
+    R"DOC(Perform mean variance normalization.)DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(MeanVarianceNormalization, 1, OpSchema()
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .SetDoc(MeanVarianceNormalization_ver1_doc)
-    .Attr("across_channels", "If 1, mean and variance are computed across channels. Default is 0.", AttributeProto::INT, static_cast<int64_t>(0))
-    .Attr("normalize_variance", "If 0, normalize the mean only.  Default is 1.", AttributeProto::INT, static_cast<int64_t>(1))
-    .Input(0, "input", "Input tensor of shape [N,C,H,W]", "T")
-    .Output(0, "output", "Result, has same shape and type as input", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    MeanVarianceNormalization,
+    1,
+    OpSchema()
+        .SetSupportLevel(SupportType::EXPERIMENTAL)
+        .SetDoc(MeanVarianceNormalization_ver1_doc)
+        .Attr(
+            "across_channels",
+            "If 1, mean and variance are computed across channels. Default is 0.",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Attr(
+            "normalize_variance",
+            "If 0, normalize the mean only.  Default is 1.",
+            AttributeProto::INT,
+            static_cast<int64_t>(1))
+        .Input(0, "input", "Input tensor of shape [N,C,H,W]", "T")
+        .Output(0, "output", "Result, has same shape and type as input", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Crop_ver1_doc = R"DOC(Crop and image to the specified spatial dimensions. If scale is given,
+static const char* Crop_ver1_doc =
+    R"DOC(Crop and image to the specified spatial dimensions. If scale is given,
 then optionally start the crop offset by the left/top border amounts.
 If scale is not provided, crop the borders as provided.)DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Crop, 1, OpSchema()
-    .SetSupportLevel(SupportType::EXPERIMENTAL)
-    .SetDoc(Crop_ver1_doc)
-    .Attr("border", "A 1-D values of (leftBorder, topBorder, rightBorder, bottomBorder).", AttributeProto::INTS, OPTIONAL)
-    .Attr("scale", "A 1-D values of (height, width).", AttributeProto::INTS, OPTIONAL)
-    .Input(0, "input", "Input tensor of shape [N,C,H,W]", "T")
-    .Output(0, "output", "Result, has same type as input, with H and W dimensions reduced.", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
-}
+ONNX_OPERATOR_SET_SCHEMA(
+    Crop,
+    1,
+    OpSchema()
+        .SetSupportLevel(SupportType::EXPERIMENTAL)
+        .SetDoc(Crop_ver1_doc)
+        .Attr(
+            "border",
+            "A 1-D values of (leftBorder, topBorder, rightBorder, bottomBorder).",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "scale",
+            "A 1-D values of (height, width).",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Input(0, "input", "Input tensor of shape [N,C,H,W]", "T")
+        .Output(
+            0,
+            "output",
+            "Result, has same type as input, with H and W dimensions reduced.",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
+} // namespace ONNX_NAMESPACE

--- a/onnx/defs/function.cc
+++ b/onnx/defs/function.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 #include "onnx/defs/function.h"
+#include "onnx/defs/schema.h"
 #include "onnx/checker.h"
 #include "onnx/string_utils.h"
 

--- a/onnx/defs/function.cc
+++ b/onnx/defs/function.cc
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 #include "onnx/defs/function.h"
-#include "onnx/defs/schema.h"
 #include "onnx/checker.h"
+#include "onnx/defs/schema.h"
 #include "onnx/string_utils.h"
 
 namespace ONNX_NAMESPACE {

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -2,10 +2,13 @@
 // Licensed under the MIT license.
 
 #include "onnx/defs/schema.h"
-using namespace ONNX_NAMESPACE;
+namespace ONNX_NAMESPACE
+{
 
-ONNX_OPERATOR_SCHEMA(Constant)
-    .SetDoc(R"DOC(A constant tensor.)DOC")
+static const char * Constant_ver1_doc = R"DOC(A constant tensor.)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Constant, 1, OpSchema()
+    .SetDoc(Constant_ver1_doc)
     .Attr(
           "value",
           "The value for the elements of the output tensor.",
@@ -23,17 +26,19 @@ ONNX_OPERATOR_SCHEMA(Constant)
         const TensorProto& tensor_proto = attr_proto->t();
         updateOutputElemType(ctx, 0, tensor_proto.data_type());
         updateOutputShape(ctx, 0, tensor_proto);
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(RandomUniform)
-    .SetDoc(R"DOC(
+static const char * RandomUniform_ver1_doc = R"DOC(
 Generate a tensor with random values drawn from a uniform distribution. The shape
 of the tensor is specified by the `shape` argument and the range by `low` and `high`.
 
 The data type is specified by the 'dtype' argument. The 'dtype' argument must
 be one of the data types specified in the 'DataType' enum field in the
 TensorProto message.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(RandomUniform, 1, OpSchema()
+    .SetDoc(RandomUniform_ver1_doc)
     .Attr(
           "low",
           "Lower boundary of the output values. If not specified, default is 0.",
@@ -67,10 +72,9 @@ TensorProto message.
     .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
         propagateElemTypeFromAttributeToOutput(ctx, "dtype", 0);
         propagateShapeFromAttributeToOutput(ctx, "shape", 0);
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(RandomNormal)
-    .SetDoc(R"DOC(
+static const char * RandomNormal_ver1_doc = R"DOC(
 Generate a tensor with random values drawn from a normal distribution. The shape
 of the tensor is specified by the `shape` argument and the parameter of the normal distribution
 specified by `mean` and `scale`.
@@ -78,7 +82,10 @@ specified by `mean` and `scale`.
 The data type is specified by the 'dtype' argument. The 'dtype' argument must
 be one of the data types specified in the 'DataType' enum field in the
 TensorProto message.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(RandomNormal, 1, OpSchema()
+    .SetDoc(RandomNormal_ver1_doc)
     .Attr(
           "mean",
           "The mean of the normal distribution. If not specified, default is 0.",
@@ -112,10 +119,9 @@ TensorProto message.
     .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
         propagateElemTypeFromAttributeToOutput(ctx, "dtype", 0);
         propagateShapeFromAttributeToOutput(ctx, "shape", 0);
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(RandomUniformLike)
-    .SetDoc(R"DOC(
+static const char * RandomUniformLike_ver1_doc = R"DOC(
 Generate a tensor with random values drawn from a uniform distribution. 
 The shape of the output tensor is copied from the shape of the input tensor, 
 and the parameters of the uniform distribution are specified by `low` and `high`.
@@ -123,7 +129,10 @@ and the parameters of the uniform distribution are specified by `low` and `high`
 The data type is specified by the 'dtype' argument, or copied from the input tensor if not provided. 
 The 'dtype' argument must be one of the data types specified in the 'DataType' enum field in the
 TensorProto message and be valid as an output type.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(RandomUniformLike, 1, OpSchema()
+    .SetDoc(RandomUniformLike_ver1_doc)
     .Attr(
           "low",
           "Lower boundary of the output values. If not specified, default is 0.",
@@ -168,10 +177,9 @@ TensorProto message and be valid as an output type.
           return;
         }
         propagateShapeFromInputToOutput(ctx, 0, 0);
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(RandomNormalLike)
-    .SetDoc(R"DOC(
+static const char * RandomNormalLike_ver1_doc = R"DOC(
 Generate a tensor with random values drawn from a normal distribution. 
 The shape of the output tensor is copied from the shape of the input tensor, 
 and the parameters of the normal distribution are specified by `mean` and `scale`.
@@ -179,7 +187,10 @@ and the parameters of the normal distribution are specified by `mean` and `scale
 The data type is specified by the 'dtype' argument, or copied from the input tensor if not provided. 
 The 'dtype' argument must be one of the data types specified in the 'DataType' enum field in the
 TensorProto message, and be valid as an output type.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(RandomNormalLike, 1, OpSchema()
+    .SetDoc(RandomNormalLike_ver1_doc)
     .Attr(
           "mean",
           "The mean of the normal distribution. If not specified, default is 0.",
@@ -224,14 +235,15 @@ TensorProto message, and be valid as an output type.
           return;
         }
         propagateShapeFromInputToOutput(ctx, 0, 0);
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(Multinomial)
-	.SinceVersion(7)
-    .SetDoc(R"DOC(
+static const char * Multinomial_ver7_doc = R"DOC(
 Generate a tensor of samples from a multinomial distribution according to the probabilities
 of each of the possible outcomes.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Multinomial, 7, OpSchema()
+    .SetDoc(Multinomial_ver7_doc)
     .Attr(
         "sample_size",
         "Number of times to sample.",
@@ -290,4 +302,6 @@ of each of the possible outcomes.
         auto dim = shape->add_dim();
         *dim = input_type->tensor_type().shape().dim(0);
         shape->add_dim()->set_dim_value(sample_size->i());
-    });
+    }));
+
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -2,33 +2,40 @@
 // Licensed under the MIT license.
 
 #include "onnx/defs/schema.h"
-namespace ONNX_NAMESPACE
-{
+namespace ONNX_NAMESPACE {
 
-static const char * Constant_ver1_doc = R"DOC(A constant tensor.)DOC";
+static const char* Constant_ver1_doc = R"DOC(A constant tensor.)DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Constant, 1, OpSchema()
-    .SetDoc(Constant_ver1_doc)
-    .Attr(
-          "value",
-          "The value for the elements of the output tensor.",
-          AttributeProto::TENSOR)
-    .Output(
+ONNX_OPERATOR_SET_SCHEMA(
+    Constant,
+    1,
+    OpSchema()
+        .SetDoc(Constant_ver1_doc)
+        .Attr(
+            "value",
+            "The value for the elements of the output tensor.",
+            AttributeProto::TENSOR)
+        .Output(
             0,
             "output",
-            "Output tensor containing the same value of the provided tensor.", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-        auto attr_proto = ctx.getAttribute("value");
-        if (nullptr == attr_proto) return; // attribute not present
-        if (!attr_proto->has_t()) return; // attribute has no tensor value
-        const TensorProto& tensor_proto = attr_proto->t();
-        updateOutputElemType(ctx, 0, tensor_proto.data_type());
-        updateOutputShape(ctx, 0, tensor_proto);
-    }));
+            "Output tensor containing the same value of the provided tensor.",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          auto attr_proto = ctx.getAttribute("value");
+          if (nullptr == attr_proto)
+            return; // attribute not present
+          if (!attr_proto->has_t())
+            return; // attribute has no tensor value
+          const TensorProto& tensor_proto = attr_proto->t();
+          updateOutputElemType(ctx, 0, tensor_proto.data_type());
+          updateOutputShape(ctx, 0, tensor_proto);
+        }));
 
-static const char * RandomUniform_ver1_doc = R"DOC(
+static const char* RandomUniform_ver1_doc = R"DOC(
 Generate a tensor with random values drawn from a uniform distribution. The shape
 of the tensor is specified by the `shape` argument and the range by `low` and `high`.
 
@@ -37,44 +44,47 @@ be one of the data types specified in the 'DataType' enum field in the
 TensorProto message.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(RandomUniform, 1, OpSchema()
-    .SetDoc(RandomUniform_ver1_doc)
-    .Attr(
-          "low",
-          "Lower boundary of the output values. If not specified, default is 0.",
-          AttributeProto::FLOAT,
-          0.0f)
-    .Attr(
-          "high",
-          "Upper boundary of the output values. If not specified, default is 1.",
-          AttributeProto::FLOAT,
-          1.0f)
-    .Attr(
-          "seed",
-          "(Optional) Seed to the random generator, if not specified we will auto generate one.",
-          AttributeProto::FLOAT,
-          OPTIONAL)
-    .Attr(
-          "dtype",
-          "The data type for the elements of the output tensor. If not specified, default is TensorProto::FLOAT.",
-          AttributeProto::INT,
-          static_cast<int64_t>(TensorProto::FLOAT))
-    .Attr(
-          "shape",
-          "The shape of the output tensor.",
-          AttributeProto::INTS)
-    .Output(
+ONNX_OPERATOR_SET_SCHEMA(
+    RandomUniform,
+    1,
+    OpSchema()
+        .SetDoc(RandomUniform_ver1_doc)
+        .Attr(
+            "low",
+            "Lower boundary of the output values. If not specified, default is 0.",
+            AttributeProto::FLOAT,
+            0.0f)
+        .Attr(
+            "high",
+            "Upper boundary of the output values. If not specified, default is 1.",
+            AttributeProto::FLOAT,
+            1.0f)
+        .Attr(
+            "seed",
+            "(Optional) Seed to the random generator, if not specified we will auto generate one.",
+            AttributeProto::FLOAT,
+            OPTIONAL)
+        .Attr(
+            "dtype",
+            "The data type for the elements of the output tensor. If not specified, default is TensorProto::FLOAT.",
+            AttributeProto::INT,
+            static_cast<int64_t>(TensorProto::FLOAT))
+        .Attr("shape", "The shape of the output tensor.", AttributeProto::INTS)
+        .Output(
             0,
             "output",
-            "Output tensor of random values drawn from uniform distribution", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain output types to float tensors.")
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-        propagateElemTypeFromAttributeToOutput(ctx, "dtype", 0);
-        propagateShapeFromAttributeToOutput(ctx, "shape", 0);
-    }));
+            "Output tensor of random values drawn from uniform distribution",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain output types to float tensors.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateElemTypeFromAttributeToOutput(ctx, "dtype", 0);
+          propagateShapeFromAttributeToOutput(ctx, "shape", 0);
+        }));
 
-static const char * RandomNormal_ver1_doc = R"DOC(
+static const char* RandomNormal_ver1_doc = R"DOC(
 Generate a tensor with random values drawn from a normal distribution. The shape
 of the tensor is specified by the `shape` argument and the parameter of the normal distribution
 specified by `mean` and `scale`.
@@ -84,44 +94,47 @@ be one of the data types specified in the 'DataType' enum field in the
 TensorProto message.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(RandomNormal, 1, OpSchema()
-    .SetDoc(RandomNormal_ver1_doc)
-    .Attr(
-          "mean",
-          "The mean of the normal distribution. If not specified, default is 0.",
-          AttributeProto::FLOAT,
-          0.0f)
-    .Attr(
-          "scale",
-          "The standard deviation of the normal distribution. If not specified, default is 1.",
-          AttributeProto::FLOAT,
-          1.0f)
-    .Attr(
-          "seed",
-          "(Optional) Seed to the random generator, if not specified we will auto generate one.",
-          AttributeProto::FLOAT,
-          OPTIONAL)
-    .Attr(
-          "dtype",
-          "The data type for the elements of the output tensor. Default is TensorProto::FLOAT.",
-          AttributeProto::INT,
-          static_cast<int64_t>(TensorProto::FLOAT))
-    .Attr(
-          "shape",
-          "The shape of the output tensor.",
-          AttributeProto::INTS)
-    .Output(
+ONNX_OPERATOR_SET_SCHEMA(
+    RandomNormal,
+    1,
+    OpSchema()
+        .SetDoc(RandomNormal_ver1_doc)
+        .Attr(
+            "mean",
+            "The mean of the normal distribution. If not specified, default is 0.",
+            AttributeProto::FLOAT,
+            0.0f)
+        .Attr(
+            "scale",
+            "The standard deviation of the normal distribution. If not specified, default is 1.",
+            AttributeProto::FLOAT,
+            1.0f)
+        .Attr(
+            "seed",
+            "(Optional) Seed to the random generator, if not specified we will auto generate one.",
+            AttributeProto::FLOAT,
+            OPTIONAL)
+        .Attr(
+            "dtype",
+            "The data type for the elements of the output tensor. Default is TensorProto::FLOAT.",
+            AttributeProto::INT,
+            static_cast<int64_t>(TensorProto::FLOAT))
+        .Attr("shape", "The shape of the output tensor.", AttributeProto::INTS)
+        .Output(
             0,
             "output",
-            "Output tensor of random values drawn from normal distribution", "T")
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain output types to float tensors.")
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-        propagateElemTypeFromAttributeToOutput(ctx, "dtype", 0);
-        propagateShapeFromAttributeToOutput(ctx, "shape", 0);
-    }));
+            "Output tensor of random values drawn from normal distribution",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain output types to float tensors.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateElemTypeFromAttributeToOutput(ctx, "dtype", 0);
+          propagateShapeFromAttributeToOutput(ctx, "shape", 0);
+        }));
 
-static const char * RandomUniformLike_ver1_doc = R"DOC(
+static const char* RandomUniformLike_ver1_doc = R"DOC(
 Generate a tensor with random values drawn from a uniform distribution. 
 The shape of the output tensor is copied from the shape of the input tensor, 
 and the parameters of the uniform distribution are specified by `low` and `high`.
@@ -131,55 +144,62 @@ The 'dtype' argument must be one of the data types specified in the 'DataType' e
 TensorProto message and be valid as an output type.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(RandomUniformLike, 1, OpSchema()
-    .SetDoc(RandomUniformLike_ver1_doc)
-    .Attr(
-          "low",
-          "Lower boundary of the output values. If not specified, default is 0.",
-          AttributeProto::FLOAT,
-          0.0f)
-    .Attr(
-          "high",
-          "Upper boundary of the output values. If not specified, default is 1.",
-          AttributeProto::FLOAT,
-          1.0f)
-    .Attr(
-          "seed",
-          "(Optional) Seed to the random generator, if not specified we will auto generate one.",
-          AttributeProto::FLOAT,
-          OPTIONAL)
-    .Attr(
-          "dtype",
-          "(Optional) The data type for the elements of the output tensor, if not specified, we will use"
-          "the data type of the input tensor.",
-          AttributeProto::INT,
-          OPTIONAL)
-    .Input(
-           0,
-           "input",
-           "Input tensor to copy shape and optionally type information from.", "T1")
-    .Output(
+ONNX_OPERATOR_SET_SCHEMA(
+    RandomUniformLike,
+    1,
+    OpSchema()
+        .SetDoc(RandomUniformLike_ver1_doc)
+        .Attr(
+            "low",
+            "Lower boundary of the output values. If not specified, default is 0.",
+            AttributeProto::FLOAT,
+            0.0f)
+        .Attr(
+            "high",
+            "Upper boundary of the output values. If not specified, default is 1.",
+            AttributeProto::FLOAT,
+            1.0f)
+        .Attr(
+            "seed",
+            "(Optional) Seed to the random generator, if not specified we will auto generate one.",
+            AttributeProto::FLOAT,
+            OPTIONAL)
+        .Attr(
+            "dtype",
+            "(Optional) The data type for the elements of the output tensor, if not specified, we will use"
+            "the data type of the input tensor.",
+            AttributeProto::INT,
+            OPTIONAL)
+        .Input(
+            0,
+            "input",
+            "Input tensor to copy shape and optionally type information from.",
+            "T1")
+        .Output(
             0,
             "output",
-            "Output tensor of random values drawn from uniform distribution", "T2")
-    .TypeConstraint(
-        "T1",
-        OpSchema::all_tensor_types(),
-        "Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type.")
-    .TypeConstraint("T2", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain output types to float tensors.")
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-        if (ctx.getAttribute("dtype") != nullptr) 
-          propagateElemTypeFromAttributeToOutput(ctx, "dtype", 0);
-        else
-          propagateElemTypeFromInputToOutput(ctx, 0, 0);
-        if (!hasNInputShapes(ctx, 1)) {
-          return;
-        }
-        propagateShapeFromInputToOutput(ctx, 0, 0);
-    }));
+            "Output tensor of random values drawn from uniform distribution",
+            "T2")
+        .TypeConstraint(
+            "T1",
+            OpSchema::all_tensor_types(),
+            "Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type.")
+        .TypeConstraint(
+            "T2",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain output types to float tensors.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          if (ctx.getAttribute("dtype") != nullptr)
+            propagateElemTypeFromAttributeToOutput(ctx, "dtype", 0);
+          else
+            propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          if (!hasNInputShapes(ctx, 1)) {
+            return;
+          }
+          propagateShapeFromInputToOutput(ctx, 0, 0);
+        }));
 
-static const char * RandomNormalLike_ver1_doc = R"DOC(
+static const char* RandomNormalLike_ver1_doc = R"DOC(
 Generate a tensor with random values drawn from a normal distribution. 
 The shape of the output tensor is copied from the shape of the input tensor, 
 and the parameters of the normal distribution are specified by `mean` and `scale`.
@@ -189,119 +209,133 @@ The 'dtype' argument must be one of the data types specified in the 'DataType' e
 TensorProto message, and be valid as an output type.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(RandomNormalLike, 1, OpSchema()
-    .SetDoc(RandomNormalLike_ver1_doc)
-    .Attr(
-          "mean",
-          "The mean of the normal distribution. If not specified, default is 0.",
-          AttributeProto::FLOAT,
-          0.0f)
-    .Attr(
-          "scale",
-          "The standard deviation of the normal distribution. If not specified, default is 1.",
-          AttributeProto::FLOAT,
-          1.0f)
-    .Attr(
-          "seed",
-          "(Optional) Seed to the random generator, if not specified we will auto generate one.",
-          AttributeProto::FLOAT,
-          OPTIONAL)
-    .Attr(
-          "dtype",
-          "(Optional) The data type for the elements of the output tensor, if not specified, we will use"
-          "the data type of the input tensor.",
-          AttributeProto::INT,
-          OPTIONAL)
-    .Input(
-           0,
-           "input",
-           "Input tensor to copy shape and optionally type information from.", "T1")
-    .Output(
+ONNX_OPERATOR_SET_SCHEMA(
+    RandomNormalLike,
+    1,
+    OpSchema()
+        .SetDoc(RandomNormalLike_ver1_doc)
+        .Attr(
+            "mean",
+            "The mean of the normal distribution. If not specified, default is 0.",
+            AttributeProto::FLOAT,
+            0.0f)
+        .Attr(
+            "scale",
+            "The standard deviation of the normal distribution. If not specified, default is 1.",
+            AttributeProto::FLOAT,
+            1.0f)
+        .Attr(
+            "seed",
+            "(Optional) Seed to the random generator, if not specified we will auto generate one.",
+            AttributeProto::FLOAT,
+            OPTIONAL)
+        .Attr(
+            "dtype",
+            "(Optional) The data type for the elements of the output tensor, if not specified, we will use"
+            "the data type of the input tensor.",
+            AttributeProto::INT,
+            OPTIONAL)
+        .Input(
+            0,
+            "input",
+            "Input tensor to copy shape and optionally type information from.",
+            "T1")
+        .Output(
             0,
             "output",
-            "Output tensor of random values drawn from normal distribution", "T2")
-    .TypeConstraint(
-        "T1",
-        OpSchema::all_tensor_types(),
-        "Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type.")
-    .TypeConstraint("T2", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain output types to float tensors.")
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-        if (ctx.getAttribute("dtype") != nullptr) 
-          propagateElemTypeFromAttributeToOutput(ctx, "dtype", 0);
-        else
-          propagateElemTypeFromInputToOutput(ctx, 0, 0);
-        if (!hasNInputShapes(ctx, 1)) {
-          return;
-        }
-        propagateShapeFromInputToOutput(ctx, 0, 0);
-    }));
+            "Output tensor of random values drawn from normal distribution",
+            "T2")
+        .TypeConstraint(
+            "T1",
+            OpSchema::all_tensor_types(),
+            "Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type.")
+        .TypeConstraint(
+            "T2",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain output types to float tensors.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          if (ctx.getAttribute("dtype") != nullptr)
+            propagateElemTypeFromAttributeToOutput(ctx, "dtype", 0);
+          else
+            propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          if (!hasNInputShapes(ctx, 1)) {
+            return;
+          }
+          propagateShapeFromInputToOutput(ctx, 0, 0);
+        }));
 
-static const char * Multinomial_ver7_doc = R"DOC(
+static const char* Multinomial_ver7_doc = R"DOC(
 Generate a tensor of samples from a multinomial distribution according to the probabilities
 of each of the possible outcomes.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Multinomial, 7, OpSchema()
-    .SetDoc(Multinomial_ver7_doc)
-    .Attr(
-        "sample_size",
-        "Number of times to sample.",
-        AttributeProto::INT,
-        static_cast<int64_t>(1))
-    .Attr(
-        "seed",
-        "(Optional) Seed to the random generator, if not specified we will auto generate one.",
-        AttributeProto::FLOAT,
-        OPTIONAL)
-    .Attr(
-        "dtype",
-        "(Optional) The data type for the elements of the output tensor, if not specified, we will use int32.",
-        AttributeProto::INT,
-        static_cast<int64_t>(TensorProto::INT32))
-    .Input(
-        0,
-        "input",
-        "Input tensor with shape [batch_size, class_size], where class_size is the number of all possible outcomes. Each value along the axis zero represents the unnormalized log-probability of each corresponding outcome in a batch.", "T1")
-    .Output(
-        0,
-        "output",
-        "Output tensor with shape [batch_size, sample_size], where sample_size is the number of times to sample. Each value along the axis zero represents the outcome of the corresponding sample in a batch.", "T2")
-    .TypeConstraint(
-        "T1",
-        { "tensor(float16)", "tensor(float)", "tensor(double)" },
-        "Constrain input types to float tensors.")
-    .TypeConstraint(
-        "T2",
-        { "tensor(int32)", "tensor(int64)" },
-        "Constrain output types to integral tensors.")
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-        auto output_type = ctx.getOutputType(0);
-        auto input_type = ctx.getInputType(0);
-        if (input_type == nullptr || output_type == nullptr ||
-            TypeProto::kTensorType != output_type->value_case() ||
-            TypeProto::kTensorType != input_type->value_case()) {
+ONNX_OPERATOR_SET_SCHEMA(
+    Multinomial,
+    7,
+    OpSchema()
+        .SetDoc(Multinomial_ver7_doc)
+        .Attr(
+            "sample_size",
+            "Number of times to sample.",
+            AttributeProto::INT,
+            static_cast<int64_t>(1))
+        .Attr(
+            "seed",
+            "(Optional) Seed to the random generator, if not specified we will auto generate one.",
+            AttributeProto::FLOAT,
+            OPTIONAL)
+        .Attr(
+            "dtype",
+            "(Optional) The data type for the elements of the output tensor, if not specified, we will use int32.",
+            AttributeProto::INT,
+            static_cast<int64_t>(TensorProto::INT32))
+        .Input(
+            0,
+            "input",
+            "Input tensor with shape [batch_size, class_size], where class_size is the number of all possible outcomes. Each value along the axis zero represents the unnormalized log-probability of each corresponding outcome in a batch.",
+            "T1")
+        .Output(
+            0,
+            "output",
+            "Output tensor with shape [batch_size, sample_size], where sample_size is the number of times to sample. Each value along the axis zero represents the outcome of the corresponding sample in a batch.",
+            "T2")
+        .TypeConstraint(
+            "T1",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input types to float tensors.")
+        .TypeConstraint(
+            "T2",
+            {"tensor(int32)", "tensor(int64)"},
+            "Constrain output types to integral tensors.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          auto output_type = ctx.getOutputType(0);
+          auto input_type = ctx.getInputType(0);
+          if (input_type == nullptr || output_type == nullptr ||
+              TypeProto::kTensorType != output_type->value_case() ||
+              TypeProto::kTensorType != input_type->value_case()) {
             return;
-        }
-        auto sample_size = ctx.getAttribute("sample_size");
-        if (nullptr == sample_size || !sample_size->has_type() || // invalid attribute : has no type
-            sample_size->type() != AttributeProto_AttributeType_INT) { // invalid attribute type
+          }
+          auto sample_size = ctx.getAttribute("sample_size");
+          if (nullptr == sample_size ||
+              !sample_size->has_type() || // invalid attribute : has no type
+              sample_size->type() !=
+                  AttributeProto_AttributeType_INT) { // invalid attribute type
             return;
-        }
-        auto dtype = ctx.getAttribute("dtype");
-        auto dataType = TensorProto_DataType::TensorProto_DataType_INT32;
-        if (dtype != nullptr) {
+          }
+          auto dtype = ctx.getAttribute("dtype");
+          auto dataType = TensorProto_DataType::TensorProto_DataType_INT32;
+          if (dtype != nullptr) {
             dataType = static_cast<TensorProto_DataType>(dtype->i());
-        }
-        if (dataType != TensorProto_DataType::TensorProto_DataType_INT32 &&
-            dataType != TensorProto_DataType::TensorProto_DataType_INT64) {
+          }
+          if (dataType != TensorProto_DataType::TensorProto_DataType_INT32 &&
+              dataType != TensorProto_DataType::TensorProto_DataType_INT64) {
             return;
-        }
-        output_type->mutable_tensor_type()->set_elem_type(dataType);
-        auto shape = output_type->mutable_tensor_type()->mutable_shape();
-        auto dim = shape->add_dim();
-        *dim = input_type->tensor_type().shape().dim(0);
-        shape->add_dim()->set_dim_value(sample_size->i());
-    }));
+          }
+          output_type->mutable_tensor_type()->set_elem_type(dataType);
+          auto shape = output_type->mutable_tensor_type()->mutable_shape();
+          auto dim = shape->add_dim();
+          *dim = input_type->tensor_type().shape().dim(0);
+          shape->add_dim()->set_dim_value(sample_size->i());
+        }));
 
-}  // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE

--- a/onnx/defs/logical/defs.cc
+++ b/onnx/defs/logical/defs.cc
@@ -3,8 +3,6 @@
 
 #include "onnx/defs/schema.h"
 
-using namespace ONNX_NAMESPACE;
-
 namespace ONNX_NAMESPACE {
 
 inline void unaryLogicalOpInference(InferenceContext& ctx) {
@@ -28,7 +26,6 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
         schema.Input(0, "A", "First input operand for the logical operator.", "T");
         schema.Input(1, "B", "Second input operand for the logical operator.", "T");
         schema.Output(0, "C", "Result tensor.", "T1");
-        schema.SinceVersion(7);
         schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
             updateOutputElemType(ctx, 0, TensorProto::BOOL);
             bidirectionalBroadcastShapeInference(
@@ -39,56 +36,58 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
     };
 }
 
-ONNX_OPERATOR_SCHEMA(And)
+ONNX_OPERATOR_SET_SCHEMA(And, 7, OpSchema()
     .FillUsing(BinaryLogicDocGenerator("and"))
     .TypeConstraint("T", { "tensor(bool)" },
                     "Constrains input to boolean tensor.")
     .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor.");
+                    "Constrains output to boolean tensor."));
 
-ONNX_OPERATOR_SCHEMA(Or)
+ONNX_OPERATOR_SET_SCHEMA(Or, 7, OpSchema()
     .FillUsing(BinaryLogicDocGenerator("or"))
     .TypeConstraint("T", { "tensor(bool)" },
                     "Constrains input to boolean tensor.")
     .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor.");
+                    "Constrains output to boolean tensor."));
 
-ONNX_OPERATOR_SCHEMA(Xor)
+ONNX_OPERATOR_SET_SCHEMA(Xor, 7, OpSchema()
     .FillUsing(BinaryLogicDocGenerator("xor"))
     .TypeConstraint("T", { "tensor(bool)" },
                     "Constrains input to boolean tensor.")
     .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor.");
+                    "Constrains output to boolean tensor."));
 
-ONNX_OPERATOR_SCHEMA(Greater)
+ONNX_OPERATOR_SET_SCHEMA(Greater, 7, OpSchema()
     .FillUsing(BinaryLogicDocGenerator("greater"))
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
                     "Constrains input to float tensors.")
     .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor.");
+                    "Constrains output to boolean tensor."));
 
-ONNX_OPERATOR_SCHEMA(Less)
+ONNX_OPERATOR_SET_SCHEMA(Less, 7, OpSchema()
     .FillUsing(BinaryLogicDocGenerator("less"))
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
                     "Constrains input to float tensors.")
     .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor.");
+                    "Constrains output to boolean tensor."));
 
-ONNX_OPERATOR_SCHEMA(Equal)
+ONNX_OPERATOR_SET_SCHEMA(Equal, 7, OpSchema()
     .FillUsing(BinaryLogicDocGenerator("equal"))
     .TypeConstraint("T", { "tensor(bool)", "tensor(int32)", "tensor(int64)" },
                     "Constrains input to integral tensors.")
     .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor.");
+                    "Constrains output to boolean tensor."));
 
-ONNX_OPERATOR_SCHEMA(Not)
-    .SetDoc(R"DOC(
+static const char * Not_ver1_doc = R"DOC(
 Returns the negation of the input tensor element-wise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Not, 1, OpSchema()
+    .SetDoc(Not_ver1_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     .TypeConstraint("T", { "tensor(bool)" },
                     "Constrains input/output to boolean tensors.")
-    .TypeAndShapeInferenceFunction(unaryLogicalOpInference);
+    .TypeAndShapeInferenceFunction(unaryLogicalOpInference));
 
 }  // namespace ONNX_NAMESPACE

--- a/onnx/defs/logical/defs.cc
+++ b/onnx/defs/logical/defs.cc
@@ -36,58 +36,105 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
     };
 }
 
-ONNX_OPERATOR_SET_SCHEMA(And, 7, OpSchema()
-    .FillUsing(BinaryLogicDocGenerator("and"))
-    .TypeConstraint("T", { "tensor(bool)" },
-                    "Constrains input to boolean tensor.")
-    .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor."));
+ONNX_OPERATOR_SET_SCHEMA(
+    And,
+    7,
+    OpSchema()
+        .FillUsing(BinaryLogicDocGenerator("and"))
+        .TypeConstraint(
+            "T",
+            {"tensor(bool)"},
+            "Constrains input to boolean tensor.")
+        .TypeConstraint(
+            "T1",
+            {"tensor(bool)"},
+            "Constrains output to boolean tensor."));
 
-ONNX_OPERATOR_SET_SCHEMA(Or, 7, OpSchema()
-    .FillUsing(BinaryLogicDocGenerator("or"))
-    .TypeConstraint("T", { "tensor(bool)" },
-                    "Constrains input to boolean tensor.")
-    .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Or,
+    7,
+    OpSchema()
+        .FillUsing(BinaryLogicDocGenerator("or"))
+        .TypeConstraint(
+            "T",
+            {"tensor(bool)"},
+            "Constrains input to boolean tensor.")
+        .TypeConstraint(
+            "T1",
+            {"tensor(bool)"},
+            "Constrains output to boolean tensor."));
 
-ONNX_OPERATOR_SET_SCHEMA(Xor, 7, OpSchema()
-    .FillUsing(BinaryLogicDocGenerator("xor"))
-    .TypeConstraint("T", { "tensor(bool)" },
-                    "Constrains input to boolean tensor.")
-    .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Xor,
+    7,
+    OpSchema()
+        .FillUsing(BinaryLogicDocGenerator("xor"))
+        .TypeConstraint(
+            "T",
+            {"tensor(bool)"},
+            "Constrains input to boolean tensor.")
+        .TypeConstraint(
+            "T1",
+            {"tensor(bool)"},
+            "Constrains output to boolean tensor."));
 
-ONNX_OPERATOR_SET_SCHEMA(Greater, 7, OpSchema()
-    .FillUsing(BinaryLogicDocGenerator("greater"))
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-                    "Constrains input to float tensors.")
-    .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Greater,
+    7,
+    OpSchema()
+        .FillUsing(BinaryLogicDocGenerator("greater"))
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrains input to float tensors.")
+        .TypeConstraint(
+            "T1",
+            {"tensor(bool)"},
+            "Constrains output to boolean tensor."));
 
-ONNX_OPERATOR_SET_SCHEMA(Less, 7, OpSchema()
-    .FillUsing(BinaryLogicDocGenerator("less"))
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-                    "Constrains input to float tensors.")
-    .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Less,
+    7,
+    OpSchema()
+        .FillUsing(BinaryLogicDocGenerator("less"))
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrains input to float tensors.")
+        .TypeConstraint(
+            "T1",
+            {"tensor(bool)"},
+            "Constrains output to boolean tensor."));
 
-ONNX_OPERATOR_SET_SCHEMA(Equal, 7, OpSchema()
-    .FillUsing(BinaryLogicDocGenerator("equal"))
-    .TypeConstraint("T", { "tensor(bool)", "tensor(int32)", "tensor(int64)" },
-                    "Constrains input to integral tensors.")
-    .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Equal,
+    7,
+    OpSchema()
+        .FillUsing(BinaryLogicDocGenerator("equal"))
+        .TypeConstraint(
+            "T",
+            {"tensor(bool)", "tensor(int32)", "tensor(int64)"},
+            "Constrains input to integral tensors.")
+        .TypeConstraint(
+            "T1",
+            {"tensor(bool)"},
+            "Constrains output to boolean tensor."));
 
-static const char * Not_ver1_doc = R"DOC(
+static const char* Not_ver1_doc = R"DOC(
 Returns the negation of the input tensor element-wise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Not, 1, OpSchema()
-    .SetDoc(Not_ver1_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint("T", { "tensor(bool)" },
-                    "Constrains input/output to boolean tensors.")
-    .TypeAndShapeInferenceFunction(unaryLogicalOpInference));
+ONNX_OPERATOR_SET_SCHEMA(
+    Not,
+    1,
+    OpSchema()
+        .SetDoc(Not_ver1_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(bool)"},
+            "Constrains input/output to boolean tensors.")
+        .TypeAndShapeInferenceFunction(unaryLogicalOpInference));
 
 }  // namespace ONNX_NAMESPACE

--- a/onnx/defs/logical/old.cc
+++ b/onnx/defs/logical/old.cc
@@ -37,46 +37,88 @@ detailed description of the broadcasting rules.
     };
 }
 
-ONNX_OPERATOR_SET_SCHEMA(And, 1, OpSchema()
-    .FillUsing(BinaryLogicDocGenerator_opset1("and"))
-    .TypeConstraint("T", { "tensor(bool)" },
-                    "Constrains input to boolean tensor.")
-    .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor."));
+ONNX_OPERATOR_SET_SCHEMA(
+    And,
+    1,
+    OpSchema()
+        .FillUsing(BinaryLogicDocGenerator_opset1("and"))
+        .TypeConstraint(
+            "T",
+            {"tensor(bool)"},
+            "Constrains input to boolean tensor.")
+        .TypeConstraint(
+            "T1",
+            {"tensor(bool)"},
+            "Constrains output to boolean tensor."));
 
-ONNX_OPERATOR_SET_SCHEMA(Or, 1, OpSchema()
-    .FillUsing(BinaryLogicDocGenerator_opset1("or"))
-    .TypeConstraint("T", { "tensor(bool)" },
-                    "Constrains input to boolean tensor.")
-    .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Or,
+    1,
+    OpSchema()
+        .FillUsing(BinaryLogicDocGenerator_opset1("or"))
+        .TypeConstraint(
+            "T",
+            {"tensor(bool)"},
+            "Constrains input to boolean tensor.")
+        .TypeConstraint(
+            "T1",
+            {"tensor(bool)"},
+            "Constrains output to boolean tensor."));
 
-ONNX_OPERATOR_SET_SCHEMA(Xor, 1, OpSchema()
-    .FillUsing(BinaryLogicDocGenerator_opset1("xor"))
-    .TypeConstraint("T", { "tensor(bool)" },
-                    "Constrains input to boolean tensor.")
-    .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Xor,
+    1,
+    OpSchema()
+        .FillUsing(BinaryLogicDocGenerator_opset1("xor"))
+        .TypeConstraint(
+            "T",
+            {"tensor(bool)"},
+            "Constrains input to boolean tensor.")
+        .TypeConstraint(
+            "T1",
+            {"tensor(bool)"},
+            "Constrains output to boolean tensor."));
 
-ONNX_OPERATOR_SET_SCHEMA(Greater, 1, OpSchema()
-    .FillUsing(BinaryLogicDocGenerator_opset1("greater"))
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-                    "Constrains input to float tensors.")
-    .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Greater,
+    1,
+    OpSchema()
+        .FillUsing(BinaryLogicDocGenerator_opset1("greater"))
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrains input to float tensors.")
+        .TypeConstraint(
+            "T1",
+            {"tensor(bool)"},
+            "Constrains output to boolean tensor."));
 
-ONNX_OPERATOR_SET_SCHEMA(Less, 1, OpSchema()
-    .FillUsing(BinaryLogicDocGenerator_opset1("less"))
-    .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
-                    "Constrains input to float tensors.")
-    .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Less,
+    1,
+    OpSchema()
+        .FillUsing(BinaryLogicDocGenerator_opset1("less"))
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrains input to float tensors.")
+        .TypeConstraint(
+            "T1",
+            {"tensor(bool)"},
+            "Constrains output to boolean tensor."));
 
-ONNX_OPERATOR_SET_SCHEMA(Equal, 1, OpSchema()
-    .FillUsing(BinaryLogicDocGenerator_opset1("equal"))
-    .TypeConstraint("T", { "tensor(bool)", "tensor(int32)", "tensor(int64)" },
-                    "Constrains input to integral tensors.")
-    .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Equal,
+    1,
+    OpSchema()
+        .FillUsing(BinaryLogicDocGenerator_opset1("equal"))
+        .TypeConstraint(
+            "T",
+            {"tensor(bool)", "tensor(int32)", "tensor(int64)"},
+            "Constrains input to integral tensors.")
+        .TypeConstraint(
+            "T1",
+            {"tensor(bool)"},
+            "Constrains output to boolean tensor."));
 
 }  // namespace ONNX_NAMESPACE

--- a/onnx/defs/logical/old.cc
+++ b/onnx/defs/logical/old.cc
@@ -33,51 +33,50 @@ detailed description of the broadcasting rules.
         schema.Input(0, "A", "Left input tensor for the logical operator.", "T");
         schema.Input(1, "B", "Right input tensor for the logical operator.", "T");
 		schema.Output(0, "C", "Result tensor.", "T1");
-        schema.SinceVersion(1);
 		schema.TypeAndShapeInferenceFunction(logicalOpInference_opset1);
     };
 }
 
-ONNX_OPERATOR_SCHEMA(And)
+ONNX_OPERATOR_SET_SCHEMA(And, 1, OpSchema()
     .FillUsing(BinaryLogicDocGenerator_opset1("and"))
     .TypeConstraint("T", { "tensor(bool)" },
                     "Constrains input to boolean tensor.")
     .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor.");
+                    "Constrains output to boolean tensor."));
 
-ONNX_OPERATOR_SCHEMA(Or)
+ONNX_OPERATOR_SET_SCHEMA(Or, 1, OpSchema()
     .FillUsing(BinaryLogicDocGenerator_opset1("or"))
     .TypeConstraint("T", { "tensor(bool)" },
                     "Constrains input to boolean tensor.")
     .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor.");
+                    "Constrains output to boolean tensor."));
 
-ONNX_OPERATOR_SCHEMA(Xor)
+ONNX_OPERATOR_SET_SCHEMA(Xor, 1, OpSchema()
     .FillUsing(BinaryLogicDocGenerator_opset1("xor"))
     .TypeConstraint("T", { "tensor(bool)" },
                     "Constrains input to boolean tensor.")
     .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor.");
+                    "Constrains output to boolean tensor."));
 
-ONNX_OPERATOR_SCHEMA(Greater)
+ONNX_OPERATOR_SET_SCHEMA(Greater, 1, OpSchema()
     .FillUsing(BinaryLogicDocGenerator_opset1("greater"))
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
                     "Constrains input to float tensors.")
     .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor.");
+                    "Constrains output to boolean tensor."));
 
-ONNX_OPERATOR_SCHEMA(Less)
+ONNX_OPERATOR_SET_SCHEMA(Less, 1, OpSchema()
     .FillUsing(BinaryLogicDocGenerator_opset1("less"))
     .TypeConstraint("T", { "tensor(float16)", "tensor(float)", "tensor(double)" },
                     "Constrains input to float tensors.")
     .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor.");
+                    "Constrains output to boolean tensor."));
 
-ONNX_OPERATOR_SCHEMA(Equal)
+ONNX_OPERATOR_SET_SCHEMA(Equal, 1, OpSchema()
     .FillUsing(BinaryLogicDocGenerator_opset1("equal"))
     .TypeConstraint("T", { "tensor(bool)", "tensor(int32)", "tensor(int64)" },
                     "Constrains input to integral tensors.")
     .TypeConstraint("T1", { "tensor(bool)" },
-                    "Constrains output to boolean tensor.");
+                    "Constrains output to boolean tensor."));
 
 }  // namespace ONNX_NAMESPACE

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -92,480 +92,579 @@ will throw errors.
   };
 }
 
-ONNX_OPERATOR_SET_SCHEMA(Add, 7, OpSchema().FillUsing(
-    MathDocGenerator("addition")));
+ONNX_OPERATOR_SET_SCHEMA(
+    Add,
+    7,
+    OpSchema().FillUsing(MathDocGenerator("addition")));
 
-ONNX_OPERATOR_SET_SCHEMA(Sub, 7, OpSchema().FillUsing(
-    MathDocGenerator("subtraction")));
+ONNX_OPERATOR_SET_SCHEMA(
+    Sub,
+    7,
+    OpSchema().FillUsing(MathDocGenerator("subtraction")));
 
-ONNX_OPERATOR_SET_SCHEMA(Mul, 7, OpSchema().FillUsing(
-    MathDocGenerator("multiplication")));
+ONNX_OPERATOR_SET_SCHEMA(
+    Mul,
+    7,
+    OpSchema().FillUsing(MathDocGenerator("multiplication")));
 
-ONNX_OPERATOR_SET_SCHEMA(Div, 7, OpSchema().FillUsing(
-    MathDocGenerator("division")));
+ONNX_OPERATOR_SET_SCHEMA(
+    Div,
+    7,
+    OpSchema().FillUsing(MathDocGenerator("division")));
 
-static const char * Neg_ver6_doc = R"DOC(
+static const char* Neg_ver6_doc = R"DOC(
 Neg takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where each element flipped sign, y = -x, is applied to
 the tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Neg, 6, OpSchema()
-    .SetDoc(Neg_ver6_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float)",
-         "tensor(int32)",
-         "tensor(int8)",
-         "tensor(int16)",
-         "tensor(int64)",
-         "tensor(float16)",
-         "tensor(double)"},
-        "Constrain input and output types to signed numeric tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Neg,
+    6,
+    OpSchema()
+        .SetDoc(Neg_ver6_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float)",
+             "tensor(int32)",
+             "tensor(int8)",
+             "tensor(int16)",
+             "tensor(int64)",
+             "tensor(float16)",
+             "tensor(double)"},
+            "Constrain input and output types to signed numeric tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Abs_ver6_doc = R"DOC(
+static const char* Abs_ver6_doc = R"DOC(
 Absolute takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the absolute is, y = abs(x), is applied to
 the tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Abs, 6, OpSchema()
-    .SetDoc(Abs_ver6_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint(
-        "T",
-        OpSchema::all_numeric_types(),
-        "Constrain input and output types to all numeric tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Abs,
+    6,
+    OpSchema()
+        .SetDoc(Abs_ver6_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        .TypeConstraint(
+            "T",
+            OpSchema::all_numeric_types(),
+            "Constrain input and output types to all numeric tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Reciprocal_ver6_doc = R"DOC(
+static const char* Reciprocal_ver6_doc = R"DOC(
 Reciprocal takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the reciprocal is, y = 1/x, is applied to
 the tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Reciprocal, 6, OpSchema()
-    .SetDoc(Reciprocal_ver6_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Reciprocal,
+    6,
+    OpSchema()
+        .SetDoc(Reciprocal_ver6_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Floor_ver6_doc = R"DOC(
+static const char* Floor_ver6_doc = R"DOC(
 Floor takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the floor is, y = floor(x), is applied to
 the tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Floor, 6, OpSchema()
-    .SetDoc(Floor_ver6_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Floor,
+    6,
+    OpSchema()
+        .SetDoc(Floor_ver6_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Ceil_ver6_doc = R"DOC(
+static const char* Ceil_ver6_doc = R"DOC(
 Ceil takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the ceil is, y = ceil(x), is applied to
 the tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Ceil, 6, OpSchema()
-    .SetDoc(Ceil_ver6_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Ceil,
+    6,
+    OpSchema()
+        .SetDoc(Ceil_ver6_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Sqrt_ver6_doc = R"DOC(
+static const char* Sqrt_ver6_doc = R"DOC(
 Square root takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the square root is, y = x^0.5, is applied to
 the tensor elementwise. If x is negative, then it will return NaN.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Sqrt, 6, OpSchema()
-    .SetDoc(Sqrt_ver6_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Sqrt,
+    6,
+    OpSchema()
+        .SetDoc(Sqrt_ver6_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Relu_ver6_doc = R"DOC(
+static const char* Relu_ver6_doc = R"DOC(
 Relu takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the rectified linear function, y = max(0, x), is applied to
 the tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Relu, 6, OpSchema()
-    .SetDoc(Relu_ver6_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Relu,
+    6,
+    OpSchema()
+        .SetDoc(Relu_ver6_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * LeakyRelu_ver6_doc = R"DOC(
+static const char* LeakyRelu_ver6_doc = R"DOC(
 LeakyRelu takes input data (Tensor<T>) and an argument alpha, and produces one
 output data (Tensor<T>) where the function `f(x) = alpha * x for x < 0`,
 `f(x) = x for x >= 0`, is applied to the data tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(LeakyRelu, 6, OpSchema()
-    .Attr(
-        "alpha",
-        "Coefficient of leakage default to 0.01.",
-        AttributeProto::FLOAT,
-        0.01f)
-    .SetDoc(LeakyRelu_ver6_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    LeakyRelu,
+    6,
+    OpSchema()
+        .Attr(
+            "alpha",
+            "Coefficient of leakage default to 0.01.",
+            AttributeProto::FLOAT,
+            0.01f)
+        .SetDoc(LeakyRelu_ver6_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Selu_ver6_doc = R"DOC(
+static const char* Selu_ver6_doc = R"DOC(
 Selu takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the scaled exponential linear unit function,
 `y = gamma * (alpha * e^x - alpha) for x <= 0`, `y = gamma * x for x > 0`,
 is applied to the tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Selu, 6, OpSchema()
-    .Attr(
-        "alpha",
-        "Coefficient of SELU default to 1.67326319217681884765625 "
-        "(i.e., float32 approximation of 1.6732632423543772848170429916717).",
-        AttributeProto::FLOAT,
-        1.67326319217681884765625f)
-    .Attr(
-        "gamma",
-        "Coefficient of SELU default to 1.05070102214813232421875 "
-        "(i.e., float32 approximation of 1.0507009873554804934193349852946).",
-        AttributeProto::FLOAT,
-        1.05070102214813232421875f)
-    .SetDoc(Selu_ver6_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Selu,
+    6,
+    OpSchema()
+        .Attr(
+            "alpha",
+            "Coefficient of SELU default to 1.67326319217681884765625 "
+            "(i.e., float32 approximation of 1.6732632423543772848170429916717).",
+            AttributeProto::FLOAT,
+            1.67326319217681884765625f)
+        .Attr(
+            "gamma",
+            "Coefficient of SELU default to 1.05070102214813232421875 "
+            "(i.e., float32 approximation of 1.0507009873554804934193349852946).",
+            AttributeProto::FLOAT,
+            1.05070102214813232421875f)
+        .SetDoc(Selu_ver6_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Elu_ver6_doc = R"DOC(
+static const char* Elu_ver6_doc = R"DOC(
 Elu takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the function `f(x) = alpha * (exp(x) - 1.) for x <
 0`, `f(x) = x for x >= 0`., is applied to the tensor elementwise.
 
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Elu, 6, OpSchema()
-    .Attr(
-        "alpha",
-        "Coefficient of ELU default to 1.0.",
-        AttributeProto::FLOAT,
-        1.0f)
-    .SetDoc(Elu_ver6_doc)
-    .Input(0, "X", "1D input tensor", "T")
-    .Output(0, "Y", "1D input tensor", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Elu,
+    6,
+    OpSchema()
+        .Attr(
+            "alpha",
+            "Coefficient of ELU default to 1.0.",
+            AttributeProto::FLOAT,
+            1.0f)
+        .SetDoc(Elu_ver6_doc)
+        .Input(0, "X", "1D input tensor", "T")
+        .Output(0, "Y", "1D input tensor", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Exp_ver6_doc = R"DOC(
+static const char* Exp_ver6_doc = R"DOC(
 Calculates the exponential of the given input tensor, element-wise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Exp, 6, OpSchema()
-    .SetDoc(Exp_ver6_doc)
-    .Input(0, "input", "Input tensor", "T")
-    .Output(
-        0,
-        "output",
-        "The exponential of the input tensor computed "
-        "element-wise",
-        "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Exp,
+    6,
+    OpSchema()
+        .SetDoc(Exp_ver6_doc)
+        .Input(0, "input", "Input tensor", "T")
+        .Output(
+            0,
+            "output",
+            "The exponential of the input tensor computed "
+            "element-wise",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Log_ver6_doc = R"DOC(
+static const char* Log_ver6_doc = R"DOC(
 Calculates the natural log of the given input tensor, element-wise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Log, 6, OpSchema()
-    .SetDoc(Log_ver6_doc)
-    .Input(0, "input", "Input tensor", "T")
-    .Output(
-        0,
-        "output",
-        "The natural log of the input tensor computed "
-        "element-wise",
-        "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Log,
+    6,
+    OpSchema()
+        .SetDoc(Log_ver6_doc)
+        .Input(0, "input", "Input tensor", "T")
+        .Output(
+            0,
+            "output",
+            "The natural log of the input tensor computed "
+            "element-wise",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Tanh_ver6_doc = R"DOC(
+static const char* Tanh_ver6_doc = R"DOC(
 Calculates the hyperbolic tangent of the given input tensor element-wise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Tanh, 6, OpSchema()
-    .SetDoc(Tanh_ver6_doc)
-    .Input(0, "input", "Input tensor", "T")
-    .Output(
-        0,
-        "output",
-        "The hyperbolic tangent values of the input tensor "
-        "computed element-wise",
-        "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Tanh,
+    6,
+    OpSchema()
+        .SetDoc(Tanh_ver6_doc)
+        .Input(0, "input", "Input tensor", "T")
+        .Output(
+            0,
+            "output",
+            "The hyperbolic tangent values of the input tensor "
+            "computed element-wise",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Pow_ver7_doc = R"DOC(
+static const char* Pow_ver7_doc = R"DOC(
 Pow takes input data (Tensor<T>) and exponent Tensor, and
 produces one output data (Tensor<T>) where the function `f(x) = x^exponent`,
 is applied to the data tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Pow, 7, OpSchema()
-    .SetDoc(std::string(Pow_ver7_doc) + GenerateBroadcastingDocMul())
-    .Input(0, "X", "First operand, base of the exponent.", "T")
-    .Input(
-        1,
-        "Y",
-        "Second operand, power of the exponent.",
-        "T")
-    .Output(0, "Z", "Output tensor (same size as X)", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-        propagateElemTypeFromInputToOutput(ctx, 0, 0);
-        bidirectionalBroadcastShapeInference(
-            ctx.getInputType(0)->tensor_type().shape(),
-            ctx.getInputType(1)->tensor_type().shape(),
-            *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
-    }));
+ONNX_OPERATOR_SET_SCHEMA(
+    Pow,
+    7,
+    OpSchema()
+        .SetDoc(std::string(Pow_ver7_doc) + GenerateBroadcastingDocMul())
+        .Input(0, "X", "First operand, base of the exponent.", "T")
+        .Input(1, "Y", "Second operand, power of the exponent.", "T")
+        .Output(0, "Z", "Output tensor (same size as X)", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          bidirectionalBroadcastShapeInference(
+              ctx.getInputType(0)->tensor_type().shape(),
+              ctx.getInputType(1)->tensor_type().shape(),
+              *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
+        }));
 
-static const char * PRelu_ver6_doc = R"DOC(
+static const char* PRelu_ver6_doc = R"DOC(
 PRelu takes input data (Tensor<T>) and slope tensor as input, and produces one
 output data (Tensor<T>) where the function `f(x) = slope * x for x < 0`,
 `f(x) = x for x >= 0`., is applied to the data tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(PRelu, 6, OpSchema()
-    .SetDoc(PRelu_ver6_doc + GenerateBroadcastingDocUni("tensor slope", "input tensor X"))
-    .Input(0, "X", "Input tensor", "T")
-    .Input(
-        1,
-        "slope",
-        "Slope tensor. The shape of slope can be smaller then first input X; "
-        "if so, its shape must be unidirectional broadcastable to X",
-        "T")
-    .Output(0, "Y", "Output tensor (same size as X)", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    PRelu,
+    6,
+    OpSchema()
+        .SetDoc(
+            PRelu_ver6_doc +
+            GenerateBroadcastingDocUni("tensor slope", "input tensor X"))
+        .Input(0, "X", "Input tensor", "T")
+        .Input(
+            1,
+            "slope",
+            "Slope tensor. The shape of slope can be smaller then first input X; "
+            "if so, its shape must be unidirectional broadcastable to X",
+            "T")
+        .Output(0, "Y", "Output tensor (same size as X)", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Sigmoid_ver6_doc = R"DOC(
+static const char* Sigmoid_ver6_doc = R"DOC(
 Sigmoid takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the sigmoid function, y = 1 / (1 + exp(-x)), is applied to the
 tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Sigmoid, 6, OpSchema()
-    .SetDoc(Sigmoid_ver6_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Sigmoid,
+    6,
+    OpSchema()
+        .SetDoc(Sigmoid_ver6_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * HardSigmoid_ver6_doc = R"DOC(
+static const char* HardSigmoid_ver6_doc = R"DOC(
 HardSigmoid takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the HardSigmoid function, y = max(0, min(1, alpha * x + beta)),
 is applied to the tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(HardSigmoid, 6, OpSchema()
-    .Attr("alpha", "Value of alpha default to 0.2", AttributeProto::FLOAT, 0.2f)
-    .Attr("beta", "Value of beta default to 0.5", AttributeProto::FLOAT, 0.5f)
-    .SetDoc(HardSigmoid_ver6_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    HardSigmoid,
+    6,
+    OpSchema()
+        .Attr(
+            "alpha",
+            "Value of alpha default to 0.2",
+            AttributeProto::FLOAT,
+            0.2f)
+        .Attr(
+            "beta",
+            "Value of beta default to 0.5",
+            AttributeProto::FLOAT,
+            0.5f)
+        .SetDoc(HardSigmoid_ver6_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Max_ver6_doc = R"DOC(
+static const char* Max_ver6_doc = R"DOC(
 Element-wise max of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Max, 6, OpSchema()
-    .SetDoc(Max_ver6_doc)
-    .Input(0, "data_0", "List of tensors for Max.", "T", OpSchema::Variadic)
-    .Output(0, "max", "Output tensor. Same dimension as inputs.", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Max,
+    6,
+    OpSchema()
+        .SetDoc(Max_ver6_doc)
+        .Input(0, "data_0", "List of tensors for Max.", "T", OpSchema::Variadic)
+        .Output(0, "max", "Output tensor. Same dimension as inputs.", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Min_ver6_doc = R"DOC(
+static const char* Min_ver6_doc = R"DOC(
 Element-wise min of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Min, 6, OpSchema()
-    .SetDoc(Min_ver6_doc)
-    .Input(0, "data_0", "List of tensors for Min", "T", OpSchema::Variadic)
-    .Output(0, "min", "Output tensor. Same dimension as inputs.", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Min,
+    6,
+    OpSchema()
+        .SetDoc(Min_ver6_doc)
+        .Input(0, "data_0", "List of tensors for Min", "T", OpSchema::Variadic)
+        .Output(0, "min", "Output tensor. Same dimension as inputs.", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Sum_ver6_doc = R"DOC(
+static const char* Sum_ver6_doc = R"DOC(
 Element-wise sum of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Sum, 6, OpSchema()
-    .SetDoc(Sum_ver6_doc)
-    .Input(0, "data_0", "List of tensors for Sum.", "T", OpSchema::Variadic)
-    .Output(0, "sum", "Output tensor. Same dimension as inputs.", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Sum,
+    6,
+    OpSchema()
+        .SetDoc(Sum_ver6_doc)
+        .Input(0, "data_0", "List of tensors for Sum.", "T", OpSchema::Variadic)
+        .Output(0, "sum", "Output tensor. Same dimension as inputs.", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Mean_ver6_doc = R"DOC(
+static const char* Mean_ver6_doc = R"DOC(
 Element-wise mean of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Mean, 6, OpSchema()
-    .SetDoc(Mean_ver6_doc)
-    .Input(0, "data_0", "List of tensors for Mean.", "T", OpSchema::Variadic)
-    .Output(0, "mean", "Output tensor. Same dimension as inputs.", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Mean,
+    6,
+    OpSchema()
+        .SetDoc(Mean_ver6_doc)
+        .Input(
+            0,
+            "data_0",
+            "List of tensors for Mean.",
+            "T",
+            OpSchema::Variadic)
+        .Output(0, "mean", "Output tensor. Same dimension as inputs.", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Clip_ver6_doc = R"DOC(
+static const char* Clip_ver6_doc = R"DOC(
 Clip operator limits the given input within an interval. The interval is
 specified with arguments 'min' and 'max'. They default to
 numeric_limits::lowest() and numeric_limits::max() respectively.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Clip, 6, OpSchema()
-    .SetDoc(Clip_ver6_doc)
-    .Attr(
-        "min",
-        "Minimum value, under which element is replaced by min",
-        AttributeProto::FLOAT,
-        std::numeric_limits<float>::lowest())
-    .Attr(
-        "max",
-        "Maximum value, above which element is replaced by max",
-        AttributeProto::FLOAT,
-        std::numeric_limits<float>::max())
-    .Input(0, "input", "Input tensor whose elements to be clipped", "T")
-    .Output(0, "output", "Output tensor with clipped input elements", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Clip,
+    6,
+    OpSchema()
+        .SetDoc(Clip_ver6_doc)
+        .Attr(
+            "min",
+            "Minimum value, under which element is replaced by min",
+            AttributeProto::FLOAT,
+            std::numeric_limits<float>::lowest())
+        .Attr(
+            "max",
+            "Maximum value, above which element is replaced by max",
+            AttributeProto::FLOAT,
+            std::numeric_limits<float>::max())
+        .Input(0, "input", "Input tensor whose elements to be clipped", "T")
+        .Output(0, "output", "Output tensor with clipped input elements", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SET_SCHEMA(Softmax, 1, OpSchema()
-    .FillUsing(SoftmaxFamilyDocGenerator("softmax", "normalized exponential")));
+ONNX_OPERATOR_SET_SCHEMA(
+    Softmax,
+    1,
+    OpSchema().FillUsing(
+        SoftmaxFamilyDocGenerator("softmax", "normalized exponential")));
 
-ONNX_OPERATOR_SET_SCHEMA(LogSoftmax, 1, OpSchema()
-    .FillUsing(SoftmaxFamilyDocGenerator("logsoftmax", "log of softmax")));
+ONNX_OPERATOR_SET_SCHEMA(
+    LogSoftmax,
+    1,
+    OpSchema().FillUsing(
+        SoftmaxFamilyDocGenerator("logsoftmax", "log of softmax")));
 
-ONNX_OPERATOR_SET_SCHEMA(Hardmax, 1, OpSchema()
-    .FillUsing(SoftmaxFamilyDocGenerator(
-      "hardmax",
-      "1 for the first maximum value, and 0 for all others")));
+ONNX_OPERATOR_SET_SCHEMA(
+    Hardmax,
+    1,
+    OpSchema().FillUsing(SoftmaxFamilyDocGenerator(
+        "hardmax",
+        "1 for the first maximum value, and 0 for all others")));
 
-static const char * Softsign_ver1_doc = R"DOC(
+static const char* Softsign_ver1_doc = R"DOC(
 Calculates the softsign (x/(1+|x|)) of the given input tensor element-wise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Softsign, 1, OpSchema()
-    .SetDoc(Softsign_ver1_doc)
-    .Input(0, "input", "Input tensor", "T")
-    .Output(
-        0,
-        "output",
-        "The softsign (x/(1+|x|)) values of the input tensor computed element-wise",
-        "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Softsign,
+    1,
+    OpSchema()
+        .SetDoc(Softsign_ver1_doc)
+        .Input(0, "input", "Input tensor", "T")
+        .Output(
+            0,
+            "output",
+            "The softsign (x/(1+|x|)) values of the input tensor computed element-wise",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Softplus_ver1_doc = R"DOC(
+static const char* Softplus_ver1_doc = R"DOC(
 Softplus takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the softplus function, y = ln(exp(x) + 1), is applied to
 the tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Softplus, 1, OpSchema()
-    .SetDoc(Softplus_ver1_doc)
-    .Input(0, "X", "1D input tensor", "T")
-    .Output(0, "Y", "1D input tensor", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Softplus,
+    1,
+    OpSchema()
+        .SetDoc(Softplus_ver1_doc)
+        .Input(0, "X", "1D input tensor", "T")
+        .Output(0, "Y", "1D input tensor", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Gemm_ver7_doc = R"DOC(General Matrix multiplication:
+static const char* Gemm_ver7_doc = R"DOC(General Matrix multiplication:
 https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms#Level_3
 
 A' = transpose(A) if transA else A
@@ -578,144 +677,173 @@ and output tensor Y has shape (M, N). A will be transposed before doing the
 computation if attribute transA is non-zero, same for B and transB.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Gemm, 7, OpSchema()
-    .SetDoc(Gemm_ver7_doc + GenerateBroadcastingDocUni("tensor C", "tensor A * B"))
-    .Input(0, "A",
-           "Input tensor A. "
-           "The shape of A should be (M, K) if transA is 0, "
-           "or (K, M) if transA is non-zero.", "T")
-    .Input(1, "B",
-           "Input tensor B. "
-           "The shape of B should be (K, N) if transB is 0, "
-           "or (N, K) if transB is non-zero.", "T")
-    .Input(2, "C",
-           "Input tensor C. "
-           "The shape of C should be unidirectional broadcastable to (M, N).", "T")
-    .Output(0, "Y", "Output tensor of shape (M, N).", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .Attr(
-        "transA",
-        "Whether A should be transposed",
-        AttributeProto::INT,
-        static_cast<int64_t>(0))
-    .Attr(
-        "transB",
-        "Whether B should be transposed",
-        AttributeProto::INT,
-        static_cast<int64_t>(0))
-    .Attr(
-        "alpha",
-        "Scalar multiplier for the product of input tensors A * B",
-        AttributeProto::FLOAT,
-        1.0f)
-    .Attr(
-        "beta",
-        "Scalar multiplier for input tensor C",
-        AttributeProto::FLOAT,
-        1.0f)
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-        propagateElemTypeFromInputToOutput(ctx, 0, 0);
-        if (hasNInputShapes(ctx, 2)) {
-          auto transAAttr = ctx.getAttribute("transA");
-          bool transA = transAAttr ? static_cast<int>(transAAttr->i()) != 0 : false;
-          auto transBAttr = ctx.getAttribute("transB");
-          bool transB = transBAttr ? static_cast<int>(transBAttr->i()) != 0 : false;
+ONNX_OPERATOR_SET_SCHEMA(
+    Gemm,
+    7,
+    OpSchema()
+        .SetDoc(
+            Gemm_ver7_doc +
+            GenerateBroadcastingDocUni("tensor C", "tensor A * B"))
+        .Input(
+            0,
+            "A",
+            "Input tensor A. "
+            "The shape of A should be (M, K) if transA is 0, "
+            "or (K, M) if transA is non-zero.",
+            "T")
+        .Input(
+            1,
+            "B",
+            "Input tensor B. "
+            "The shape of B should be (K, N) if transB is 0, "
+            "or (N, K) if transB is non-zero.",
+            "T")
+        .Input(
+            2,
+            "C",
+            "Input tensor C. "
+            "The shape of C should be unidirectional broadcastable to (M, N).",
+            "T")
+        .Output(0, "Y", "Output tensor of shape (M, N).", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .Attr(
+            "transA",
+            "Whether A should be transposed",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Attr(
+            "transB",
+            "Whether B should be transposed",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Attr(
+            "alpha",
+            "Scalar multiplier for the product of input tensors A * B",
+            AttributeProto::FLOAT,
+            1.0f)
+        .Attr(
+            "beta",
+            "Scalar multiplier for input tensor C",
+            AttributeProto::FLOAT,
+            1.0f)
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          if (hasNInputShapes(ctx, 2)) {
+            auto transAAttr = ctx.getAttribute("transA");
+            bool transA =
+                transAAttr ? static_cast<int>(transAAttr->i()) != 0 : false;
+            auto transBAttr = ctx.getAttribute("transB");
+            bool transB =
+                transBAttr ? static_cast<int>(transBAttr->i()) != 0 : false;
 
-          *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim() =
-            ctx.getInputType(0)->tensor_type().shape().dim(transA ? 1 : 0);
-          *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim() =
-            ctx.getInputType(1)->tensor_type().shape().dim(transB ? 0 : 1);
-        }
-      }));
+            *ctx.getOutputType(0)
+                 ->mutable_tensor_type()
+                 ->mutable_shape()
+                 ->add_dim() =
+                ctx.getInputType(0)->tensor_type().shape().dim(transA ? 1 : 0);
+            *ctx.getOutputType(0)
+                 ->mutable_tensor_type()
+                 ->mutable_shape()
+                 ->add_dim() =
+                ctx.getInputType(1)->tensor_type().shape().dim(transB ? 0 : 1);
+          }
+        }));
 
-
-static const char * MatMul_ver6_doc = R"DOC(
+static const char* MatMul_ver6_doc = R"DOC(
 Matrix product that behaves like numpy.matmul: https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.matmul.html
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(MatMul, 1, OpSchema()
-    .Input(0, "A", "N-dimensional matrix A", "T")
-    .Input(1, "B", "N-dimensional matrix B", "T")
-    .Output(0, "Y", "Matrix multiply results from A * B", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .SetDoc(MatMul_ver6_doc)
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-        propagateElemTypeFromInputToOutput(ctx, 0, 0);
-        if (!hasNInputShapes(ctx, 2)) {
-          return;
-        }
-
-        const auto shape0 = ctx.getInputType(0)->tensor_type().shape();
-        const auto shape1 = ctx.getInputType(1)->tensor_type().shape();
-
-        if (shape0.dim_size() == 0 || shape1.dim_size() == 0) {
-          fail_shape_inference("Input tensors of wrong rank (0).");;
-        }
-
-        TensorShapeProto shapeL, shapeR;
-
-        // First promote each shape to at least rank-2. This logic is
-        // specific to matmul, not generic broadcasting.
-        {
-          if (shape0.dim_size() == 1) {
-            shapeL.add_dim()->set_dim_value(1);
-            *shapeL.add_dim() = shape0.dim(0);
-          } else {
-            *shapeL.mutable_dim() = shape0.dim();
+ONNX_OPERATOR_SET_SCHEMA(
+    MatMul,
+    1,
+    OpSchema()
+        .Input(0, "A", "N-dimensional matrix A", "T")
+        .Input(1, "B", "N-dimensional matrix B", "T")
+        .Output(0, "Y", "Matrix multiply results from A * B", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .SetDoc(MatMul_ver6_doc)
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          if (!hasNInputShapes(ctx, 2)) {
+            return;
           }
-          if (shape1.dim_size() == 1) {
-            *shapeR.add_dim() = shape1.dim(0);
-            shapeR.add_dim()->set_dim_value(1);
-          } else {
-            *shapeR.mutable_dim() = shape1.dim();
-          }
-        }
 
-        // Check for compatible matrix multiply dimensions
-        {
-          auto dimL = shapeL.dim(shapeL.dim_size() - 1);
-          auto dimR = shapeR.dim(shapeR.dim_size() - 2);
-          if (dimL.has_dim_value() && dimR.has_dim_value() &&
-              dimL.dim_value() != dimR.dim_value()) {
-            fail_shape_inference("Incompatible dimensions for matrix multiplication");;
-          }
-        }
+          const auto shape0 = ctx.getInputType(0)->tensor_type().shape();
+          const auto shape1 = ctx.getInputType(1)->tensor_type().shape();
 
-        TensorShapeProto resultShape;
-
-        // Now call out to generic multidimensional broadcasting for
-        // the broadcastable prefixes.
-        {
-          TensorShapeProto prefixShapeL, prefixShapeR;
-          for (int i = 0; i < shapeL.dim_size() - 2; ++i) {
-            *prefixShapeL.add_dim() = shapeL.dim(i);
+          if (shape0.dim_size() == 0 || shape1.dim_size() == 0) {
+            fail_shape_inference("Input tensors of wrong rank (0).");
+            ;
           }
-          for (int i = 0; i < shapeR.dim_size() - 2; ++i) {
-            *prefixShapeR.add_dim() = shapeR.dim(i);
-          }
-          bidirectionalBroadcastShapeInference(prefixShapeL, prefixShapeR, resultShape);
-        }
 
-        // Back to matmul-specific. Add the trailing dimensions back in.
-        {
-          if (shape0.dim_size() != 1) {
-            *resultShape.add_dim() = shapeL.dim(shapeL.dim_size() - 2);
-          }
-          if (shape1.dim_size() != 1) {
-            *resultShape.add_dim() = shapeR.dim(shapeR.dim_size() - 1);
-          }
-        }
+          TensorShapeProto shapeL, shapeR;
 
-        *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape() = resultShape;
-      }));
+          // First promote each shape to at least rank-2. This logic is
+          // specific to matmul, not generic broadcasting.
+          {
+            if (shape0.dim_size() == 1) {
+              shapeL.add_dim()->set_dim_value(1);
+              *shapeL.add_dim() = shape0.dim(0);
+            } else {
+              *shapeL.mutable_dim() = shape0.dim();
+            }
+            if (shape1.dim_size() == 1) {
+              *shapeR.add_dim() = shape1.dim(0);
+              shapeR.add_dim()->set_dim_value(1);
+            } else {
+              *shapeR.mutable_dim() = shape1.dim();
+            }
+          }
 
-static const char * TopK_ver1_doc = R"DOC(
+          // Check for compatible matrix multiply dimensions
+          {
+            auto dimL = shapeL.dim(shapeL.dim_size() - 1);
+            auto dimR = shapeR.dim(shapeR.dim_size() - 2);
+            if (dimL.has_dim_value() && dimR.has_dim_value() &&
+                dimL.dim_value() != dimR.dim_value()) {
+              fail_shape_inference(
+                  "Incompatible dimensions for matrix multiplication");
+              ;
+            }
+          }
+
+          TensorShapeProto resultShape;
+
+          // Now call out to generic multidimensional broadcasting for
+          // the broadcastable prefixes.
+          {
+            TensorShapeProto prefixShapeL, prefixShapeR;
+            for (int i = 0; i < shapeL.dim_size() - 2; ++i) {
+              *prefixShapeL.add_dim() = shapeL.dim(i);
+            }
+            for (int i = 0; i < shapeR.dim_size() - 2; ++i) {
+              *prefixShapeR.add_dim() = shapeR.dim(i);
+            }
+            bidirectionalBroadcastShapeInference(
+                prefixShapeL, prefixShapeR, resultShape);
+          }
+
+          // Back to matmul-specific. Add the trailing dimensions back in.
+          {
+            if (shape0.dim_size() != 1) {
+              *resultShape.add_dim() = shapeL.dim(shapeL.dim_size() - 2);
+            }
+            if (shape1.dim_size() != 1) {
+              *resultShape.add_dim() = shapeR.dim(shapeR.dim_size() - 1);
+            }
+          }
+
+          *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape() =
+              resultShape;
+        }));
+
+static const char* TopK_ver1_doc = R"DOC(
 Retrieve the top-K elements along a specified axis. Given an input tensor of
 shape [a_1, a_2, ..., a_n, r] and integer argument k, return two outputs:
   -Value tensor of shape [a_1, a_2, ..., a_{axis-1}, k, a_{axis+1}, ... a_n]
@@ -728,174 +856,200 @@ Given two equivalent values, this operator uses the indices along the axis  as
  a tiebreaker. That is, the element with the lower index will appear first.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(TopK, 1, OpSchema()
-    .SetDoc(TopK_ver1_doc)
-    .Input(0, "X", "Tensor of shape [a_1, a_2, ..., a_n, r]", "T")
-    .Output(
-        0,
-        "Values",
-        "Tensor of shape [a_1, a_2, ..., a_{axis-1}, k, a_{axis+1}, ... a_n] "
-        "containing top K values from the input tensor",
-        "T")
-    .Output(
-        1,
-        "Indices",
-        "Tensor of shape [a_1, a_2, ..., a_{axis-1}, k, a_{axis+1}, ... a_n] "
-        "containing the corresponding input tensor indices for the top K "
-        "values.",
-        "I")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeConstraint(
-        "I",
-        {"tensor(int64)"},
-        "Constrain index tensor to int64")
-    .Attr("k", "Number of top elements to retrieve", AttributeProto::INT, true)
-    .Attr(
-        "axis",
-        "Dimension on which to do the sort. Default -1, which indicates the last"
-        " axis",
-        AttributeProto::INT,
-        static_cast<int64_t>(-1))
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-        // Type inference:
-        propagateElemTypeFromInputToOutput(ctx, 0, 0);
-        updateOutputElemType(ctx, 1, TensorProto::INT64);
+ONNX_OPERATOR_SET_SCHEMA(
+    TopK,
+    1,
+    OpSchema()
+        .SetDoc(TopK_ver1_doc)
+        .Input(0, "X", "Tensor of shape [a_1, a_2, ..., a_n, r]", "T")
+        .Output(
+            0,
+            "Values",
+            "Tensor of shape [a_1, a_2, ..., a_{axis-1}, k, a_{axis+1}, ... a_n] "
+            "containing top K values from the input tensor",
+            "T")
+        .Output(
+            1,
+            "Indices",
+            "Tensor of shape [a_1, a_2, ..., a_{axis-1}, k, a_{axis+1}, ... a_n] "
+            "containing the corresponding input tensor indices for the top K "
+            "values.",
+            "I")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeConstraint(
+            "I",
+            {"tensor(int64)"},
+            "Constrain index tensor to int64")
+        .Attr(
+            "k",
+            "Number of top elements to retrieve",
+            AttributeProto::INT,
+            true)
+        .Attr(
+            "axis",
+            "Dimension on which to do the sort. Default -1, which indicates the last"
+            " axis",
+            AttributeProto::INT,
+            static_cast<int64_t>(-1))
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          // Type inference:
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          updateOutputElemType(ctx, 1, TensorProto::INT64);
 
-        // Shape inference:
-        if (!hasInputShape(ctx, 0))
-        return;
-        auto& input_shape = getInputShape(ctx, 0);
-        int64_t rank = input_shape.dim_size();
-        int64_t axis = getAttribute(ctx, "axis", -1);
-        if (axis < 0) axis += rank;
-        if (axis < 0 || axis >= rank)
-        fail_shape_inference("Invalid value for attribute axis");
-        int64_t k = getAttribute(ctx, "k", -1);
-        if (k <= 0) fail_shape_inference("Invalid value for attribute k");
-        // TODO: unclear what results should be if axis has less than k elements.
-        TensorShapeProto result_shape = input_shape;
-        result_shape.mutable_dim(static_cast<int>(axis))->set_dim_value(k);
-        updateOutputShape(ctx, 0, result_shape);
-        updateOutputShape(ctx, 1, result_shape);
-    }));
+          // Shape inference:
+          if (!hasInputShape(ctx, 0))
+            return;
+          auto& input_shape = getInputShape(ctx, 0);
+          int64_t rank = input_shape.dim_size();
+          int64_t axis = getAttribute(ctx, "axis", -1);
+          if (axis < 0)
+            axis += rank;
+          if (axis < 0 || axis >= rank)
+            fail_shape_inference("Invalid value for attribute axis");
+          int64_t k = getAttribute(ctx, "k", -1);
+          if (k <= 0)
+            fail_shape_inference("Invalid value for attribute k");
+          // TODO: unclear what results should be if axis has less than k
+          // elements.
+          TensorShapeProto result_shape = input_shape;
+          result_shape.mutable_dim(static_cast<int>(axis))->set_dim_value(k);
+          updateOutputShape(ctx, 0, result_shape);
+          updateOutputShape(ctx, 1, result_shape);
+        }));
 
-static const char * Sin_ver7_doc = R"DOC(
+static const char* Sin_ver7_doc = R"DOC(
 Calculates the sine of the given input tensor, element-wise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Sin, 7, OpSchema()
-    .SetDoc(Sin_ver7_doc)
-    .Input(0, "input", "Input tensor", "T")
-    .Output(
-        0,
-        "output",
-        "The sine of the input tensor computed "
-        "element-wise",
-        "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Sin,
+    7,
+    OpSchema()
+        .SetDoc(Sin_ver7_doc)
+        .Input(0, "input", "Input tensor", "T")
+        .Output(
+            0,
+            "output",
+            "The sine of the input tensor computed "
+            "element-wise",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Cos_ver7_doc = R"DOC(
+static const char* Cos_ver7_doc = R"DOC(
 Calculates the cosine of the given input tensor, element-wise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Cos, 7, OpSchema()
-    .SetDoc(Cos_ver7_doc)
-    .Input(0, "input", "Input tensor", "T")
-    .Output(
-        0,
-        "output",
-        "The cosine of the input tensor computed "
-        "element-wise",
-        "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Cos,
+    7,
+    OpSchema()
+        .SetDoc(Cos_ver7_doc)
+        .Input(0, "input", "Input tensor", "T")
+        .Output(
+            0,
+            "output",
+            "The cosine of the input tensor computed "
+            "element-wise",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-
-static const char * Tan_ver7_doc = R"DOC(
+static const char* Tan_ver7_doc = R"DOC(
 Calculates the tangent of the given input tensor, element-wise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Tan, 7, OpSchema()
-    .SetDoc(Tan_ver7_doc)
-    .Input(0, "input", "Input tensor", "T")
-    .Output(
-        0,
-        "output",
-        "The tangent of the input tensor computed "
-        "element-wise",
-        "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Tan,
+    7,
+    OpSchema()
+        .SetDoc(Tan_ver7_doc)
+        .Input(0, "input", "Input tensor", "T")
+        .Output(
+            0,
+            "output",
+            "The tangent of the input tensor computed "
+            "element-wise",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Asin_ver7_doc = R"DOC(
+static const char* Asin_ver7_doc = R"DOC(
 Calculates the arcsine (inverse of sine) of the given input tensor, element-wise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Asin, 7, OpSchema()
-    .SetDoc(Asin_ver7_doc)
-    .Input(0, "input", "Input tensor", "T")
-    .Output(
-        0,
-        "output",
-        "The arcsine of the input tensor computed "
-        "element-wise",
-        "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Asin,
+    7,
+    OpSchema()
+        .SetDoc(Asin_ver7_doc)
+        .Input(0, "input", "Input tensor", "T")
+        .Output(
+            0,
+            "output",
+            "The arcsine of the input tensor computed "
+            "element-wise",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Acos_ver7_doc = R"DOC(
+static const char* Acos_ver7_doc = R"DOC(
 Calculates the arccosine (inverse of cosine) of the given input tensor, element-wise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Acos, 7, OpSchema()
-    .SetDoc(Acos_ver7_doc)
-    .Input(0, "input", "Input tensor", "T")
-    .Output(
-        0,
-        "output",
-        "The arccosine of the input tensor computed "
-        "element-wise",
-        "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Acos,
+    7,
+    OpSchema()
+        .SetDoc(Acos_ver7_doc)
+        .Input(0, "input", "Input tensor", "T")
+        .Output(
+            0,
+            "output",
+            "The arccosine of the input tensor computed "
+            "element-wise",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-
-static const char * Atan_ver7_doc = R"DOC(
+static const char* Atan_ver7_doc = R"DOC(
 Calculates the arctangent (inverse of tangent) of the given input tensor, element-wise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Atan, 7, OpSchema()
-    .SetDoc(Atan_ver7_doc)
-    .Input(0, "input", "Input tensor", "T")
-    .Output(
-        0,
-        "output",
-        "The arctangent of the input tensor computed "
-        "element-wise",
-        "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
-          
+ONNX_OPERATOR_SET_SCHEMA(
+    Atan,
+    7,
+    OpSchema()
+        .SetDoc(Atan_ver7_doc)
+        .Input(0, "input", "Input tensor", "T")
+        .Output(
+            0,
+            "output",
+            "The arctangent of the input tensor computed "
+            "element-wise",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -4,8 +4,6 @@
 #include <functional>
 #include "onnx/defs/schema.h"
 
-using namespace ONNX_NAMESPACE;
-
 namespace ONNX_NAMESPACE {
 
 std::function<void(OpSchema&)> MathDocGenerator(const char* name) {
@@ -94,26 +92,26 @@ will throw errors.
   };
 }
 
-ONNX_OPERATOR_SCHEMA(Add).SinceVersion(7).FillUsing(
-    MathDocGenerator("addition"));
+ONNX_OPERATOR_SET_SCHEMA(Add, 7, OpSchema().FillUsing(
+    MathDocGenerator("addition")));
 
-ONNX_OPERATOR_SCHEMA(Sub).SinceVersion(7).FillUsing(
-    MathDocGenerator("subtraction"));
+ONNX_OPERATOR_SET_SCHEMA(Sub, 7, OpSchema().FillUsing(
+    MathDocGenerator("subtraction")));
 
-ONNX_OPERATOR_SCHEMA(Mul).SinceVersion(7).FillUsing(
-    MathDocGenerator("multiplication"));
+ONNX_OPERATOR_SET_SCHEMA(Mul, 7, OpSchema().FillUsing(
+    MathDocGenerator("multiplication")));
 
-ONNX_OPERATOR_SCHEMA(Div).SinceVersion(7).FillUsing(
-    MathDocGenerator("division"));
-} // namespace ONNX_NAMESPACE
+ONNX_OPERATOR_SET_SCHEMA(Div, 7, OpSchema().FillUsing(
+    MathDocGenerator("division")));
 
-ONNX_OPERATOR_SCHEMA(Neg)
-    .SinceVersion(6)
-    .SetDoc(R"DOC(
+static const char * Neg_ver6_doc = R"DOC(
 Neg takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where each element flipped sign, y = -x, is applied to
 the tensor elementwise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Neg, 6, OpSchema()
+    .SetDoc(Neg_ver6_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     .TypeConstraint(
@@ -126,120 +124,133 @@ the tensor elementwise.
          "tensor(float16)",
          "tensor(double)"},
         "Constrain input and output types to signed numeric tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Abs)
-    .SinceVersion(6)
-    .SetDoc(R"DOC(
+static const char * Abs_ver6_doc = R"DOC(
 Absolute takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the absolute is, y = abs(x), is applied to
 the tensor elementwise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Abs, 6, OpSchema()
+    .SetDoc(Abs_ver6_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     .TypeConstraint(
         "T",
         OpSchema::all_numeric_types(),
         "Constrain input and output types to all numeric tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Reciprocal)
-    .SinceVersion(6)
-    .SetDoc(R"DOC(
+static const char * Reciprocal_ver6_doc = R"DOC(
 Reciprocal takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the reciprocal is, y = 1/x, is applied to
 the tensor elementwise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Reciprocal, 6, OpSchema()
+    .SetDoc(Reciprocal_ver6_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Floor)
-    .SinceVersion(6)
-    .SetDoc(R"DOC(
+static const char * Floor_ver6_doc = R"DOC(
 Floor takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the floor is, y = floor(x), is applied to
 the tensor elementwise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Floor, 6, OpSchema()
+    .SetDoc(Floor_ver6_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Ceil)
-    .SinceVersion(6)
-    .SetDoc(R"DOC(
+static const char * Ceil_ver6_doc = R"DOC(
 Ceil takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the ceil is, y = ceil(x), is applied to
 the tensor elementwise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Ceil, 6, OpSchema()
+    .SetDoc(Ceil_ver6_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Sqrt)
-    .SinceVersion(6)
-    .SetDoc(R"DOC(
+static const char * Sqrt_ver6_doc = R"DOC(
 Square root takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the square root is, y = x^0.5, is applied to
 the tensor elementwise. If x is negative, then it will return NaN.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Sqrt, 6, OpSchema()
+    .SetDoc(Sqrt_ver6_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Relu)
-    .SinceVersion(6)
-    .SetDoc(R"DOC(
+static const char * Relu_ver6_doc = R"DOC(
 Relu takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the rectified linear function, y = max(0, x), is applied to
 the tensor elementwise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Relu, 6, OpSchema()
+    .SetDoc(Relu_ver6_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(LeakyRelu)
-    .SinceVersion(6)
+static const char * LeakyRelu_ver6_doc = R"DOC(
+LeakyRelu takes input data (Tensor<T>) and an argument alpha, and produces one
+output data (Tensor<T>) where the function `f(x) = alpha * x for x < 0`,
+`f(x) = x for x >= 0`, is applied to the data tensor elementwise.
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(LeakyRelu, 6, OpSchema()
     .Attr(
         "alpha",
         "Coefficient of leakage default to 0.01.",
         AttributeProto::FLOAT,
         0.01f)
-    .SetDoc(R"DOC(
-LeakyRelu takes input data (Tensor<T>) and an argument alpha, and produces one
-output data (Tensor<T>) where the function `f(x) = alpha * x for x < 0`,
-`f(x) = x for x >= 0`, is applied to the data tensor elementwise.
-)DOC")
+    .SetDoc(LeakyRelu_ver6_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Selu)
-    .SinceVersion(6)
+static const char * Selu_ver6_doc = R"DOC(
+Selu takes one input data (Tensor<T>) and produces one output data
+(Tensor<T>) where the scaled exponential linear unit function,
+`y = gamma * (alpha * e^x - alpha) for x <= 0`, `y = gamma * x for x > 0`,
+is applied to the tensor elementwise.
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Selu, 6, OpSchema()
     .Attr(
         "alpha",
         "Coefficient of SELU default to 1.67326319217681884765625 "
@@ -252,46 +263,43 @@ ONNX_OPERATOR_SCHEMA(Selu)
         "(i.e., float32 approximation of 1.0507009873554804934193349852946).",
         AttributeProto::FLOAT,
         1.05070102214813232421875f)
-    .SetDoc(R"DOC(
-Selu takes one input data (Tensor<T>) and produces one output data
-(Tensor<T>) where the scaled exponential linear unit function,
-`y = gamma * (alpha * e^x - alpha) for x <= 0`, `y = gamma * x for x > 0`,
-is applied to the tensor elementwise.
-)DOC")
+    .SetDoc(Selu_ver6_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Elu)
-    .SinceVersion(6)
+static const char * Elu_ver6_doc = R"DOC(
+Elu takes one input data (Tensor<T>) and produces one output data
+(Tensor<T>) where the function `f(x) = alpha * (exp(x) - 1.) for x <
+0`, `f(x) = x for x >= 0`., is applied to the tensor elementwise.
+
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Elu, 6, OpSchema()
     .Attr(
         "alpha",
         "Coefficient of ELU default to 1.0.",
         AttributeProto::FLOAT,
         1.0f)
-    .SetDoc(R"DOC(
-Elu takes one input data (Tensor<T>) and produces one output data
-(Tensor<T>) where the function `f(x) = alpha * (exp(x) - 1.) for x <
-0`, `f(x) = x for x >= 0`., is applied to the tensor elementwise.
-
-)DOC")
+    .SetDoc(Elu_ver6_doc)
     .Input(0, "X", "1D input tensor", "T")
     .Output(0, "Y", "1D input tensor", "T")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Exp)
-    .SinceVersion(6)
-    .SetDoc(R"DOC(
+static const char * Exp_ver6_doc = R"DOC(
 Calculates the exponential of the given input tensor, element-wise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Exp, 6, OpSchema()
+    .SetDoc(Exp_ver6_doc)
     .Input(0, "input", "Input tensor", "T")
     .Output(
         0,
@@ -303,13 +311,14 @@ Calculates the exponential of the given input tensor, element-wise.
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Log)
-    .SinceVersion(6)
-    .SetDoc(R"DOC(
+static const char * Log_ver6_doc = R"DOC(
 Calculates the natural log of the given input tensor, element-wise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Log, 6, OpSchema()
+    .SetDoc(Log_ver6_doc)
     .Input(0, "input", "Input tensor", "T")
     .Output(
         0,
@@ -321,13 +330,14 @@ Calculates the natural log of the given input tensor, element-wise.
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Tanh)
-    .SinceVersion(6)
-    .SetDoc(R"DOC(
+static const char * Tanh_ver6_doc = R"DOC(
 Calculates the hyperbolic tangent of the given input tensor element-wise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Tanh, 6, OpSchema()
+    .SetDoc(Tanh_ver6_doc)
     .Input(0, "input", "Input tensor", "T")
     .Output(
         0,
@@ -339,16 +349,16 @@ Calculates the hyperbolic tangent of the given input tensor element-wise.
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Pow)
-    .SinceVersion(7)
-    .SetDoc(R"DOC(
+static const char * Pow_ver7_doc = R"DOC(
 Pow takes input data (Tensor<T>) and exponent Tensor, and
 produces one output data (Tensor<T>) where the function `f(x) = x^exponent`,
 is applied to the data tensor elementwise.
+)DOC";
 
-)DOC" + GenerateBroadcastingDocMul())
+ONNX_OPERATOR_SET_SCHEMA(Pow, 7, OpSchema()
+    .SetDoc(std::string(Pow_ver7_doc) + GenerateBroadcastingDocMul())
     .Input(0, "X", "First operand, base of the exponent.", "T")
     .Input(
         1,
@@ -366,16 +376,16 @@ is applied to the data tensor elementwise.
             ctx.getInputType(0)->tensor_type().shape(),
             ctx.getInputType(1)->tensor_type().shape(),
             *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(PRelu)
-    .SinceVersion(6)
-    .SetDoc(R"DOC(
+static const char * PRelu_ver6_doc = R"DOC(
 PRelu takes input data (Tensor<T>) and slope tensor as input, and produces one
 output data (Tensor<T>) where the function `f(x) = slope * x for x < 0`,
 `f(x) = x for x >= 0`., is applied to the data tensor elementwise.
+)DOC";
 
-)DOC" + GenerateBroadcastingDocUni("tensor slope", "input tensor X"))
+ONNX_OPERATOR_SET_SCHEMA(PRelu, 6, OpSchema()
+    .SetDoc(PRelu_ver6_doc + GenerateBroadcastingDocUni("tensor slope", "input tensor X"))
     .Input(0, "X", "Input tensor", "T")
     .Input(
         1,
@@ -388,103 +398,110 @@ output data (Tensor<T>) where the function `f(x) = slope * x for x < 0`,
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Sigmoid)
-    .SinceVersion(6)
-    .SetDoc(R"DOC(
+static const char * Sigmoid_ver6_doc = R"DOC(
 Sigmoid takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the sigmoid function, y = 1 / (1 + exp(-x)), is applied to the
 tensor elementwise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Sigmoid, 6, OpSchema()
+    .SetDoc(Sigmoid_ver6_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(HardSigmoid)
-    .SinceVersion(6)
-    .Attr("alpha", "Value of alpha default to 0.2", AttributeProto::FLOAT, 0.2f)
-    .Attr("beta", "Value of beta default to 0.5", AttributeProto::FLOAT, 0.5f)
-    .SetDoc(R"DOC(
+static const char * HardSigmoid_ver6_doc = R"DOC(
 HardSigmoid takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the HardSigmoid function, y = max(0, min(1, alpha * x + beta)),
 is applied to the tensor elementwise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(HardSigmoid, 6, OpSchema()
+    .Attr("alpha", "Value of alpha default to 0.2", AttributeProto::FLOAT, 0.2f)
+    .Attr("beta", "Value of beta default to 0.5", AttributeProto::FLOAT, 0.5f)
+    .SetDoc(HardSigmoid_ver6_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Max)
-    .SinceVersion(6)
-    .SetDoc(R"DOC(
+static const char * Max_ver6_doc = R"DOC(
 Element-wise max of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Max, 6, OpSchema()
+    .SetDoc(Max_ver6_doc)
     .Input(0, "data_0", "List of tensors for Max.", "T", OpSchema::Variadic)
     .Output(0, "max", "Output tensor. Same dimension as inputs.", "T")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Min)
-    .SinceVersion(6)
-    .SetDoc(R"DOC(
+static const char * Min_ver6_doc = R"DOC(
 Element-wise min of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Min, 6, OpSchema()
+    .SetDoc(Min_ver6_doc)
     .Input(0, "data_0", "List of tensors for Min", "T", OpSchema::Variadic)
     .Output(0, "min", "Output tensor. Same dimension as inputs.", "T")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Sum)
-    .SinceVersion(6)
-    .SetDoc(R"DOC(
+static const char * Sum_ver6_doc = R"DOC(
 Element-wise sum of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Sum, 6, OpSchema()
+    .SetDoc(Sum_ver6_doc)
     .Input(0, "data_0", "List of tensors for Sum.", "T", OpSchema::Variadic)
     .Output(0, "sum", "Output tensor. Same dimension as inputs.", "T")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Mean)
-    .SinceVersion(6)
-    .SetDoc(R"DOC(
+static const char * Mean_ver6_doc = R"DOC(
 Element-wise mean of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Mean, 6, OpSchema()
+    .SetDoc(Mean_ver6_doc)
     .Input(0, "data_0", "List of tensors for Mean.", "T", OpSchema::Variadic)
     .Output(0, "mean", "Output tensor. Same dimension as inputs.", "T")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Clip)
-    .SinceVersion(6)
-    .SetDoc(R"DOC(
+static const char * Clip_ver6_doc = R"DOC(
 Clip operator limits the given input within an interval. The interval is
 specified with arguments 'min' and 'max'. They default to
 numeric_limits::lowest() and numeric_limits::max() respectively.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Clip, 6, OpSchema()
+    .SetDoc(Clip_ver6_doc)
     .Attr(
         "min",
         "Minimum value, under which element is replaced by min",
@@ -501,22 +518,25 @@ numeric_limits::lowest() and numeric_limits::max() respectively.
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Softmax).FillUsing(
-    SoftmaxFamilyDocGenerator("softmax", "normalized exponential"));
+ONNX_OPERATOR_SET_SCHEMA(Softmax, 1, OpSchema()
+    .FillUsing(SoftmaxFamilyDocGenerator("softmax", "normalized exponential")));
 
-ONNX_OPERATOR_SCHEMA(LogSoftmax)
-    .FillUsing(SoftmaxFamilyDocGenerator("logsoftmax", "log of softmax"));
+ONNX_OPERATOR_SET_SCHEMA(LogSoftmax, 1, OpSchema()
+    .FillUsing(SoftmaxFamilyDocGenerator("logsoftmax", "log of softmax")));
 
-ONNX_OPERATOR_SCHEMA(Hardmax).FillUsing(SoftmaxFamilyDocGenerator(
-    "hardmax",
-    "1 for the first maximum value, and 0 for all others"));
+ONNX_OPERATOR_SET_SCHEMA(Hardmax, 1, OpSchema()
+    .FillUsing(SoftmaxFamilyDocGenerator(
+      "hardmax",
+      "1 for the first maximum value, and 0 for all others")));
 
-ONNX_OPERATOR_SCHEMA(Softsign)
-    .SetDoc(R"DOC(
+static const char * Softsign_ver1_doc = R"DOC(
 Calculates the softsign (x/(1+|x|)) of the given input tensor element-wise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Softsign, 1, OpSchema()
+    .SetDoc(Softsign_ver1_doc)
     .Input(0, "input", "Input tensor", "T")
     .Output(
         0,
@@ -527,25 +547,25 @@ Calculates the softsign (x/(1+|x|)) of the given input tensor element-wise.
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Softplus)
-    .SetDoc(R"DOC(
+static const char * Softplus_ver1_doc = R"DOC(
 Softplus takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the softplus function, y = ln(exp(x) + 1), is applied to
 the tensor elementwise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Softplus, 1, OpSchema()
+    .SetDoc(Softplus_ver1_doc)
     .Input(0, "X", "1D input tensor", "T")
     .Output(0, "Y", "1D input tensor", "T")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Gemm)
-    .SinceVersion(7)
-    .SetDoc(R"DOC(General Matrix multiplication:
+static const char * Gemm_ver7_doc = R"DOC(General Matrix multiplication:
 https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms#Level_3
 
 A' = transpose(A) if transA else A
@@ -556,8 +576,10 @@ Compute Y = alpha * A' * B' + beta * C, where input tensor A has shape (M, K) or
 input tensor B has shape (K, N) or (N, K), input tensor C is broadcastable to shape (M, N),
 and output tensor Y has shape (M, N). A will be transposed before doing the
 computation if attribute transA is non-zero, same for B and transB.
+)DOC";
 
-)DOC" + GenerateBroadcastingDocUni("tensor C", "tensor A * B"))
+ONNX_OPERATOR_SET_SCHEMA(Gemm, 7, OpSchema()
+    .SetDoc(Gemm_ver7_doc + GenerateBroadcastingDocUni("tensor C", "tensor A * B"))
     .Input(0, "A",
            "Input tensor A. "
            "The shape of A should be (M, K) if transA is 0, "
@@ -607,9 +629,14 @@ computation if attribute transA is non-zero, same for B and transB.
           *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim() =
             ctx.getInputType(1)->tensor_type().shape().dim(transB ? 0 : 1);
         }
-      });
+      }));
 
-ONNX_OPERATOR_SCHEMA(MatMul)
+
+static const char * MatMul_ver6_doc = R"DOC(
+Matrix product that behaves like numpy.matmul: https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.matmul.html
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(MatMul, 1, OpSchema()
     .Input(0, "A", "N-dimensional matrix A", "T")
     .Input(1, "B", "N-dimensional matrix B", "T")
     .Output(0, "Y", "Matrix multiply results from A * B", "T")
@@ -617,9 +644,7 @@ ONNX_OPERATOR_SCHEMA(MatMul)
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .SetDoc(R"DOC(
-Matrix product that behaves like numpy.matmul: https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.matmul.html
-)DOC")
+    .SetDoc(MatMul_ver6_doc)
     .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
         propagateElemTypeFromInputToOutput(ctx, 0, 0);
         if (!hasNInputShapes(ctx, 2)) {
@@ -688,10 +713,9 @@ Matrix product that behaves like numpy.matmul: https://docs.scipy.org/doc/numpy-
         }
 
         *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape() = resultShape;
-      });
+      }));
 
-ONNX_OPERATOR_SCHEMA(TopK)
-    .SetDoc(R"DOC(
+static const char * TopK_ver1_doc = R"DOC(
 Retrieve the top-K elements along a specified axis. Given an input tensor of
 shape [a_1, a_2, ..., a_n, r] and integer argument k, return two outputs:
   -Value tensor of shape [a_1, a_2, ..., a_{axis-1}, k, a_{axis+1}, ... a_n]
@@ -702,7 +726,10 @@ shape [a_1, a_2, ..., a_n, r] and integer argument k, return two outputs:
 
 Given two equivalent values, this operator uses the indices along the axis  as
  a tiebreaker. That is, the element with the lower index will appear first.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(TopK, 1, OpSchema()
+    .SetDoc(TopK_ver1_doc)
     .Input(0, "X", "Tensor of shape [a_1, a_2, ..., a_n, r]", "T")
     .Output(
         0,
@@ -753,13 +780,14 @@ Given two equivalent values, this operator uses the indices along the axis  as
         result_shape.mutable_dim(static_cast<int>(axis))->set_dim_value(k);
         updateOutputShape(ctx, 0, result_shape);
         updateOutputShape(ctx, 1, result_shape);
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(Sin)
-    .SinceVersion(7)
-    .SetDoc(R"DOC(
+static const char * Sin_ver7_doc = R"DOC(
 Calculates the sine of the given input tensor, element-wise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Sin, 7, OpSchema()
+    .SetDoc(Sin_ver7_doc)
     .Input(0, "input", "Input tensor", "T")
     .Output(
         0,
@@ -771,13 +799,14 @@ Calculates the sine of the given input tensor, element-wise.
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Cos)
-    .SinceVersion(7)
-    .SetDoc(R"DOC(
+static const char * Cos_ver7_doc = R"DOC(
 Calculates the cosine of the given input tensor, element-wise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Cos, 7, OpSchema()
+    .SetDoc(Cos_ver7_doc)
     .Input(0, "input", "Input tensor", "T")
     .Output(
         0,
@@ -789,14 +818,15 @@ Calculates the cosine of the given input tensor, element-wise.
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
 
-ONNX_OPERATOR_SCHEMA(Tan)
-    .SinceVersion(7)
-    .SetDoc(R"DOC(
+static const char * Tan_ver7_doc = R"DOC(
 Calculates the tangent of the given input tensor, element-wise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Tan, 7, OpSchema()
+    .SetDoc(Tan_ver7_doc)
     .Input(0, "input", "Input tensor", "T")
     .Output(
         0,
@@ -808,13 +838,14 @@ Calculates the tangent of the given input tensor, element-wise.
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Asin)
-    .SinceVersion(7)
-    .SetDoc(R"DOC(
+static const char * Asin_ver7_doc = R"DOC(
 Calculates the arcsine (inverse of sine) of the given input tensor, element-wise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Asin, 7, OpSchema()
+    .SetDoc(Asin_ver7_doc)
     .Input(0, "input", "Input tensor", "T")
     .Output(
         0,
@@ -826,13 +857,14 @@ Calculates the arcsine (inverse of sine) of the given input tensor, element-wise
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Acos)
-    .SinceVersion(7)
-    .SetDoc(R"DOC(
+static const char * Acos_ver7_doc = R"DOC(
 Calculates the arccosine (inverse of cosine) of the given input tensor, element-wise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Acos, 7, OpSchema()
+    .SetDoc(Acos_ver7_doc)
     .Input(0, "input", "Input tensor", "T")
     .Output(
         0,
@@ -844,14 +876,15 @@ Calculates the arccosine (inverse of cosine) of the given input tensor, element-
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
 
-ONNX_OPERATOR_SCHEMA(Atan)
-    .SinceVersion(7)
-    .SetDoc(R"DOC(
+static const char * Atan_ver7_doc = R"DOC(
 Calculates the arctangent (inverse of tangent) of the given input tensor, element-wise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Atan, 7, OpSchema()
+    .SetDoc(Atan_ver7_doc)
     .Input(0, "input", "Input tensor", "T")
     .Output(
         0,
@@ -863,4 +896,6 @@ Calculates the arctangent (inverse of tangent) of the given input tensor, elemen
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+          
+} // namespace ONNX_NAMESPACE

--- a/onnx/defs/math/old.cc
+++ b/onnx/defs/math/old.cc
@@ -111,385 +111,451 @@ Performs element-wise binary {name} (with limited broadcast support).
   };
 }
 
-ONNX_OPERATOR_SET_SCHEMA(Add, 1, OpSchema().FillUsing(MathDocGenerator_old("addition")));
+ONNX_OPERATOR_SET_SCHEMA(
+    Add,
+    1,
+    OpSchema().FillUsing(MathDocGenerator_old("addition")));
 
-ONNX_OPERATOR_SET_SCHEMA(Sub, 1, OpSchema().FillUsing(MathDocGenerator_old("subtraction")));
+ONNX_OPERATOR_SET_SCHEMA(
+    Sub,
+    1,
+    OpSchema().FillUsing(MathDocGenerator_old("subtraction")));
 
-ONNX_OPERATOR_SET_SCHEMA(Mul, 1, OpSchema().FillUsing(MathDocGenerator_old("multiplication")));
+ONNX_OPERATOR_SET_SCHEMA(
+    Mul,
+    1,
+    OpSchema().FillUsing(MathDocGenerator_old("multiplication")));
 
-ONNX_OPERATOR_SET_SCHEMA(Div, 1, OpSchema().FillUsing(MathDocGenerator_old("division")));
+ONNX_OPERATOR_SET_SCHEMA(
+    Div,
+    1,
+    OpSchema().FillUsing(MathDocGenerator_old("division")));
 
-ONNX_OPERATOR_SET_SCHEMA(Add, 6, OpSchema().FillUsing(MathDocGenerator_old_opset6("addition")));
+ONNX_OPERATOR_SET_SCHEMA(
+    Add,
+    6,
+    OpSchema().FillUsing(MathDocGenerator_old_opset6("addition")));
 
-ONNX_OPERATOR_SET_SCHEMA(Sub, 6, OpSchema().FillUsing(MathDocGenerator_old_opset6("subtraction")));
+ONNX_OPERATOR_SET_SCHEMA(
+    Sub,
+    6,
+    OpSchema().FillUsing(MathDocGenerator_old_opset6("subtraction")));
 
-ONNX_OPERATOR_SET_SCHEMA(Mul, 6, OpSchema().FillUsing(MathDocGenerator_old_opset6("multiplication")));
+ONNX_OPERATOR_SET_SCHEMA(
+    Mul,
+    6,
+    OpSchema().FillUsing(MathDocGenerator_old_opset6("multiplication")));
 
-ONNX_OPERATOR_SET_SCHEMA(Div, 6, OpSchema().FillUsing(MathDocGenerator_old_opset6("division")));
+ONNX_OPERATOR_SET_SCHEMA(
+    Div,
+    6,
+    OpSchema().FillUsing(MathDocGenerator_old_opset6("division")));
 
-static const char * Pow_ver1_doc = R"DOC(
+static const char* Pow_ver1_doc = R"DOC(
 Pow takes input data (Tensor<T>) and exponent Tensor, and
 produces one output data (Tensor<T>) where the function `f(x) = x^exponent`,
 is applied to the data tensor elementwise.
-)DOC" ;
+)DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Pow, 1, OpSchema()
-    .SetDoc(Pow_ver1_doc + std::string(kBroadcastDoc_old))
-    .Input(0, "X", "Input tensor of any shape, base of the exponent.", "T")
-    .Input(
-        1,
-        "Y",
-        "Input tensor of any shape broadcastable to X shape, "
-        "the exponent component.",
-        "T")
-    .Attr(
-        "broadcast",
-        "Pass 1 to enable broadcasting",
-        AttributeProto::INT,
-        static_cast<int64_t>(0))
-    .Attr(
-        "axis",
-        "If set, defines the broadcast dimensions. See doc for details.",
-        AttributeProto::INT,
-        OPTIONAL)
-    .Output(0, "Z", "Output tensor (same size as X)", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Pow,
+    1,
+    OpSchema()
+        .SetDoc(Pow_ver1_doc + std::string(kBroadcastDoc_old))
+        .Input(0, "X", "Input tensor of any shape, base of the exponent.", "T")
+        .Input(
+            1,
+            "Y",
+            "Input tensor of any shape broadcastable to X shape, "
+            "the exponent component.",
+            "T")
+        .Attr(
+            "broadcast",
+            "Pass 1 to enable broadcasting",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Attr(
+            "axis",
+            "If set, defines the broadcast dimensions. See doc for details.",
+            AttributeProto::INT,
+            OPTIONAL)
+        .Output(0, "Z", "Output tensor (same size as X)", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Neg_ver1_doc = R"DOC(
+static const char* Neg_ver1_doc = R"DOC(
 Neg takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where each element flipped sign, y = -x, is applied to
 the tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Neg, 1, OpSchema()
-    .SetDoc(Neg_ver1_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Neg,
+    1,
+    OpSchema()
+        .SetDoc(Neg_ver1_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * Abs_ver1_doc = R"DOC(
+static const char* Abs_ver1_doc = R"DOC(
 Absolute takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the absolute is, y = abs(x), is applied to
 the tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Abs, 1, OpSchema()
-    .SetDoc(Abs_ver1_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Abs,
+    1,
+    OpSchema()
+        .SetDoc(Abs_ver1_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * Reciprocal_ver1_doc = R"DOC(
+static const char* Reciprocal_ver1_doc = R"DOC(
 Reciprocal takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the reciprocal is, y = 1/x, is applied to
 the tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Reciprocal, 1, OpSchema()
-    .SetDoc(Reciprocal_ver1_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Reciprocal,
+    1,
+    OpSchema()
+        .SetDoc(Reciprocal_ver1_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * Floor_ver1_doc = R"DOC(
+static const char* Floor_ver1_doc = R"DOC(
 Floor takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the floor is, y = floor(x), is applied to
 the tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Floor, 1, OpSchema()
-    .SetDoc(Floor_ver1_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Floor,
+    1,
+    OpSchema()
+        .SetDoc(Floor_ver1_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * Ceil_ver1_doc = R"DOC(
+static const char* Ceil_ver1_doc = R"DOC(
 Ceil takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the ceil is, y = ceil(x), is applied to
 the tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Ceil, 1, OpSchema()
-    .SetDoc(Ceil_ver1_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Ceil,
+    1,
+    OpSchema()
+        .SetDoc(Ceil_ver1_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * Sqrt_ver1_doc = R"DOC(
+static const char* Sqrt_ver1_doc = R"DOC(
 Square root takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the square root is, y = x^0.5, is applied to
 the tensor elementwise. If x is negative, then it will return NaN.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Sqrt, 1, OpSchema()
-    .SetDoc(Sqrt_ver1_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Sqrt,
+    1,
+    OpSchema()
+        .SetDoc(Sqrt_ver1_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * Relu_ver1_doc = R"DOC(
+static const char* Relu_ver1_doc = R"DOC(
 Relu takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the rectified linear function, y = max(0, x), is applied to
 the tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Relu, 1, OpSchema()
-    .SetDoc(Relu_ver1_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Relu,
+    1,
+    OpSchema()
+        .SetDoc(Relu_ver1_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * LeakyRelu_ver1_doc = R"DOC(
+static const char* LeakyRelu_ver1_doc = R"DOC(
 LeakyRelu takes input data (Tensor<T>) and an argument alpha, and produces one
 output data (Tensor<T>) where the function `f(x) = alpha * x for x < 0`,
 `f(x) = x for x >= 0`, is applied to the data tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(LeakyRelu, 1, OpSchema()
-    .Attr(
-        "alpha",
-        "Coefficient of leakage default to 0.01.",
-        AttributeProto::FLOAT,
-        0.01f)
-    .SetDoc(LeakyRelu_ver1_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    LeakyRelu,
+    1,
+    OpSchema()
+        .Attr(
+            "alpha",
+            "Coefficient of leakage default to 0.01.",
+            AttributeProto::FLOAT,
+            0.01f)
+        .SetDoc(LeakyRelu_ver1_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * Selu_ver1_doc = R"DOC(
+static const char* Selu_ver1_doc = R"DOC(
 Selu takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the scaled exponential linear unit function,
 `y = gamma * (alpha * e^x - alpha) for x <= 0`, `y = gamma * x for x > 0`,
 is applied to the tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Selu, 1, OpSchema()
-    .Attr(
-        "alpha",
-        "Coefficient of SELU default to 1.6732.",
-        AttributeProto::FLOAT,
-        1.6732f)
-    .Attr(
-        "gamma",
-        "Coefficient of SELU default to 1.0507.",
-        AttributeProto::FLOAT,
-        1.0507f)
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .SetDoc(Selu_ver1_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Selu,
+    1,
+    OpSchema()
+        .Attr(
+            "alpha",
+            "Coefficient of SELU default to 1.6732.",
+            AttributeProto::FLOAT,
+            1.6732f)
+        .Attr(
+            "gamma",
+            "Coefficient of SELU default to 1.0507.",
+            AttributeProto::FLOAT,
+            1.0507f)
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .SetDoc(Selu_ver1_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * Elu_ver1_doc = R"DOC(
+static const char* Elu_ver1_doc = R"DOC(
 Elu takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the function `f(x) = alpha * (exp(x) - 1.) for x <
 0`, `f(x) = x for x >= 0`., is applied to the tensor elementwise.
 
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Elu, 1, OpSchema()
-    .Attr(
-        "alpha",
-        "Coefficient of ELU default to 1.0.",
-        AttributeProto::FLOAT,
-        1.0f)
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .SetDoc(Elu_ver1_doc)
-    .Input(0, "X", "1D input tensor", "T")
-    .Output(0, "Y", "1D input tensor", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Elu,
+    1,
+    OpSchema()
+        .Attr(
+            "alpha",
+            "Coefficient of ELU default to 1.0.",
+            AttributeProto::FLOAT,
+            1.0f)
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .SetDoc(Elu_ver1_doc)
+        .Input(0, "X", "1D input tensor", "T")
+        .Output(0, "Y", "1D input tensor", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * Exp_ver1_doc = R"DOC(
+static const char* Exp_ver1_doc = R"DOC(
 Calculates the exponential of the given input tensor, element-wise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Exp, 1, OpSchema()
-    .SetDoc(Exp_ver1_doc)
-    .Input(0, "input", "Input tensor", "T")
-    .Output(
-        0,
-        "output",
-        "The exponential of the input tensor computed "
-        "element-wise",
-        "T")
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Exp,
+    1,
+    OpSchema()
+        .SetDoc(Exp_ver1_doc)
+        .Input(0, "input", "Input tensor", "T")
+        .Output(
+            0,
+            "output",
+            "The exponential of the input tensor computed "
+            "element-wise",
+            "T")
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * Log_ver1_doc = R"DOC(
+static const char* Log_ver1_doc = R"DOC(
 Calculates the natural log of the given input tensor, element-wise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Log, 1, OpSchema()
-    .SetDoc(Log_ver1_doc)
-    .Input(0, "input", "Input tensor", "T")
-    .Output(
-        0,
-        "output",
-        "The natural log of the input tensor computed "
-        "element-wise",
-        "T")
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Log,
+    1,
+    OpSchema()
+        .SetDoc(Log_ver1_doc)
+        .Input(0, "input", "Input tensor", "T")
+        .Output(
+            0,
+            "output",
+            "The natural log of the input tensor computed "
+            "element-wise",
+            "T")
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * Tanh_ver1_doc = R"DOC(
+static const char* Tanh_ver1_doc = R"DOC(
 Calculates the hyperbolic tangent of the given input tensor element-wise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Tanh, 1, OpSchema()
-    .SetDoc(Tanh_ver1_doc)
-    .Input(0, "input", "1-D input tensor", "T")
-    .Output(
-        0,
-        "output",
-        "The hyperbolic tangent values of the input tensor "
-        "computed element-wise",
-        "T")
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Tanh,
+    1,
+    OpSchema()
+        .SetDoc(Tanh_ver1_doc)
+        .Input(0, "input", "1-D input tensor", "T")
+        .Output(
+            0,
+            "output",
+            "The hyperbolic tangent values of the input tensor "
+            "computed element-wise",
+            "T")
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * PRelu_ver1_doc = R"DOC(
+static const char* PRelu_ver1_doc = R"DOC(
 
 PRelu takes input data (Tensor<T>) and slope tensor as input, and produces one
 output data (Tensor<T>) where the function `f(x) = slope * x for x < 0`,
@@ -497,199 +563,236 @@ output data (Tensor<T>) where the function `f(x) = slope * x for x < 0`,
 
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(PRelu, 1, OpSchema()
-    .SetDoc(PRelu_ver1_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Input(
-        1,
-        "slope",
-        "Slope tensor. If `Slope` is of size 1, the value is shared"
-        "across different channels",
-        "T")
-    .Output(0, "Y", "Output tensor", "T")
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    PRelu,
+    1,
+    OpSchema()
+        .SetDoc(PRelu_ver1_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Input(
+            1,
+            "slope",
+            "Slope tensor. If `Slope` is of size 1, the value is shared"
+            "across different channels",
+            "T")
+        .Output(0, "Y", "Output tensor", "T")
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * Sigmoid_ver1_doc = R"DOC(
+static const char* Sigmoid_ver1_doc = R"DOC(
 Sigmoid takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the sigmoid function, y = 1 / (1 + exp(-x)), is applied to the
 tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Sigmoid, 1, OpSchema()
-    .SetDoc(Sigmoid_ver1_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Sigmoid,
+    1,
+    OpSchema()
+        .SetDoc(Sigmoid_ver1_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * HardSigmoid_ver1_doc = R"DOC(
+static const char* HardSigmoid_ver1_doc = R"DOC(
 HardSigmoid takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the HardSigmoid function, y = max(0, min(1, alpha * x + beta)),
 is applied to the tensor elementwise.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(HardSigmoid, 1, OpSchema()
-    .Attr("alpha", "Value of alpha default to 0.2", AttributeProto::FLOAT, 0.2f)
-    .Attr("beta", "Value of beta default to 0.5", AttributeProto::FLOAT, 0.5f)
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .SetDoc(HardSigmoid_ver1_doc)
-    .Input(0, "X", "Input tensor", "T")
-    .Output(0, "Y", "Output tensor", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    HardSigmoid,
+    1,
+    OpSchema()
+        .Attr(
+            "alpha",
+            "Value of alpha default to 0.2",
+            AttributeProto::FLOAT,
+            0.2f)
+        .Attr(
+            "beta",
+            "Value of beta default to 0.5",
+            AttributeProto::FLOAT,
+            0.5f)
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .SetDoc(HardSigmoid_ver1_doc)
+        .Input(0, "X", "Input tensor", "T")
+        .Output(0, "Y", "Output tensor", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * Max_ver1_doc = R"DOC(
+static const char* Max_ver1_doc = R"DOC(
 Element-wise max of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Max, 1, OpSchema()
-    .SetDoc(Max_ver1_doc)
-    .Input(0, "data_0", "List of tensors for Max.", "T", OpSchema::Variadic)
-    .Output(0, "max", "Output tensor. Same dimension as inputs.", "T")
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Max,
+    1,
+    OpSchema()
+        .SetDoc(Max_ver1_doc)
+        .Input(0, "data_0", "List of tensors for Max.", "T", OpSchema::Variadic)
+        .Output(0, "max", "Output tensor. Same dimension as inputs.", "T")
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * Min_ver1_doc = R"DOC(
+static const char* Min_ver1_doc = R"DOC(
 Element-wise min of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Min, 1, OpSchema()
-    .SetDoc(Min_ver1_doc)
-    .Input(0, "data_0", "List of tensors for Min", "T", OpSchema::Variadic)
-    .Output(0, "min", "Output tensor. Same dimension as inputs.", "T")
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Min,
+    1,
+    OpSchema()
+        .SetDoc(Min_ver1_doc)
+        .Input(0, "data_0", "List of tensors for Min", "T", OpSchema::Variadic)
+        .Output(0, "min", "Output tensor. Same dimension as inputs.", "T")
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * Sum_ver1_doc = R"DOC(
+static const char* Sum_ver1_doc = R"DOC(
 Element-wise sum of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Sum, 1, OpSchema()
-    .SetDoc(Sum_ver1_doc)
-    .Input(0, "data_0", "List of tensors for Sum.", "T", OpSchema::Variadic)
-    .Output(0, "sum", "Output tensor. Same dimension as inputs.", "T")
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Sum,
+    1,
+    OpSchema()
+        .SetDoc(Sum_ver1_doc)
+        .Input(0, "data_0", "List of tensors for Sum.", "T", OpSchema::Variadic)
+        .Output(0, "sum", "Output tensor. Same dimension as inputs.", "T")
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * Mean_ver1_doc = R"DOC(
+static const char* Mean_ver1_doc = R"DOC(
 Element-wise mean of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Mean, 1, OpSchema()
-    .SetDoc(Mean_ver1_doc)
-    .Input(0, "data_0", "List of tensors for Mean.", "T", OpSchema::Variadic)
-    .Output(0, "mean", "Output tensor. Same dimension as inputs.", "T")
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Mean,
+    1,
+    OpSchema()
+        .SetDoc(Mean_ver1_doc)
+        .Input(
+            0,
+            "data_0",
+            "List of tensors for Mean.",
+            "T",
+            OpSchema::Variadic)
+        .Output(0, "mean", "Output tensor. Same dimension as inputs.", "T")
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * Clip_ver1_doc = R"DOC(
+static const char* Clip_ver1_doc = R"DOC(
 Clip operator limits the given input within an interval. The interval is
 specified with arguments 'min' and 'max'. They default to
 numeric_limits::lowest() and numeric_limits::max() respectively.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Clip, 1, OpSchema()
-    .SetDoc(Clip_ver1_doc)
-    .Attr(
-        "min",
-        "Minimum value, under which element is replaced by min",
-        AttributeProto::FLOAT,
-        OPTIONAL)
-    .Attr(
-        "max",
-        "Maximum value, above which element is replaced by max",
-        AttributeProto::FLOAT,
-        OPTIONAL)
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Input(0, "input", "Input tensor whose elements to be clipped", "T")
-    .Output(0, "output", "Output tensor with clipped input elements", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Clip,
+    1,
+    OpSchema()
+        .SetDoc(Clip_ver1_doc)
+        .Attr(
+            "min",
+            "Minimum value, under which element is replaced by min",
+            AttributeProto::FLOAT,
+            OPTIONAL)
+        .Attr(
+            "max",
+            "Maximum value, above which element is replaced by max",
+            AttributeProto::FLOAT,
+            OPTIONAL)
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Input(0, "input", "Input tensor whose elements to be clipped", "T")
+        .Output(0, "output", "Output tensor with clipped input elements", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * Gemm_ver1_doc = R"DOC(General Matrix multiplication:
+static const char* Gemm_ver1_doc = R"DOC(General Matrix multiplication:
 https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms#Level_3
 Compute Y = alpha * A * B + beta * C, where input tensor A has dimension (M X K)
 , input tensor B has dimension (K X N), input tensor C and output tensor Y have
@@ -699,46 +802,49 @@ the dimension requirement. A will be transposed before doing the computation
 if attribute transA is non-zero, same for B and transB.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Gemm, 1, OpSchema()
-    .SetDoc(Gemm_ver1_doc)
-    .Input(0, "A", "Input tensor A", "T")
-    .Input(1, "B", "Input tensor B", "T")
-    .Input(2, "C", "Input tensor C, can be inplace.", "T")
-    .Output(0, "Y", "Output tensor.", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "transA",
-        "Whether A should be transposed",
-        AttributeProto::INT,
-        static_cast<int64_t>(0))
-    .Attr(
-        "transB",
-        "Whether B should be transposed",
-        AttributeProto::INT,
-        static_cast<int64_t>(0))
-    .Attr(
-        "broadcast",
-        "Whether C should be broadcasted",
-        AttributeProto::INT,
-        static_cast<int64_t>(0))
-    .Attr(
-        "alpha",
-        "Scalar multiplier for the product of input tensors A * B",
-        AttributeProto::FLOAT,
-        1.0f)
-    .Attr(
-        "beta",
-        "Scalar multiplier for input tensor C",
-        AttributeProto::FLOAT,
-        1.0f));
+ONNX_OPERATOR_SET_SCHEMA(
+    Gemm,
+    1,
+    OpSchema()
+        .SetDoc(Gemm_ver1_doc)
+        .Input(0, "A", "Input tensor A", "T")
+        .Input(1, "B", "Input tensor B", "T")
+        .Input(2, "C", "Input tensor C, can be inplace.", "T")
+        .Output(0, "Y", "Output tensor.", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "transA",
+            "Whether A should be transposed",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Attr(
+            "transB",
+            "Whether B should be transposed",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Attr(
+            "broadcast",
+            "Whether C should be broadcasted",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Attr(
+            "alpha",
+            "Scalar multiplier for the product of input tensors A * B",
+            AttributeProto::FLOAT,
+            1.0f)
+        .Attr(
+            "beta",
+            "Scalar multiplier for input tensor C",
+            AttributeProto::FLOAT,
+            1.0f));
 
-static const char * Gemm_ver6_doc = R"DOC(General Matrix multiplication:
+static const char* Gemm_ver6_doc = R"DOC(General Matrix multiplication:
 https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms#Level_3
 Compute Y = alpha * A * B + beta * C, where input tensor A has dimension (M X K)
 , input tensor B has dimension (K X N), input tensor C and output tensor Y have
@@ -748,58 +854,70 @@ the dimension requirement. A will be transposed before doing the computation
 if attribute transA is non-zero, same for B and transB.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Gemm, 6, OpSchema()
-    .SetDoc(Gemm_ver6_doc)
-    .Input(0, "A", "Input tensor A", "T")
-    .Input(1, "B", "Input tensor B", "T")
-    .Input(2, "C", "Input tensor C", "T")
-    .Output(0, "Y", "Output tensor.", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .Attr(
-        "transA",
-        "Whether A should be transposed",
-        AttributeProto::INT,
-        static_cast<int64_t>(0))
-    .Attr(
-        "transB",
-        "Whether B should be transposed",
-        AttributeProto::INT,
-        static_cast<int64_t>(0))
-    .Attr(
-        "broadcast",
-        "Whether C should be broadcasted",
-        AttributeProto::INT,
-        static_cast<int64_t>(0))
-    .Attr(
-        "alpha",
-        "Scalar multiplier for the product of input tensors A * B",
-        AttributeProto::FLOAT,
-        1.0f)
-    .Attr(
-        "beta",
-        "Scalar multiplier for input tensor C",
-        AttributeProto::FLOAT,
-        1.0f)
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-        propagateElemTypeFromInputToOutput(ctx, 0, 0);
-        if (hasNInputShapes(ctx, 2)) {
-          auto transAAttr = ctx.getAttribute("transA");
-          bool transA = transAAttr ? static_cast<int>(transAAttr->i()) != 0 : false;
-          auto transBAttr = ctx.getAttribute("transB");
-          bool transB = transBAttr ? static_cast<int>(transBAttr->i()) != 0 : false;
+ONNX_OPERATOR_SET_SCHEMA(
+    Gemm,
+    6,
+    OpSchema()
+        .SetDoc(Gemm_ver6_doc)
+        .Input(0, "A", "Input tensor A", "T")
+        .Input(1, "B", "Input tensor B", "T")
+        .Input(2, "C", "Input tensor C", "T")
+        .Output(0, "Y", "Output tensor.", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .Attr(
+            "transA",
+            "Whether A should be transposed",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Attr(
+            "transB",
+            "Whether B should be transposed",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Attr(
+            "broadcast",
+            "Whether C should be broadcasted",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Attr(
+            "alpha",
+            "Scalar multiplier for the product of input tensors A * B",
+            AttributeProto::FLOAT,
+            1.0f)
+        .Attr(
+            "beta",
+            "Scalar multiplier for input tensor C",
+            AttributeProto::FLOAT,
+            1.0f)
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          if (hasNInputShapes(ctx, 2)) {
+            auto transAAttr = ctx.getAttribute("transA");
+            bool transA =
+                transAAttr ? static_cast<int>(transAAttr->i()) != 0 : false;
+            auto transBAttr = ctx.getAttribute("transB");
+            bool transB =
+                transBAttr ? static_cast<int>(transBAttr->i()) != 0 : false;
 
-          *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim() =
-            ctx.getInputType(0)->tensor_type().shape().dim(transA ? 1 : 0);
-          *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim() =
-            ctx.getInputType(1)->tensor_type().shape().dim(transB ? 0 : 1);
-        } else if (hasInputShape(ctx, 2) &&
-                   (!ctx.getAttribute("broadcast") ||
-                    static_cast<int>(ctx.getAttribute("broadcast")->i()) == 0)) {
-          *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape() =
-            ctx.getInputType(2)->tensor_type().shape();
-        }
-      }));
+            *ctx.getOutputType(0)
+                 ->mutable_tensor_type()
+                 ->mutable_shape()
+                 ->add_dim() =
+                ctx.getInputType(0)->tensor_type().shape().dim(transA ? 1 : 0);
+            *ctx.getOutputType(0)
+                 ->mutable_tensor_type()
+                 ->mutable_shape()
+                 ->add_dim() =
+                ctx.getInputType(1)->tensor_type().shape().dim(transB ? 0 : 1);
+          } else if (
+              hasInputShape(ctx, 2) &&
+              (!ctx.getAttribute("broadcast") ||
+               static_cast<int>(ctx.getAttribute("broadcast")->i()) == 0)) {
+            *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape() =
+                ctx.getInputType(2)->tensor_type().shape();
+          }
+        }));
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/math/old.cc
+++ b/onnx/defs/math/old.cc
@@ -4,8 +4,6 @@
 #include <functional>
 #include "onnx/defs/schema.h"
 
-using namespace ONNX_NAMESPACE;
-
 namespace ONNX_NAMESPACE {
 
 const char* kBroadcastDoc_old = R"DOC(
@@ -110,35 +108,33 @@ Performs element-wise binary {name} (with limited broadcast support).
         OpSchema::high_precision_numeric_types(),
         "Constrain input and output types to high-precision numeric tensors.");
     schema.TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
-    schema.SinceVersion(6);
   };
 }
 
+ONNX_OPERATOR_SET_SCHEMA(Add, 1, OpSchema().FillUsing(MathDocGenerator_old("addition")));
 
-ONNX_OPERATOR_SCHEMA(Add).FillUsing(MathDocGenerator_old("addition"));
+ONNX_OPERATOR_SET_SCHEMA(Sub, 1, OpSchema().FillUsing(MathDocGenerator_old("subtraction")));
 
-ONNX_OPERATOR_SCHEMA(Sub).FillUsing(MathDocGenerator_old("subtraction"));
+ONNX_OPERATOR_SET_SCHEMA(Mul, 1, OpSchema().FillUsing(MathDocGenerator_old("multiplication")));
 
-ONNX_OPERATOR_SCHEMA(Mul).FillUsing(MathDocGenerator_old("multiplication"));
+ONNX_OPERATOR_SET_SCHEMA(Div, 1, OpSchema().FillUsing(MathDocGenerator_old("division")));
 
-ONNX_OPERATOR_SCHEMA(Div).FillUsing(MathDocGenerator_old("division"));
+ONNX_OPERATOR_SET_SCHEMA(Add, 6, OpSchema().FillUsing(MathDocGenerator_old_opset6("addition")));
 
-ONNX_OPERATOR_SCHEMA(Add).FillUsing(MathDocGenerator_old_opset6("addition"));
+ONNX_OPERATOR_SET_SCHEMA(Sub, 6, OpSchema().FillUsing(MathDocGenerator_old_opset6("subtraction")));
 
-ONNX_OPERATOR_SCHEMA(Sub).FillUsing(MathDocGenerator_old_opset6("subtraction"));
+ONNX_OPERATOR_SET_SCHEMA(Mul, 6, OpSchema().FillUsing(MathDocGenerator_old_opset6("multiplication")));
 
-ONNX_OPERATOR_SCHEMA(Mul).FillUsing(MathDocGenerator_old_opset6("multiplication"));
+ONNX_OPERATOR_SET_SCHEMA(Div, 6, OpSchema().FillUsing(MathDocGenerator_old_opset6("division")));
 
-ONNX_OPERATOR_SCHEMA(Div).FillUsing(MathDocGenerator_old_opset6("division"));
-
-} // namespace ONNX_NAMESPACE
-
-ONNX_OPERATOR_SCHEMA(Pow)
-    .SetDoc(R"DOC(
+static const char * Pow_ver1_doc = R"DOC(
 Pow takes input data (Tensor<T>) and exponent Tensor, and
 produces one output data (Tensor<T>) where the function `f(x) = x^exponent`,
 is applied to the data tensor elementwise.
-)DOC" + std::string(kBroadcastDoc_old))
+)DOC" ;
+
+ONNX_OPERATOR_SET_SCHEMA(Pow, 1, OpSchema()
+    .SetDoc(Pow_ver1_doc + std::string(kBroadcastDoc_old))
     .Input(0, "X", "Input tensor of any shape, base of the exponent.", "T")
     .Input(
         1,
@@ -161,14 +157,16 @@ is applied to the data tensor elementwise.
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Neg)
-    .SetDoc(R"DOC(
+static const char * Neg_ver1_doc = R"DOC(
 Neg takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where each element flipped sign, y = -x, is applied to
 the tensor elementwise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Neg, 1, OpSchema()
+    .SetDoc(Neg_ver1_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     // This attribute was added via AllowConsumed API in OpSchema.
@@ -182,14 +180,16 @@ the tensor elementwise.
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Abs)
-    .SetDoc(R"DOC(
+static const char * Abs_ver1_doc = R"DOC(
 Absolute takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the absolute is, y = abs(x), is applied to
 the tensor elementwise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Abs, 1, OpSchema()
+    .SetDoc(Abs_ver1_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     // This attribute was added via AllowConsumed API in OpSchema.
@@ -203,14 +203,16 @@ the tensor elementwise.
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Reciprocal)
-    .SetDoc(R"DOC(
+static const char * Reciprocal_ver1_doc = R"DOC(
 Reciprocal takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the reciprocal is, y = 1/x, is applied to
 the tensor elementwise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Reciprocal, 1, OpSchema()
+    .SetDoc(Reciprocal_ver1_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     // This attribute was added via AllowConsumed API in OpSchema.
@@ -224,14 +226,16 @@ the tensor elementwise.
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Floor)
-    .SetDoc(R"DOC(
+static const char * Floor_ver1_doc = R"DOC(
 Floor takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the floor is, y = floor(x), is applied to
 the tensor elementwise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Floor, 1, OpSchema()
+    .SetDoc(Floor_ver1_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     // This attribute was added via AllowConsumed API in OpSchema.
@@ -245,14 +249,16 @@ the tensor elementwise.
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Ceil)
-    .SetDoc(R"DOC(
+static const char * Ceil_ver1_doc = R"DOC(
 Ceil takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the ceil is, y = ceil(x), is applied to
 the tensor elementwise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Ceil, 1, OpSchema()
+    .SetDoc(Ceil_ver1_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     // This attribute was added via AllowConsumed API in OpSchema.
@@ -266,14 +272,16 @@ the tensor elementwise.
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Sqrt)
-    .SetDoc(R"DOC(
+static const char * Sqrt_ver1_doc = R"DOC(
 Square root takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the square root is, y = x^0.5, is applied to
 the tensor elementwise. If x is negative, then it will return NaN.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Sqrt, 1, OpSchema()
+    .SetDoc(Sqrt_ver1_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     // This attribute was added via AllowConsumed API in OpSchema.
@@ -287,14 +295,16 @@ the tensor elementwise. If x is negative, then it will return NaN.
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Relu)
-    .SetDoc(R"DOC(
+static const char * Relu_ver1_doc = R"DOC(
 Relu takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the rectified linear function, y = max(0, x), is applied to
 the tensor elementwise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Relu, 1, OpSchema()
+    .SetDoc(Relu_ver1_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     // This attribute was added via AllowConsumed API in OpSchema.
@@ -308,19 +318,21 @@ the tensor elementwise.
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(LeakyRelu)
+static const char * LeakyRelu_ver1_doc = R"DOC(
+LeakyRelu takes input data (Tensor<T>) and an argument alpha, and produces one
+output data (Tensor<T>) where the function `f(x) = alpha * x for x < 0`,
+`f(x) = x for x >= 0`, is applied to the data tensor elementwise.
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(LeakyRelu, 1, OpSchema()
     .Attr(
         "alpha",
         "Coefficient of leakage default to 0.01.",
         AttributeProto::FLOAT,
         0.01f)
-    .SetDoc(R"DOC(
-LeakyRelu takes input data (Tensor<T>) and an argument alpha, and produces one
-output data (Tensor<T>) where the function `f(x) = alpha * x for x < 0`,
-`f(x) = x for x >= 0`, is applied to the data tensor elementwise.
-)DOC")
+    .SetDoc(LeakyRelu_ver1_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     // This attribute was added via AllowConsumed API in OpSchema.
@@ -334,9 +346,16 @@ output data (Tensor<T>) where the function `f(x) = alpha * x for x < 0`,
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Selu)
+static const char * Selu_ver1_doc = R"DOC(
+Selu takes one input data (Tensor<T>) and produces one output data
+(Tensor<T>) where the scaled exponential linear unit function,
+`y = gamma * (alpha * e^x - alpha) for x <= 0`, `y = gamma * x for x > 0`,
+is applied to the tensor elementwise.
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Selu, 1, OpSchema()
     .Attr(
         "alpha",
         "Coefficient of SELU default to 1.6732.",
@@ -355,20 +374,22 @@ ONNX_OPERATOR_SCHEMA(Selu)
         "legacy optimization attribute.",
         AttributeProto::INTS,
         OPTIONAL)
-    .SetDoc(R"DOC(
-Selu takes one input data (Tensor<T>) and produces one output data
-(Tensor<T>) where the scaled exponential linear unit function,
-`y = gamma * (alpha * e^x - alpha) for x <= 0`, `y = gamma * x for x > 0`,
-is applied to the tensor elementwise.
-)DOC")
+    .SetDoc(Selu_ver1_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Elu)
+static const char * Elu_ver1_doc = R"DOC(
+Elu takes one input data (Tensor<T>) and produces one output data
+(Tensor<T>) where the function `f(x) = alpha * (exp(x) - 1.) for x <
+0`, `f(x) = x for x >= 0`., is applied to the tensor elementwise.
+
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Elu, 1, OpSchema()
     .Attr(
         "alpha",
         "Coefficient of ELU default to 1.0.",
@@ -382,23 +403,20 @@ ONNX_OPERATOR_SCHEMA(Elu)
         "legacy optimization attribute.",
         AttributeProto::INTS,
         OPTIONAL)
-    .SetDoc(R"DOC(
-Elu takes one input data (Tensor<T>) and produces one output data
-(Tensor<T>) where the function `f(x) = alpha * (exp(x) - 1.) for x <
-0`, `f(x) = x for x >= 0`., is applied to the tensor elementwise.
-
-)DOC")
+    .SetDoc(Elu_ver1_doc)
     .Input(0, "X", "1D input tensor", "T")
     .Output(0, "Y", "1D input tensor", "T")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Exp)
-    .SetDoc(R"DOC(
+static const char * Exp_ver1_doc = R"DOC(
 Calculates the exponential of the given input tensor, element-wise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Exp, 1, OpSchema()
+    .SetDoc(Exp_ver1_doc)
     .Input(0, "input", "Input tensor", "T")
     .Output(
         0,
@@ -417,12 +435,14 @@ Calculates the exponential of the given input tensor, element-wise.
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Log)
-    .SetDoc(R"DOC(
+static const char * Log_ver1_doc = R"DOC(
 Calculates the natural log of the given input tensor, element-wise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Log, 1, OpSchema()
+    .SetDoc(Log_ver1_doc)
     .Input(0, "input", "Input tensor", "T")
     .Output(
         0,
@@ -441,12 +461,14 @@ Calculates the natural log of the given input tensor, element-wise.
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Tanh)
-    .SetDoc(R"DOC(
+static const char * Tanh_ver1_doc = R"DOC(
 Calculates the hyperbolic tangent of the given input tensor element-wise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Tanh, 1, OpSchema()
+    .SetDoc(Tanh_ver1_doc)
     .Input(0, "input", "1-D input tensor", "T")
     .Output(
         0,
@@ -465,16 +487,18 @@ Calculates the hyperbolic tangent of the given input tensor element-wise.
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(PRelu)
-    .SetDoc(R"DOC(
+static const char * PRelu_ver1_doc = R"DOC(
 
 PRelu takes input data (Tensor<T>) and slope tensor as input, and produces one
 output data (Tensor<T>) where the function `f(x) = slope * x for x < 0`,
 `f(x) = x for x >= 0`., is applied to the data tensor elementwise.
 
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(PRelu, 1, OpSchema()
+    .SetDoc(PRelu_ver1_doc)
     .Input(0, "X", "Input tensor", "T")
     .Input(
         1,
@@ -494,14 +518,16 @@ output data (Tensor<T>) where the function `f(x) = slope * x for x < 0`,
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Sigmoid)
-    .SetDoc(R"DOC(
+static const char * Sigmoid_ver1_doc = R"DOC(
 Sigmoid takes one input data (Tensor<T>) and produces one output data
 (Tensor<T>) where the sigmoid function, y = 1 / (1 + exp(-x)), is applied to the
 tensor elementwise.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Sigmoid, 1, OpSchema()
+    .SetDoc(Sigmoid_ver1_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     // This attribute was added via AllowConsumed API in OpSchema.
@@ -515,9 +541,15 @@ tensor elementwise.
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(HardSigmoid)
+static const char * HardSigmoid_ver1_doc = R"DOC(
+HardSigmoid takes one input data (Tensor<T>) and produces one output data
+(Tensor<T>) where the HardSigmoid function, y = max(0, min(1, alpha * x + beta)),
+is applied to the tensor elementwise.
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(HardSigmoid, 1, OpSchema()
     .Attr("alpha", "Value of alpha default to 0.2", AttributeProto::FLOAT, 0.2f)
     .Attr("beta", "Value of beta default to 0.5", AttributeProto::FLOAT, 0.5f)
     // This attribute was added via AllowConsumed API in OpSchema.
@@ -528,23 +560,21 @@ ONNX_OPERATOR_SCHEMA(HardSigmoid)
         "legacy optimization attribute.",
         AttributeProto::INTS,
         OPTIONAL)
-    .SetDoc(R"DOC(
-HardSigmoid takes one input data (Tensor<T>) and produces one output data
-(Tensor<T>) where the HardSigmoid function, y = max(0, min(1, alpha * x + beta)),
-is applied to the tensor elementwise.
-)DOC")
+    .SetDoc(HardSigmoid_ver1_doc)
     .Input(0, "X", "Input tensor", "T")
     .Output(0, "Y", "Output tensor", "T")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Max)
-    .SetDoc(R"DOC(
+static const char * Max_ver1_doc = R"DOC(
 Element-wise max of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Max, 1, OpSchema()
+    .SetDoc(Max_ver1_doc)
     .Input(0, "data_0", "List of tensors for Max.", "T", OpSchema::Variadic)
     .Output(0, "max", "Output tensor. Same dimension as inputs.", "T")
     // This attribute was added via AllowConsumed API in OpSchema.
@@ -558,13 +588,15 @@ have the same shape and data type.
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Min)
-    .SetDoc(R"DOC(
+static const char * Min_ver1_doc = R"DOC(
 Element-wise min of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Min, 1, OpSchema()
+    .SetDoc(Min_ver1_doc)
     .Input(0, "data_0", "List of tensors for Min", "T", OpSchema::Variadic)
     .Output(0, "min", "Output tensor. Same dimension as inputs.", "T")
     // This attribute was added via AllowConsumed API in OpSchema.
@@ -578,13 +610,15 @@ have the same shape and data type.
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Sum)
-    .SetDoc(R"DOC(
+static const char * Sum_ver1_doc = R"DOC(
 Element-wise sum of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Sum, 1, OpSchema()
+    .SetDoc(Sum_ver1_doc)
     .Input(0, "data_0", "List of tensors for Sum.", "T", OpSchema::Variadic)
     .Output(0, "sum", "Output tensor. Same dimension as inputs.", "T")
     // This attribute was added via AllowConsumed API in OpSchema.
@@ -598,13 +632,15 @@ have the same shape and data type.
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Mean)
-    .SetDoc(R"DOC(
+static const char * Mean_ver1_doc = R"DOC(
 Element-wise mean of each of the input tensors. All inputs and outputs must
 have the same shape and data type.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Mean, 1, OpSchema()
+    .SetDoc(Mean_ver1_doc)
     .Input(0, "data_0", "List of tensors for Mean.", "T", OpSchema::Variadic)
     .Output(0, "mean", "Output tensor. Same dimension as inputs.", "T")
     // This attribute was added via AllowConsumed API in OpSchema.
@@ -618,14 +654,16 @@ have the same shape and data type.
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Clip)
-    .SetDoc(R"DOC(
+static const char * Clip_ver1_doc = R"DOC(
 Clip operator limits the given input within an interval. The interval is
 specified with arguments 'min' and 'max'. They default to
 numeric_limits::lowest() and numeric_limits::max() respectively.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Clip, 1, OpSchema()
+    .SetDoc(Clip_ver1_doc)
     .Attr(
         "min",
         "Minimum value, under which element is replaced by min",
@@ -649,10 +687,9 @@ numeric_limits::lowest() and numeric_limits::max() respectively.
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Gemm)
-    .SetDoc(R"DOC(General Matrix multiplication:
+static const char * Gemm_ver1_doc = R"DOC(General Matrix multiplication:
 https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms#Level_3
 Compute Y = alpha * A * B + beta * C, where input tensor A has dimension (M X K)
 , input tensor B has dimension (K X N), input tensor C and output tensor Y have
@@ -660,7 +697,10 @@ dimension (M X N).
 If attribute broadcast is non-zero, input tensor C will be broadcasted to match
 the dimension requirement. A will be transposed before doing the computation
 if attribute transA is non-zero, same for B and transB.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Gemm, 1, OpSchema()
+    .SetDoc(Gemm_ver1_doc)
     .Input(0, "A", "Input tensor A", "T")
     .Input(1, "B", "Input tensor B", "T")
     .Input(2, "C", "Input tensor C, can be inplace.", "T")
@@ -696,11 +736,9 @@ if attribute transA is non-zero, same for B and transB.
         "beta",
         "Scalar multiplier for input tensor C",
         AttributeProto::FLOAT,
-        1.0f);
+        1.0f));
 
-ONNX_OPERATOR_SCHEMA(Gemm)
-    .SinceVersion(6)
-    .SetDoc(R"DOC(General Matrix multiplication:
+static const char * Gemm_ver6_doc = R"DOC(General Matrix multiplication:
 https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms#Level_3
 Compute Y = alpha * A * B + beta * C, where input tensor A has dimension (M X K)
 , input tensor B has dimension (K X N), input tensor C and output tensor Y have
@@ -708,7 +746,10 @@ dimension (M X N).
 If attribute broadcast is non-zero, input tensor C will be broadcasted to match
 the dimension requirement. A will be transposed before doing the computation
 if attribute transA is non-zero, same for B and transB.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Gemm, 6, OpSchema()
+    .SetDoc(Gemm_ver6_doc)
     .Input(0, "A", "Input tensor A", "T")
     .Input(1, "B", "Input tensor B", "T")
     .Input(2, "C", "Input tensor C", "T")
@@ -760,4 +801,5 @@ if attribute transA is non-zero, same for B and transB.
           *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape() =
             ctx.getInputType(2)->tensor_type().shape();
         }
-      });
+      }));
+} // namespace ONNX_NAMESPACE

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -5,7 +5,7 @@
 using namespace ONNX_NAMESPACE;
 
 namespace ONNX_NAMESPACE {
-const char * pads_doc =
+const char* pads_doc =
     "Padding for the beginning and ending along each axis, it can take any value greater "
     "than or equal to 0. The value represent the number of pixels added to the beginning "
     "and end part of the corresponding axis. `pads` format should be as follow "
@@ -13,7 +13,7 @@ const char * pads_doc =
     "added at the beginning of axis `i` and xi_end, the number of pixels added at "
     "the end of axis `i`. This attribute cannot be used simultaneously with "
     "auto_pad attribute. If not present, the padding defaults to 0 along start and end of each axis.";
-const char * auto_pad_doc =
+const char* auto_pad_doc =
     "auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where "
     "SAME_UPPER or SAME_LOWER mean pad the input so that the output size match the input."
     "In case of odd number add the extra padding at the end for SAME_UPPER and at the "
@@ -223,27 +223,35 @@ std::function<void(OpSchema&)> PoolOpSchemaGenerator(
   };
 } // namespace ONNX_NAMESPACE
 
-ONNX_OPERATOR_SET_SCHEMA(AveragePool, 1, OpSchema()
-    .FillUsing(PoolOpSchemaGenerator(
+ONNX_OPERATOR_SET_SCHEMA(
+    AveragePool,
+    1,
+    OpSchema().FillUsing(PoolOpSchemaGenerator(
         "AveragePool",
         "average",
         "The output of each pooling window is divided by the number of elements exclude pad.")));
 
-ONNX_OPERATOR_SET_SCHEMA(AveragePool, 7, OpSchema()
-    .FillUsing(PoolOpSchemaGenerator(
-        "AveragePool",
-        "average",
-        "The output of each pooling window is divided by the number of elements (exclude pad when attribute count_include_pad is zero)."))
-    .Attr(
-        "count_include_pad",
-        "Whether include pad pixels when calculating values for the edges.",
-        AttributeProto::INT,
-        static_cast<int64_t>(0)));
+ONNX_OPERATOR_SET_SCHEMA(
+    AveragePool,
+    7,
+    OpSchema()
+        .FillUsing(PoolOpSchemaGenerator(
+            "AveragePool",
+            "average",
+            "The output of each pooling window is divided by the number of elements (exclude pad when attribute count_include_pad is zero)."))
+        .Attr(
+            "count_include_pad",
+            "Whether include pad pixels when calculating values for the edges.",
+            AttributeProto::INT,
+            static_cast<int64_t>(0)));
 
-ONNX_OPERATOR_SET_SCHEMA(MaxPool, 1, OpSchema().FillUsing(PoolOpSchemaGenerator(
-    "MaxPool",
-    "max",
-    "The output of each pooling window is maximum number of elements exclude pad.")));
+ONNX_OPERATOR_SET_SCHEMA(
+    MaxPool,
+    1,
+    OpSchema().FillUsing(PoolOpSchemaGenerator(
+        "MaxPool",
+        "max",
+        "The output of each pooling window is maximum number of elements exclude pad.")));
 
 } // namespace ONNX_NAMESPACE
 
@@ -307,7 +315,10 @@ std::function<void(OpSchema&)> LpPoolOpSchemaGenerator(const char* name) {
   };
 }
 
-ONNX_OPERATOR_SET_SCHEMA(LpPool, 2, OpSchema().FillUsing(LpPoolOpSchemaGenerator("LpPool")));
+ONNX_OPERATOR_SET_SCHEMA(
+    LpPool,
+    2,
+    OpSchema().FillUsing(LpPoolOpSchemaGenerator("LpPool")));
 
 } // namespace ONNX_NAMESPACE
 
@@ -393,7 +404,10 @@ std::function<void(OpSchema&)> RoiPoolOpSchemaGenerator(const char* name) {
   };
 }
 
-ONNX_OPERATOR_SET_SCHEMA(MaxRoiPool, 1, OpSchema().FillUsing(RoiPoolOpSchemaGenerator("max")));
+ONNX_OPERATOR_SET_SCHEMA(
+    MaxRoiPool,
+    1,
+    OpSchema().FillUsing(RoiPoolOpSchemaGenerator("max")));
 } // namespace ONNX_NAMESPACE
 
 namespace ONNX_NAMESPACE {
@@ -481,7 +495,10 @@ computes the output.)DOC";
   };
 }
 
-ONNX_OPERATOR_SET_SCHEMA(Conv, 1, OpSchema().FillUsing(ConvOpSchemaGenerator("a filter")));
+ONNX_OPERATOR_SET_SCHEMA(
+    Conv,
+    1,
+    OpSchema().FillUsing(ConvOpSchemaGenerator("a filter")));
 
 } // namespace ONNX_NAMESPACE
 
@@ -705,8 +722,10 @@ output_shape can also be explicitly specified in which case pads values are auto
   };
 }
 
-ONNX_OPERATOR_SET_SCHEMA(ConvTranspose, 1, OpSchema()
-    .FillUsing(ConvTransposeOpSchemaGenerator("a filter")));
+ONNX_OPERATOR_SET_SCHEMA(
+    ConvTranspose,
+    1,
+    OpSchema().FillUsing(ConvTransposeOpSchemaGenerator("a filter")));
 
 } // namespace ONNX_NAMESPACE
 
@@ -775,10 +794,15 @@ std::function<void(OpSchema&)> GlobalPoolingOpSchemaGenerator(
         [](InferenceContext& ctx) { gloablPoolTypeShapeInference(ctx); });
   };
 }
-ONNX_OPERATOR_SET_SCHEMA(GlobalAveragePool, 1, OpSchema()
-    .FillUsing(GlobalPoolingOpSchemaGenerator("AveragePool", "average")));
-ONNX_OPERATOR_SET_SCHEMA(GlobalMaxPool, 1, OpSchema()
-    .FillUsing(GlobalPoolingOpSchemaGenerator("MaxPool", "max")));
+ONNX_OPERATOR_SET_SCHEMA(
+    GlobalAveragePool,
+    1,
+    OpSchema().FillUsing(
+        GlobalPoolingOpSchemaGenerator("AveragePool", "average")));
+ONNX_OPERATOR_SET_SCHEMA(
+    GlobalMaxPool,
+    1,
+    OpSchema().FillUsing(GlobalPoolingOpSchemaGenerator("MaxPool", "max")));
 
 std::function<void(OpSchema&)> GlobalLpPoolingOpSchemaGenerator(
     const char* op_type,
@@ -823,10 +847,13 @@ std::function<void(OpSchema&)> GlobalLpPoolingOpSchemaGenerator(
   };
 }
 
-ONNX_OPERATOR_SET_SCHEMA(GlobalLpPool, 2, OpSchema()
-    .FillUsing(GlobalLpPoolingOpSchemaGenerator("LpPool", "lp pool")));
+ONNX_OPERATOR_SET_SCHEMA(
+    GlobalLpPool,
+    2,
+    OpSchema().FillUsing(
+        GlobalLpPoolingOpSchemaGenerator("LpPool", "lp pool")));
 
-static const char * BatchNormalization_ver7_doc = R"DOC(
+static const char* BatchNormalization_ver7_doc = R"DOC(
 Carries out batch normalization as described in the paper
 https://arxiv.org/abs/1502.03167. Depending on the mode it is being run,
 there are multiple cases for the number of outputs, which we list below:
@@ -835,102 +862,104 @@ Output case #1: Y, mean, var, saved_mean, saved_var (training mode)
 Output case #2: Y (test mode)
     )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(BatchNormalization, 7, OpSchema()
-    .NumOutputs({1, 5})
-    .SetDoc(BatchNormalization_ver7_doc + GenerateOptionalArgumentsDoc())
-    .Attr(
-        "spatial",
-        "If true, compute the mean and variance across all spatial elements "
-        "If false, compute the mean and variance across per feature."
-        "Default is 1.",
-        AttributeProto::INT,
-        static_cast<int64_t>(1))
-    .Attr(
-        "epsilon",
-        "The epsilon value to use to avoid division by zero, default is 1e-5f.",
-        AttributeProto::FLOAT,
-        1e-5f)
-    .Attr(
-        "momentum",
-        "Factor used in computing the running mean and variance."
-        "e.g., running_mean = running_mean * momentum + mean * (1 - momentum), default is 0.9f.",
-        AttributeProto::FLOAT,
-        0.9f)
-    .Input(
-        0,
-        "X",
-        "Input data tensor from the previous operator; "
-        "dimensions for image case are (N x C x H x W), "
-        "where N is the batch size, C is the number of "
-        "channels, and H and W are the height and the "
-        "width of the data. For non image case, the "
-        "dimensions are in the form of "
-        "(N x C x D1 x D2 ... Dn), where N is the batch "
-        "size.",
-        "T")
-    .Input(
-        1,
-        "scale",
-        "The scale as a 1-dimensional tensor of size C to be applied to the "
-        "output.",
-        "T")
-    .Input(
-        2,
-        "B",
-        "The bias as a 1-dimensional tensor of size C to be applied to the "
-        "output.",
-        "T")
-    .Input(
-        3,
-        "mean",
-        "The running mean (training) or the estimated mean (testing) "
-        "as a 1-dimensional tensor of size C.",
-        "T")
-    .Input(
-        4,
-        "var",
-        "The running variance (training) or the estimated "
-        "variance (testing) as a 1-dimensional tensor of size C.",
-        "T")
-    .Output(0, "Y", "The output tensor of the same shape as X.", "T")
-    .Output(
-        1,
-        "mean",
-        "The running mean after the BatchNormalization operator.",
-        "T",
-        OpSchema::Optional)
-    .Output(
-        2,
-        "var",
-        "The running variance after the BatchNormalization operator.",
-        "T",
-        OpSchema::Optional)
-    .Output(
-        3,
-        "saved_mean",
-        "Saved mean used during training to speed up gradient "
-        "computation.",
-        "T",
-        OpSchema::Optional)
-    .Output(
-        4,
-        "saved_var",
-        "Saved variance used during training to speed up "
-        "gradient computation.",
-        "T",
-        OpSchema::Optional)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      propagateShapeAndTypeFromFirstInput(ctx);
-      // TODO in training mode, it may be possible to infer some of
-      // the other outputs as well.
-    }));
+ONNX_OPERATOR_SET_SCHEMA(
+    BatchNormalization,
+    7,
+    OpSchema()
+        .NumOutputs({1, 5})
+        .SetDoc(BatchNormalization_ver7_doc + GenerateOptionalArgumentsDoc())
+        .Attr(
+            "spatial",
+            "If true, compute the mean and variance across all spatial elements "
+            "If false, compute the mean and variance across per feature."
+            "Default is 1.",
+            AttributeProto::INT,
+            static_cast<int64_t>(1))
+        .Attr(
+            "epsilon",
+            "The epsilon value to use to avoid division by zero, default is 1e-5f.",
+            AttributeProto::FLOAT,
+            1e-5f)
+        .Attr(
+            "momentum",
+            "Factor used in computing the running mean and variance."
+            "e.g., running_mean = running_mean * momentum + mean * (1 - momentum), default is 0.9f.",
+            AttributeProto::FLOAT,
+            0.9f)
+        .Input(
+            0,
+            "X",
+            "Input data tensor from the previous operator; "
+            "dimensions for image case are (N x C x H x W), "
+            "where N is the batch size, C is the number of "
+            "channels, and H and W are the height and the "
+            "width of the data. For non image case, the "
+            "dimensions are in the form of "
+            "(N x C x D1 x D2 ... Dn), where N is the batch "
+            "size.",
+            "T")
+        .Input(
+            1,
+            "scale",
+            "The scale as a 1-dimensional tensor of size C to be applied to the "
+            "output.",
+            "T")
+        .Input(
+            2,
+            "B",
+            "The bias as a 1-dimensional tensor of size C to be applied to the "
+            "output.",
+            "T")
+        .Input(
+            3,
+            "mean",
+            "The running mean (training) or the estimated mean (testing) "
+            "as a 1-dimensional tensor of size C.",
+            "T")
+        .Input(
+            4,
+            "var",
+            "The running variance (training) or the estimated "
+            "variance (testing) as a 1-dimensional tensor of size C.",
+            "T")
+        .Output(0, "Y", "The output tensor of the same shape as X.", "T")
+        .Output(
+            1,
+            "mean",
+            "The running mean after the BatchNormalization operator.",
+            "T",
+            OpSchema::Optional)
+        .Output(
+            2,
+            "var",
+            "The running variance after the BatchNormalization operator.",
+            "T",
+            OpSchema::Optional)
+        .Output(
+            3,
+            "saved_mean",
+            "Saved mean used during training to speed up gradient "
+            "computation.",
+            "T",
+            OpSchema::Optional)
+        .Output(
+            4,
+            "saved_var",
+            "Saved variance used during training to speed up "
+            "gradient computation.",
+            "T",
+            OpSchema::Optional)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateShapeAndTypeFromFirstInput(ctx);
+          // TODO in training mode, it may be possible to infer some of
+          // the other outputs as well.
+        }));
 
-
-static const char * InstanceNormalization_ver6_doc = R"DOC(
+static const char* InstanceNormalization_ver6_doc = R"DOC(
 Carries out instance normalization as described in the paper
 https://arxiv.org/abs/1607.08022.
 
@@ -939,63 +968,77 @@ where mean and variance are computed per instance per channel.
 
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(InstanceNormalization, 6, OpSchema()
-    .SetDoc(InstanceNormalization_ver6_doc)
-    .Attr(
-        "epsilon",
-        "The epsilon value to use to avoid division by zero, default is 1e-5f.",
-        AttributeProto::FLOAT,
-        1e-5f)
-    .Input(
-        0,
-        "input",
-        "Input data tensor from the previous operator; "
-        "dimensions for image case are (N x C x H x W), "
-        "where N is the batch size, C is the number of "
-        "channels, and H and W are the height and the "
-        "width of the data. For non image case, the "
-        "dimensions are in the form of "
-        "(N x C x D1 x D2 ... Dn), where N is the batch "
-        "size.",
-        "T")
-    .Input(1, "scale", "The input 1-dimensional scale tensor of size C.", "T")
-    .Input(2, "B", "The input 1-dimensional bias tensor of size C.", "T")
-    .Output(0, "output", "The output tensor of the same shape as input.", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      propagateShapeAndTypeFromFirstInput(ctx);
-    }));
+ONNX_OPERATOR_SET_SCHEMA(
+    InstanceNormalization,
+    6,
+    OpSchema()
+        .SetDoc(InstanceNormalization_ver6_doc)
+        .Attr(
+            "epsilon",
+            "The epsilon value to use to avoid division by zero, default is 1e-5f.",
+            AttributeProto::FLOAT,
+            1e-5f)
+        .Input(
+            0,
+            "input",
+            "Input data tensor from the previous operator; "
+            "dimensions for image case are (N x C x H x W), "
+            "where N is the batch size, C is the number of "
+            "channels, and H and W are the height and the "
+            "width of the data. For non image case, the "
+            "dimensions are in the form of "
+            "(N x C x D1 x D2 ... Dn), where N is the batch "
+            "size.",
+            "T")
+        .Input(
+            1,
+            "scale",
+            "The input 1-dimensional scale tensor of size C.",
+            "T")
+        .Input(2, "B", "The input 1-dimensional bias tensor of size C.", "T")
+        .Output(
+            0,
+            "output",
+            "The output tensor of the same shape as input.",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateShapeAndTypeFromFirstInput(ctx);
+        }));
 
-static const char * LpNormalization_ver1_doc = R"DOC(
+static const char* LpNormalization_ver1_doc = R"DOC(
 Given a matrix, apply Lp-normalization along the provided axis.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(LpNormalization, 1, OpSchema()
-    .Input(0, "input", "Input matrix", "T")
-    .Output(0, "output", "Matrix after normalization", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .SetDoc(LpNormalization_ver1_doc)
-    .Attr(
-        "axis",
-        "(int64, default -1) the axis on which to apply normalization, -1 mean last axis.",
-        AttributeProto::INT,
-        static_cast<int64_t>(-1))
-    .Attr(
-        "p",
-        "(int64, default 2) the order of the normalization, only 1 or 2 are supported.",
-        AttributeProto::INT,
-        static_cast<int64_t>(2))
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      propagateShapeAndTypeFromFirstInput(ctx);
-    }));
+ONNX_OPERATOR_SET_SCHEMA(
+    LpNormalization,
+    1,
+    OpSchema()
+        .Input(0, "input", "Input matrix", "T")
+        .Output(0, "output", "Matrix after normalization", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .SetDoc(LpNormalization_ver1_doc)
+        .Attr(
+            "axis",
+            "(int64, default -1) the axis on which to apply normalization, -1 mean last axis.",
+            AttributeProto::INT,
+            static_cast<int64_t>(-1))
+        .Attr(
+            "p",
+            "(int64, default 2) the order of the normalization, only 1 or 2 are supported.",
+            AttributeProto::INT,
+            static_cast<int64_t>(2))
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateShapeAndTypeFromFirstInput(ctx);
+        }));
 
-static const char * Dropout_ver7_doc = R"DOC(
+static const char* Dropout_ver7_doc = R"DOC(
 Dropout takes one input data (Tensor<float>) and produces two Tensor outputs,
 output (Tensor<float>) and mask (Tensor<bool>). Depending on whether it is in
 test mode or not, the output Y will either be a random dropout, or a simple
@@ -1003,75 +1046,76 @@ copy of the input. Note that our implementation of Dropout does scaling in
 the training phase, so during testing nothing needs to be done.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Dropout, 7, OpSchema()
-    .SetDoc(Dropout_ver7_doc + GenerateOptionalArgumentsDoc())
-    .Attr(
-        "ratio",
-        "(float, default 0.5) the ratio of random dropout",
-        AttributeProto::FLOAT,
-        0.5f)
-    .Input(0, "data", "The input data as Tensor.", "T")
-    .Output(0, "output", "The output.", "T")
-    .Output(
-        1,
-        "mask",
-        "The output mask.",
-        "T",
-        OpSchema::Optional)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Dropout,
+    7,
+    OpSchema()
+        .SetDoc(Dropout_ver7_doc + GenerateOptionalArgumentsDoc())
+        .Attr(
+            "ratio",
+            "(float, default 0.5) the ratio of random dropout",
+            AttributeProto::FLOAT,
+            0.5f)
+        .Input(0, "data", "The input data as Tensor.", "T")
+        .Output(0, "output", "The output.", "T")
+        .Output(1, "mask", "The output mask.", "T", OpSchema::Optional)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * Flatten_ver1_doc = R"DOC(
+static const char* Flatten_ver1_doc = R"DOC(
 Flattens the input tensor into a 2D matrix. If input tensor has shape
 (d_0, d_1, ... d_n) then the output will have shape
 (d_0 X d_1 ... d_(axis-1), d_axis X d_(axis+1) ... X dn).
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Flatten, 1, OpSchema()
-    .SetDoc(Flatten_ver1_doc)
-    .Input(0, "input", "A tensor of rank >= axis.", "T")
-    .Output(
-        0,
-        "output",
-        "A 2D tensor with the contents of the input tensor, "
-        "with input dimensions up to axis flattened to the outer dimension "
-        "of the output and remaining input dimensions flattened into the inner "
-        "dimension of the output.",
-        "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .Attr(
-        "axis",
-        "(Default to 1) Indicate up to which input dimensions "
-        "(exclusive) should be flattened to the outer dimension of the output. "
-        "The value for axis must be in the range [0, R], where R is the rank of the input tensor. "
-        "When axis = 0, the shape of the output tensor is (1, (d_0 X d_1 ... d_n), "
-        "where the shape of the input tensor is (d_0, d_1, ... d_n). ",
-        AttributeProto::INT,
-        static_cast<int64_t>(1))
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      propagateElemTypeFromInputToOutput(ctx, 0, 0);
-      if (hasInputShape(ctx, 0)) {
-        auto& input_shape = getInputShape(ctx, 0);
-        int rank = static_cast<int>(input_shape.dim_size());
-        int axis = static_cast<int>(getAttribute(ctx, "axis", 1));
-        if (axis > rank)
-          axis = rank;
-        // TODO: is the operation defined for input-rank < 2?
-        updateOutputShape(
-            ctx,
+ONNX_OPERATOR_SET_SCHEMA(
+    Flatten,
+    1,
+    OpSchema()
+        .SetDoc(Flatten_ver1_doc)
+        .Input(0, "input", "A tensor of rank >= axis.", "T")
+        .Output(
             0,
-            {multiplyDims(input_shape, 0, axis),
-             multiplyDims(input_shape, axis, rank)});
-      }
-    }));
+            "output",
+            "A 2D tensor with the contents of the input tensor, "
+            "with input dimensions up to axis flattened to the outer dimension "
+            "of the output and remaining input dimensions flattened into the inner "
+            "dimension of the output.",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .Attr(
+            "axis",
+            "(Default to 1) Indicate up to which input dimensions "
+            "(exclusive) should be flattened to the outer dimension of the output. "
+            "The value for axis must be in the range [0, R], where R is the rank of the input tensor. "
+            "When axis = 0, the shape of the output tensor is (1, (d_0 X d_1 ... d_n), "
+            "where the shape of the input tensor is (d_0, d_1, ... d_n). ",
+            AttributeProto::INT,
+            static_cast<int64_t>(1))
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          if (hasInputShape(ctx, 0)) {
+            auto& input_shape = getInputShape(ctx, 0);
+            int rank = static_cast<int>(input_shape.dim_size());
+            int axis = static_cast<int>(getAttribute(ctx, "axis", 1));
+            if (axis > rank)
+              axis = rank;
+            // TODO: is the operation defined for input-rank < 2?
+            updateOutputShape(
+                ctx,
+                0,
+                {multiplyDims(input_shape, 0, axis),
+                 multiplyDims(input_shape, axis, rank)});
+          }
+        }));
 
-static const char * LRN_ver1_doc = R"DOC(
+static const char* LRN_ver1_doc = R"DOC(
 Local Response Normalization proposed in the [AlexNet paper](https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf).
 It normalizes over local input regions.
 The local region is defined across the channels. For an element X[n, c, d1, ..., dk] in a tensor
@@ -1084,33 +1128,48 @@ where max(0, c - floor((size - 1) / 2)) <= i <= min(C - 1, c + ceil((size - 1) /
 Y[n, c, d1, ..., dk] = X[n, c, d1, ..., dk] / (bias + alpha / size * square_sum[n, c, d1, ..., dk] ) ^ beta
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(LRN, 1, OpSchema()
-    .Attr("size", "The number of channels to sum over", AttributeProto::INT)
-    .Attr("alpha", "Scaling parameter, default is 1e-4f.", AttributeProto::FLOAT, 0.0001f)
-    .Attr("beta", "The exponent, default is 0.75f", AttributeProto::FLOAT, 0.75f)
-    .Attr("bias", "Default to 1.0f", AttributeProto::FLOAT, 1.0f)
-    .Input(
-        0,
-        "X",
-        "Input data tensor from the previous operator; "
-        "dimensions for image case are (N x C x H x W), "
-        "where N is the batch size, C is the number of "
-        "channels, and H and W are the height and the "
-        "width of the data. For non image case, the "
-        "dimensions are in the form of "
-        "(N x C x D1 x D2 ... Dn), where N is the batch "
-        "size. Optionally, if dimension denotation is "
-        "in effect, the operation expects the input "
-        "data tensor to arrive with the dimension denotation "
-        "of [DATA_BATCH, DATA_CHANNEL, DATA_FEATURE, DATA_FEATURE ...].",
-        "T")
-    .Output(0, "Y", "Output tensor, which has the shape and type as input tensor", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output "
-        " types to float tensors.")
-    .SetDoc(LRN_ver1_doc)
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    LRN,
+    1,
+    OpSchema()
+        .Attr("size", "The number of channels to sum over", AttributeProto::INT)
+        .Attr(
+            "alpha",
+            "Scaling parameter, default is 1e-4f.",
+            AttributeProto::FLOAT,
+            0.0001f)
+        .Attr(
+            "beta",
+            "The exponent, default is 0.75f",
+            AttributeProto::FLOAT,
+            0.75f)
+        .Attr("bias", "Default to 1.0f", AttributeProto::FLOAT, 1.0f)
+        .Input(
+            0,
+            "X",
+            "Input data tensor from the previous operator; "
+            "dimensions for image case are (N x C x H x W), "
+            "where N is the batch size, C is the number of "
+            "channels, and H and W are the height and the "
+            "width of the data. For non image case, the "
+            "dimensions are in the form of "
+            "(N x C x D1 x D2 ... Dn), where N is the batch "
+            "size. Optionally, if dimension denotation is "
+            "in effect, the operation expects the input "
+            "data tensor to arrive with the dimension denotation "
+            "of [DATA_BATCH, DATA_CHANNEL, DATA_FEATURE, DATA_FEATURE ...].",
+            "T")
+        .Output(
+            0,
+            "Y",
+            "Output tensor, which has the shape and type as input tensor",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output "
+            " types to float tensors.")
+        .SetDoc(LRN_ver1_doc)
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -5,7 +5,7 @@
 using namespace ONNX_NAMESPACE;
 
 namespace ONNX_NAMESPACE {
-static std::string pads_doc =
+const char * pads_doc =
     "Padding for the beginning and ending along each axis, it can take any value greater "
     "than or equal to 0. The value represent the number of pixels added to the beginning "
     "and end part of the corresponding axis. `pads` format should be as follow "
@@ -13,7 +13,7 @@ static std::string pads_doc =
     "added at the beginning of axis `i` and xi_end, the number of pixels added at "
     "the end of axis `i`. This attribute cannot be used simultaneously with "
     "auto_pad attribute. If not present, the padding defaults to 0 along start and end of each axis.";
-static std::string auto_pad_doc =
+const char * auto_pad_doc =
     "auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where "
     "SAME_UPPER or SAME_LOWER mean pad the input so that the output size match the input."
     "In case of odd number add the extra padding at the end for SAME_UPPER and at the "
@@ -186,10 +186,10 @@ std::function<void(OpSchema&)> PoolOpSchemaGenerator(
         OPTIONAL);
     schema.Attr(
         "auto_pad",
-        auto_pad_doc.c_str(),
+        auto_pad_doc,
         AttributeProto::STRING,
         std::string("NOTSET"));
-    schema.Attr("pads", pads_doc.c_str(), AttributeProto::INTS, OPTIONAL);
+    schema.Attr("pads", pads_doc, AttributeProto::INTS, OPTIONAL);
     schema.Input(
         0,
         "X",
@@ -223,14 +223,13 @@ std::function<void(OpSchema&)> PoolOpSchemaGenerator(
   };
 } // namespace ONNX_NAMESPACE
 
-ONNX_OPERATOR_SCHEMA(AveragePool)
+ONNX_OPERATOR_SET_SCHEMA(AveragePool, 1, OpSchema()
     .FillUsing(PoolOpSchemaGenerator(
         "AveragePool",
         "average",
-        "The output of each pooling window is divided by the number of elements exclude pad."));
+        "The output of each pooling window is divided by the number of elements exclude pad.")));
 
-ONNX_OPERATOR_SCHEMA(AveragePool)
-    .SinceVersion(7)
+ONNX_OPERATOR_SET_SCHEMA(AveragePool, 7, OpSchema()
     .FillUsing(PoolOpSchemaGenerator(
         "AveragePool",
         "average",
@@ -239,12 +238,12 @@ ONNX_OPERATOR_SCHEMA(AveragePool)
         "count_include_pad",
         "Whether include pad pixels when calculating values for the edges.",
         AttributeProto::INT,
-        static_cast<int64_t>(0));
+        static_cast<int64_t>(0)));
 
-ONNX_OPERATOR_SCHEMA(MaxPool).FillUsing(PoolOpSchemaGenerator(
+ONNX_OPERATOR_SET_SCHEMA(MaxPool, 1, OpSchema().FillUsing(PoolOpSchemaGenerator(
     "MaxPool",
     "max",
-    "The output of each pooling window is maximum number of elements exclude pad."));
+    "The output of each pooling window is maximum number of elements exclude pad.")));
 
 } // namespace ONNX_NAMESPACE
 
@@ -259,7 +258,6 @@ std::function<void(OpSchema&)> LpPoolOpSchemaGenerator(const char* name) {
  data into the output tensor Y for further processing.)DOC";
     ReplaceAll(doc, "{name}", name);
     schema.SetDoc(doc);
-    schema.SinceVersion(2);
     schema.Attr(
         "kernel_shape",
         "The size of the kernel along each axis.",
@@ -271,10 +269,10 @@ std::function<void(OpSchema&)> LpPoolOpSchemaGenerator(const char* name) {
         OPTIONAL);
     schema.Attr(
         "auto_pad",
-        auto_pad_doc.c_str(),
+        auto_pad_doc,
         AttributeProto::STRING,
         std::string("NOTSET"));
-    schema.Attr("pads", pads_doc.c_str(), AttributeProto::INTS, OPTIONAL);
+    schema.Attr("pads", pads_doc, AttributeProto::INTS, OPTIONAL);
     schema.Attr(
         "p",
         "p value of the Lp norm used to pool over the input data, default is 2.",
@@ -309,7 +307,7 @@ std::function<void(OpSchema&)> LpPoolOpSchemaGenerator(const char* name) {
   };
 }
 
-ONNX_OPERATOR_SCHEMA(LpPool).FillUsing(LpPoolOpSchemaGenerator("LpPool"));
+ONNX_OPERATOR_SET_SCHEMA(LpPool, 2, OpSchema().FillUsing(LpPoolOpSchemaGenerator("LpPool")));
 
 } // namespace ONNX_NAMESPACE
 
@@ -395,7 +393,7 @@ std::function<void(OpSchema&)> RoiPoolOpSchemaGenerator(const char* name) {
   };
 }
 
-ONNX_OPERATOR_SCHEMA(MaxRoiPool).FillUsing(RoiPoolOpSchemaGenerator("max"));
+ONNX_OPERATOR_SET_SCHEMA(MaxRoiPool, 1, OpSchema().FillUsing(RoiPoolOpSchemaGenerator("max")));
 } // namespace ONNX_NAMESPACE
 
 namespace ONNX_NAMESPACE {
@@ -468,10 +466,10 @@ computes the output.)DOC";
         OPTIONAL);
     schema.Attr(
         "auto_pad",
-        auto_pad_doc.c_str(),
+        auto_pad_doc,
         AttributeProto::STRING,
         std::string("NOTSET"));
-    schema.Attr("pads", pads_doc.c_str(), AttributeProto::INTS, OPTIONAL);
+    schema.Attr("pads", pads_doc, AttributeProto::INTS, OPTIONAL);
     schema.Attr(
         "group",
         "number of groups input channels and output channels are divided into, default is 1.",
@@ -483,7 +481,7 @@ computes the output.)DOC";
   };
 }
 
-ONNX_OPERATOR_SCHEMA(Conv).FillUsing(ConvOpSchemaGenerator("a filter"));
+ONNX_OPERATOR_SET_SCHEMA(Conv, 1, OpSchema().FillUsing(ConvOpSchemaGenerator("a filter")));
 
 } // namespace ONNX_NAMESPACE
 
@@ -693,10 +691,10 @@ output_shape can also be explicitly specified in which case pads values are auto
         OPTIONAL);
     schema.Attr(
         "auto_pad",
-        auto_pad_doc.c_str(),
+        auto_pad_doc,
         AttributeProto::STRING,
         std::string("NOTSET"));
-    schema.Attr("pads", pads_doc.c_str(), AttributeProto::INTS, OPTIONAL);
+    schema.Attr("pads", pads_doc, AttributeProto::INTS, OPTIONAL);
     schema.Attr(
         "group",
         "number of groups input channels and output channels are divided into, default is 1.",
@@ -707,8 +705,8 @@ output_shape can also be explicitly specified in which case pads values are auto
   };
 }
 
-ONNX_OPERATOR_SCHEMA(ConvTranspose)
-    .FillUsing(ConvTransposeOpSchemaGenerator("a filter"));
+ONNX_OPERATOR_SET_SCHEMA(ConvTranspose, 1, OpSchema()
+    .FillUsing(ConvTransposeOpSchemaGenerator("a filter")));
 
 } // namespace ONNX_NAMESPACE
 
@@ -773,18 +771,15 @@ std::function<void(OpSchema&)> GlobalPoolingOpSchemaGenerator(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.");
-    schema.SetDoc(doc);
     schema.TypeAndShapeInferenceFunction(
         [](InferenceContext& ctx) { gloablPoolTypeShapeInference(ctx); });
   };
 }
-ONNX_OPERATOR_SCHEMA(GlobalAveragePool)
-    .FillUsing(GlobalPoolingOpSchemaGenerator("AveragePool", "average"));
-ONNX_OPERATOR_SCHEMA(GlobalMaxPool)
-    .FillUsing(GlobalPoolingOpSchemaGenerator("MaxPool", "max"));
-} // namespace ONNX_NAMESPACE
+ONNX_OPERATOR_SET_SCHEMA(GlobalAveragePool, 1, OpSchema()
+    .FillUsing(GlobalPoolingOpSchemaGenerator("AveragePool", "average")));
+ONNX_OPERATOR_SET_SCHEMA(GlobalMaxPool, 1, OpSchema()
+    .FillUsing(GlobalPoolingOpSchemaGenerator("MaxPool", "max")));
 
-namespace ONNX_NAMESPACE {
 std::function<void(OpSchema&)> GlobalLpPoolingOpSchemaGenerator(
     const char* op_type,
     const char* op) {
@@ -796,7 +791,6 @@ std::function<void(OpSchema&)> GlobalLpPoolingOpSchemaGenerator(
     ReplaceAll(doc, "{op_type}", op_type);
     ReplaceAll(doc, "{op}", op);
     schema.SetDoc(doc);
-    schema.SinceVersion(2);
     schema.Attr(
         "p",
         "p value of the Lp norm used to pool over the input data, default is 2.",
@@ -829,21 +823,21 @@ std::function<void(OpSchema&)> GlobalLpPoolingOpSchemaGenerator(
   };
 }
 
-ONNX_OPERATOR_SCHEMA(GlobalLpPool)
-    .FillUsing(GlobalLpPoolingOpSchemaGenerator("LpPool", "lp pool"));
-} // namespace ONNX_NAMESPACE
+ONNX_OPERATOR_SET_SCHEMA(GlobalLpPool, 2, OpSchema()
+    .FillUsing(GlobalLpPoolingOpSchemaGenerator("LpPool", "lp pool")));
 
-ONNX_OPERATOR_SCHEMA(BatchNormalization)
-    .SinceVersion(7)
-    .NumOutputs({1, 5})
-    .SetDoc(R"DOC(
+static const char * BatchNormalization_ver7_doc = R"DOC(
 Carries out batch normalization as described in the paper
 https://arxiv.org/abs/1502.03167. Depending on the mode it is being run,
 there are multiple cases for the number of outputs, which we list below:
 
 Output case #1: Y, mean, var, saved_mean, saved_var (training mode)
 Output case #2: Y (test mode)
-    )DOC" + GenerateOptionalArgumentsDoc())
+    )DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(BatchNormalization, 7, OpSchema()
+    .NumOutputs({1, 5})
+    .SetDoc(BatchNormalization_ver7_doc + GenerateOptionalArgumentsDoc())
     .Attr(
         "spatial",
         "If true, compute the mean and variance across all spatial elements "
@@ -933,18 +927,20 @@ Output case #2: Y (test mode)
       propagateShapeAndTypeFromFirstInput(ctx);
       // TODO in training mode, it may be possible to infer some of
       // the other outputs as well.
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(InstanceNormalization)
-    .SinceVersion(6)
-    .SetDoc(R"DOC(
+
+static const char * InstanceNormalization_ver6_doc = R"DOC(
 Carries out instance normalization as described in the paper
 https://arxiv.org/abs/1607.08022.
 
 y = scale * (x - mean) / sqrt(variance + epsilon) + B,
 where mean and variance are computed per instance per channel.
 
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(InstanceNormalization, 6, OpSchema()
+    .SetDoc(InstanceNormalization_ver6_doc)
     .Attr(
         "epsilon",
         "The epsilon value to use to avoid division by zero, default is 1e-5f.",
@@ -971,18 +967,20 @@ where mean and variance are computed per instance per channel.
         "Constrain input and output types to float tensors.")
     .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       propagateShapeAndTypeFromFirstInput(ctx);
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(LpNormalization)
+static const char * LpNormalization_ver6_doc = R"DOC(
+Given a matrix, apply Lp-normalization along the provided axis.
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(LpNormalization, 1, OpSchema()
     .Input(0, "input", "Input matrix", "T")
     .Output(0, "output", "Matrix after normalization", "T")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .SetDoc(R"DOC(
-Given a matrix, apply Lp-normalization along the provided axis.
-)DOC")
+    .SetDoc(LpNormalization_ver6_doc)
     .Attr(
         "axis",
         "(int64, default -1) the axis on which to apply normalization, -1 mean last axis.",
@@ -995,17 +993,18 @@ Given a matrix, apply Lp-normalization along the provided axis.
         static_cast<int64_t>(2))
     .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       propagateShapeAndTypeFromFirstInput(ctx);
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(Dropout)
-    .SinceVersion(7)
-    .SetDoc(R"DOC(
+static const char * Dropout_ver7_doc = R"DOC(
 Dropout takes one input data (Tensor<float>) and produces two Tensor outputs,
 output (Tensor<float>) and mask (Tensor<bool>). Depending on whether it is in
 test mode or not, the output Y will either be a random dropout, or a simple
 copy of the input. Note that our implementation of Dropout does scaling in
 the training phase, so during testing nothing needs to be done.
-)DOC" + GenerateOptionalArgumentsDoc())
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Dropout, 7, OpSchema()
+    .SetDoc(Dropout_ver7_doc + GenerateOptionalArgumentsDoc())
     .Attr(
         "ratio",
         "(float, default 0.5) the ratio of random dropout",
@@ -1023,14 +1022,16 @@ the training phase, so during testing nothing needs to be done.
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(Flatten)
-    .SetDoc(R"DOC(
+static const char * Flatten_ver1_doc = R"DOC(
 Flattens the input tensor into a 2D matrix. If input tensor has shape
 (d_0, d_1, ... d_n) then the output will have shape
 (d_0 X d_1 ... d_(axis-1), d_axis X d_(axis+1) ... X dn).
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Flatten, 1, OpSchema()
+    .SetDoc(Flatten_ver1_doc)
     .Input(0, "input", "A tensor of rank >= axis.", "T")
     .Output(
         0,
@@ -1068,9 +1069,22 @@ Flattens the input tensor into a 2D matrix. If input tensor has shape
             {multiplyDims(input_shape, 0, axis),
              multiplyDims(input_shape, axis, rank)});
       }
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(LRN)
+static const char * LRN_ver6_doc = R"DOC(
+Local Response Normalization proposed in the [AlexNet paper](https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf).
+It normalizes over local input regions.
+The local region is defined across the channels. For an element X[n, c, d1, ..., dk] in a tensor
+of shape (N x C x D1 x D2, ..., Dk), its region is
+{X[n, i, d1, ..., dk] | max(0, c - floor((size - 1) / 2)) <= i <= min(C - 1, c + ceil((size - 1) / 2) - 1)}.
+
+square_sum[n, c, d1, ..., dk] = sum(X[n, i, d1, ..., dk] ^ 2),
+where max(0, c - floor((size - 1) / 2)) <= i <= min(C - 1, c + ceil((size - 1) / 2) - 1).
+
+Y[n, c, d1, ..., dk] = X[n, c, d1, ..., dk] / (bias + alpha / size * square_sum[n, c, d1, ..., dk] ) ^ beta
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(LRN, 1, OpSchema()
     .Attr("size", "The number of channels to sum over", AttributeProto::INT)
     .Attr("alpha", "Scaling parameter, default is 1e-4f.", AttributeProto::FLOAT, 0.0001f)
     .Attr("beta", "The exponent, default is 0.75f", AttributeProto::FLOAT, 0.75f)
@@ -1096,16 +1110,7 @@ ONNX_OPERATOR_SCHEMA(LRN)
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output "
         " types to float tensors.")
-    .SetDoc(R"DOC(
-Local Response Normalization proposed in the [AlexNet paper](https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf).
-It normalizes over local input regions.
-The local region is defined across the channels. For an element X[n, c, d1, ..., dk] in a tensor
-of shape (N x C x D1 x D2, ..., Dk), its region is
-{X[n, i, d1, ..., dk] | max(0, c - floor((size - 1) / 2)) <= i <= min(C - 1, c + ceil((size - 1) / 2) - 1)}.
+    .SetDoc(LRN_ver6_doc)
+    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-square_sum[n, c, d1, ..., dk] = sum(X[n, i, d1, ..., dk] ^ 2),
-where max(0, c - floor((size - 1) / 2)) <= i <= min(C - 1, c + ceil((size - 1) / 2) - 1).
-
-Y[n, c, d1, ..., dk] = X[n, c, d1, ..., dk] / (bias + alpha / size * square_sum[n, c, d1, ..., dk] ) ^ beta
-)DOC")
-    .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+} // namespace ONNX_NAMESPACE

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -969,7 +969,7 @@ ONNX_OPERATOR_SET_SCHEMA(InstanceNormalization, 6, OpSchema()
       propagateShapeAndTypeFromFirstInput(ctx);
     }));
 
-static const char * LpNormalization_ver6_doc = R"DOC(
+static const char * LpNormalization_ver1_doc = R"DOC(
 Given a matrix, apply Lp-normalization along the provided axis.
 )DOC";
 
@@ -980,7 +980,7 @@ ONNX_OPERATOR_SET_SCHEMA(LpNormalization, 1, OpSchema()
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output types to float tensors.")
-    .SetDoc(LpNormalization_ver6_doc)
+    .SetDoc(LpNormalization_ver1_doc)
     .Attr(
         "axis",
         "(int64, default -1) the axis on which to apply normalization, -1 mean last axis.",
@@ -1071,7 +1071,7 @@ ONNX_OPERATOR_SET_SCHEMA(Flatten, 1, OpSchema()
       }
     }));
 
-static const char * LRN_ver6_doc = R"DOC(
+static const char * LRN_ver1_doc = R"DOC(
 Local Response Normalization proposed in the [AlexNet paper](https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf).
 It normalizes over local input regions.
 The local region is defined across the channels. For an element X[n, c, d1, ..., dk] in a tensor
@@ -1110,7 +1110,7 @@ ONNX_OPERATOR_SET_SCHEMA(LRN, 1, OpSchema()
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
         "Constrain input and output "
         " types to float tensors.")
-    .SetDoc(LRN_ver6_doc)
+    .SetDoc(LRN_ver1_doc)
     .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/nn/old.cc
+++ b/onnx/defs/nn/old.cc
@@ -316,16 +316,18 @@ ONNX_OPERATOR_SET_SCHEMA(Dropout, 6, OpSchema()
 		"Constrain input and output types to float tensors.")
 	.TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SET_SCHEMA(BatchNormalization, 6, OpSchema()
-.NumOutputs({ 1, 5 })
-.SetDoc(R"DOC(
+static const char * BatchNorm_ver6_doc =  R"DOC(
 Carries out batch normalization as described in the paper
 https://arxiv.org/abs/1502.03167. Depending on the mode it is being run,
 there are multiple cases for the number of outputs, which we list below:
 
 Output case #1: Y, mean, var, saved_mean, saved_var (training mode)
 Output case #2: Y (test mode)
-    )DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(BatchNormalization, 6, OpSchema()
+.NumOutputs({ 1, 5 })
+.SetDoc(BatchNorm_ver6_doc)
 	.Attr(
 		"spatial",
 		"If true, compute the mean and variance across all spatial elements "

--- a/onnx/defs/nn/old.cc
+++ b/onnx/defs/nn/old.cc
@@ -3,10 +3,9 @@
 
 #include "onnx/defs/schema.h"
 
-using namespace ONNX_NAMESPACE;
-
-namespace ONNX_NAMESPACE {
-static std::string pads_doc =
+namespace ONNX_NAMESPACE
+{
+const char * pads_doc_old =
     "Padding for the beginning and ending along each axis, it can take any value greater "
     "than or equal to 0. The value represent the number of pixels added to the beginning "
     "and end part of the corresponding axis. `pads` format should be as follow "
@@ -14,23 +13,23 @@ static std::string pads_doc =
     "added at the beginning of axis `i` and xi_end, the number of pixels added at "
     "the end of axis `i`. This attribute cannot be used simultaneously with "
     "auto_pad attribute.";
-static std::string auto_pad_doc =
+const char * auto_pad_doc_old =
     "auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where "
     "SAME_UPPER or SAME_LOWER mean pad the input so that the output size match the input."
     "In case of odd number add the extra padding at the end for SAME_UPPER and at the "
     "beginning for SAME_LOWER. VALID mean no padding. DEPRECATION NOTE: auto_pad is "
     "only intended to support legacy uses, and for framework authors, one is explicitly "
     "encouraged to use explicit padding specified in the pads attribute.";
-} // namespace ONNX_NAMESPACE
 
-ONNX_OPERATOR_SCHEMA(LpPool)
-    .SinceVersion(1)
-    .SetDoc(R"DOC(
+static const char * LpPool_ver1_doc = R"DOC(
  LpPool consumes an input tensor X and applies Lp pooling across the
  the tensor according to kernel sizes, stride sizes, and pad lengths.
  Lp pooling consisting of computing the Lp norm on all values of a subset
  of the input tensor according to the kernel size and downsampling the
- data into the output tensor Y for further processing.)DOC")
+ data into the output tensor Y for further processing.)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(LpPool, 1, OpSchema()
+    .SetDoc(LpPool_ver1_doc)
     .Attr(
         "kernel_shape",
         "The size of the kernel along each axis.",
@@ -39,10 +38,10 @@ ONNX_OPERATOR_SCHEMA(LpPool)
     .Attr("strides", "Stride along each axis.", AttributeProto::INTS, OPTIONAL)
     .Attr(
         "auto_pad",
-        auto_pad_doc.c_str(),
+        auto_pad_doc_old,
         AttributeProto::STRING,
         std::string("NOTSET"))
-    .Attr("pads", pads_doc.c_str(), AttributeProto::INTS, OPTIONAL)
+    .Attr("pads", pads_doc_old, AttributeProto::INTS, OPTIONAL)
     .Attr(
         "p",
         "p value of the Lp norm used to pool over the input data, default is 2.0.",
@@ -70,14 +69,15 @@ ONNX_OPERATOR_SCHEMA(LpPool)
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(GlobalLpPool)
-    .SinceVersion(1)
-    .SetDoc(R"DOC(
+static const char * GlobalLpPool_ver1_doc = R"DOC(
  GlobalLpPool consumes an input tensor X and applies lp pool pooling across the
  the values in the same channel. This is equivalent to LpPool with kernel size
- equal to the spatial dimension of input tensor.)DOC")
+ equal to the spatial dimension of input tensor.)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(GlobalLpPool, 1, OpSchema()
+    .SetDoc(GlobalLpPool_ver1_doc)
     .Attr(
         "p",
         "p value of the Lp norm used to pool over the input data, default is 2.0.",
@@ -103,19 +103,20 @@ ONNX_OPERATOR_SCHEMA(GlobalLpPool)
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(BatchNormalization)
-    .SinceVersion(1)
-    .NumOutputs({1, 5})
-    .SetDoc(R"DOC(
+static const char * BatchNormalization_ver1_doc = R"DOC(
 Carries out batch normalization as described in the paper
 https://arxiv.org/abs/1502.03167. Depending on the mode it is being run,
 there are multiple cases for the number of outputs, which we list below:
 
 Output case #1: Y, mean, var, saved_mean, saved_var (training mode)
 Output case #2: Y (test mode)
-    )DOC")
+    )DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(BatchNormalization, 1, OpSchema()
+    .NumOutputs({1, 5})
+    .SetDoc(BatchNormalization_ver1_doc)
     .Attr(
         "spatial",
         "If true, compute the mean and variance across all spatial elements "
@@ -207,17 +208,19 @@ Output case #2: Y (test mode)
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(InstanceNormalization)
-    .SetDoc(R"DOC(
+static const char * InstanceNormalization_ver1_doc = R"DOC(
 Carries out instance normalization as described in the paper
 https://arxiv.org/abs/1607.08022.
 
 y = scale * (x - mean) / sqrt(variance + epsilon) + B,
 where mean and variance are computed per instance per channel.
 
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(InstanceNormalization, 1, OpSchema()
+    .SetDoc(InstanceNormalization_ver1_doc)
     // This attribute was added via AllowConsumed API in OpSchema.
     // After removing the API, we're now using the Attr API to simulate the old
     // definition.
@@ -242,16 +245,18 @@ where mean and variance are computed per instance per channel.
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Dropout)
-    .SetDoc(R"DOC(
+static const char * Dropout_old_doc = R"DOC(
 Dropout takes one input data (Tensor<float>) and produces two Tensor outputs,
 output (Tensor<float>) and mask (Tensor<bool>). Depending on whether it is in
 test mode or not, the output Y will either be a random dropout, or a simple
 copy of the input. Note that our implementation of Dropout does scaling in
 the training phase, so during testing nothing needs to be done.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Dropout, 1, OpSchema()
+    .SetDoc(Dropout_old_doc)
     .Attr(
         "ratio",
         "(float, default 0.5) the ratio of random dropout",
@@ -282,17 +287,10 @@ the training phase, so during testing nothing needs to be done.
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Dropout)
-.SinceVersion(6)
-.SetDoc(R"DOC(
-Dropout takes one input data (Tensor<float>) and produces two Tensor outputs,
-output (Tensor<float>) and mask (Tensor<bool>). Depending on whether it is in
-test mode or not, the output Y will either be a random dropout, or a simple
-copy of the input. Note that our implementation of Dropout does scaling in
-the training phase, so during testing nothing needs to be done.
-)DOC")
+ONNX_OPERATOR_SET_SCHEMA(Dropout, 6, OpSchema()
+.SetDoc(Dropout_old_doc)
 .Attr(
 	"ratio",
 	"(float, default 0.5) the ratio of random dropout",
@@ -316,10 +314,9 @@ the training phase, so during testing nothing needs to be done.
 		"T",
 		{ "tensor(float16)", "tensor(float)", "tensor(double)" },
 		"Constrain input and output types to float tensors.")
-	.TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+	.TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-ONNX_OPERATOR_SCHEMA(BatchNormalization)
-.SinceVersion(6)
+ONNX_OPERATOR_SET_SCHEMA(BatchNormalization, 6, OpSchema()
 .NumOutputs({ 1, 5 })
 .SetDoc(R"DOC(
 Carries out batch normalization as described in the paper
@@ -425,4 +422,6 @@ Output case #2: Y (test mode)
 	propagateShapeAndTypeFromFirstInput(ctx);
 	// TODO in training mode, it may be possible to infer some of
 	// the other outputs as well.
-});
+}));
+
+} // namespace ONNX_NAMESPACE

--- a/onnx/defs/nn/old.cc
+++ b/onnx/defs/nn/old.cc
@@ -3,9 +3,8 @@
 
 #include "onnx/defs/schema.h"
 
-namespace ONNX_NAMESPACE
-{
-const char * pads_doc_old =
+namespace ONNX_NAMESPACE {
+const char* pads_doc_old =
     "Padding for the beginning and ending along each axis, it can take any value greater "
     "than or equal to 0. The value represent the number of pixels added to the beginning "
     "and end part of the corresponding axis. `pads` format should be as follow "
@@ -13,7 +12,7 @@ const char * pads_doc_old =
     "added at the beginning of axis `i` and xi_end, the number of pixels added at "
     "the end of axis `i`. This attribute cannot be used simultaneously with "
     "auto_pad attribute.";
-const char * auto_pad_doc_old =
+const char* auto_pad_doc_old =
     "auto_pad must be either SAME_UPPER, SAME_LOWER or VALID. Where "
     "SAME_UPPER or SAME_LOWER mean pad the input so that the output size match the input."
     "In case of odd number add the extra padding at the end for SAME_UPPER and at the "
@@ -21,91 +20,101 @@ const char * auto_pad_doc_old =
     "only intended to support legacy uses, and for framework authors, one is explicitly "
     "encouraged to use explicit padding specified in the pads attribute.";
 
-static const char * LpPool_ver1_doc = R"DOC(
+static const char* LpPool_ver1_doc = R"DOC(
  LpPool consumes an input tensor X and applies Lp pooling across the
  the tensor according to kernel sizes, stride sizes, and pad lengths.
  Lp pooling consisting of computing the Lp norm on all values of a subset
  of the input tensor according to the kernel size and downsampling the
  data into the output tensor Y for further processing.)DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(LpPool, 1, OpSchema()
-    .SetDoc(LpPool_ver1_doc)
-    .Attr(
-        "kernel_shape",
-        "The size of the kernel along each axis.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr("strides", "Stride along each axis.", AttributeProto::INTS, OPTIONAL)
-    .Attr(
-        "auto_pad",
-        auto_pad_doc_old,
-        AttributeProto::STRING,
-        std::string("NOTSET"))
-    .Attr("pads", pads_doc_old, AttributeProto::INTS, OPTIONAL)
-    .Attr(
-        "p",
-        "p value of the Lp norm used to pool over the input data, default is 2.0.",
-        AttributeProto::FLOAT,
-        2.0f)
-    .Input(
-        0,
-        "X",
-        "Input data tensor from the previous operator; "
-        "dimensions for image case are (N x C x H x W), "
-        "where N is the batch size, C is the number of "
-        "channels, and H and W are the height and the "
-        "width of the data. For non image case, the "
-        "dimension are in the form of "
-        "(N x C x D1 x D2 ... Dn), where N is the "
-        "batch size.",
-        "T")
-    .Output(
-        0,
-        "Y",
-        "Output data tensor from Lp pooling across the input "
-        "tensor. Dimensions will vary based on various kernel, stride, and pad "
-        "sizes.",
-        "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    LpPool,
+    1,
+    OpSchema()
+        .SetDoc(LpPool_ver1_doc)
+        .Attr(
+            "kernel_shape",
+            "The size of the kernel along each axis.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "strides",
+            "Stride along each axis.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "auto_pad",
+            auto_pad_doc_old,
+            AttributeProto::STRING,
+            std::string("NOTSET"))
+        .Attr("pads", pads_doc_old, AttributeProto::INTS, OPTIONAL)
+        .Attr(
+            "p",
+            "p value of the Lp norm used to pool over the input data, default is 2.0.",
+            AttributeProto::FLOAT,
+            2.0f)
+        .Input(
+            0,
+            "X",
+            "Input data tensor from the previous operator; "
+            "dimensions for image case are (N x C x H x W), "
+            "where N is the batch size, C is the number of "
+            "channels, and H and W are the height and the "
+            "width of the data. For non image case, the "
+            "dimension are in the form of "
+            "(N x C x D1 x D2 ... Dn), where N is the "
+            "batch size.",
+            "T")
+        .Output(
+            0,
+            "Y",
+            "Output data tensor from Lp pooling across the input "
+            "tensor. Dimensions will vary based on various kernel, stride, and pad "
+            "sizes.",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * GlobalLpPool_ver1_doc = R"DOC(
+static const char* GlobalLpPool_ver1_doc = R"DOC(
  GlobalLpPool consumes an input tensor X and applies lp pool pooling across the
  the values in the same channel. This is equivalent to LpPool with kernel size
  equal to the spatial dimension of input tensor.)DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(GlobalLpPool, 1, OpSchema()
-    .SetDoc(GlobalLpPool_ver1_doc)
-    .Attr(
-        "p",
-        "p value of the Lp norm used to pool over the input data, default is 2.0.",
-        AttributeProto::FLOAT,
-        2.0f)
-    .Input(
-        0,
-        "X",
-        "Input data tensor from the previous operator; "
-        "dimensions for image case are (N x C x H x W), "
-        "where N is the batch size, C is the number of "
-        "channels, and H and W are the height and the width "
-        "of the data. For non image case, the dimension are "
-        "in the form of (N x C x D1 x D2 ... Dn), "
-        "where N is the batch size.",
-        "T")
-    .Output(
-        0,
-        "Y",
-        "Output data tensor from pooling across the input "
-        "tensor. Dimensions will be N x C x 1 x 1",
-        "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    GlobalLpPool,
+    1,
+    OpSchema()
+        .SetDoc(GlobalLpPool_ver1_doc)
+        .Attr(
+            "p",
+            "p value of the Lp norm used to pool over the input data, default is 2.0.",
+            AttributeProto::FLOAT,
+            2.0f)
+        .Input(
+            0,
+            "X",
+            "Input data tensor from the previous operator; "
+            "dimensions for image case are (N x C x H x W), "
+            "where N is the batch size, C is the number of "
+            "channels, and H and W are the height and the width "
+            "of the data. For non image case, the dimension are "
+            "in the form of (N x C x D1 x D2 ... Dn), "
+            "where N is the batch size.",
+            "T")
+        .Output(
+            0,
+            "Y",
+            "Output data tensor from pooling across the input "
+            "tensor. Dimensions will be N x C x 1 x 1",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * BatchNormalization_ver1_doc = R"DOC(
+static const char* BatchNormalization_ver1_doc = R"DOC(
 Carries out batch normalization as described in the paper
 https://arxiv.org/abs/1502.03167. Depending on the mode it is being run,
 there are multiple cases for the number of outputs, which we list below:
@@ -114,103 +123,106 @@ Output case #1: Y, mean, var, saved_mean, saved_var (training mode)
 Output case #2: Y (test mode)
     )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(BatchNormalization, 1, OpSchema()
-    .NumOutputs({1, 5})
-    .SetDoc(BatchNormalization_ver1_doc)
-    .Attr(
-        "spatial",
-        "If true, compute the mean and variance across all spatial elements "
-        "If false, compute the mean and variance across per feature."
-        "Default is 1.",
-        AttributeProto::INT,
-        static_cast<int64_t>(1))
-    .Attr(
-        "is_test",
-        "If set to nonzero, run spatial batch normalization in test mode, default is 0.",
-        AttributeProto::INT,
-        static_cast<int64_t>(0))
-    .Attr(
-        "epsilon",
-        "The epsilon value to use to avoid division by zero, default is 1e-5f.",
-        AttributeProto::FLOAT,
-        1e-5f)
-    .Attr(
-        "momentum",
-        "Factor used in computing the running mean and variance."
-        "e.g., running_mean = running_mean * momentum + mean * (1 - momentum), default is 0.9f.",
-        AttributeProto::FLOAT,
-        0.9f)
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS)
-    .Input(0, "X", "The input 4-dimensional tensor of shape NCHW.", "T")
-    .Input(
-        1,
-        "scale",
-        "The scale as a 1-dimensional tensor of size C to be applied to the "
-        "output.",
-        "T")
-    .Input(
-        2,
-        "B",
-        "The bias as a 1-dimensional tensor of size C to be applied to the "
-        "output.",
-        "T")
-    .Input(
-        3,
-        "mean",
-        "The running mean (training) or the estimated mean (testing) "
-        "as a 1-dimensional tensor of size C.",
-        "T")
-    .Input(
-        4,
-        "var",
-        "The running variance (training) or the estimated "
-        "variance (testing) as a 1-dimensional tensor of size C.",
-        "T")
-    .Output(
-        0,
-        "Y",
-        "The output 4-dimensional tensor of the same shape as X.",
-        "T")
-    .Output(
-        1,
-        "mean",
-        "The running mean after the BatchNormalization operator. Must be in-place "
-        "with the input mean. Should not be used for testing.",
-        "T",
-        OpSchema::Optional)
-    .Output(
-        2,
-        "var",
-        "The running variance after the BatchNormalization operator. Must be "
-        "in-place with the input var. Should not be used for testing.",
-        "T",
-        OpSchema::Optional)
-    .Output(
-        3,
-        "saved_mean",
-        "Saved mean used during training to speed up gradient "
-        "computation. Should not be used for testing.",
-        "T",
-        OpSchema::Optional)
-    .Output(
-        4,
-        "saved_var",
-        "Saved variance used during training to speed up "
-        "gradient computation. Should not be used for testing.",
-        "T",
-        OpSchema::Optional)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    BatchNormalization,
+    1,
+    OpSchema()
+        .NumOutputs({1, 5})
+        .SetDoc(BatchNormalization_ver1_doc)
+        .Attr(
+            "spatial",
+            "If true, compute the mean and variance across all spatial elements "
+            "If false, compute the mean and variance across per feature."
+            "Default is 1.",
+            AttributeProto::INT,
+            static_cast<int64_t>(1))
+        .Attr(
+            "is_test",
+            "If set to nonzero, run spatial batch normalization in test mode, default is 0.",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Attr(
+            "epsilon",
+            "The epsilon value to use to avoid division by zero, default is 1e-5f.",
+            AttributeProto::FLOAT,
+            1e-5f)
+        .Attr(
+            "momentum",
+            "Factor used in computing the running mean and variance."
+            "e.g., running_mean = running_mean * momentum + mean * (1 - momentum), default is 0.9f.",
+            AttributeProto::FLOAT,
+            0.9f)
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS)
+        .Input(0, "X", "The input 4-dimensional tensor of shape NCHW.", "T")
+        .Input(
+            1,
+            "scale",
+            "The scale as a 1-dimensional tensor of size C to be applied to the "
+            "output.",
+            "T")
+        .Input(
+            2,
+            "B",
+            "The bias as a 1-dimensional tensor of size C to be applied to the "
+            "output.",
+            "T")
+        .Input(
+            3,
+            "mean",
+            "The running mean (training) or the estimated mean (testing) "
+            "as a 1-dimensional tensor of size C.",
+            "T")
+        .Input(
+            4,
+            "var",
+            "The running variance (training) or the estimated "
+            "variance (testing) as a 1-dimensional tensor of size C.",
+            "T")
+        .Output(
+            0,
+            "Y",
+            "The output 4-dimensional tensor of the same shape as X.",
+            "T")
+        .Output(
+            1,
+            "mean",
+            "The running mean after the BatchNormalization operator. Must be in-place "
+            "with the input mean. Should not be used for testing.",
+            "T",
+            OpSchema::Optional)
+        .Output(
+            2,
+            "var",
+            "The running variance after the BatchNormalization operator. Must be "
+            "in-place with the input var. Should not be used for testing.",
+            "T",
+            OpSchema::Optional)
+        .Output(
+            3,
+            "saved_mean",
+            "Saved mean used during training to speed up gradient "
+            "computation. Should not be used for testing.",
+            "T",
+            OpSchema::Optional)
+        .Output(
+            4,
+            "saved_var",
+            "Saved variance used during training to speed up "
+            "gradient computation. Should not be used for testing.",
+            "T",
+            OpSchema::Optional)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * InstanceNormalization_ver1_doc = R"DOC(
+static const char* InstanceNormalization_ver1_doc = R"DOC(
 Carries out instance normalization as described in the paper
 https://arxiv.org/abs/1607.08022.
 
@@ -219,35 +231,42 @@ where mean and variance are computed per instance per channel.
 
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(InstanceNormalization, 1, OpSchema()
-    .SetDoc(InstanceNormalization_ver1_doc)
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "epsilon",
-        "The epsilon value to use to avoid division by zero, default is 1e-5f.",
-        AttributeProto::FLOAT,
-        1e-5f)
-    .Input(0, "input", "The input 4-dimensional tensor of shape NCHW.", "T")
-    .Input(1, "scale", "The input 1-dimensional scale tensor of size C.", "T")
-    .Input(2, "B", "The input 1-dimensional bias tensor of size C.", "T")
-    .Output(
-        0,
-        "output",
-        "The output 4-dimensional tensor of the same shape as input.",
-        "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    InstanceNormalization,
+    1,
+    OpSchema()
+        .SetDoc(InstanceNormalization_ver1_doc)
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "epsilon",
+            "The epsilon value to use to avoid division by zero, default is 1e-5f.",
+            AttributeProto::FLOAT,
+            1e-5f)
+        .Input(0, "input", "The input 4-dimensional tensor of shape NCHW.", "T")
+        .Input(
+            1,
+            "scale",
+            "The input 1-dimensional scale tensor of size C.",
+            "T")
+        .Input(2, "B", "The input 1-dimensional bias tensor of size C.", "T")
+        .Output(
+            0,
+            "output",
+            "The output 4-dimensional tensor of the same shape as input.",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * Dropout_old_doc = R"DOC(
+static const char* Dropout_old_doc = R"DOC(
 Dropout takes one input data (Tensor<float>) and produces two Tensor outputs,
 output (Tensor<float>) and mask (Tensor<bool>). Depending on whether it is in
 test mode or not, the output Y will either be a random dropout, or a simple
@@ -255,68 +274,74 @@ copy of the input. Note that our implementation of Dropout does scaling in
 the training phase, so during testing nothing needs to be done.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Dropout, 1, OpSchema()
-    .SetDoc(Dropout_old_doc)
-    .Attr(
-        "ratio",
-        "(float, default 0.5) the ratio of random dropout",
-        AttributeProto::FLOAT,
-        0.5f)
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "is_test",
-        "(int, default 0) if nonzero, run dropout in test mode where "
-        "the output is simply Y = X.",
-        AttributeProto::INT,
-        static_cast<int64_t>(0))
-    .Input(0, "data", "The input data as Tensor.", "T")
-    .Output(0, "output", "The output.", "T")
-    .Output(
-        1,
-        "mask",
-        "The output mask. If is_test is nonzero, this output is not filled.",
-        "T",
-        OpSchema::Optional)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Dropout,
+    1,
+    OpSchema()
+        .SetDoc(Dropout_old_doc)
+        .Attr(
+            "ratio",
+            "(float, default 0.5) the ratio of random dropout",
+            AttributeProto::FLOAT,
+            0.5f)
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "is_test",
+            "(int, default 0) if nonzero, run dropout in test mode where "
+            "the output is simply Y = X.",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Input(0, "data", "The input data as Tensor.", "T")
+        .Output(0, "output", "The output.", "T")
+        .Output(
+            1,
+            "mask",
+            "The output mask. If is_test is nonzero, this output is not filled.",
+            "T",
+            OpSchema::Optional)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SET_SCHEMA(Dropout, 6, OpSchema()
-.SetDoc(Dropout_old_doc)
-.Attr(
-	"ratio",
-	"(float, default 0.5) the ratio of random dropout",
-	AttributeProto::FLOAT,
-	0.5f)
-	.Attr(
-		"is_test",
-		"(int, default 0) if nonzero, run dropout in test mode where "
-		"the output is simply Y = X.",
-		AttributeProto::INT,
-		static_cast<int64_t>(0))
-	.Input(0, "data", "The input data as Tensor.", "T")
-	.Output(0, "output", "The output.", "T")
-	.Output(
-		1,
-		"mask",
-		"The output mask. If is_test is nonzero, this output is not filled.",
-		"T",
-		OpSchema::Optional)
-	.TypeConstraint(
-		"T",
-		{ "tensor(float16)", "tensor(float)", "tensor(double)" },
-		"Constrain input and output types to float tensors.")
-	.TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+ONNX_OPERATOR_SET_SCHEMA(
+    Dropout,
+    6,
+    OpSchema()
+        .SetDoc(Dropout_old_doc)
+        .Attr(
+            "ratio",
+            "(float, default 0.5) the ratio of random dropout",
+            AttributeProto::FLOAT,
+            0.5f)
+        .Attr(
+            "is_test",
+            "(int, default 0) if nonzero, run dropout in test mode where "
+            "the output is simply Y = X.",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Input(0, "data", "The input data as Tensor.", "T")
+        .Output(0, "output", "The output.", "T")
+        .Output(
+            1,
+            "mask",
+            "The output mask. If is_test is nonzero, this output is not filled.",
+            "T",
+            OpSchema::Optional)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
-static const char * BatchNorm_ver6_doc =  R"DOC(
+static const char* BatchNorm_ver6_doc = R"DOC(
 Carries out batch normalization as described in the paper
 https://arxiv.org/abs/1502.03167. Depending on the mode it is being run,
 there are multiple cases for the number of outputs, which we list below:
@@ -325,105 +350,108 @@ Output case #1: Y, mean, var, saved_mean, saved_var (training mode)
 Output case #2: Y (test mode)
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(BatchNormalization, 6, OpSchema()
-.NumOutputs({ 1, 5 })
-.SetDoc(BatchNorm_ver6_doc)
-	.Attr(
-		"spatial",
-		"If true, compute the mean and variance across all spatial elements "
-		"If false, compute the mean and variance across per feature."
-		"Default is 1.",
-		AttributeProto::INT,
-		static_cast<int64_t>(1))
-	.Attr(
-		"is_test",
-		"If set to nonzero, run spatial batch normalization in test mode, default is 0.",
-		AttributeProto::INT,
-		static_cast<int64_t>(0))
-	.Attr(
-		"epsilon",
-		"The epsilon value to use to avoid division by zero, default is 1e-5f.",
-		AttributeProto::FLOAT,
-		1e-5f)
-	.Attr(
-		"momentum",
-		"Factor used in computing the running mean and variance."
-		"e.g., running_mean = running_mean * momentum + mean * (1 - momentum), default is 0.9f.",
-		AttributeProto::FLOAT,
-		0.9f)
-	.Input(
-		0,
-		"X",
-		"Input data tensor from the previous operator; "
-		"dimensions for image case are (N x C x H x W), "
-		"where N is the batch size, C is the number of "
-		"channels, and H and W are the height and the "
-		"width of the data. For non image case, the "
-		"dimensions are in the form of "
-		"(N x C x D1 x D2 ... Dn), where N is the batch "
-		"size.",
-		"T")
-	.Input(
-		1,
-		"scale",
-		"The scale as a 1-dimensional tensor of size C to be applied to the "
-		"output.",
-		"T")
-	.Input(
-		2,
-		"B",
-		"The bias as a 1-dimensional tensor of size C to be applied to the "
-		"output.",
-		"T")
-	.Input(
-		3,
-		"mean",
-		"The running mean (training) or the estimated mean (testing) "
-		"as a 1-dimensional tensor of size C.",
-		"T")
-	.Input(
-		4,
-		"var",
-		"The running variance (training) or the estimated "
-		"variance (testing) as a 1-dimensional tensor of size C.",
-		"T")
-	.Output(0, "Y", "The output tensor of the same shape as X.", "T")
-	.Output(
-		1,
-		"mean",
-		"The running mean after the BatchNormalization operator. Must be in-place "
-		"with the input mean. Should not be used for testing.",
-		"T",
-		OpSchema::Optional)
-	.Output(
-		2,
-		"var",
-		"The running variance after the BatchNormalization operator. Must be "
-		"in-place with the input var. Should not be used for testing.",
-		"T",
-		OpSchema::Optional)
-	.Output(
-		3,
-		"saved_mean",
-		"Saved mean used during training to speed up gradient "
-		"computation. Should not be used for testing.",
-		"T",
-		OpSchema::Optional)
-	.Output(
-		4,
-		"saved_var",
-		"Saved variance used during training to speed up "
-		"gradient computation. Should not be used for testing.",
-		"T",
-		OpSchema::Optional)
-	.TypeConstraint(
-		"T",
-		{ "tensor(float16)", "tensor(float)", "tensor(double)" },
-		"Constrain input and output types to float tensors.")
-	.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-	propagateShapeAndTypeFromFirstInput(ctx);
-	// TODO in training mode, it may be possible to infer some of
-	// the other outputs as well.
-}));
+ONNX_OPERATOR_SET_SCHEMA(
+    BatchNormalization,
+    6,
+    OpSchema()
+        .NumOutputs({1, 5})
+        .SetDoc(BatchNorm_ver6_doc)
+        .Attr(
+            "spatial",
+            "If true, compute the mean and variance across all spatial elements "
+            "If false, compute the mean and variance across per feature."
+            "Default is 1.",
+            AttributeProto::INT,
+            static_cast<int64_t>(1))
+        .Attr(
+            "is_test",
+            "If set to nonzero, run spatial batch normalization in test mode, default is 0.",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Attr(
+            "epsilon",
+            "The epsilon value to use to avoid division by zero, default is 1e-5f.",
+            AttributeProto::FLOAT,
+            1e-5f)
+        .Attr(
+            "momentum",
+            "Factor used in computing the running mean and variance."
+            "e.g., running_mean = running_mean * momentum + mean * (1 - momentum), default is 0.9f.",
+            AttributeProto::FLOAT,
+            0.9f)
+        .Input(
+            0,
+            "X",
+            "Input data tensor from the previous operator; "
+            "dimensions for image case are (N x C x H x W), "
+            "where N is the batch size, C is the number of "
+            "channels, and H and W are the height and the "
+            "width of the data. For non image case, the "
+            "dimensions are in the form of "
+            "(N x C x D1 x D2 ... Dn), where N is the batch "
+            "size.",
+            "T")
+        .Input(
+            1,
+            "scale",
+            "The scale as a 1-dimensional tensor of size C to be applied to the "
+            "output.",
+            "T")
+        .Input(
+            2,
+            "B",
+            "The bias as a 1-dimensional tensor of size C to be applied to the "
+            "output.",
+            "T")
+        .Input(
+            3,
+            "mean",
+            "The running mean (training) or the estimated mean (testing) "
+            "as a 1-dimensional tensor of size C.",
+            "T")
+        .Input(
+            4,
+            "var",
+            "The running variance (training) or the estimated "
+            "variance (testing) as a 1-dimensional tensor of size C.",
+            "T")
+        .Output(0, "Y", "The output tensor of the same shape as X.", "T")
+        .Output(
+            1,
+            "mean",
+            "The running mean after the BatchNormalization operator. Must be in-place "
+            "with the input mean. Should not be used for testing.",
+            "T",
+            OpSchema::Optional)
+        .Output(
+            2,
+            "var",
+            "The running variance after the BatchNormalization operator. Must be "
+            "in-place with the input var. Should not be used for testing.",
+            "T",
+            OpSchema::Optional)
+        .Output(
+            3,
+            "saved_mean",
+            "Saved mean used during training to speed up gradient "
+            "computation. Should not be used for testing.",
+            "T",
+            OpSchema::Optional)
+        .Output(
+            4,
+            "saved_var",
+            "Saved variance used during training to speed up "
+            "gradient computation. Should not be used for testing.",
+            "T",
+            OpSchema::Optional)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateShapeAndTypeFromFirstInput(ctx);
+          // TODO in training mode, it may be possible to infer some of
+          // the other outputs as well.
+        }));
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/operator_sets-ml.h
+++ b/onnx/defs/operator_sets-ml.h
@@ -31,27 +31,41 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, ZipMap);
 
 // Iterate over schema from ai.onnx.ml version 1
 class OpSet_OnnxML_ver1 {
-  public:
-    static void ForEachSchema(std::function<void(OpSchema &&)> fn){
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, ArrayFeatureExtractor)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, Binarizer)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, CastMap)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, CategoryMapper)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, DictVectorizer)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, FeatureVectorizer)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, Imputer)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, LabelEncoder)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, LinearClassifier)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, LinearRegressor)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, Normalizer)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, OneHotEncoder)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, SVMClassifier)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, SVMRegressor)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, Scaler)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, TreeEnsembleClassifier)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, TreeEnsembleRegressor)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, ZipMap)>());
-    }
+ public:
+  static void ForEachSchema(std::function<void(OpSchema&&)> fn) {
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           OnnxML, 1, ArrayFeatureExtractor)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           OnnxML, 1, Binarizer)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, CastMap)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           OnnxML, 1, CategoryMapper)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           OnnxML, 1, DictVectorizer)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           OnnxML, 1, FeatureVectorizer)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, Imputer)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           OnnxML, 1, LabelEncoder)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           OnnxML, 1, LinearClassifier)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           OnnxML, 1, LinearRegressor)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           OnnxML, 1, Normalizer)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           OnnxML, 1, OneHotEncoder)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           OnnxML, 1, SVMClassifier)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           OnnxML, 1, SVMRegressor)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, Scaler)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           OnnxML, 1, TreeEnsembleClassifier)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           OnnxML, 1, TreeEnsembleRegressor)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, ZipMap)>());
+  }
 };
 
 inline void RegisterOnnxMLOperatorSetSchema() {
@@ -59,4 +73,4 @@ inline void RegisterOnnxMLOperatorSetSchema() {
 }
 } // namespace ONNX_NAMESPACE
 
-#endif 
+#endif

--- a/onnx/defs/operator_sets-ml.h
+++ b/onnx/defs/operator_sets-ml.h
@@ -1,0 +1,60 @@
+// Copyright (c) Facebook Inc. and Microsoft Corporation.
+// Licensed under the MIT license.
+
+#ifdef ONNX_ML
+
+#include "onnx/defs/schema.h"
+
+namespace ONNX_NAMESPACE {
+
+// Forward declarations for ai.onnx.ml version 1
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, ArrayFeatureExtractor);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, Binarizer);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, CastMap);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, CategoryMapper);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, DictVectorizer);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, FeatureVectorizer);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, Imputer);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, LabelEncoder);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, LinearClassifier);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, LinearRegressor);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, Normalizer);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, OneHotEncoder);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, SVMClassifier);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, SVMRegressor);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, Scaler);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, TreeEnsembleClassifier);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, TreeEnsembleRegressor);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, ZipMap);
+
+// Iterate over schema from ai.onnx.ml version 1
+class OpSet_OnnxML_ver1 {
+  public:
+    static void ForEachSchema(std::function<void(OpSchema &&)> fn){
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, ArrayFeatureExtractor)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, Binarizer)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, CastMap)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, CategoryMapper)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, DictVectorizer)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, FeatureVectorizer)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, Imputer)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, LabelEncoder)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, LinearClassifier)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, LinearRegressor)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, Normalizer)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, OneHotEncoder)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, SVMClassifier)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, SVMRegressor)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, Scaler)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, TreeEnsembleClassifier)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, TreeEnsembleRegressor)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(OnnxML, 1, ZipMap)>());
+    }
+};
+
+inline void RegisterOnnxMLOperatorSetSchema() {
+  RegisterOpSetSchema<OpSet_OnnxML_ver1>();
+}
+} // namespace ONNX_NAMESPACE
+
+#endif 

--- a/onnx/defs/operator_sets-ml.h
+++ b/onnx/defs/operator_sets-ml.h
@@ -1,6 +1,8 @@
 // Copyright (c) Facebook Inc. and Microsoft Corporation.
 // Licensed under the MIT license.
 
+#pragma once
+
 #ifdef ONNX_ML
 
 #include "onnx/defs/schema.h"

--- a/onnx/defs/operator_sets.h
+++ b/onnx/defs/operator_sets.h
@@ -119,117 +119,142 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Xor);
 
 // Iterate over schema from ai.onnx version 1
 class OpSet_Onnx_ver1 {
-  public:
-    static void ForEachSchema(std::function<void(OpSchema &&)> fn){
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ATen)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Abs)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Add)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Affine)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, And)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ArgMax)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ArgMin)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, AveragePool)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, BatchNormalization)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Cast)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Ceil)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Clip)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Concat)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Constant)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ConstantFill)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Conv)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ConvTranspose)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Crop)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, DepthToSpace)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Div)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Dropout)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Elu)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Equal)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Exp)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Flatten)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Floor)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, GRU)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, GRUUnit)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Gather)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Gemm)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, GivenTensorFill)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, GlobalAveragePool)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, GlobalLpPool)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, GlobalMaxPool)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Greater)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, HardSigmoid)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Hardmax)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Identity)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, If)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ImageScaler)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, InstanceNormalization)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LRN)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LSTM)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LeakyRelu)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Less)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Log)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LogSoftmax)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Loop)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LoopIndexTensor)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LpNormalization)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LpPool)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, MatMul)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Max)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, MaxPool)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, MaxRoiPool)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Mean)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, MeanVarianceNormalization)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Min)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Mul)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Neg)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Not)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Or)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, PRelu)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Pad)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ParametricSoftplus)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Pow)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, RNN)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, RandomNormal)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, RandomNormalLike)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, RandomUniform)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, RandomUniformLike)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Reciprocal)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceL1)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceL2)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceLogSum)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceLogSumExp)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceMax)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceMean)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceMin)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceProd)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceSum)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceSumSquare)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Relu)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Reshape)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Scale)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ScaledTanh)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Selu)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Shape)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Sigmoid)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Size)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Slice)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Softmax)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Softplus)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Softsign)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, SpaceToDepth)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Split)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Sqrt)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Squeeze)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Sub)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Sum)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Tanh)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ThresholdedRelu)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Tile)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, TopK)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Transpose)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Unsqueeze)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Upsample)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Xor)>());
-    }
+ public:
+  static void ForEachSchema(std::function<void(OpSchema&&)> fn) {
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ATen)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Abs)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Add)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Affine)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, And)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ArgMax)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ArgMin)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, AveragePool)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, BatchNormalization)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Cast)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Ceil)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Clip)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Concat)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Constant)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, ConstantFill)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Conv)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, ConvTranspose)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Crop)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, DepthToSpace)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Div)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Dropout)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Elu)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Equal)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Exp)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Flatten)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Floor)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, GRU)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, GRUUnit)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Gather)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Gemm)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, GivenTensorFill)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, GlobalAveragePool)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, GlobalLpPool)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, GlobalMaxPool)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Greater)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, HardSigmoid)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Hardmax)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Identity)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, If)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, ImageScaler)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, InstanceNormalization)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LRN)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LSTM)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LeakyRelu)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Less)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Log)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LogSoftmax)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Loop)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, LoopIndexTensor)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, LpNormalization)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LpPool)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, MatMul)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Max)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, MaxPool)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, MaxRoiPool)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Mean)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, MeanVarianceNormalization)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Min)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Mul)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Neg)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Not)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Or)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, PRelu)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Pad)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, ParametricSoftplus)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Pow)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, RNN)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, RandomNormal)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, RandomNormalLike)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, RandomUniform)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, RandomUniformLike)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Reciprocal)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceL1)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceL2)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, ReduceLogSum)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, ReduceLogSumExp)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceMax)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceMean)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceMin)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceProd)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceSum)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, ReduceSumSquare)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Relu)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Reshape)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Scale)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ScaledTanh)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Selu)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Shape)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Sigmoid)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Size)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Slice)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Softmax)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Softplus)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Softsign)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, SpaceToDepth)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Split)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Sqrt)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Squeeze)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Sub)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Sum)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Tanh)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 1, ThresholdedRelu)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Tile)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, TopK)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Transpose)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Unsqueeze)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Upsample)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Xor)>());
+  }
 };
 
 // Forward declarations for ai.onnx version 2
@@ -240,13 +265,14 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 2, Split);
 
 // Iterate over schema from ai.onnx version 2
 class OpSet_Onnx_ver2 {
-  public:
-    static void ForEachSchema(std::function<void(OpSchema &&)> fn){
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 2, GlobalLpPool)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 2, LpPool)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 2, Pad)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 2, Split)>());
-    }
+ public:
+  static void ForEachSchema(std::function<void(OpSchema&&)> fn) {
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 2, GlobalLpPool)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 2, LpPool)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 2, Pad)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 2, Split)>());
+  }
 };
 
 // Forward declarations for ai.onnx version 3
@@ -254,10 +280,10 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 3, GRU);
 
 // Iterate over schema from ai.onnx version 3
 class OpSet_Onnx_ver3 {
-  public:
-    static void ForEachSchema(std::function<void(OpSchema &&)> fn){
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 3, GRU)>());
-    }
+ public:
+  static void ForEachSchema(std::function<void(OpSchema&&)> fn) {
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 3, GRU)>());
+  }
 };
 
 // Forward declarations for ai.onnx version 4
@@ -265,10 +291,10 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 4, Concat);
 
 // Iterate over schema from ai.onnx version 4
 class OpSet_Onnx_ver4 {
-  public:
-    static void ForEachSchema(std::function<void(OpSchema &&)> fn){
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 4, Concat)>());
-    }
+ public:
+  static void ForEachSchema(std::function<void(OpSchema&&)> fn) {
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 4, Concat)>());
+  }
 };
 
 // Forward declarations for ai.onnx version 5
@@ -276,10 +302,10 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 5, Reshape);
 
 // Iterate over schema from ai.onnx version 5
 class OpSet_Onnx_ver5 {
-  public:
-    static void ForEachSchema(std::function<void(OpSchema &&)> fn){
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 5, Reshape)>());
-    }
+ public:
+  static void ForEachSchema(std::function<void(OpSchema&&)> fn) {
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 5, Reshape)>());
+  }
 };
 
 // Forward declarations for ai.onnx version 6
@@ -317,40 +343,43 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Tile);
 
 // Iterate over schema from ai.onnx version 6
 class OpSet_Onnx_ver6 {
-  public:
-    static void ForEachSchema(std::function<void(OpSchema &&)> fn){
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Abs)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Add)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, BatchNormalization)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Cast)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Ceil)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Clip)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Div)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Dropout)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Elu)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Exp)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Floor)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Gemm)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, HardSigmoid)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, InstanceNormalization)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, LeakyRelu)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Log)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Max)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Mean)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Min)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Mul)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Neg)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, PRelu)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Reciprocal)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Relu)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Selu)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Sigmoid)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Sqrt)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Sub)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Sum)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Tanh)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Tile)>());
-    }
+ public:
+  static void ForEachSchema(std::function<void(OpSchema&&)> fn) {
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Abs)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Add)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 6, BatchNormalization)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Cast)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Ceil)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Clip)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Div)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Dropout)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Elu)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Exp)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Floor)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Gemm)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 6, HardSigmoid)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 6, InstanceNormalization)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, LeakyRelu)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Log)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Max)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Mean)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Min)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Mul)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Neg)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, PRelu)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Reciprocal)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Relu)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Selu)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Sigmoid)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Sqrt)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Sub)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Sum)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Tanh)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Tile)>());
+  }
 };
 
 // Forward declarations for ai.onnx version 7
@@ -383,38 +412,41 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Xor);
 
 // Iterate over schema from ai.onnx version 7
 class OpSet_Onnx_ver7 {
-  public:
-    static void ForEachSchema(std::function<void(OpSchema &&)> fn){
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Acos)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Add)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, And)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Asin)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Atan)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, AveragePool)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, BatchNormalization)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Cos)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Div)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Dropout)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Equal)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Gemm)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Greater)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, GRU)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Less)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, LSTM)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Mul)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Or)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Pow)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, RNN)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Sin)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Sub)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Tan)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Upsample)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Multinomial)>());
-      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Xor)>());
+ public:
+  static void ForEachSchema(std::function<void(OpSchema&&)> fn) {
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Acos)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Add)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, And)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Asin)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Atan)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 7, AveragePool)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 7, BatchNormalization)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Cos)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Div)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Dropout)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Equal)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Gemm)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Greater)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, GRU)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Less)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, LSTM)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Mul)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Or)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Pow)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, RNN)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Sin)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Sub)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Tan)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Upsample)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 7, Multinomial)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Xor)>());
   }
 };
 
-inline void RegisterOnnxOperatorSetSchema(){
+inline void RegisterOnnxOperatorSetSchema() {
   RegisterOpSetSchema<OpSet_Onnx_ver1>();
   RegisterOpSetSchema<OpSet_Onnx_ver2>();
   RegisterOpSetSchema<OpSet_Onnx_ver3>();
@@ -422,6 +454,6 @@ inline void RegisterOnnxOperatorSetSchema(){
   RegisterOpSetSchema<OpSet_Onnx_ver5>();
   RegisterOpSetSchema<OpSet_Onnx_ver6>();
   RegisterOpSetSchema<OpSet_Onnx_ver7>();
-  }
+}
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/operator_sets.h
+++ b/onnx/defs/operator_sets.h
@@ -1,0 +1,425 @@
+// Copyright (c) Facebook Inc. and Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "onnx/defs/schema.h"
+
+namespace ONNX_NAMESPACE {
+
+// Forward declarations for ai.onnx version 1
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ATen);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Abs);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Add);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Affine);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, And);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ArgMax);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ArgMin);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, AveragePool);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, BatchNormalization);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Cast);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Ceil);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Clip);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Concat);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Constant);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ConstantFill);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Conv);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ConvTranspose);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Crop);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, DepthToSpace);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Div);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Dropout);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Elu);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Equal);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Exp);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Flatten);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Floor);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, GRU);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, GRUUnit);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Gather);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Gemm);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, GivenTensorFill);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, GlobalAveragePool);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, GlobalLpPool);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, GlobalMaxPool);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Greater);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, HardSigmoid);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Hardmax);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Identity);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, If);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ImageScaler);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, InstanceNormalization);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LRN);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LSTM);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LeakyRelu);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Less);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Log);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LogSoftmax);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Loop);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LoopIndexTensor);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LpNormalization);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LpPool);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, MatMul);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Max);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, MaxPool);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, MaxRoiPool);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Mean);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, MeanVarianceNormalization);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Min);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Mul);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Neg);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Not);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Or);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, PRelu);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Pad);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ParametricSoftplus);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Pow);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, RNN);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, RandomNormal);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, RandomNormalLike);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, RandomUniform);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, RandomUniformLike);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Reciprocal);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceL1);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceL2);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceLogSum);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceLogSumExp);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceMax);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceMean);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceMin);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceProd);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceSum);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceSumSquare);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Relu);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Reshape);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Scale);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ScaledTanh);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Selu);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Shape);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Sigmoid);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Size);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Slice);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Softmax);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Softplus);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Softsign);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, SpaceToDepth);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Split);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Sqrt);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Squeeze);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Sub);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Sum);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Tanh);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ThresholdedRelu);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Tile);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, TopK);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Transpose);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Unsqueeze);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Upsample);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Xor);
+
+// Iterate over schema from ai.onnx version 1
+class OpSet_Onnx_ver1 {
+  public:
+    static void ForEachSchema(std::function<void(OpSchema &&)> fn){
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ATen)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Abs)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Add)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Affine)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, And)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ArgMax)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ArgMin)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, AveragePool)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, BatchNormalization)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Cast)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Ceil)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Clip)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Concat)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Constant)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ConstantFill)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Conv)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ConvTranspose)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Crop)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, DepthToSpace)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Div)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Dropout)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Elu)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Equal)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Exp)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Flatten)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Floor)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, GRU)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, GRUUnit)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Gather)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Gemm)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, GivenTensorFill)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, GlobalAveragePool)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, GlobalLpPool)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, GlobalMaxPool)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Greater)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, HardSigmoid)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Hardmax)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Identity)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, If)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ImageScaler)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, InstanceNormalization)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LRN)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LSTM)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LeakyRelu)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Less)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Log)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LogSoftmax)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Loop)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LoopIndexTensor)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LpNormalization)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LpPool)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, MatMul)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Max)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, MaxPool)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, MaxRoiPool)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Mean)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, MeanVarianceNormalization)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Min)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Mul)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Neg)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Not)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Or)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, PRelu)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Pad)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ParametricSoftplus)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Pow)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, RNN)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, RandomNormal)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, RandomNormalLike)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, RandomUniform)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, RandomUniformLike)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Reciprocal)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceL1)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceL2)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceLogSum)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceLogSumExp)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceMax)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceMean)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceMin)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceProd)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceSum)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ReduceSumSquare)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Relu)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Reshape)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Scale)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ScaledTanh)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Selu)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Shape)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Sigmoid)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Size)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Slice)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Softmax)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Softplus)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Softsign)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, SpaceToDepth)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Split)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Sqrt)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Squeeze)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Sub)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Sum)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Tanh)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, ThresholdedRelu)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Tile)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, TopK)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Transpose)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Unsqueeze)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Upsample)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Xor)>());
+    }
+};
+
+// Forward declarations for ai.onnx version 2
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 2, GlobalLpPool);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 2, LpPool);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 2, Pad);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 2, Split);
+
+// Iterate over schema from ai.onnx version 2
+class OpSet_Onnx_ver2 {
+  public:
+    static void ForEachSchema(std::function<void(OpSchema &&)> fn){
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 2, GlobalLpPool)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 2, LpPool)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 2, Pad)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 2, Split)>());
+    }
+};
+
+// Forward declarations for ai.onnx version 3
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 3, GRU);
+
+// Iterate over schema from ai.onnx version 3
+class OpSet_Onnx_ver3 {
+  public:
+    static void ForEachSchema(std::function<void(OpSchema &&)> fn){
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 3, GRU)>());
+    }
+};
+
+// Forward declarations for ai.onnx version 4
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 4, Concat);
+
+// Iterate over schema from ai.onnx version 4
+class OpSet_Onnx_ver4 {
+  public:
+    static void ForEachSchema(std::function<void(OpSchema &&)> fn){
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 4, Concat)>());
+    }
+};
+
+// Forward declarations for ai.onnx version 5
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 5, Reshape);
+
+// Iterate over schema from ai.onnx version 5
+class OpSet_Onnx_ver5 {
+  public:
+    static void ForEachSchema(std::function<void(OpSchema &&)> fn){
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 5, Reshape)>());
+    }
+};
+
+// Forward declarations for ai.onnx version 6
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Abs);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Add);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, BatchNormalization);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Cast);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Ceil);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Clip);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Div);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Dropout);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Elu);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Exp);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Floor);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Gemm);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, HardSigmoid);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, InstanceNormalization);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, LeakyRelu);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Log);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Max);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Mean);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Min);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Mul);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Neg);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, PRelu);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Reciprocal);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Relu);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Selu);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Sigmoid);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Sqrt);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Sub);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Sum);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Tanh);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Tile);
+
+// Iterate over schema from ai.onnx version 6
+class OpSet_Onnx_ver6 {
+  public:
+    static void ForEachSchema(std::function<void(OpSchema &&)> fn){
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Abs)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Add)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, BatchNormalization)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Cast)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Ceil)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Clip)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Div)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Dropout)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Elu)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Exp)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Floor)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Gemm)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, HardSigmoid)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, InstanceNormalization)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, LeakyRelu)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Log)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Max)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Mean)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Min)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Mul)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Neg)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, PRelu)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Reciprocal)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Relu)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Selu)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Sigmoid)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Sqrt)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Sub)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Sum)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Tanh)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 6, Tile)>());
+    }
+};
+
+// Forward declarations for ai.onnx version 7
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Acos);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Add);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, And);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Asin);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Atan);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, AveragePool);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, BatchNormalization);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Cos);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Div);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Dropout);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Equal);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Gemm);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Greater);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, GRU);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Less);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, LSTM);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Mul);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Or);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Pow);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, RNN);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Sin);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Sub);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Tan);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Upsample);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Multinomial);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Xor);
+
+// Iterate over schema from ai.onnx version 7
+class OpSet_Onnx_ver7 {
+  public:
+    static void ForEachSchema(std::function<void(OpSchema &&)> fn){
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Acos)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Add)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, And)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Asin)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Atan)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, AveragePool)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, BatchNormalization)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Cos)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Div)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Dropout)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Equal)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Gemm)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Greater)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, GRU)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Less)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, LSTM)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Mul)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Or)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Pow)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, RNN)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Sin)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Sub)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Tan)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Upsample)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Multinomial)>());
+      fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 7, Xor)>());
+  }
+};
+
+inline void RegisterOnnxOperatorSetSchema(){
+  RegisterOpSetSchema<OpSet_Onnx_ver1>();
+  RegisterOpSetSchema<OpSet_Onnx_ver2>();
+  RegisterOpSetSchema<OpSet_Onnx_ver3>();
+  RegisterOpSetSchema<OpSet_Onnx_ver4>();
+  RegisterOpSetSchema<OpSet_Onnx_ver5>();
+  RegisterOpSetSchema<OpSet_Onnx_ver6>();
+  RegisterOpSetSchema<OpSet_Onnx_ver7>();
+  }
+
+} // namespace ONNX_NAMESPACE

--- a/onnx/defs/operator_sets.h
+++ b/onnx/defs/operator_sets.h
@@ -1,6 +1,8 @@
 // Copyright (c) Facebook Inc. and Microsoft Corporation.
 // Licensed under the MIT license.
 
+#pragma once
+
 #include "onnx/defs/schema.h"
 
 namespace ONNX_NAMESPACE {

--- a/onnx/defs/reduction/defs.cc
+++ b/onnx/defs/reduction/defs.cc
@@ -17,7 +17,7 @@ the resulted tensor have the reduced dimension pruned.
 The above behavior is similar to numpy, with the exception that numpy default keepdims to
 False instead of True.)DOC";
     ReplaceAll(doc, "{name}", name);
-    schema.SetDoc(doc);
+    schema.SetDoc(doc.c_str());
     schema.Attr(
         "axes",
         "A list of integers, along which to reduce. The default is to reduce over "
@@ -77,31 +77,35 @@ False instead of True.)DOC";
   };
 }
 
-ONNX_OPERATOR_SCHEMA(ReduceMax).FillUsing(ReduceDocGenerator("max"));
+ONNX_OPERATOR_SET_SCHEMA(ReduceMax, 1, OpSchema()
+    .FillUsing(ReduceDocGenerator("max")));
 
-ONNX_OPERATOR_SCHEMA(ReduceMin).FillUsing(ReduceDocGenerator("min"));
+ONNX_OPERATOR_SET_SCHEMA(ReduceMin, 1, OpSchema()
+    .FillUsing(ReduceDocGenerator("min")));
 
-ONNX_OPERATOR_SCHEMA(ReduceSum).FillUsing(ReduceDocGenerator("sum"));
+ONNX_OPERATOR_SET_SCHEMA(ReduceSum, 1, OpSchema()
+    .FillUsing(ReduceDocGenerator("sum")));
 
-ONNX_OPERATOR_SCHEMA(ReduceSumSquare)
-    .FillUsing(ReduceDocGenerator("sum square"));
+ONNX_OPERATOR_SET_SCHEMA(ReduceSumSquare, 1, OpSchema()
+    .FillUsing(ReduceDocGenerator("sum square")));
 
-ONNX_OPERATOR_SCHEMA(ReduceMean).FillUsing(ReduceDocGenerator("mean"));
+ONNX_OPERATOR_SET_SCHEMA(ReduceMean, 1, OpSchema()
+    .FillUsing(ReduceDocGenerator("mean")));
 
-ONNX_OPERATOR_SCHEMA(ReduceProd).FillUsing(ReduceDocGenerator("product"));
+ONNX_OPERATOR_SET_SCHEMA(ReduceProd, 1, OpSchema()
+    .FillUsing(ReduceDocGenerator("product")));
 
-ONNX_OPERATOR_SCHEMA(ReduceLogSum).FillUsing(ReduceDocGenerator("log sum"));
+ONNX_OPERATOR_SET_SCHEMA(ReduceLogSum, 1, OpSchema()
+    .FillUsing(ReduceDocGenerator("log sum")));
 
-ONNX_OPERATOR_SCHEMA(ReduceLogSumExp)
-    .FillUsing(ReduceDocGenerator("log sum exponent"));
+ONNX_OPERATOR_SET_SCHEMA(ReduceLogSumExp, 1, OpSchema()
+    .FillUsing(ReduceDocGenerator("log sum exponent")));
 
-ONNX_OPERATOR_SCHEMA(ReduceL1).FillUsing(ReduceDocGenerator("L1 norm"));
+ONNX_OPERATOR_SET_SCHEMA(ReduceL1, 1, OpSchema()
+    .FillUsing(ReduceDocGenerator("L1 norm")));
 
-ONNX_OPERATOR_SCHEMA(ReduceL2).FillUsing(ReduceDocGenerator("L2 norm"));
-
-} // namespace ONNX_NAMESPACE
-
-namespace ONNX_NAMESPACE {
+ONNX_OPERATOR_SET_SCHEMA(ReduceL2, 1, OpSchema()
+    .FillUsing(ReduceDocGenerator("L2 norm")));
 
 std::function<void(OpSchema&)> ArgReduceDocGenerator(const char* name) {
   return [=](OpSchema& schema) {
@@ -111,7 +115,7 @@ provided axis. The resulted tensor has the same rank as the input if keepdims eq
 If keepdims equal 0, then the resulted tensor have the reduced dimension pruned. 
 The type of the output tensor is integer.)DOC";
     ReplaceAll(doc, "{name}", name);
-    schema.SetDoc(doc);
+    schema.SetDoc(doc.c_str());
     schema.Attr(
         "axis",
         "The axis in which to compute the arg indices. Default is 0.",
@@ -173,8 +177,8 @@ The type of the output tensor is integer.)DOC";
   };
 } // namespace ONNX_NAMESPACE
 
-ONNX_OPERATOR_SCHEMA(ArgMax).FillUsing(ArgReduceDocGenerator("max"));
+ONNX_OPERATOR_SET_SCHEMA(ArgMax, 1, OpSchema().FillUsing(ArgReduceDocGenerator("max")));
 
-ONNX_OPERATOR_SCHEMA(ArgMin).FillUsing(ArgReduceDocGenerator("min"));
+ONNX_OPERATOR_SET_SCHEMA(ArgMin, 1, OpSchema().FillUsing(ArgReduceDocGenerator("min")));
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/reduction/defs.cc
+++ b/onnx/defs/reduction/defs.cc
@@ -77,35 +77,55 @@ False instead of True.)DOC";
   };
 }
 
-ONNX_OPERATOR_SET_SCHEMA(ReduceMax, 1, OpSchema()
-    .FillUsing(ReduceDocGenerator("max")));
+ONNX_OPERATOR_SET_SCHEMA(
+    ReduceMax,
+    1,
+    OpSchema().FillUsing(ReduceDocGenerator("max")));
 
-ONNX_OPERATOR_SET_SCHEMA(ReduceMin, 1, OpSchema()
-    .FillUsing(ReduceDocGenerator("min")));
+ONNX_OPERATOR_SET_SCHEMA(
+    ReduceMin,
+    1,
+    OpSchema().FillUsing(ReduceDocGenerator("min")));
 
-ONNX_OPERATOR_SET_SCHEMA(ReduceSum, 1, OpSchema()
-    .FillUsing(ReduceDocGenerator("sum")));
+ONNX_OPERATOR_SET_SCHEMA(
+    ReduceSum,
+    1,
+    OpSchema().FillUsing(ReduceDocGenerator("sum")));
 
-ONNX_OPERATOR_SET_SCHEMA(ReduceSumSquare, 1, OpSchema()
-    .FillUsing(ReduceDocGenerator("sum square")));
+ONNX_OPERATOR_SET_SCHEMA(
+    ReduceSumSquare,
+    1,
+    OpSchema().FillUsing(ReduceDocGenerator("sum square")));
 
-ONNX_OPERATOR_SET_SCHEMA(ReduceMean, 1, OpSchema()
-    .FillUsing(ReduceDocGenerator("mean")));
+ONNX_OPERATOR_SET_SCHEMA(
+    ReduceMean,
+    1,
+    OpSchema().FillUsing(ReduceDocGenerator("mean")));
 
-ONNX_OPERATOR_SET_SCHEMA(ReduceProd, 1, OpSchema()
-    .FillUsing(ReduceDocGenerator("product")));
+ONNX_OPERATOR_SET_SCHEMA(
+    ReduceProd,
+    1,
+    OpSchema().FillUsing(ReduceDocGenerator("product")));
 
-ONNX_OPERATOR_SET_SCHEMA(ReduceLogSum, 1, OpSchema()
-    .FillUsing(ReduceDocGenerator("log sum")));
+ONNX_OPERATOR_SET_SCHEMA(
+    ReduceLogSum,
+    1,
+    OpSchema().FillUsing(ReduceDocGenerator("log sum")));
 
-ONNX_OPERATOR_SET_SCHEMA(ReduceLogSumExp, 1, OpSchema()
-    .FillUsing(ReduceDocGenerator("log sum exponent")));
+ONNX_OPERATOR_SET_SCHEMA(
+    ReduceLogSumExp,
+    1,
+    OpSchema().FillUsing(ReduceDocGenerator("log sum exponent")));
 
-ONNX_OPERATOR_SET_SCHEMA(ReduceL1, 1, OpSchema()
-    .FillUsing(ReduceDocGenerator("L1 norm")));
+ONNX_OPERATOR_SET_SCHEMA(
+    ReduceL1,
+    1,
+    OpSchema().FillUsing(ReduceDocGenerator("L1 norm")));
 
-ONNX_OPERATOR_SET_SCHEMA(ReduceL2, 1, OpSchema()
-    .FillUsing(ReduceDocGenerator("L2 norm")));
+ONNX_OPERATOR_SET_SCHEMA(
+    ReduceL2,
+    1,
+    OpSchema().FillUsing(ReduceDocGenerator("L2 norm")));
 
 std::function<void(OpSchema&)> ArgReduceDocGenerator(const char* name) {
   return [=](OpSchema& schema) {
@@ -177,8 +197,14 @@ The type of the output tensor is integer.)DOC";
   };
 } // namespace ONNX_NAMESPACE
 
-ONNX_OPERATOR_SET_SCHEMA(ArgMax, 1, OpSchema().FillUsing(ArgReduceDocGenerator("max")));
+ONNX_OPERATOR_SET_SCHEMA(
+    ArgMax,
+    1,
+    OpSchema().FillUsing(ArgReduceDocGenerator("max")));
 
-ONNX_OPERATOR_SET_SCHEMA(ArgMin, 1, OpSchema().FillUsing(ArgReduceDocGenerator("min")));
+ONNX_OPERATOR_SET_SCHEMA(
+    ArgMin,
+    1,
+    OpSchema().FillUsing(ArgReduceDocGenerator("min")));
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/rnn/defs.cc
+++ b/onnx/defs/rnn/defs.cc
@@ -3,8 +3,6 @@
 
 #include "onnx/defs/schema.h"
 
-using namespace ONNX_NAMESPACE;
-
 namespace ONNX_NAMESPACE {
 
 void RNNShapeInference(InferenceContext& ctx) {
@@ -99,11 +97,7 @@ std::function<void(OpSchema&)> RNNDocGenerator(const char* /*name*/) {
     };
 }
 
-
-
-ONNX_OPERATOR_SCHEMA(RNN)
-    .SinceVersion(7)
-    .SetDoc(R"DOC(
+static const char * RNN_ver7_doc = R"DOC(
 Computes an one-layer simple RNN. This operator is usually supported
 via some custom implementation such as CuDNN.
 
@@ -164,8 +158,10 @@ Activation functions:
 Equations (Default: f=Tanh):
 
   - Ht = f(Xt*(Wi^T) + Ht-1*Ri + Wbi + Rbi)
+)DOC";
 
-)DOC" + GenerateOptionalArgumentsDoc())
+ONNX_OPERATOR_SET_SCHEMA(RNN, 7, OpSchema()
+    .SetDoc(RNN_ver7_doc + GenerateOptionalArgumentsDoc())
     .Attr("activations", "One (or two if bidirectional) activation function for "
           "input gate. The activation function must be one of the activation "
           "functions specified above. Optional: Default `Tanh` if not specified.",
@@ -185,12 +181,10 @@ Equations (Default: f=Tanh):
            "`[num_directions, 2*hidden_size]`. Optional: If not specified - assumed "
            "to be 0.", "T",
         OpSchema::Optional)
-    .FillUsing(RNNDocGenerator("RNN"));
+    .FillUsing(RNNDocGenerator("RNN")));
 
 
-ONNX_OPERATOR_SCHEMA(GRU)
-    .SinceVersion(7)
-    .SetDoc(R"DOC(
+static const char * GRU_ver7_doc = R"DOC(
 Computes an one-layer GRU. This operator is usually supported via some custom
 implementation such as CuDNN.
 
@@ -263,8 +257,10 @@ Equations (Default: f=Sigmoid, g=Tanh):
   - ht = g(Xt*(Wh^T) + (rt (.) (Ht-1*Rh + Rbh) + Wbh) # when linear_before_reset != 0
 
   - Ht = (1 - zt) (.) ht + zt (.) Ht-1
+)DOC";
 
-)DOC" + GenerateOptionalArgumentsDoc())
+ONNX_OPERATOR_SET_SCHEMA(GRU, 7, OpSchema()
+    .SetDoc(GRU_ver7_doc + GenerateOptionalArgumentsDoc())
     .Attr("activations", "A list of 2 (or 4 if bidirectional) activation functions "
           "for update, reset, and hidden gates. The activation functions must be one "
           "of the activation functions specified above. Optional: See the equations "
@@ -290,12 +286,10 @@ Equations (Default: f=Sigmoid, g=Tanh):
            "has shape `[num_directions, 6*hidden_size]`. Optional: If not specified "
            "- assumed to be 0", "T",
         OpSchema::Optional)
-    .FillUsing(RNNDocGenerator("GRU"));
+    .FillUsing(RNNDocGenerator("GRU")));
 
 
-ONNX_OPERATOR_SCHEMA(LSTM)
-    .SinceVersion(7)
-    .SetDoc(R"DOC(
+static const char * LSTM_ver7_doc = R"DOC(
 Computes an one-layer LSTM. This operator is usually supported via some
 custom implementation such as CuDNN.
 
@@ -376,8 +370,10 @@ Equations (Default: f=Sigmoid, g=Tanh, h=Tanh):
   - ot = f(Xt*(Wo^T) + Ht-1*Ro + Po (.) Ct + Wbo + Rbo)
 
   - Ht = ot (.) h(Ct)
+)DOC";
 
-)DOC" + GenerateOptionalArgumentsDoc())
+ONNX_OPERATOR_SET_SCHEMA(LSTM, 7, OpSchema()
+    .SetDoc(LSTM_ver7_doc + GenerateOptionalArgumentsDoc())
     .Attr("activations", "A list of 3 (or 6 if bidirectional) activation functions "
           "for input, output, forget, cell, and hidden. The activation functions must "
           "be one of the activation functions specified above. Optional: See the equations "
@@ -414,5 +410,5 @@ Equations (Default: f=Sigmoid, g=Tanh, h=Tanh):
     .FillUsing(RNNDocGenerator("LSTM"))
     .Output(2, "Y_c",
             "The last output value of the cell. It has shape "
-            "`[num_directions, batch_size, hidden_size]`.", "T", OpSchema::Optional);
+            "`[num_directions, batch_size, hidden_size]`.", "T", OpSchema::Optional));
 }  // namespace ONNX_NAMESPACE

--- a/onnx/defs/rnn/defs.cc
+++ b/onnx/defs/rnn/defs.cc
@@ -97,7 +97,7 @@ std::function<void(OpSchema&)> RNNDocGenerator(const char* /*name*/) {
     };
 }
 
-static const char * RNN_ver7_doc = R"DOC(
+static const char* RNN_ver7_doc = R"DOC(
 Computes an one-layer simple RNN. This operator is usually supported
 via some custom implementation such as CuDNN.
 
@@ -160,31 +160,44 @@ Equations (Default: f=Tanh):
   - Ht = f(Xt*(Wi^T) + Ht-1*Ri + Wbi + Rbi)
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(RNN, 7, OpSchema()
-    .SetDoc(RNN_ver7_doc + GenerateOptionalArgumentsDoc())
-    .Attr("activations", "One (or two if bidirectional) activation function for "
-          "input gate. The activation function must be one of the activation "
-          "functions specified above. Optional: Default `Tanh` if not specified.",
-          AttributeProto::STRINGS,
-          std::vector<std::string>{"Tanh", "Tanh"})
-    .Input(1, "W",
-	   "The weight tensor for input gate. Concatenation of `Wi` and `WBi` "
-           "(if bidirectional). The tensor has shape "
-           "`[num_directions, hidden_size, input_size]`.", "T")
-    .Input(2, "R",
-	   "The recurrence weight tensor. Concatenation of `Ri` and `RBi` "
-           "(if bidirectional). The tensor has shape "
-	   "`[num_directions, hidden_size, hidden_size]`.", "T")
-    .Input(3, "B",
-	   "The bias tensor for input gate. Concatenation of `[Wbi, Rbi]` "
-           "and `[WBbi, RBbi]` (if bidirectional). The tensor has shape "
-           "`[num_directions, 2*hidden_size]`. Optional: If not specified - assumed "
-           "to be 0.", "T",
-        OpSchema::Optional)
-    .FillUsing(RNNDocGenerator("RNN")));
+ONNX_OPERATOR_SET_SCHEMA(
+    RNN,
+    7,
+    OpSchema()
+        .SetDoc(RNN_ver7_doc + GenerateOptionalArgumentsDoc())
+        .Attr(
+            "activations",
+            "One (or two if bidirectional) activation function for "
+            "input gate. The activation function must be one of the activation "
+            "functions specified above. Optional: Default `Tanh` if not specified.",
+            AttributeProto::STRINGS,
+            std::vector<std::string>{"Tanh", "Tanh"})
+        .Input(
+            1,
+            "W",
+            "The weight tensor for input gate. Concatenation of `Wi` and `WBi` "
+            "(if bidirectional). The tensor has shape "
+            "`[num_directions, hidden_size, input_size]`.",
+            "T")
+        .Input(
+            2,
+            "R",
+            "The recurrence weight tensor. Concatenation of `Ri` and `RBi` "
+            "(if bidirectional). The tensor has shape "
+            "`[num_directions, hidden_size, hidden_size]`.",
+            "T")
+        .Input(
+            3,
+            "B",
+            "The bias tensor for input gate. Concatenation of `[Wbi, Rbi]` "
+            "and `[WBbi, RBbi]` (if bidirectional). The tensor has shape "
+            "`[num_directions, 2*hidden_size]`. Optional: If not specified - assumed "
+            "to be 0.",
+            "T",
+            OpSchema::Optional)
+        .FillUsing(RNNDocGenerator("RNN")));
 
-
-static const char * GRU_ver7_doc = R"DOC(
+static const char* GRU_ver7_doc = R"DOC(
 Computes an one-layer GRU. This operator is usually supported via some custom
 implementation such as CuDNN.
 
@@ -259,37 +272,52 @@ Equations (Default: f=Sigmoid, g=Tanh):
   - Ht = (1 - zt) (.) ht + zt (.) Ht-1
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(GRU, 7, OpSchema()
-    .SetDoc(GRU_ver7_doc + GenerateOptionalArgumentsDoc())
-    .Attr("activations", "A list of 2 (or 4 if bidirectional) activation functions "
-          "for update, reset, and hidden gates. The activation functions must be one "
-          "of the activation functions specified above. Optional: See the equations "
-          "for default if not specified.",
-          AttributeProto::STRINGS,
-          OPTIONAL)
-    .Attr("linear_before_reset", "When computing the output of the hidden gate, "
-          "apply the linear transformation before multiplying by the output of the "
-          "reset gate.",
-          AttributeProto::INT,
-          static_cast<int64_t>(0))
-    .Input(1, "W",
-	   "The weight tensor for the gates. Concatenation of `W[zrh]` and `WB[zrh]` "
-	   "(if bidirectional) along dimension 0. This tensor has shape "
-	   "`[num_directions, 3*hidden_size, input_size]`.", "T")
-    .Input(2, "R",
-	   "The recurrence weight tensor. Concatenation of `R[zrh]` and `RB[zrh]` "
-	   "(if bidirectional) along dimension 0. This tensor has shape "
-	   "`[num_directions, 3*hidden_size, hidden_size]`.", "T")
-    .Input(3, "B",
-	   "The bias tensor for the gates. Concatenation of `[Wb[zrh], Rb[zrh]]` and "
-           "`[WBb[zrh], RBb[zrh]]` (if bidirectional) along dimension 0. This tensor "
-           "has shape `[num_directions, 6*hidden_size]`. Optional: If not specified "
-           "- assumed to be 0", "T",
-        OpSchema::Optional)
-    .FillUsing(RNNDocGenerator("GRU")));
+ONNX_OPERATOR_SET_SCHEMA(
+    GRU,
+    7,
+    OpSchema()
+        .SetDoc(GRU_ver7_doc + GenerateOptionalArgumentsDoc())
+        .Attr(
+            "activations",
+            "A list of 2 (or 4 if bidirectional) activation functions "
+            "for update, reset, and hidden gates. The activation functions must be one "
+            "of the activation functions specified above. Optional: See the equations "
+            "for default if not specified.",
+            AttributeProto::STRINGS,
+            OPTIONAL)
+        .Attr(
+            "linear_before_reset",
+            "When computing the output of the hidden gate, "
+            "apply the linear transformation before multiplying by the output of the "
+            "reset gate.",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Input(
+            1,
+            "W",
+            "The weight tensor for the gates. Concatenation of `W[zrh]` and `WB[zrh]` "
+            "(if bidirectional) along dimension 0. This tensor has shape "
+            "`[num_directions, 3*hidden_size, input_size]`.",
+            "T")
+        .Input(
+            2,
+            "R",
+            "The recurrence weight tensor. Concatenation of `R[zrh]` and `RB[zrh]` "
+            "(if bidirectional) along dimension 0. This tensor has shape "
+            "`[num_directions, 3*hidden_size, hidden_size]`.",
+            "T")
+        .Input(
+            3,
+            "B",
+            "The bias tensor for the gates. Concatenation of `[Wb[zrh], Rb[zrh]]` and "
+            "`[WBb[zrh], RBb[zrh]]` (if bidirectional) along dimension 0. This tensor "
+            "has shape `[num_directions, 6*hidden_size]`. Optional: If not specified "
+            "- assumed to be 0",
+            "T",
+            OpSchema::Optional)
+        .FillUsing(RNNDocGenerator("GRU")));
 
-
-static const char * LSTM_ver7_doc = R"DOC(
+static const char* LSTM_ver7_doc = R"DOC(
 Computes an one-layer LSTM. This operator is usually supported via some
 custom implementation such as CuDNN.
 
@@ -372,43 +400,69 @@ Equations (Default: f=Sigmoid, g=Tanh, h=Tanh):
   - Ht = ot (.) h(Ct)
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(LSTM, 7, OpSchema()
-    .SetDoc(LSTM_ver7_doc + GenerateOptionalArgumentsDoc())
-    .Attr("activations", "A list of 3 (or 6 if bidirectional) activation functions "
-          "for input, output, forget, cell, and hidden. The activation functions must "
-          "be one of the activation functions specified above. Optional: See the equations "
-          "for default if not specified.",
-          AttributeProto::STRINGS,
-          OPTIONAL)
-    .Attr("input_forget", "Couple the input and forget gates if 1, default 0.",
-          AttributeProto::INT,
-          static_cast<int64_t>(0))
-    .Input(1, "W",
-	   "The weight tensor for the gates. Concatenation of `W[iofc]` and "
-           "`WB[iofc]` (if bidirectional) along dimension 0. The tensor has shape "
-	   "`[num_directions, 4*hidden_size, input_size]`.", "T")
-    .Input(2, "R",
-	   "The recurrence weight tensor. Concatenation of `R[iofc]` and "
-	   "`RB[iofc]` (if bidirectional) along dimension 0. This tensor has shape "
-           "`[num_directions, 4*hidden_size, hidden_size]`.", "T")
-    .Input(3, "B",
-	   "The bias tensor for input gate. Concatenation of `[Wb[iofc], Rb[iofc]]`, "
-	   "and `[WBb[iofc], RBb[iofc]]` (if bidirectional) along dimension 0. This "
-           "tensor has shape `[num_directions, 8*hidden_size]`. Optional: If not "
-	   "specified - assumed to be 0.", "T",
-       OpSchema::Optional)
-    .Input(6, "initial_c",
-           "Optional initial value of the cell. If not specified - assumed "
-	   "to be 0. It has shape `[num_directions, batch_size, hidden_size]`.",
-	   "T", OpSchema::Optional)
-    .Input(7, "P",
-	   "The weight tensor for peepholes. Concatenation of `P[iof]` and "
-	   "`PB[iof]` (if bidirectional) along dimension 0. It has shape "
-	   "`[num_directions, 3*hidde_size]`. Optional: If not specified - "
-	   "assumed to be 0.", "T",
-       OpSchema::Optional)
-    .FillUsing(RNNDocGenerator("LSTM"))
-    .Output(2, "Y_c",
+ONNX_OPERATOR_SET_SCHEMA(
+    LSTM,
+    7,
+    OpSchema()
+        .SetDoc(LSTM_ver7_doc + GenerateOptionalArgumentsDoc())
+        .Attr(
+            "activations",
+            "A list of 3 (or 6 if bidirectional) activation functions "
+            "for input, output, forget, cell, and hidden. The activation functions must "
+            "be one of the activation functions specified above. Optional: See the equations "
+            "for default if not specified.",
+            AttributeProto::STRINGS,
+            OPTIONAL)
+        .Attr(
+            "input_forget",
+            "Couple the input and forget gates if 1, default 0.",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Input(
+            1,
+            "W",
+            "The weight tensor for the gates. Concatenation of `W[iofc]` and "
+            "`WB[iofc]` (if bidirectional) along dimension 0. The tensor has shape "
+            "`[num_directions, 4*hidden_size, input_size]`.",
+            "T")
+        .Input(
+            2,
+            "R",
+            "The recurrence weight tensor. Concatenation of `R[iofc]` and "
+            "`RB[iofc]` (if bidirectional) along dimension 0. This tensor has shape "
+            "`[num_directions, 4*hidden_size, hidden_size]`.",
+            "T")
+        .Input(
+            3,
+            "B",
+            "The bias tensor for input gate. Concatenation of `[Wb[iofc], Rb[iofc]]`, "
+            "and `[WBb[iofc], RBb[iofc]]` (if bidirectional) along dimension 0. This "
+            "tensor has shape `[num_directions, 8*hidden_size]`. Optional: If not "
+            "specified - assumed to be 0.",
+            "T",
+            OpSchema::Optional)
+        .Input(
+            6,
+            "initial_c",
+            "Optional initial value of the cell. If not specified - assumed "
+            "to be 0. It has shape `[num_directions, batch_size, hidden_size]`.",
+            "T",
+            OpSchema::Optional)
+        .Input(
+            7,
+            "P",
+            "The weight tensor for peepholes. Concatenation of `P[iof]` and "
+            "`PB[iof]` (if bidirectional) along dimension 0. It has shape "
+            "`[num_directions, 3*hidde_size]`. Optional: If not specified - "
+            "assumed to be 0.",
+            "T",
+            OpSchema::Optional)
+        .FillUsing(RNNDocGenerator("LSTM"))
+        .Output(
+            2,
+            "Y_c",
             "The last output value of the cell. It has shape "
-            "`[num_directions, batch_size, hidden_size]`.", "T", OpSchema::Optional));
+            "`[num_directions, batch_size, hidden_size]`.",
+            "T",
+            OpSchema::Optional));
 }  // namespace ONNX_NAMESPACE

--- a/onnx/defs/rnn/old.cc
+++ b/onnx/defs/rnn/old.cc
@@ -1,6 +1,5 @@
 #include "onnx/defs/schema.h"
 
-using namespace ONNX_NAMESPACE;
 
 namespace ONNX_NAMESPACE {
 
@@ -88,8 +87,7 @@ std::function<void(OpSchema&)> RNNDocGeneratorOld(const char* /*name*/) {
 }
 
 
-ONNX_OPERATOR_SCHEMA(GRU)
-    .SetDoc(R"DOC(
+static const char * GRU_ver1_doc = R"DOC(
 Computes an one-layer GRU. This operator is usually supported via some custom
 implementation such as CuDNN.
 
@@ -162,7 +160,10 @@ Equations (Default: f=Sigmoid, g=Tanh):
   - ht = g(Xt*(Wh^T) + (rt (.) (Ht-1*Rh + Rbh) + Wbh) # when linear_before_reset != 0
 
   - Ht = (1 - zt) (.) ht + zt (.) Ht-1
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(GRU, 1, OpSchema()
+    .SetDoc(GRU_ver1_doc)
     .Attr(
         "activations",
         "A list of 2 (or 4 if bidirectional) activation functions "
@@ -194,7 +195,7 @@ Equations (Default: f=Sigmoid, g=Tanh):
         "- assumed to be 0",
         "T",
         OpSchema::Optional)
-    .FillUsing(RNNDocGeneratorOld("GRU"));
+    .FillUsing(RNNDocGeneratorOld("GRU")));
 
 // Versions 1 to 6 of RNN/LSTM and versions 3 to 6 of GRU:
 
@@ -306,10 +307,7 @@ std::function<void(OpSchema&)> RNNDocGenerator1(const char* /*name*/) {
     };
 }
 
-
-
-ONNX_OPERATOR_SCHEMA(RNN)
-    .SetDoc(R"DOC(
+static const char * RNN_ver1_doc = R"DOC(
 Computes an one-layer simple RNN. This operator is usually supported
 via some custom implementation such as CuDNN.
 
@@ -370,7 +368,10 @@ Activation functions:
 Equations (Default: f=Tanh):
 
   - Ht = f(Xt*(Wi^T) + Ht-1*Ri + Wbi + Rbi)
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(RNN, 1, OpSchema()
+    .SetDoc(RNN_ver1_doc)
     .Attr("activations", "One (or two if bidirectional) activation function for "
           "input gate. The activation function must be one of the activation "
           "functions specified above. Optional: Default `Tanh` if not specified.",
@@ -390,11 +391,9 @@ Equations (Default: f=Tanh):
            "`[num_directions, 2*hidden_size]`. Optional: If not specified - assumed "
            "to be 0.", "T",
         OpSchema::Optional)
-    .FillUsing(RNNDocGenerator1("RNN"));
+    .FillUsing(RNNDocGenerator1("RNN")));
 
-
-ONNX_OPERATOR_SCHEMA(GRU)
-    .SetDoc(R"DOC(
+static const char * GRU_ver3_doc = R"DOC(
 Computes an one-layer GRU. This operator is usually supported via some custom
 implementation such as CuDNN.
 
@@ -467,14 +466,16 @@ Equations (Default: f=Sigmoid, g=Tanh):
   - ht = g(Xt*(Wh^T) + (rt (.) (Ht-1*Rh + Rbh) + Wbh) # when linear_before_reset != 0
 
   - Ht = (1 - zt) (.) ht + zt (.) Ht-1
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(GRU, 3, OpSchema()
+    .SetDoc(GRU_ver3_doc)
     .Attr("activations", "A list of 2 (or 4 if bidirectional) activation functions "
           "for update, reset, and hidden gates. The activation functions must be one "
           "of the activation functions specified above. Optional: See the equations "
           "for default if not specified.",
           AttributeProto::STRINGS,
           OPTIONAL)
-    .SinceVersion(3)
     .Attr("linear_before_reset", "When computing the output of the hidden gate, "
           "apply the linear transformation before multiplying by the output of the "
           "reset gate.",
@@ -494,11 +495,9 @@ Equations (Default: f=Sigmoid, g=Tanh):
            "has shape `[num_directions, 6*hidden_size]`. Optional: If not specified "
            "- assumed to be 0", "T",
         OpSchema::Optional)
-    .FillUsing(RNNDocGenerator1("GRU"));
+    .FillUsing(RNNDocGenerator1("GRU")));
 
-
-ONNX_OPERATOR_SCHEMA(LSTM)
-    .SetDoc(R"DOC(
+static const char * LSTM_ver1_doc = R"DOC(
 Computes an one-layer LSTM. This operator is usually supported via some
 custom implementation such as CuDNN.
 
@@ -579,7 +578,10 @@ Equations (Default: f=Sigmoid, g=Tanh, h=Tanh):
   - ot = f(Xt*(Wo^T) + Ht-1*Ro + Po (.) Ct + Wbo + Rbo)
 
   - Ht = ot (.) h(Ct)
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(LSTM, 1, OpSchema()
+    .SetDoc(LSTM_ver1_doc)
     .Attr("activations", "A list of 3 (or 6 if bidirectional) activation functions "
           "for input, output, forget, cell, and hidden. The activation functions must "
           "be one of the activation functions specified above. Optional: See the equations "
@@ -616,6 +618,6 @@ Equations (Default: f=Sigmoid, g=Tanh, h=Tanh):
     .FillUsing(RNNDocGenerator1("LSTM"))
     .Output(2, "Y_c",
             "The last output value of the cell. It has shape "
-            "`[num_directions, batch_size, hidden_size]`.", "T", OpSchema::Optional);
+            "`[num_directions, batch_size, hidden_size]`.", "T", OpSchema::Optional));
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/rnn/old.cc
+++ b/onnx/defs/rnn/old.cc
@@ -86,8 +86,7 @@ std::function<void(OpSchema&)> RNNDocGeneratorOld(const char* /*name*/) {
   };
 }
 
-
-static const char * GRU_ver1_doc = R"DOC(
+static const char* GRU_ver1_doc = R"DOC(
 Computes an one-layer GRU. This operator is usually supported via some custom
 implementation such as CuDNN.
 
@@ -162,40 +161,43 @@ Equations (Default: f=Sigmoid, g=Tanh):
   - Ht = (1 - zt) (.) ht + zt (.) Ht-1
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(GRU, 1, OpSchema()
-    .SetDoc(GRU_ver1_doc)
-    .Attr(
-        "activations",
-        "A list of 2 (or 4 if bidirectional) activation functions "
-        "for update, reset, and hidden gates. The activation functions must be one "
-        "of the activation functions specified above. Optional: See the equations "
-        "for default if not specified.",
-        AttributeProto::STRINGS,
-        OPTIONAL)
-    .Input(
-        1,
-        "W",
-        "The weight tensor for the gates. Concatenation of `W[zrh]` and `WB[zrh]` "
-        "(if bidirectional) along dimension 0. This tensor has shape "
-        "`[num_directions, 3*hidden_size, input_size]`.",
-        "T")
-    .Input(
-        2,
-        "R",
-        "The recurrence weight tensor. Concatenation of `R[zrh]` and `RB[zrh]` "
-        "(if bidirectional) along dimension 0. This tensor has shape "
-        "`[num_directions, 3*hidden_size, hidden_size]`.",
-        "T")
-    .Input(
-        3,
-        "B",
-        "The bias tensor for the gates. Concatenation of `[Wb[zrh], Rb[zrh]]` and "
-        "`[WBb[zrh], RBb[zrh]]` (if bidirectional) along dimension 0. This tensor "
-        "has shape `[num_directions, 6*hidden_size]`. Optional: If not specified "
-        "- assumed to be 0",
-        "T",
-        OpSchema::Optional)
-    .FillUsing(RNNDocGeneratorOld("GRU")));
+ONNX_OPERATOR_SET_SCHEMA(
+    GRU,
+    1,
+    OpSchema()
+        .SetDoc(GRU_ver1_doc)
+        .Attr(
+            "activations",
+            "A list of 2 (or 4 if bidirectional) activation functions "
+            "for update, reset, and hidden gates. The activation functions must be one "
+            "of the activation functions specified above. Optional: See the equations "
+            "for default if not specified.",
+            AttributeProto::STRINGS,
+            OPTIONAL)
+        .Input(
+            1,
+            "W",
+            "The weight tensor for the gates. Concatenation of `W[zrh]` and `WB[zrh]` "
+            "(if bidirectional) along dimension 0. This tensor has shape "
+            "`[num_directions, 3*hidden_size, input_size]`.",
+            "T")
+        .Input(
+            2,
+            "R",
+            "The recurrence weight tensor. Concatenation of `R[zrh]` and `RB[zrh]` "
+            "(if bidirectional) along dimension 0. This tensor has shape "
+            "`[num_directions, 3*hidden_size, hidden_size]`.",
+            "T")
+        .Input(
+            3,
+            "B",
+            "The bias tensor for the gates. Concatenation of `[Wb[zrh], Rb[zrh]]` and "
+            "`[WBb[zrh], RBb[zrh]]` (if bidirectional) along dimension 0. This tensor "
+            "has shape `[num_directions, 6*hidden_size]`. Optional: If not specified "
+            "- assumed to be 0",
+            "T",
+            OpSchema::Optional)
+        .FillUsing(RNNDocGeneratorOld("GRU")));
 
 // Versions 1 to 6 of RNN/LSTM and versions 3 to 6 of GRU:
 
@@ -307,7 +309,7 @@ std::function<void(OpSchema&)> RNNDocGenerator1(const char* /*name*/) {
     };
 }
 
-static const char * RNN_ver1_doc = R"DOC(
+static const char* RNN_ver1_doc = R"DOC(
 Computes an one-layer simple RNN. This operator is usually supported
 via some custom implementation such as CuDNN.
 
@@ -370,30 +372,44 @@ Equations (Default: f=Tanh):
   - Ht = f(Xt*(Wi^T) + Ht-1*Ri + Wbi + Rbi)
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(RNN, 1, OpSchema()
-    .SetDoc(RNN_ver1_doc)
-    .Attr("activations", "One (or two if bidirectional) activation function for "
-          "input gate. The activation function must be one of the activation "
-          "functions specified above. Optional: Default `Tanh` if not specified.",
-          AttributeProto::STRINGS,
-          std::vector<std::string>{"Tanh", "Tanh"})
-    .Input(1, "W",
-	   "The weight tensor for input gate. Concatenation of `Wi` and `WBi` "
-           "(if bidirectional). The tensor has shape "
-           "`[num_directions, hidden_size, input_size]`.", "T")
-    .Input(2, "R",
-	   "The recurrence weight tensor. Concatenation of `Ri` and `RBi` "
-           "(if bidirectional). The tensor has shape "
-	   "`[num_directions, hidden_size, hidden_size]`.", "T")
-    .Input(3, "B",
-	   "The bias tensor for input gate. Concatenation of `[Wbi, Rbi]` "
-           "and `[WBbi, RBbi]` (if bidirectional). The tensor has shape "
-           "`[num_directions, 2*hidden_size]`. Optional: If not specified - assumed "
-           "to be 0.", "T",
-        OpSchema::Optional)
-    .FillUsing(RNNDocGenerator1("RNN")));
+ONNX_OPERATOR_SET_SCHEMA(
+    RNN,
+    1,
+    OpSchema()
+        .SetDoc(RNN_ver1_doc)
+        .Attr(
+            "activations",
+            "One (or two if bidirectional) activation function for "
+            "input gate. The activation function must be one of the activation "
+            "functions specified above. Optional: Default `Tanh` if not specified.",
+            AttributeProto::STRINGS,
+            std::vector<std::string>{"Tanh", "Tanh"})
+        .Input(
+            1,
+            "W",
+            "The weight tensor for input gate. Concatenation of `Wi` and `WBi` "
+            "(if bidirectional). The tensor has shape "
+            "`[num_directions, hidden_size, input_size]`.",
+            "T")
+        .Input(
+            2,
+            "R",
+            "The recurrence weight tensor. Concatenation of `Ri` and `RBi` "
+            "(if bidirectional). The tensor has shape "
+            "`[num_directions, hidden_size, hidden_size]`.",
+            "T")
+        .Input(
+            3,
+            "B",
+            "The bias tensor for input gate. Concatenation of `[Wbi, Rbi]` "
+            "and `[WBbi, RBbi]` (if bidirectional). The tensor has shape "
+            "`[num_directions, 2*hidden_size]`. Optional: If not specified - assumed "
+            "to be 0.",
+            "T",
+            OpSchema::Optional)
+        .FillUsing(RNNDocGenerator1("RNN")));
 
-static const char * GRU_ver3_doc = R"DOC(
+static const char* GRU_ver3_doc = R"DOC(
 Computes an one-layer GRU. This operator is usually supported via some custom
 implementation such as CuDNN.
 
@@ -468,36 +484,52 @@ Equations (Default: f=Sigmoid, g=Tanh):
   - Ht = (1 - zt) (.) ht + zt (.) Ht-1
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(GRU, 3, OpSchema()
-    .SetDoc(GRU_ver3_doc)
-    .Attr("activations", "A list of 2 (or 4 if bidirectional) activation functions "
-          "for update, reset, and hidden gates. The activation functions must be one "
-          "of the activation functions specified above. Optional: See the equations "
-          "for default if not specified.",
-          AttributeProto::STRINGS,
-          OPTIONAL)
-    .Attr("linear_before_reset", "When computing the output of the hidden gate, "
-          "apply the linear transformation before multiplying by the output of the "
-          "reset gate.",
-          AttributeProto::INT,
-          static_cast<int64_t>(0))
-    .Input(1, "W",
-	   "The weight tensor for the gates. Concatenation of `W[zrh]` and `WB[zrh]` "
-	   "(if bidirectional) along dimension 0. This tensor has shape "
-	   "`[num_directions, 3*hidden_size, input_size]`.", "T")
-    .Input(2, "R",
-	   "The recurrence weight tensor. Concatenation of `R[zrh]` and `RB[zrh]` "
-	   "(if bidirectional) along dimension 0. This tensor has shape "
-	   "`[num_directions, 3*hidden_size, hidden_size]`.", "T")
-    .Input(3, "B",
-	   "The bias tensor for the gates. Concatenation of `[Wb[zrh], Rb[zrh]]` and "
-           "`[WBb[zrh], RBb[zrh]]` (if bidirectional) along dimension 0. This tensor "
-           "has shape `[num_directions, 6*hidden_size]`. Optional: If not specified "
-           "- assumed to be 0", "T",
-        OpSchema::Optional)
-    .FillUsing(RNNDocGenerator1("GRU")));
+ONNX_OPERATOR_SET_SCHEMA(
+    GRU,
+    3,
+    OpSchema()
+        .SetDoc(GRU_ver3_doc)
+        .Attr(
+            "activations",
+            "A list of 2 (or 4 if bidirectional) activation functions "
+            "for update, reset, and hidden gates. The activation functions must be one "
+            "of the activation functions specified above. Optional: See the equations "
+            "for default if not specified.",
+            AttributeProto::STRINGS,
+            OPTIONAL)
+        .Attr(
+            "linear_before_reset",
+            "When computing the output of the hidden gate, "
+            "apply the linear transformation before multiplying by the output of the "
+            "reset gate.",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Input(
+            1,
+            "W",
+            "The weight tensor for the gates. Concatenation of `W[zrh]` and `WB[zrh]` "
+            "(if bidirectional) along dimension 0. This tensor has shape "
+            "`[num_directions, 3*hidden_size, input_size]`.",
+            "T")
+        .Input(
+            2,
+            "R",
+            "The recurrence weight tensor. Concatenation of `R[zrh]` and `RB[zrh]` "
+            "(if bidirectional) along dimension 0. This tensor has shape "
+            "`[num_directions, 3*hidden_size, hidden_size]`.",
+            "T")
+        .Input(
+            3,
+            "B",
+            "The bias tensor for the gates. Concatenation of `[Wb[zrh], Rb[zrh]]` and "
+            "`[WBb[zrh], RBb[zrh]]` (if bidirectional) along dimension 0. This tensor "
+            "has shape `[num_directions, 6*hidden_size]`. Optional: If not specified "
+            "- assumed to be 0",
+            "T",
+            OpSchema::Optional)
+        .FillUsing(RNNDocGenerator1("GRU")));
 
-static const char * LSTM_ver1_doc = R"DOC(
+static const char* LSTM_ver1_doc = R"DOC(
 Computes an one-layer LSTM. This operator is usually supported via some
 custom implementation such as CuDNN.
 
@@ -580,44 +612,70 @@ Equations (Default: f=Sigmoid, g=Tanh, h=Tanh):
   - Ht = ot (.) h(Ct)
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(LSTM, 1, OpSchema()
-    .SetDoc(LSTM_ver1_doc)
-    .Attr("activations", "A list of 3 (or 6 if bidirectional) activation functions "
-          "for input, output, forget, cell, and hidden. The activation functions must "
-          "be one of the activation functions specified above. Optional: See the equations "
-          "for default if not specified.",
-          AttributeProto::STRINGS,
-          OPTIONAL)
-    .Attr("input_forget", "Couple the input and forget gates if 1, default 0.",
-          AttributeProto::INT,
-          static_cast<int64_t>(0))
-    .Input(1, "W",
-	   "The weight tensor for the gates. Concatenation of `W[iofc]` and "
-           "`WB[iofc]` (if bidirectional) along dimension 0. The tensor has shape "
-	   "`[num_directions, 4*hidden_size, input_size]`.", "T")
-    .Input(2, "R",
-	   "The recurrence weight tensor. Concatenation of `R[iofc]` and "
-	   "`RB[iofc]` (if bidirectional) along dimension 0. This tensor has shape "
-           "`[num_directions, 4*hidden_size, hidden_size]`.", "T")
-    .Input(3, "B",
-	   "The bias tensor for input gate. Concatenation of `[Wb[iofc], Rb[iofc]]`, "
-	   "and `[WBb[iofc], RBb[iofc]]` (if bidirectional) along dimension 0. This "
-           "tensor has shape `[num_directions, 8*hidden_size]`. Optional: If not "
-	   "specified - assumed to be 0.", "T",
-       OpSchema::Optional)
-    .Input(6, "initial_c",
-           "Optional initial value of the cell. If not specified - assumed "
-	   "to be 0. It has shape `[num_directions, batch_size, hidden_size]`.",
-	   "T", OpSchema::Optional)
-    .Input(7, "P",
-	   "The weight tensor for peepholes. Concatenation of `P[iof]` and "
-	   "`PB[iof]` (if bidirectional) along dimension 0. It has shape "
-	   "`[num_directions, 3*hidde_size]`. Optional: If not specified - "
-	   "assumed to be 0.", "T",
-       OpSchema::Optional)
-    .FillUsing(RNNDocGenerator1("LSTM"))
-    .Output(2, "Y_c",
+ONNX_OPERATOR_SET_SCHEMA(
+    LSTM,
+    1,
+    OpSchema()
+        .SetDoc(LSTM_ver1_doc)
+        .Attr(
+            "activations",
+            "A list of 3 (or 6 if bidirectional) activation functions "
+            "for input, output, forget, cell, and hidden. The activation functions must "
+            "be one of the activation functions specified above. Optional: See the equations "
+            "for default if not specified.",
+            AttributeProto::STRINGS,
+            OPTIONAL)
+        .Attr(
+            "input_forget",
+            "Couple the input and forget gates if 1, default 0.",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Input(
+            1,
+            "W",
+            "The weight tensor for the gates. Concatenation of `W[iofc]` and "
+            "`WB[iofc]` (if bidirectional) along dimension 0. The tensor has shape "
+            "`[num_directions, 4*hidden_size, input_size]`.",
+            "T")
+        .Input(
+            2,
+            "R",
+            "The recurrence weight tensor. Concatenation of `R[iofc]` and "
+            "`RB[iofc]` (if bidirectional) along dimension 0. This tensor has shape "
+            "`[num_directions, 4*hidden_size, hidden_size]`.",
+            "T")
+        .Input(
+            3,
+            "B",
+            "The bias tensor for input gate. Concatenation of `[Wb[iofc], Rb[iofc]]`, "
+            "and `[WBb[iofc], RBb[iofc]]` (if bidirectional) along dimension 0. This "
+            "tensor has shape `[num_directions, 8*hidden_size]`. Optional: If not "
+            "specified - assumed to be 0.",
+            "T",
+            OpSchema::Optional)
+        .Input(
+            6,
+            "initial_c",
+            "Optional initial value of the cell. If not specified - assumed "
+            "to be 0. It has shape `[num_directions, batch_size, hidden_size]`.",
+            "T",
+            OpSchema::Optional)
+        .Input(
+            7,
+            "P",
+            "The weight tensor for peepholes. Concatenation of `P[iof]` and "
+            "`PB[iof]` (if bidirectional) along dimension 0. It has shape "
+            "`[num_directions, 3*hidde_size]`. Optional: If not specified - "
+            "assumed to be 0.",
+            "T",
+            OpSchema::Optional)
+        .FillUsing(RNNDocGenerator1("LSTM"))
+        .Output(
+            2,
+            "Y_c",
             "The last output value of the cell. It has shape "
-            "`[num_directions, batch_size, hidden_size]`.", "T", OpSchema::Optional));
+            "`[num_directions, batch_size, hidden_size]`.",
+            "T",
+            OpSchema::Optional));
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -12,7 +12,6 @@
 #endif
 
 #include "onnx/common/stl_backports.h"
-#include "onnx/common/assertions.h"
 
 namespace ONNX_NAMESPACE {
 

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -12,6 +12,7 @@
 #endif
 
 #include "onnx/common/stl_backports.h"
+#include "onnx/common/assertions.h"
 
 namespace ONNX_NAMESPACE {
 

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -15,8 +15,7 @@
 
 namespace ONNX_NAMESPACE {
 
-void RegisterSchema(OpSchema&& schema)
-{
+void RegisterSchema(OpSchema&& schema) {
   OpSchemaRegistry::OpSchemaRegisterOnce(registration) = schema;
 }
 
@@ -350,47 +349,51 @@ OpSchema& OpSchema::Attr(
   return Attr(std::string(name), std::string(description), type, required);
 }
 
-#define ATTR_SETTER_WITH_SINGLE_VALUE(type, field, attrtype)                  \
-  OpSchema& OpSchema::Attr(                                                   \
-      std::string name,                                                       \
-      std::string description,                                                \
-      AttributeProto::AttributeType attr_type,                                \
-      const type& default_value) {                                            \
-    if (attrtype != attr_type) {                                              \
-      fail_schema("Attribute specification type mismatch.");                  \
-    }                                                                         \
-    AttributeProto a;                                                         \
-    a.set_name(name);                                                         \
-    a.set_##field(default_value);                                             \
-    a.set_type(attr_type);                                                    \
-    Attr(Attribute(std::move(name), std::move(description), std::move(a)));   \
-    return *this;                                                             \
-  }                                                                           \
-  OpSchema& OpSchema::Attr(                                                   \
-      const char* name,                                                       \
-      const char* description,                                                \
-      AttributeProto::AttributeType attr_type,                                \
-      const type& default_value) {                                            \
-    return Attr(std::string(name), std::string(description), attr_type, default_value); \
+#define ATTR_SETTER_WITH_SINGLE_VALUE(type, field, attrtype)                \
+  OpSchema& OpSchema::Attr(                                                 \
+      std::string name,                                                     \
+      std::string description,                                              \
+      AttributeProto::AttributeType attr_type,                              \
+      const type& default_value) {                                          \
+    if (attrtype != attr_type) {                                            \
+      fail_schema("Attribute specification type mismatch.");                \
+    }                                                                       \
+    AttributeProto a;                                                       \
+    a.set_name(name);                                                       \
+    a.set_##field(default_value);                                           \
+    a.set_type(attr_type);                                                  \
+    Attr(Attribute(std::move(name), std::move(description), std::move(a))); \
+    return *this;                                                           \
+  }                                                                         \
+  OpSchema& OpSchema::Attr(                                                 \
+      const char* name,                                                     \
+      const char* description,                                              \
+      AttributeProto::AttributeType attr_type,                              \
+      const type& default_value) {                                          \
+    return Attr(                                                            \
+        std::string(name),                                                  \
+        std::string(description),                                           \
+        attr_type,                                                          \
+        default_value);                                                     \
   }
 
-#define ATTR_SETTER_WITH_LIST_VALUE(type, field, attrtype)                    \
-  OpSchema& OpSchema::Attr(                                                   \
-      std::string name,                                                       \
-      std::string description,                                                \
-      AttributeProto::AttributeType attr_type,                                \
-      const std::vector<type>& default_value) {                               \
-    if (attrtype != attr_type) {                                              \
-      fail_schema("Attribute specification type mismatch.");                  \
-    }                                                                         \
-    AttributeProto a;                                                         \
-    a.set_name(name);                                                         \
-    a.set_type(attr_type);                                                    \
-    for (const auto& v : default_value) {                                     \
-      a.add_##field(v);                                                       \
-    }                                                                         \
-    Attr(Attribute(std::move(name), std::move(description), std::move(a)));   \
-    return *this;                                                             \
+#define ATTR_SETTER_WITH_LIST_VALUE(type, field, attrtype)                  \
+  OpSchema& OpSchema::Attr(                                                 \
+      std::string name,                                                     \
+      std::string description,                                              \
+      AttributeProto::AttributeType attr_type,                              \
+      const std::vector<type>& default_value) {                             \
+    if (attrtype != attr_type) {                                            \
+      fail_schema("Attribute specification type mismatch.");                \
+    }                                                                       \
+    AttributeProto a;                                                       \
+    a.set_name(name);                                                       \
+    a.set_type(attr_type);                                                  \
+    for (const auto& v : default_value) {                                   \
+      a.add_##field(v);                                                     \
+    }                                                                       \
+    Attr(Attribute(std::move(name), std::move(description), std::move(a))); \
+    return *this;                                                           \
   }
 
 #define ATTR_SETTER_WITH_SINGLE_COMPLEXVALUE(type, field, attrtype) \
@@ -410,23 +413,23 @@ OpSchema& OpSchema::Attr(
     return *this;                                                   \
   }
 
-#define ATTR_SETTER_WITH_LIST_COMPLEXVALUE(type, field, attrtype) \
-  OpSchema& OpSchema::Attr(                                       \
-      std::string name,                                           \
-      std::string description,                                    \
-      AttributeProto::AttributeType attr_type,                    \
-      const std::vector<type>& default_value) {                   \
-    if (attrtype != attr_type) {                                  \
-      fail_schema("Attribute specification type mismatch.");      \
-    }                                                             \
-    AttributeProto a;                                             \
-    a.set_name(name);                                             \
-    a.set_type(attr_type);                                        \
-    for (const auto& v : default_value) {                         \
-      *(a.add_##field()) = v;                                     \
-    }                                                             \
+#define ATTR_SETTER_WITH_LIST_COMPLEXVALUE(type, field, attrtype)           \
+  OpSchema& OpSchema::Attr(                                                 \
+      std::string name,                                                     \
+      std::string description,                                              \
+      AttributeProto::AttributeType attr_type,                              \
+      const std::vector<type>& default_value) {                             \
+    if (attrtype != attr_type) {                                            \
+      fail_schema("Attribute specification type mismatch.");                \
+    }                                                                       \
+    AttributeProto a;                                                       \
+    a.set_name(name);                                                       \
+    a.set_type(attr_type);                                                  \
+    for (const auto& v : default_value) {                                   \
+      *(a.add_##field()) = v;                                               \
+    }                                                                       \
     Attr(Attribute(std::move(name), std::move(description), std::move(a))); \
-    return *this;                                                 \
+    return *this;                                                           \
   }
 
 ATTR_SETTER_WITH_SINGLE_VALUE(int64_t, i, AttributeProto::INT)
@@ -470,7 +473,12 @@ OpSchema& OpSchema::Input(
     const char* description,
     const char* type_str,
     FormalParameterOption param_option) {
-  return Input(n, std::string(name), std::string(description), std::string(type_str), param_option);
+  return Input(
+      n,
+      std::string(name),
+      std::string(description),
+      std::string(type_str),
+      param_option);
 }
 
 OpSchema& OpSchema::Output(
@@ -492,7 +500,12 @@ OpSchema& OpSchema::Output(
     const char* description,
     const char* type_str,
     FormalParameterOption param_option) {
-  return Output(n, std::string(name), std::string(description), std::string(type_str), param_option);
+  return Output(
+      n,
+      std::string(name),
+      std::string(description),
+      std::string(type_str),
+      param_option);
 }
 
 OpSchema& OpSchema::TypeConstraint(
@@ -521,7 +534,8 @@ OpSchema& OpSchema::TypeConstraint(
     constraints_vector.push_back(*iter);
   }
 
-  return TypeConstraint(std::string(type_str), constraints_vector, std::string(description));
+  return TypeConstraint(
+      std::string(type_str), constraints_vector, std::string(description));
 }
 
 void OpSchema::ParseAndSetTypes(
@@ -666,14 +680,15 @@ std::ostream& operator<<(std::ostream& out, const OpSchema& schema) {
 }
 
 // Private method used by OpSchemaRegisterOnce and OpSchemaRegistry::map()
-OpName_Domain_Version_Schema_Map& OpSchemaRegistry::GetMapWithoutEnsuringRegistration() {
+OpName_Domain_Version_Schema_Map&
+OpSchemaRegistry::GetMapWithoutEnsuringRegistration() {
   static OpName_Domain_Version_Schema_Map map;
   return map;
 }
 
-OpName_Domain_Version_Schema_Map& OpSchemaRegistry::map() {  
+OpName_Domain_Version_Schema_Map& OpSchemaRegistry::map() {
   auto& map = GetMapWithoutEnsuringRegistration();
-  
+
   // The following class is used to register operators the
   // first time this method is called, in a thread-safe fashion.
   class SchemasRegisterer {
@@ -698,7 +713,8 @@ OpName_Domain_Version_Schema_Map& OpSchemaRegistry::map() {
           dbg_registered_schema_count == ONNX_DBG_GET_COUNT_IN_OPSETS(),
           "%u schema were exposed from operator sets and automatically placed into the static registry.  "
           "%u were expected based on calls to registration macros. Operator set functions may need to be updated.",
-          dbg_registered_schema_count, ONNX_DBG_GET_COUNT_IN_OPSETS());
+          dbg_registered_schema_count,
+          ONNX_DBG_GET_COUNT_IN_OPSETS());
 #endif
     }
 

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -11,8 +11,8 @@
 #include "onnx/defs/operator_sets-ml.h"
 #endif
 
-#include "onnx/common/stl_backports.h"
 #include "onnx/common/assertions.h"
+#include "onnx/common/stl_backports.h"
 
 namespace ONNX_NAMESPACE {
 

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -5,9 +5,28 @@
 #include <stdexcept>
 #include <unordered_set>
 #include "onnx/checker.h"
+#include "onnx/defs/operator_sets.h"
+
+#ifdef ONNX_ML
+#include "onnx/defs/operator_sets-ml.h"
+#endif
+
 #include "onnx/common/stl_backports.h"
+#include "onnx/common/assertions.h"
 
 namespace ONNX_NAMESPACE {
+
+void RegisterSchema(OpSchema&& schema)
+{
+  OpSchemaRegistry::OpSchemaRegisterOnce(registration) = schema;
+}
+
+#ifndef NDEBUG
+DbgOperatorSetTracker& DbgOperatorSetTracker::Instance() {
+  static DbgOperatorSetTracker instance;
+  return instance;
+}
+#endif
 
 OpSchema::FormalParameter::FormalParameter(
     std::string name,
@@ -53,6 +72,11 @@ const std::string& OpSchema::FormalParameter::GetDescription() const {
 
 OpSchema::FormalParameterOption OpSchema::FormalParameter::GetOption() const {
   return param_option_;
+}
+
+OpSchemaRegistry* OpSchemaRegistry::Instance() {
+  static OpSchemaRegistry instance;
+  return &instance;
 }
 
 void OpSchema::Verify(const NodeProto& node) const {
@@ -274,9 +298,34 @@ OpSchema& OpSchema::SetDoc(std::string doc) {
   return *this;
 }
 
+// Functions to specify name for the operator schema.
+OpSchema& OpSchema::SetName(std::string name) {
+  name_ = std::move(name);
+  return *this;
+}
+
+OpSchema& OpSchema::SetName(const char* name) {
+  return SetName(std::string(name));
+}
+
+// Functions to specify code location for the operator schema.
+OpSchema& OpSchema::SetLocation(std::string file, int line) {
+  file_ = std::move(file);
+  line_ = line;
+  return *this;
+}
+
+OpSchema& OpSchema::SetLocation(const char* file, int line) {
+  return SetLocation(std::string(file), line);
+}
+
 OpSchema& OpSchema::SetDomain(std::string domain) {
   domain_ = std::move(domain);
   return *this;
+}
+
+OpSchema& OpSchema::SetDomain(const char* domain) {
+  return SetDomain(std::string(domain));
 }
 
 OpSchema& OpSchema::Attr(Attribute attr) {
@@ -294,6 +343,14 @@ OpSchema& OpSchema::Attr(
   return *this;
 }
 
+OpSchema& OpSchema::Attr(
+    const char* name,
+    const char* description,
+    AttributeProto::AttributeType type,
+    bool required) {
+  return Attr(std::string(name), std::string(description), type, required);
+}
+
 #define ATTR_SETTER_WITH_SINGLE_VALUE(type, field, attrtype)                  \
   OpSchema& OpSchema::Attr(                                                   \
       std::string name,                                                       \
@@ -301,8 +358,7 @@ OpSchema& OpSchema::Attr(
       AttributeProto::AttributeType attr_type,                                \
       const type& default_value) {                                            \
     if (attrtype != attr_type) {                                              \
-      std::cerr << "Attribute specification type mismatch.";                  \
-      abort();                                                                \
+      fail_schema("Attribute specification type mismatch.");                  \
     }                                                                         \
     AttributeProto a;                                                         \
     a.set_name(name);                                                         \
@@ -310,6 +366,13 @@ OpSchema& OpSchema::Attr(
     a.set_type(attr_type);                                                    \
     Attr(Attribute(std::move(name), std::move(description), std::move(a)));   \
     return *this;                                                             \
+  }                                                                           \
+  OpSchema& OpSchema::Attr(                                                   \
+      const char* name,                                                       \
+      const char* description,                                                \
+      AttributeProto::AttributeType attr_type,                                \
+      const type& default_value) {                                            \
+    return Attr(std::string(name), std::string(description), attr_type, default_value); \
   }
 
 #define ATTR_SETTER_WITH_LIST_VALUE(type, field, attrtype)                    \
@@ -319,8 +382,7 @@ OpSchema& OpSchema::Attr(
       AttributeProto::AttributeType attr_type,                                \
       const std::vector<type>& default_value) {                               \
     if (attrtype != attr_type) {                                              \
-      std::cerr << "Attribute specification type mismatch.";                  \
-      abort();                                                                \
+      fail_schema("Attribute specification type mismatch.");                  \
     }                                                                         \
     AttributeProto a;                                                         \
     a.set_name(name);                                                         \
@@ -339,8 +401,7 @@ OpSchema& OpSchema::Attr(
       AttributeProto::AttributeType attr_type,                      \
       const type& default_value) {                                  \
     if (attrtype != attr_type) {                                    \
-      std::cerr << "Attribute specification type mismatch.";        \
-      abort();                                                      \
+      fail_schema("Attribute specification type mismatch.");        \
     }                                                               \
     AttributeProto a;                                               \
     a.set_name(name);                                               \
@@ -357,8 +418,7 @@ OpSchema& OpSchema::Attr(
       AttributeProto::AttributeType attr_type,                    \
       const std::vector<type>& default_value) {                   \
     if (attrtype != attr_type) {                                  \
-      std::cerr << "Attribute specification type mismatch.";      \
-      abort();                                                    \
+      fail_schema("Attribute specification type mismatch.");      \
     }                                                             \
     AttributeProto a;                                             \
     a.set_name(name);                                             \
@@ -366,7 +426,7 @@ OpSchema& OpSchema::Attr(
     for (const auto& v : default_value) {                         \
       *(a.add_##field()) = v;                                     \
     }                                                             \
-    Attr(Attribute(std::move(name), std::move(description), std::move(a)));  \
+    Attr(Attribute(std::move(name), std::move(description), std::move(a))); \
     return *this;                                                 \
   }
 
@@ -405,6 +465,15 @@ OpSchema& OpSchema::Input(
   return *this;
 }
 
+OpSchema& OpSchema::Input(
+    int n,
+    const char* name,
+    const char* description,
+    const char* type_str,
+    FormalParameterOption param_option) {
+  return Input(n, std::string(name), std::string(description), std::string(type_str), param_option);
+}
+
 OpSchema& OpSchema::Output(
     int n,
     std::string name,
@@ -416,6 +485,15 @@ OpSchema& OpSchema::Output(
   }
   outputs_[n] = FormalParameter(std::move(name), std::move(description), std::move(type_str), param_option);
   return *this;
+}
+
+OpSchema& OpSchema::Output(
+    int n,
+    const char* name,
+    const char* description,
+    const char* type_str,
+    FormalParameterOption param_option) {
+  return Output(n, std::string(name), std::string(description), std::string(type_str), param_option);
 }
 
 OpSchema& OpSchema::TypeConstraint(
@@ -432,6 +510,19 @@ OpSchema& OpSchema::TypeConstraint(
   type_constraint_params_.push_back(
       TypeConstraintParam(std::move(type_str), std::move(constraints), std::move(description)));
   return *this;
+}
+
+OpSchema& OpSchema::TypeConstraint(
+    const char* type_str,
+    std::initializer_list<const char*> constraints,
+    const char* description) {
+  std::vector<std::string> constraints_vector;
+  constraints_vector.reserve(constraints.size());
+  for (auto iter = constraints.begin(); iter != constraints.end(); ++iter) {
+    constraints_vector.push_back(*iter);
+  }
+
+  return TypeConstraint(std::string(type_str), constraints_vector, std::string(description));
 }
 
 void OpSchema::ParseAndSetTypes(
@@ -575,8 +666,59 @@ std::ostream& operator<<(std::ostream& out, const OpSchema& schema) {
   return out;
 }
 
-OpName_Domain_Version_Schema_Map& OpSchemaRegistry::map() {
+// Private method used by OpSchemaRegisterOnce and OpSchemaRegistry::map()
+OpName_Domain_Version_Schema_Map& OpSchemaRegistry::GetMapWithoutEnsuringRegistration() {
   static OpName_Domain_Version_Schema_Map map;
+  return map;
+}
+
+OpName_Domain_Version_Schema_Map& OpSchemaRegistry::map() {  
+  auto& map = GetMapWithoutEnsuringRegistration();
+  
+  // The following class is used to register operators the
+  // first time this method is called, in a thread-safe fashion.
+  class SchemasRegisterer {
+   public:
+    SchemasRegisterer() {
+      // In debug builds, the number of schema registered in this constructor
+      // is compared against the number of calls to schema registration macros.
+#ifndef NDEBUG
+      size_t dbg_initial_schema_count = GetRegisteredSchemaCount();
+#endif
+
+      RegisterOnnxOperatorSetSchema();
+#ifdef ONNX_ML
+      RegisterOnnxMLOperatorSetSchema();
+#endif
+
+#ifndef NDEBUG
+      size_t dbg_registered_schema_count =
+          GetRegisteredSchemaCount() - dbg_initial_schema_count;
+
+      ONNX_EXPECTM(
+          dbg_registered_schema_count == ONNX_DBG_GET_COUNT_IN_OPSETS(),
+          "%u schema were exposed from operator sets and automatically placed into the static registry.  "
+          "%u were expected based on calls to registration macros. Operator set functions may need to be updated.",
+          dbg_registered_schema_count, ONNX_DBG_GET_COUNT_IN_OPSETS());
+#endif
+    }
+
+   private:
+    static size_t GetRegisteredSchemaCount() {
+      size_t count = 0;
+      for (auto x : GetMapWithoutEnsuringRegistration()) {
+        for (auto y : x.second) {
+          count += y.second.size();
+        }
+      }
+      return count;
+    }
+  };
+
+#ifndef __ONNX_DISABLE_STATIC_REGISTRATION
+  static SchemasRegisterer schemasRegisterer;
+#endif
+
   return map;
 }
 

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -22,8 +22,35 @@
 
 namespace ONNX_NAMESPACE {
 
+class SchemaError final : public std::runtime_error {
+public:
+	using std::runtime_error::runtime_error;
+
+	SchemaError(const std::string& message) : std::runtime_error(message) {}
+
+	const char* what() const noexcept override {
+		if (!expanded_message_.empty()) {
+			return expanded_message_.c_str();
+		}
+		return std::runtime_error::what();
+	}
+
+	void AppendContext(const std::string& context) {
+		expanded_message_ = ONNX_NAMESPACE::MakeString(
+			std::runtime_error::what(), "\n\n==> Context: ", context);
+	}
+
+private:
+	std::string expanded_message_;
+};
+
+#define fail_schema(...)                           \
+  throw ONNX_NAMESPACE::SchemaError(               \
+      ONNX_NAMESPACE::MakeString(__VA_ARGS__));
+
 using OperatorSetVersion = int;
 
+constexpr const char* AI_ONNX_ML_DOMAIN = "ai.onnx.ml";
 constexpr const char* ONNX_DOMAIN = "";
 constexpr bool OPTIONAL = false;
 
@@ -46,6 +73,12 @@ using TypeConstraintMap =
  *
  *     ONNX_OPERATOR_SCHEMA(name)
  *         .NumInputs(2).NumOutputs(1).AllowConsumed({{0, 0}});
+ *
+ * To manufacture methods that may be used to register an OpSchema non-statically,  
+ * the following may be used:
+ * 
+ *     ONNX_OPERATOR_SET_SCHEMA(name, version, OpSchema()
+ *         .NumInputs(2).NumOutputs(1).AllowConsumed({{0, 0}}));
  */
 class OpSchema final {
  public:
@@ -209,10 +242,30 @@ class OpSchema final {
   OpSchema& SetSupportLevel(SupportType supportType);
 
   // Functions to do documentation for the operator schema.
+  // This may be disabled to save memory.
+  OpSchema& SetDoc(const char* doc) {
+#ifndef __ONNX_NO_DOC_STRINGS
+    SetDoc(std::string(doc));
+#else
+    doc;
+#endif
+
+    return *this;
+  }
+  
   OpSchema& SetDoc(std::string doc);
+
+  // Functions to specify name for the operator schema.
+  OpSchema& SetName(const char* name);
+  OpSchema& SetName(std::string name);
+
+  // Functions to specify code location for the operator schema.
+  OpSchema& SetLocation(const char* file, int line);
+  OpSchema& SetLocation(std::string file, int line);
 
   // Functions to specify domain for the operator schema.
   // Default domain value (ONNX_DOMAIN) means it's ONNX domain.
+  OpSchema& SetDomain(const char* domain);
   OpSchema& SetDomain(std::string domain);
 
   struct Attribute final {
@@ -253,11 +306,17 @@ class OpSchema final {
       std::string description,                   \
       AttributeProto::AttributeType type,        \
       const TypeName& defaultValue);             \
+  /* non-STL wrapper to reduce binary size */    \
+  OpSchema& Attr(                                \
+      const char* name,                          \
+      const char* description,                   \
+      AttributeProto::AttributeType type,        \
+      const TypeName& defaultValue);             \
   OpSchema& Attr(                                \
       std::string name,                          \
       std::string description,                   \
       AttributeProto::AttributeType type,        \
-      const std::vector<TypeName>& defaultValue);
+      const std::vector<TypeName>& defaultValue); \
 
   ATTR_SETTER_WITH_DEFAULT_VALUE(int64_t)
   ATTR_SETTER_WITH_DEFAULT_VALUE(float)
@@ -271,6 +330,14 @@ class OpSchema final {
       std::string description,
       AttributeProto::AttributeType type,
       bool required = true);
+
+  // Non-STL wrapper to reduce binary size 
+  OpSchema& Attr(
+      const char* name,
+      const char* description,
+      AttributeProto::AttributeType type,
+      bool required = true);
+
   OpSchema& AllowUncheckedAttributes();
 
   // Type constraint.
@@ -307,12 +374,12 @@ class OpSchema final {
   //       2) <type> ::= <data_type> means the data is scalar (zero dimension).
   //
   // Example:
-  // ONNX_OPERATOR_SCHEMA(Sum)
+  // ONNX_OPERATOR_SET_SCHEMA(Sum, 1, OpSchema()
   // .Input(0, "input_a", "the first input", "T")
   // .Input(1, "input_b", "the second input", "T")
   // .Output(0, "sum", "the sum of two numbers", "T")
   // .TypeConstraint("T", {"float", "double", "int32"}, "allowed data types for
-  // sum.")
+  // sum."))
   //
   // Optional = true means that the input might have empty input value
   // (represented as "") in the graph even though the later inputs have values.
@@ -324,16 +391,38 @@ class OpSchema final {
       std::string description,
       std::string type_str,
       FormalParameterOption param_option = Single);
+
+  // Non-STL wrapper to reduce binary size 
+  OpSchema& Input(
+      int n,
+      const char* name,
+      const char* description,
+      const char* type_str,
+      FormalParameterOption param_option = Single);
   OpSchema& Output(
       int n,
       std::string name,
       std::string description,
       std::string type_str,
       FormalParameterOption param_option = Single);
+
+  // Non-STL wrapper to reduce binary size 
+  OpSchema& Output(
+      int n,
+      const char* name,
+      const char* description,
+      const char* type_str,
+      FormalParameterOption param_option = Single);
   OpSchema& TypeConstraint(
       std::string type_str,
       std::vector<std::string> constraints,
       std::string description);
+
+  // Non-STL wrapper to reduce binary size 
+  OpSchema& TypeConstraint(
+      const char* type_str,
+      std::initializer_list<const char* > constraints,
+      const char* description);
 
   // Convenience members for types
 
@@ -447,7 +536,7 @@ class OpSchema final {
  private:
   void ParseAndSetTypes(
       /*out*/ std::vector<OpSchema::FormalParameter>* formalParameters);
-
+  
   std::string name_;
   std::string file_;
   std::string doc_;
@@ -478,10 +567,20 @@ using OpName_Domain_Version_Schema_Map = std::unordered_map<
     std::string,
     std::unordered_map<std::string, std::map<OperatorSetVersion, OpSchema>>>;
 
+class ISchemaRegistry {
+  public:
+    virtual ~ISchemaRegistry() = default;
+
+    virtual const OpSchema* GetSchema(
+      const std::string& key,
+      const int maxInclusiveVersion,
+      const std::string& domain = ONNX_DOMAIN) const = 0;
+};
+
 /**
  * @brief A registry to hold all the operator schemas.
  */
-class OpSchemaRegistry final {
+class OpSchemaRegistry final : public ISchemaRegistry {
  public:
   // A singleton class to store domain to min/max op_set version map.
   class DomainToVersionRange final {
@@ -525,54 +624,60 @@ class OpSchemaRegistry final {
   class OpSchemaRegisterOnce final {
    public:
     OpSchemaRegisterOnce(OpSchema& op_schema) {
-      // TODO: when we fix all issues - we can add abort() here
+
       try {
         op_schema.Finalize();
+      
+        auto& m = GetMapWithoutEnsuringRegistration();
+
+        auto& op_name = op_schema.Name();
+        auto& op_domain = op_schema.domain();
+        auto ver = op_schema.SinceVersion();
+
+        if (m[op_name][op_domain].count(ver)) {
+          const auto& schema = m[op_name][op_domain][ver];
+          std::stringstream err;
+          err << "Trying to register schema with name " << op_name
+              << " (domain: " << op_domain << " version: " << ver
+              << ") from file " << op_schema.file() << " line "
+              << op_schema.line()
+              << ", but it is already registered from file "
+              << schema.file() << " line " << schema.line() << std::endl;
+          fail_schema(err.str());
+        }
+
+        auto ver_range_map = DomainToVersionRange::Instance().Map();
+        auto ver_range_it = ver_range_map.find(op_domain);
+        if (ver_range_it == ver_range_map.end()) {
+          std::stringstream err;
+          err << "Trying to register schema with name " << op_name
+              << " (domain: " << op_domain << " version: " << ver
+              << ") from file " << op_schema.file() << " line "
+              << op_schema.line() << ", but it its domain is not"
+              << "known by the checker." << std::endl;
+        
+          fail_schema(err.str());
+        }
+        auto lower_bound_incl = ver_range_it->second.first;
+        auto upper_bound_incl = ver_range_it->second.second;
+        if (!(lower_bound_incl <= ver && upper_bound_incl >= ver)) {
+          std::stringstream err;
+          err << "Trying to register schema with name " << op_name
+              << " (domain: " << op_domain << " version: " << ver
+              << ") from file " << op_schema.file() << " line "
+              << op_schema.line() << ", but it its version is not"
+              << "in the inclusive range [" << lower_bound_incl << ", "
+              << upper_bound_incl << "] (usually, this means you "
+              << "bumped the operator version but "
+              << "forgot to update the version range in DomainToVersionRange "
+              << "in onnx/defs/schema.h)." << std::endl;
+          fail_schema(err.str());
+        }
+        m[op_name][op_domain].emplace(std::make_pair(ver, op_schema));
+      
       } catch (const std::exception& e) {
         std::cerr << "Schema error: " << e.what() << std::endl;
       }
-      auto& m = map();
-      auto& op_name = op_schema.Name();
-      auto& op_domain = op_schema.domain();
-      auto ver = op_schema.SinceVersion();
-
-      if (m[op_name][op_domain].count(ver)) {
-        const auto& schema = m[op_name][op_domain][ver];
-        std::cerr << "Trying to register schema with name " << op_name
-                  << " (domain: " << op_domain << " version: " << ver
-                  << ") from file " << op_schema.file() << " line "
-                  << op_schema.line()
-                  << ", but it is already registered from file "
-                  << schema.file() << " line " << schema.line() << std::endl;
-        abort();
-      }
-
-      auto ver_range_map = DomainToVersionRange::Instance().Map();
-      auto ver_range_it = ver_range_map.find(op_domain);
-      if (ver_range_it == ver_range_map.end()) {
-        std::cerr << "Trying to register schema with name " << op_name
-                  << " (domain: " << op_domain << " version: " << ver
-                  << ") from file " << op_schema.file() << " line "
-                  << op_schema.line() << ", but it its domain is not"
-                  << "known by the checker." << std::endl;
-        abort();
-      }
-      auto lower_bound_incl = ver_range_it->second.first;
-      auto upper_bound_incl = ver_range_it->second.second;
-      if (!(lower_bound_incl <= ver && upper_bound_incl >= ver)) {
-        std::cerr
-            << "Trying to register schema with name " << op_name
-            << " (domain: " << op_domain << " version: " << ver
-            << ") from file " << op_schema.file() << " line "
-            << op_schema.line() << ", but it its version is not"
-            << "in the inclusive range [" << lower_bound_incl << ", "
-            << upper_bound_incl << "] (usually, this means you "
-            << "bumped the operator version but "
-            << "forgot to update the version range in DomainToVersionRange "
-            << "in onnx/defs/schema.h)." << std::endl;
-        abort();
-      }
-      m[op_name][op_domain].emplace(std::make_pair(ver, op_schema));
     }
   };
 
@@ -616,20 +721,31 @@ class OpSchemaRegistry final {
     }
   }
 
+  static OpSchemaRegistry *Instance();
+  
+  const OpSchema* GetSchema(
+      const std::string& key,
+      const int maxInclusiveVersion,
+      const std::string& domain = ONNX_DOMAIN) const override {
+    return Schema(key, maxInclusiveVersion, domain);
+  }
+
  private:
-  // OpSchemaRegistry should not need to be instantiated.
-  OpSchemaRegistry() = delete;
+  // OpSchemaRegistry should not need to be instantiated except statically
+  // within this class
+  OpSchemaRegistry() = default;
 
   /**
    * @brief Returns the underlying string to OpSchema map.
    *
    * You should not manually manipulate the map object returned. Instead, use
-   * the macros defined such as ONNX_OPERATOR_SCHEMA to register your operator
+   * the macros defined such as ONNX_OPERATOR_SET_SCHEMA to register your operator
    * schema.
    *
    * We wrap it inside a function to avoid the statia initialization order
    * fiasco.
    */
+  static OpName_Domain_Version_Schema_Map& GetMapWithoutEnsuringRegistration();
   static OpName_Domain_Version_Schema_Map& map();
 
  public:
@@ -657,6 +773,69 @@ class OpSchemaRegistry final {
   }
 };
 
+void RegisterSchema(OpSchema&& schema);
+
+// Registers all schema of a given operator set
+template<class T> 
+void RegisterOpSetSchema(){
+  T::ForEachSchema(RegisterSchema);
+};
+
+// Forward declaration for the non-specialized GetOpSchema method.  This enforces a consistent
+// signature on functions that query individual schema, which are defined as specializations
+// of this function.
+template <typename T> OpSchema GetOpSchema();
+
+#define ONNX_OPERATOR_SET_SCHEMA(name, ver, impl) \
+  ONNX_OPERATOR_SET_SCHEMA_EX(name, Onnx, ONNX_DOMAIN, ver, true, impl)
+
+#define ONNX_ML_OPERATOR_SET_SCHEMA(name, ver, impl) \
+  ONNX_OPERATOR_SET_SCHEMA_EX(name, OnnxML, AI_ONNX_ML_DOMAIN, ver, true, impl)
+
+// Defines specialization of GetOpSchema for a class whose name is determined based on 
+// a convention using name, domain, and version.  Operator schema are normally included
+// in operator sets and registered in OpSchemaRegistry::map(). In this case, callers should 
+// set dbg_included_in_static_opset to true.  This assists with runtime validation in
+// in DEBUG builds ensuring the intended set of operator schema is registered.
+#define ONNX_OPERATOR_SET_SCHEMA_EX(name, domain, domain_str, ver, dbg_included_in_static_opset, impl) \
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(domain, ver, name);\
+template<> OpSchema GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(domain, ver, name)>(){ \
+return impl.SetName(#name).SetDomain(domain_str).SinceVersion(ver).SetLocation(__FILE__, __LINE__); \
+} \
+size_t dbg_count_check_##name##_##domain##_ver##ver = \
+  (dbg_included_in_static_opset) ? ONNX_DBG_INCREMENT_COUNT_IN_OPSETS() : 0;
+
+#ifdef NDEBUG
+#define ONNX_DBG_INCREMENT_COUNT_IN_OPSETS() 0
+#else
+#define ONNX_DBG_INCREMENT_COUNT_IN_OPSETS() DbgOperatorSetTracker::Instance().IncrementCount()
+#define ONNX_DBG_GET_COUNT_IN_OPSETS() DbgOperatorSetTracker::Instance().GetCount()
+
+class DbgOperatorSetTracker
+{
+public:
+  static DbgOperatorSetTracker& Instance();
+
+  size_t IncrementCount() {
+    return ++count_;
+  }
+
+  size_t GetCount() const {
+    return count_;
+  }
+
+private:
+  size_t count_ = 0;
+};
+#endif
+
+// Naming convention for operator schema classes
+#define ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(domain, ver, name) name##_##domain##_ver##ver
+
+// Helper function
+size_t ReplaceAll(std::string& s, const char* from, const char* to);
+
+// Legacy macros to register schema at static initialization
 #define ONNX_OPERATOR_SCHEMA(name) \
   ONNX_OPERATOR_SCHEMA_UNIQ_HELPER(__COUNTER__, name)
 #define ONNX_OPERATOR_SCHEMA_UNIQ_HELPER(Counter, name) \

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -23,30 +23,29 @@
 namespace ONNX_NAMESPACE {
 
 class SchemaError final : public std::runtime_error {
-public:
-	using std::runtime_error::runtime_error;
+ public:
+  using std::runtime_error::runtime_error;
 
-	SchemaError(const std::string& message) : std::runtime_error(message) {}
+  SchemaError(const std::string& message) : std::runtime_error(message) {}
 
-	const char* what() const noexcept override {
-		if (!expanded_message_.empty()) {
-			return expanded_message_.c_str();
-		}
-		return std::runtime_error::what();
-	}
+  const char* what() const noexcept override {
+    if (!expanded_message_.empty()) {
+      return expanded_message_.c_str();
+    }
+    return std::runtime_error::what();
+  }
 
-	void AppendContext(const std::string& context) {
-		expanded_message_ = ONNX_NAMESPACE::MakeString(
-			std::runtime_error::what(), "\n\n==> Context: ", context);
-	}
+  void AppendContext(const std::string& context) {
+    expanded_message_ = ONNX_NAMESPACE::MakeString(
+        std::runtime_error::what(), "\n\n==> Context: ", context);
+  }
 
-private:
-	std::string expanded_message_;
+ private:
+  std::string expanded_message_;
 };
 
-#define fail_schema(...)                           \
-  throw ONNX_NAMESPACE::SchemaError(               \
-      ONNX_NAMESPACE::MakeString(__VA_ARGS__));
+#define fail_schema(...) \
+  throw ONNX_NAMESPACE::SchemaError(ONNX_NAMESPACE::MakeString(__VA_ARGS__));
 
 using OperatorSetVersion = int;
 
@@ -74,9 +73,9 @@ using TypeConstraintMap =
  *     ONNX_OPERATOR_SCHEMA(name)
  *         .NumInputs(2).NumOutputs(1).AllowConsumed({{0, 0}});
  *
- * To manufacture methods that may be used to register an OpSchema non-statically,  
- * the following may be used:
- * 
+ * To manufacture methods that may be used to register an OpSchema
+ * non-statically, the following may be used:
+ *
  *     ONNX_OPERATOR_SET_SCHEMA(name, version, OpSchema()
  *         .NumInputs(2).NumOutputs(1).AllowConsumed({{0, 0}}));
  */
@@ -252,7 +251,7 @@ class OpSchema final {
 
     return *this;
   }
-  
+
   OpSchema& SetDoc(std::string doc);
 
   // Functions to specify name for the operator schema.
@@ -316,7 +315,7 @@ class OpSchema final {
       std::string name,                          \
       std::string description,                   \
       AttributeProto::AttributeType type,        \
-      const std::vector<TypeName>& defaultValue); \
+      const std::vector<TypeName>& defaultValue);
 
   ATTR_SETTER_WITH_DEFAULT_VALUE(int64_t)
   ATTR_SETTER_WITH_DEFAULT_VALUE(float)
@@ -331,7 +330,7 @@ class OpSchema final {
       AttributeProto::AttributeType type,
       bool required = true);
 
-  // Non-STL wrapper to reduce binary size 
+  // Non-STL wrapper to reduce binary size
   OpSchema& Attr(
       const char* name,
       const char* description,
@@ -392,7 +391,7 @@ class OpSchema final {
       std::string type_str,
       FormalParameterOption param_option = Single);
 
-  // Non-STL wrapper to reduce binary size 
+  // Non-STL wrapper to reduce binary size
   OpSchema& Input(
       int n,
       const char* name,
@@ -406,7 +405,7 @@ class OpSchema final {
       std::string type_str,
       FormalParameterOption param_option = Single);
 
-  // Non-STL wrapper to reduce binary size 
+  // Non-STL wrapper to reduce binary size
   OpSchema& Output(
       int n,
       const char* name,
@@ -418,10 +417,10 @@ class OpSchema final {
       std::vector<std::string> constraints,
       std::string description);
 
-  // Non-STL wrapper to reduce binary size 
+  // Non-STL wrapper to reduce binary size
   OpSchema& TypeConstraint(
       const char* type_str,
-      std::initializer_list<const char* > constraints,
+      std::initializer_list<const char*> constraints,
       const char* description);
 
   // Convenience members for types
@@ -536,7 +535,7 @@ class OpSchema final {
  private:
   void ParseAndSetTypes(
       /*out*/ std::vector<OpSchema::FormalParameter>* formalParameters);
-  
+
   std::string name_;
   std::string file_;
   std::string doc_;
@@ -568,10 +567,10 @@ using OpName_Domain_Version_Schema_Map = std::unordered_map<
     std::unordered_map<std::string, std::map<OperatorSetVersion, OpSchema>>>;
 
 class ISchemaRegistry {
-  public:
-    virtual ~ISchemaRegistry() = default;
+ public:
+  virtual ~ISchemaRegistry() = default;
 
-    virtual const OpSchema* GetSchema(
+  virtual const OpSchema* GetSchema(
       const std::string& key,
       const int maxInclusiveVersion,
       const std::string& domain = ONNX_DOMAIN) const = 0;
@@ -624,10 +623,9 @@ class OpSchemaRegistry final : public ISchemaRegistry {
   class OpSchemaRegisterOnce final {
    public:
     OpSchemaRegisterOnce(OpSchema& op_schema) {
-
       try {
         op_schema.Finalize();
-      
+
         auto& m = GetMapWithoutEnsuringRegistration();
 
         auto& op_name = op_schema.Name();
@@ -640,8 +638,7 @@ class OpSchemaRegistry final : public ISchemaRegistry {
           err << "Trying to register schema with name " << op_name
               << " (domain: " << op_domain << " version: " << ver
               << ") from file " << op_schema.file() << " line "
-              << op_schema.line()
-              << ", but it is already registered from file "
+              << op_schema.line() << ", but it is already registered from file "
               << schema.file() << " line " << schema.line() << std::endl;
           fail_schema(err.str());
         }
@@ -655,7 +652,7 @@ class OpSchemaRegistry final : public ISchemaRegistry {
               << ") from file " << op_schema.file() << " line "
               << op_schema.line() << ", but it its domain is not"
               << "known by the checker." << std::endl;
-        
+
           fail_schema(err.str());
         }
         auto lower_bound_incl = ver_range_it->second.first;
@@ -674,7 +671,7 @@ class OpSchemaRegistry final : public ISchemaRegistry {
           fail_schema(err.str());
         }
         m[op_name][op_domain].emplace(std::make_pair(ver, op_schema));
-      
+
       } catch (const std::exception& e) {
         std::cerr << "Schema error: " << e.what() << std::endl;
       }
@@ -721,8 +718,8 @@ class OpSchemaRegistry final : public ISchemaRegistry {
     }
   }
 
-  static OpSchemaRegistry *Instance();
-  
+  static OpSchemaRegistry* Instance();
+
   const OpSchema* GetSchema(
       const std::string& key,
       const int maxInclusiveVersion,
@@ -739,8 +736,8 @@ class OpSchemaRegistry final : public ISchemaRegistry {
    * @brief Returns the underlying string to OpSchema map.
    *
    * You should not manually manipulate the map object returned. Instead, use
-   * the macros defined such as ONNX_OPERATOR_SET_SCHEMA to register your operator
-   * schema.
+   * the macros defined such as ONNX_OPERATOR_SET_SCHEMA to register your
+   * operator schema.
    *
    * We wrap it inside a function to avoid the statia initialization order
    * fiasco.
@@ -776,15 +773,16 @@ class OpSchemaRegistry final : public ISchemaRegistry {
 void RegisterSchema(OpSchema&& schema);
 
 // Registers all schema of a given operator set
-template<class T> 
-void RegisterOpSetSchema(){
+template <class T>
+void RegisterOpSetSchema() {
   T::ForEachSchema(RegisterSchema);
 };
 
-// Forward declaration for the non-specialized GetOpSchema method.  This enforces a consistent
-// signature on functions that query individual schema, which are defined as specializations
-// of this function.
-template <typename T> OpSchema GetOpSchema();
+// Forward declaration for the non-specialized GetOpSchema method.  This
+// enforces a consistent signature on functions that query individual schema,
+// which are defined as specializations of this function.
+template <typename T>
+OpSchema GetOpSchema();
 
 #define ONNX_OPERATOR_SET_SCHEMA(name, ver, impl) \
   ONNX_OPERATOR_SET_SCHEMA_EX(name, Onnx, ONNX_DOMAIN, ver, true, impl)
@@ -792,28 +790,37 @@ template <typename T> OpSchema GetOpSchema();
 #define ONNX_ML_OPERATOR_SET_SCHEMA(name, ver, impl) \
   ONNX_OPERATOR_SET_SCHEMA_EX(name, OnnxML, AI_ONNX_ML_DOMAIN, ver, true, impl)
 
-// Defines specialization of GetOpSchema for a class whose name is determined based on 
-// a convention using name, domain, and version.  Operator schema are normally included
-// in operator sets and registered in OpSchemaRegistry::map(). In this case, callers should 
-// set dbg_included_in_static_opset to true.  This assists with runtime validation in
-// in DEBUG builds ensuring the intended set of operator schema is registered.
-#define ONNX_OPERATOR_SET_SCHEMA_EX(name, domain, domain_str, ver, dbg_included_in_static_opset, impl) \
-class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(domain, ver, name);\
-template<> OpSchema GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(domain, ver, name)>(){ \
-return impl.SetName(#name).SetDomain(domain_str).SinceVersion(ver).SetLocation(__FILE__, __LINE__); \
-} \
-size_t dbg_count_check_##name##_##domain##_ver##ver = \
-  (dbg_included_in_static_opset) ? ONNX_DBG_INCREMENT_COUNT_IN_OPSETS() : 0;
+// Defines specialization of GetOpSchema for a class whose name is determined
+// based on a convention using name, domain, and version.  Operator schema are
+// normally included in operator sets and registered in OpSchemaRegistry::map().
+// In this case, callers should set dbg_included_in_static_opset to true.  This
+// assists with runtime validation in in DEBUG builds ensuring the intended set
+// of operator schema is registered.
+#define ONNX_OPERATOR_SET_SCHEMA_EX(                                        \
+    name, domain, domain_str, ver, dbg_included_in_static_opset, impl)      \
+  class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(domain, ver, name);             \
+  template <>                                                               \
+  OpSchema                                                                  \
+  GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(domain, ver, name)>() {   \
+    return impl.SetName(#name)                                              \
+        .SetDomain(domain_str)                                              \
+        .SinceVersion(ver)                                                  \
+        .SetLocation(__FILE__, __LINE__);                                   \
+  }                                                                         \
+  size_t dbg_count_check_##name##_##domain##_ver##ver =                     \
+      (dbg_included_in_static_opset) ? ONNX_DBG_INCREMENT_COUNT_IN_OPSETS() \
+                                     : 0;
 
 #ifdef NDEBUG
 #define ONNX_DBG_INCREMENT_COUNT_IN_OPSETS() 0
 #else
-#define ONNX_DBG_INCREMENT_COUNT_IN_OPSETS() DbgOperatorSetTracker::Instance().IncrementCount()
-#define ONNX_DBG_GET_COUNT_IN_OPSETS() DbgOperatorSetTracker::Instance().GetCount()
+#define ONNX_DBG_INCREMENT_COUNT_IN_OPSETS() \
+  DbgOperatorSetTracker::Instance().IncrementCount()
+#define ONNX_DBG_GET_COUNT_IN_OPSETS() \
+  DbgOperatorSetTracker::Instance().GetCount()
 
-class DbgOperatorSetTracker
-{
-public:
+class DbgOperatorSetTracker {
+ public:
   static DbgOperatorSetTracker& Instance();
 
   size_t IncrementCount() {
@@ -824,13 +831,14 @@ public:
     return count_;
   }
 
-private:
+ private:
   size_t count_ = 0;
 };
 #endif
 
 // Naming convention for operator schema classes
-#define ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(domain, ver, name) name##_##domain##_ver##ver
+#define ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(domain, ver, name) \
+  name##_##domain##_ver##ver
 
 // Helper function
 size_t ReplaceAll(std::string& s, const char* from, const char* to);

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -5,10 +5,9 @@
 
 #include <algorithm>
 
-namespace ONNX_NAMESPACE
-{
+namespace ONNX_NAMESPACE {
 
-static const char * Cast_ver6_doc = R"DOC(
+static const char* Cast_ver6_doc = R"DOC(
 The operator casts the elements of a given input tensor to a data type
 specified by the 'to' argument and returns an output tensor of the same size in
 the converted type. The 'to' argument must be one of the data types specified
@@ -16,60 +15,63 @@ in the 'DataType' enum field in the TensorProto message.
 NOTE: Casting to and from strings is not supported yet.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Cast, 6, OpSchema()
-    .SetDoc(Cast_ver6_doc)
-    .Attr(
-        "to",
-        "The data type to which the elements of the input tensor are cast."
-        "Strictly must be one of the types from DataType enum in TensorProto",
-        AttributeProto::INT)
-    .Input(0, "input", "Input tensor to be cast.", "T1")
-    .Output(
-        0,
-        "output",
-        "Output tensor with the same shape as input with type "
-        "specified by the 'to' argument",
-        "T2")
-    .TypeConstraint(
-        "T1",
-        {"tensor(float16)",
-         "tensor(float)",
-         "tensor(double)",
-         "tensor(int8)",
-         "tensor(int16)",
-         "tensor(int32)",
-         "tensor(int64)",
-         "tensor(uint8)",
-         "tensor(uint16)",
-         "tensor(uint32)",
-         "tensor(uint64)",
-         "tensor(bool)"},
-        "Constrain input types. Casting from strings and complex are not supported.")
-    .TypeConstraint(
-        "T2",
-        {"tensor(float16)",
-         "tensor(float)",
-         "tensor(double)",
-         "tensor(int8)",
-         "tensor(int16)",
-         "tensor(int32)",
-         "tensor(int64)",
-         "tensor(uint8)",
-         "tensor(uint16)",
-         "tensor(uint32)",
-         "tensor(uint64)",
-         "tensor(bool)"},
-        "Constrain output types. Casting to strings and complex are not supported.")
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      ctx.getOutputType(0)->mutable_tensor_type()->set_elem_type(
-          static_cast<TensorProto_DataType>(ctx.getAttribute("to")->i()));
-      if (!hasNInputShapes(ctx, 1)) {
-        return;
-      }
-      propagateShapeFromInputToOutput(ctx, 0, 0);
-    }));
+ONNX_OPERATOR_SET_SCHEMA(
+    Cast,
+    6,
+    OpSchema()
+        .SetDoc(Cast_ver6_doc)
+        .Attr(
+            "to",
+            "The data type to which the elements of the input tensor are cast."
+            "Strictly must be one of the types from DataType enum in TensorProto",
+            AttributeProto::INT)
+        .Input(0, "input", "Input tensor to be cast.", "T1")
+        .Output(
+            0,
+            "output",
+            "Output tensor with the same shape as input with type "
+            "specified by the 'to' argument",
+            "T2")
+        .TypeConstraint(
+            "T1",
+            {"tensor(float16)",
+             "tensor(float)",
+             "tensor(double)",
+             "tensor(int8)",
+             "tensor(int16)",
+             "tensor(int32)",
+             "tensor(int64)",
+             "tensor(uint8)",
+             "tensor(uint16)",
+             "tensor(uint32)",
+             "tensor(uint64)",
+             "tensor(bool)"},
+            "Constrain input types. Casting from strings and complex are not supported.")
+        .TypeConstraint(
+            "T2",
+            {"tensor(float16)",
+             "tensor(float)",
+             "tensor(double)",
+             "tensor(int8)",
+             "tensor(int16)",
+             "tensor(int32)",
+             "tensor(int64)",
+             "tensor(uint8)",
+             "tensor(uint16)",
+             "tensor(uint32)",
+             "tensor(uint64)",
+             "tensor(bool)"},
+            "Constrain output types. Casting to strings and complex are not supported.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          ctx.getOutputType(0)->mutable_tensor_type()->set_elem_type(
+              static_cast<TensorProto_DataType>(ctx.getAttribute("to")->i()));
+          if (!hasNInputShapes(ctx, 1)) {
+            return;
+          }
+          propagateShapeFromInputToOutput(ctx, 0, 0);
+        }));
 
-static const char * Reshape_ver5_doc = R"DOC(
+static const char* Reshape_ver5_doc = R"DOC(
 Reshape the input tensor similar to numpy.reshape.
 First input is the data tensor, second input is a shape tensor which specifies the output shape. It outputs the reshaped tensor.
 At most one dimension of the new shape can be -1. In this case, the value is
@@ -77,230 +79,250 @@ inferred from the size of the tensor and the remaining dimensions. A dimension
 could also be 0, in which case the actual dimension value is unchanged (i.e. taken
 from the input tensor).)DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Reshape, 5, OpSchema()
-    .SetDoc(Reshape_ver5_doc)
-    .Input(0, "data", "An input tensor.", "T")
-    .Input(1, "shape", "Specified shape for output.", "tensor(int64)")
-    .Output(0, "reshaped", "Reshaped data.", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      propagateElemTypeFromInputToOutput(ctx, 0, 0);
-    }));
+ONNX_OPERATOR_SET_SCHEMA(
+    Reshape,
+    5,
+    OpSchema()
+        .SetDoc(Reshape_ver5_doc)
+        .Input(0, "data", "An input tensor.", "T")
+        .Input(1, "shape", "Specified shape for output.", "tensor(int64)")
+        .Output(0, "reshaped", "Reshaped data.", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+        }));
 
-static const char * Shape_ver1_doc = R"DOC(
+static const char* Shape_ver1_doc = R"DOC(
 Takes a tensor as input and outputs an 1D int64 tensor containing the shape of the input tensor.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Shape, 1, OpSchema()
-    .SetDoc(Shape_ver1_doc)
-    .Input(0, "data", "An input tensor.", "T")
-    .Output(0, "shape", "Shape of the input tensor", "T1")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)",
-         "tensor(float)",
-         "tensor(double)",
-         "tensor(int8)",
-         "tensor(int16)",
-         "tensor(int32)",
-         "tensor(int64)",
-         "tensor(uint8)",
-         "tensor(uint16)",
-         "tensor(bool)"},
-        "Input tensor can be of arbitrary type.")
-    .TypeConstraint(
-        "T1",
-        {"tensor(int64)"},
-        "Constrains output to int64 tensor.")
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      ctx.getOutputType(0)->mutable_tensor_type()->set_elem_type(
-          TensorProto::INT64);
+ONNX_OPERATOR_SET_SCHEMA(
+    Shape,
+    1,
+    OpSchema()
+        .SetDoc(Shape_ver1_doc)
+        .Input(0, "data", "An input tensor.", "T")
+        .Output(0, "shape", "Shape of the input tensor", "T1")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)",
+             "tensor(float)",
+             "tensor(double)",
+             "tensor(int8)",
+             "tensor(int16)",
+             "tensor(int32)",
+             "tensor(int64)",
+             "tensor(uint8)",
+             "tensor(uint16)",
+             "tensor(bool)"},
+            "Input tensor can be of arbitrary type.")
+        .TypeConstraint(
+            "T1",
+            {"tensor(int64)"},
+            "Constrains output to int64 tensor.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          ctx.getOutputType(0)->mutable_tensor_type()->set_elem_type(
+              TensorProto::INT64);
 
-      if (!hasNInputShapes(ctx, 1)) {
-        return;
-      }
+          if (!hasNInputShapes(ctx, 1)) {
+            return;
+          }
 
-      if (ctx.getInputType(0)->tensor_type().has_shape()) {
-        ctx.getOutputType(0)
-            ->mutable_tensor_type()
-            ->mutable_shape()
-            ->add_dim()
-            ->set_dim_value(
-                ctx.getInputType(0)->tensor_type().shape().dim_size());
-      }
-    }));
+          if (ctx.getInputType(0)->tensor_type().has_shape()) {
+            ctx.getOutputType(0)
+                ->mutable_tensor_type()
+                ->mutable_shape()
+                ->add_dim()
+                ->set_dim_value(
+                    ctx.getInputType(0)->tensor_type().shape().dim_size());
+          }
+        }));
 
-static const char * Size_ver1_doc = R"DOC(
+static const char* Size_ver1_doc = R"DOC(
 Takes a tensor as input and outputs a int64 scalar that equals to the total number of elements of the input tensor.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Size, 1, OpSchema()
-    .SetDoc(Size_ver1_doc)
-    .Input(0, "data", "An input tensor.", "T")
-    .Output(0, "size", "Total number of elements of the input tensor", "T1")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)",
-         "tensor(float)",
-         "tensor(double)",
-         "tensor(int8)",
-         "tensor(int16)",
-         "tensor(int32)",
-         "tensor(int64)",
-         "tensor(uint8)",
-         "tensor(uint16)",
-         "tensor(bool)"},
-        "Input tensor can be of arbitrary type.")
-    .TypeConstraint(
-        "T1",
-        {"tensor(int64)"},
-        "Constrains output to int64 tensor, which should be a scalar though.")
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      ctx.getOutputType(0)->mutable_tensor_type()->set_elem_type(
-          TensorProto::INT64);
-      ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
-    }));
-
-ONNX_OPERATOR_SET_SCHEMA(Concat, 4, OpSchema()
-    .Attr("axis", "Which axis to concat on", AttributeProto::INT)
-    .SetDoc("Concatenate a list of tensors into a single tensor")
-    .Input(
-        0,
-        "inputs",
-        "List of tensors for concatenation",
-        "T",
-        OpSchema::Variadic)
-    .Output(0, "concat_result", "Concatenated tensor", "T")
-    .TypeConstraint(
-        "T",
-        OpSchema::all_tensor_types(),
-        "Constrain output types to any tensor type.")
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      propagateElemTypeFromInputToOutput(ctx, 0, 0);
-      if (ctx.getNumInputs() < 1 || !hasNInputShapes(ctx, static_cast<int>(ctx.getNumInputs()))) {
-        return;
-      }
-
-      auto axisAttr = ctx.getAttribute("axis");
-      if (!axisAttr) {
-        fail_shape_inference("Required attribute axis is missing");;
-      }
-      int axis = static_cast<int>(axisAttr->i());
-      if (axis < 0) {
-        return; // TODO: check if negative axis must be supported
-      }
-
-      bool all_lengths_known = true;
-      int total_length = 0;
-
-      auto* output_shape =
+ONNX_OPERATOR_SET_SCHEMA(
+    Size,
+    1,
+    OpSchema()
+        .SetDoc(Size_ver1_doc)
+        .Input(0, "data", "An input tensor.", "T")
+        .Output(0, "size", "Total number of elements of the input tensor", "T1")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)",
+             "tensor(float)",
+             "tensor(double)",
+             "tensor(int8)",
+             "tensor(int16)",
+             "tensor(int32)",
+             "tensor(int64)",
+             "tensor(uint8)",
+             "tensor(uint16)",
+             "tensor(bool)"},
+            "Input tensor can be of arbitrary type.")
+        .TypeConstraint(
+            "T1",
+            {"tensor(int64)"},
+            "Constrains output to int64 tensor, which should be a scalar though.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          ctx.getOutputType(0)->mutable_tensor_type()->set_elem_type(
+              TensorProto::INT64);
           ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
+        }));
 
-      for (int64_t i = 0;
-           i < ctx.getInputType(0)->tensor_type().shape().dim_size();
-           ++i) {
-        output_shape->add_dim();
-      }
+ONNX_OPERATOR_SET_SCHEMA(
+    Concat,
+    4,
+    OpSchema()
+        .Attr("axis", "Which axis to concat on", AttributeProto::INT)
+        .SetDoc("Concatenate a list of tensors into a single tensor")
+        .Input(
+            0,
+            "inputs",
+            "List of tensors for concatenation",
+            "T",
+            OpSchema::Variadic)
+        .Output(0, "concat_result", "Concatenated tensor", "T")
+        .TypeConstraint(
+            "T",
+            OpSchema::all_tensor_types(),
+            "Constrain output types to any tensor type.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          if (ctx.getNumInputs() < 1 ||
+              !hasNInputShapes(ctx, static_cast<int>(ctx.getNumInputs()))) {
+            return;
+          }
 
-      for (size_t i = 0; i < ctx.getNumInputs(); i++) {
-        const auto& shape = ctx.getInputType(i)->tensor_type().shape();
-        for (int j = 0; j < shape.dim_size(); j++) {
-          if (j == axis) {
-            if (shape.dim(j).has_dim_value()) {
-              total_length += static_cast<int>(shape.dim(j).dim_value());
-            } else {
-              all_lengths_known = false;
-            }
-          } else if (shape.dim(j).has_dim_value()) {
-            if (output_shape->dim(j).has_dim_value()) {
-              if (shape.dim(j).dim_value() !=
-                  output_shape->dim(j).dim_value()) {
-                fail_shape_inference("Dimension mismatch");;
+          auto axisAttr = ctx.getAttribute("axis");
+          if (!axisAttr) {
+            fail_shape_inference("Required attribute axis is missing");
+            ;
+          }
+          int axis = static_cast<int>(axisAttr->i());
+          if (axis < 0) {
+            return; // TODO: check if negative axis must be supported
+          }
+
+          bool all_lengths_known = true;
+          int total_length = 0;
+
+          auto* output_shape =
+              ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
+
+          for (int64_t i = 0;
+               i < ctx.getInputType(0)->tensor_type().shape().dim_size();
+               ++i) {
+            output_shape->add_dim();
+          }
+
+          for (size_t i = 0; i < ctx.getNumInputs(); i++) {
+            const auto& shape = ctx.getInputType(i)->tensor_type().shape();
+            for (int j = 0; j < shape.dim_size(); j++) {
+              if (j == axis) {
+                if (shape.dim(j).has_dim_value()) {
+                  total_length += static_cast<int>(shape.dim(j).dim_value());
+                } else {
+                  all_lengths_known = false;
+                }
+              } else if (shape.dim(j).has_dim_value()) {
+                if (output_shape->dim(j).has_dim_value()) {
+                  if (shape.dim(j).dim_value() !=
+                      output_shape->dim(j).dim_value()) {
+                    fail_shape_inference("Dimension mismatch");
+                    ;
+                  }
+                } else {
+                  *output_shape->mutable_dim(j) = shape.dim(j);
+                }
               }
-            } else {
-              *output_shape->mutable_dim(j) = shape.dim(j);
             }
           }
-        }
-      }
 
-      if (all_lengths_known) {
-        output_shape->mutable_dim(axis)->set_dim_value(total_length);
-      }
-    }));
+          if (all_lengths_known) {
+            output_shape->mutable_dim(axis)->set_dim_value(total_length);
+          }
+        }));
 
-static const char * Split_ver2_doc = R"DOC(Split a tensor into a list of tensors, along the specified
+static const char* Split_ver2_doc =
+    R"DOC(Split a tensor into a list of tensors, along the specified
 'axis'. Lengths of the parts can be specified using argument 'split'.
 Otherwise, the tensor is split to equal sized parts.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Split, 2, OpSchema()
-    .Input(0, "input", "The tensor to split", "T")
-    .Output(
-        0,
-        "outputs",
-        "One or more outputs forming list of tensors after splitting",
-        "T",
-        OpSchema::Variadic)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input types to float tensors.")
-    .Attr(
-        "axis",
-        "Which axis to split on (defaults to 0)",
-        AttributeProto::INT,
-        static_cast<int64_t>(0))
-    .Attr("split", "length of each output", AttributeProto::INTS, OPTIONAL)
-    .SetDoc(Split_ver2_doc)
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      for (int i = 0; i < static_cast<int>(ctx.getNumOutputs()); ++i) {
-        propagateElemTypeFromInputToOutput(ctx, 0, i);
-      }
+ONNX_OPERATOR_SET_SCHEMA(
+    Split,
+    2,
+    OpSchema()
+        .Input(0, "input", "The tensor to split", "T")
+        .Output(
+            0,
+            "outputs",
+            "One or more outputs forming list of tensors after splitting",
+            "T",
+            OpSchema::Variadic)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input types to float tensors.")
+        .Attr(
+            "axis",
+            "Which axis to split on (defaults to 0)",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Attr("split", "length of each output", AttributeProto::INTS, OPTIONAL)
+        .SetDoc(Split_ver2_doc)
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          for (int i = 0; i < static_cast<int>(ctx.getNumOutputs()); ++i) {
+            propagateElemTypeFromInputToOutput(ctx, 0, i);
+          }
 
-      if (!hasNInputShapes(ctx, 1)) {
-        return;
-      }
+          if (!hasNInputShapes(ctx, 1)) {
+            return;
+          }
 
-      auto axisAttr = ctx.getAttribute("axis");
-      int axis = axisAttr ? static_cast<int>(axisAttr->i()) : 0;
-      if (axis < 0) {
-        return;
-      }
-      std::vector<int64_t> split;
-      if (!getRepeatedAttribute(ctx, "split", split)) {
-        if (!ctx.getInputType(0)->tensor_type().has_shape()) {
-          return;
-        }
-        const auto& splitDim =
-            ctx.getInputType(0)->tensor_type().shape().dim(axis);
-        if (!splitDim.has_dim_value()) {
-          return;
-        }
-        int splitDimValue = static_cast<int>(splitDim.dim_value());
-        int chunkSize = splitDimValue / static_cast<int>(ctx.getNumOutputs());
-        int leftOver =
-            splitDimValue - (chunkSize * static_cast<int>(ctx.getNumOutputs()));
-        for (int i = 0; i < static_cast<int>(ctx.getNumOutputs()); i++) {
-          split.push_back(i < leftOver ? chunkSize + 1 : chunkSize);
-        }
+          auto axisAttr = ctx.getAttribute("axis");
+          int axis = axisAttr ? static_cast<int>(axisAttr->i()) : 0;
+          if (axis < 0) {
+            return;
+          }
+          std::vector<int64_t> split;
+          if (!getRepeatedAttribute(ctx, "split", split)) {
+            if (!ctx.getInputType(0)->tensor_type().has_shape()) {
+              return;
+            }
+            const auto& splitDim =
+                ctx.getInputType(0)->tensor_type().shape().dim(axis);
+            if (!splitDim.has_dim_value()) {
+              return;
+            }
+            int splitDimValue = static_cast<int>(splitDim.dim_value());
+            int chunkSize =
+                splitDimValue / static_cast<int>(ctx.getNumOutputs());
+            int leftOver = splitDimValue -
+                (chunkSize * static_cast<int>(ctx.getNumOutputs()));
+            for (int i = 0; i < static_cast<int>(ctx.getNumOutputs()); i++) {
+              split.push_back(i < leftOver ? chunkSize + 1 : chunkSize);
+            }
 
-        for (size_t i = 0; i < ctx.getNumOutputs(); i++) {
-          *ctx.getOutputType(i)->mutable_tensor_type()->mutable_shape() =
-              ctx.getInputType(0)->tensor_type().shape();
-          ctx.getOutputType(i)
-              ->mutable_tensor_type()
-              ->mutable_shape()
-              ->mutable_dim(axis)
-              ->set_dim_value(split[i]);
-        }
-      }
-    }));
+            for (size_t i = 0; i < ctx.getNumOutputs(); i++) {
+              *ctx.getOutputType(i)->mutable_tensor_type()->mutable_shape() =
+                  ctx.getInputType(0)->tensor_type().shape();
+              ctx.getOutputType(i)
+                  ->mutable_tensor_type()
+                  ->mutable_shape()
+                  ->mutable_dim(axis)
+                  ->set_dim_value(split[i]);
+            }
+          }
+        }));
 
-static const char * Slice_ver1_doc = R"DOC(
+static const char* Slice_ver1_doc = R"DOC(
 Produces a slice of the input tensor along multiple axes. Similar to numpy:
 https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html
 Slices uses `axes`, `starts` and `ends` attributes to specify the start and end
@@ -334,133 +356,143 @@ Example 2:
   ]
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Slice, 1, OpSchema()
-    .SetDoc(Slice_ver1_doc)
-    .Input(0, "data", "Tensor of data to extract slices from.", "T")
-    .Attr(
-        "axes",
-        "Axes that `starts` and `ends` apply to. "
-        "It's optional. If not present, will be treated as "
-        "[0, 1, ..., len(`starts`) - 1].",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "starts",
-        "Starting indices of corresponding axis in `axes`",
-        AttributeProto::INTS)
-    .Attr(
-        "ends",
-        "Ending indices (exclusive) of corresponding axis in axes`",
-        AttributeProto::INTS)
-    .Output(0, "output", "Sliced data tensor.", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      propagateElemTypeFromInputToOutput(ctx, 0, 0);
-      if (!hasNInputShapes(ctx, 1)) {
-        return;
-      }
-      std::vector<int64_t> starts;
-      std::vector<int64_t> ends;
-      if (!getRepeatedAttribute(ctx, "starts", starts) ||
-          !getRepeatedAttribute(ctx, "ends", ends) ||
-          starts.size() != ends.size()) {
-        fail_shape_inference("Incorrect or missing attribute value for starts and ends");;
-      }
-      std::vector<int64_t> axes;
-      if (!getRepeatedAttribute(ctx, "axes", axes)) {
-        for (int i = 0; (size_t)i < starts.size(); ++i) {
-          axes.push_back(i);
-        }
-      } else if (axes.size() != starts.size()) {
-        fail_shape_inference("Attribute axes has incorrect length");;
-      } else if (!std::is_sorted(axes.begin(), axes.end())) {
-        // TODO support shape inference for unsorted axes
-        return;
-      }
+ONNX_OPERATOR_SET_SCHEMA(
+    Slice,
+    1,
+    OpSchema()
+        .SetDoc(Slice_ver1_doc)
+        .Input(0, "data", "Tensor of data to extract slices from.", "T")
+        .Attr(
+            "axes",
+            "Axes that `starts` and `ends` apply to. "
+            "It's optional. If not present, will be treated as "
+            "[0, 1, ..., len(`starts`) - 1].",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "starts",
+            "Starting indices of corresponding axis in `axes`",
+            AttributeProto::INTS)
+        .Attr(
+            "ends",
+            "Ending indices (exclusive) of corresponding axis in axes`",
+            AttributeProto::INTS)
+        .Output(0, "output", "Sliced data tensor.", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          if (!hasNInputShapes(ctx, 1)) {
+            return;
+          }
+          std::vector<int64_t> starts;
+          std::vector<int64_t> ends;
+          if (!getRepeatedAttribute(ctx, "starts", starts) ||
+              !getRepeatedAttribute(ctx, "ends", ends) ||
+              starts.size() != ends.size()) {
+            fail_shape_inference(
+                "Incorrect or missing attribute value for starts and ends");
+            ;
+          }
+          std::vector<int64_t> axes;
+          if (!getRepeatedAttribute(ctx, "axes", axes)) {
+            for (int i = 0; (size_t)i < starts.size(); ++i) {
+              axes.push_back(i);
+            }
+          } else if (axes.size() != starts.size()) {
+            fail_shape_inference("Attribute axes has incorrect length");
+            ;
+          } else if (!std::is_sorted(axes.begin(), axes.end())) {
+            // TODO support shape inference for unsorted axes
+            return;
+          }
 
-      ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
+          ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
 
-      for (size_t i = 0, j = 0;
-           (int64_t)i < ctx.getInputType(0)->tensor_type().shape().dim_size();
-           ++i) {
-        auto* newdim = ctx.getOutputType(0)
-                           ->mutable_tensor_type()
-                           ->mutable_shape()
-                           ->add_dim();
-        if (j < axes.size() && static_cast<size_t>(axes[j]) == i) {
-          // There's a lot of potential behaviors. For now just
-          // handle some simple cases.
-          if (ctx.getInputType(0)
-                  ->tensor_type()
-                  .shape()
-                  .dim((int)i)
-                  .has_dim_value() &&
-              starts[j] >= 0 && ends[j] >= 0) {
-            auto newval = std::min(
-                              (int64_t)ctx.getInputType(0)
-                                  ->tensor_type()
-                                  .shape()
-                                  .dim((int)i)
-                                  .dim_value(),
-                              ends[j]) -
-                starts[j];
-            if (newval >= 0) {
-              newdim->set_dim_value(newval);
+          for (size_t i = 0, j = 0; (int64_t)i <
+               ctx.getInputType(0)->tensor_type().shape().dim_size();
+               ++i) {
+            auto* newdim = ctx.getOutputType(0)
+                               ->mutable_tensor_type()
+                               ->mutable_shape()
+                               ->add_dim();
+            if (j < axes.size() && static_cast<size_t>(axes[j]) == i) {
+              // There's a lot of potential behaviors. For now just
+              // handle some simple cases.
+              if (ctx.getInputType(0)
+                      ->tensor_type()
+                      .shape()
+                      .dim((int)i)
+                      .has_dim_value() &&
+                  starts[j] >= 0 && ends[j] >= 0) {
+                auto newval = std::min(
+                                  (int64_t)ctx.getInputType(0)
+                                      ->tensor_type()
+                                      .shape()
+                                      .dim((int)i)
+                                      .dim_value(),
+                                  ends[j]) -
+                    starts[j];
+                if (newval >= 0) {
+                  newdim->set_dim_value(newval);
+                }
+              }
+              ++j;
+            } else {
+              *newdim = ctx.getInputType(0)->tensor_type().shape().dim((int)i);
             }
           }
-          ++j;
-        } else {
-          *newdim = ctx.getInputType(0)->tensor_type().shape().dim((int)i);
-        }
-      }
-    }));
+        }));
 
-static const char * Transpose_ver1_doc = R"DOC(
+static const char* Transpose_ver1_doc = R"DOC(
 Transpose the input tensor similar to numpy.transpose. For example, when
 perm=(1, 0, 2), given an input tensor of shape (1, 2, 3), the output shape
 will be (2, 1, 3).
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Transpose, 1, OpSchema()
-    .SetDoc(Transpose_ver1_doc)
-    .Attr(
-        "perm",
-        "A list of integers. By default, reverse the dimensions, "
-        "otherwise permute the axes according to the values given.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Input(0, "data", "An input tensor.", "T")
-    .Output(0, "transposed", "Transposed output.", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      propagateElemTypeFromInputToOutput(ctx, 0, 0);
-      if (!hasNInputShapes(ctx, 1)) {
-        return;
-      }
+ONNX_OPERATOR_SET_SCHEMA(
+    Transpose,
+    1,
+    OpSchema()
+        .SetDoc(Transpose_ver1_doc)
+        .Attr(
+            "perm",
+            "A list of integers. By default, reverse the dimensions, "
+            "otherwise permute the axes according to the values given.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Input(0, "data", "An input tensor.", "T")
+        .Output(0, "transposed", "Transposed output.", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          if (!hasNInputShapes(ctx, 1)) {
+            return;
+          }
 
-      std::vector<int64_t> perm;
-      if (!getRepeatedAttribute(ctx, "perm", perm)) {
-        for (int i = ctx.getInputType(0)->tensor_type().shape().dim_size() - 1;
-             i >= 0;
-             --i) {
-          perm.push_back(i);
-        }
-      }
+          std::vector<int64_t> perm;
+          if (!getRepeatedAttribute(ctx, "perm", perm)) {
+            for (int i =
+                     ctx.getInputType(0)->tensor_type().shape().dim_size() - 1;
+                 i >= 0;
+                 --i) {
+              perm.push_back(i);
+            }
+          }
 
-      propagateElemTypeFromInputToOutput(ctx, 0, 0);
-      for (size_t i = 0; i < perm.size(); ++i) {
-        appendSingleDimCopiedFromInputTypeToOutputType(
-            ctx, 0, 0, static_cast<size_t>(perm[i]));
-      }
-    }));
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          for (size_t i = 0; i < perm.size(); ++i) {
+            appendSingleDimCopiedFromInputTypeToOutputType(
+                ctx, 0, 0, static_cast<size_t>(perm[i]));
+          }
+        }));
 
-static const char * Gather_ver1_doc = R"DOC(
+static const char* Gather_ver1_doc = R"DOC(
 Given `data` tensor of rank r >= 1, and `indices` tensor of rank q, gather
 entries of the axis dimension of `data` (by default outer-most one as axis=0) indexed by `indices`, and concatenates
 them in an output tensor of rank q + (r - 1).
@@ -503,98 +535,108 @@ Example 2:
   ]
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Gather, 1, OpSchema()
-    .SetDoc(Gather_ver1_doc)
-    .Attr(
-        "axis",
-        "Which axis to gather on, defaults to 0. Negative value means "
-        "counting dimensions from the back. Accepted range in [-r, r-1]",
-        AttributeProto::INT,
-        static_cast<int64_t>(0))
-    .Input(0, "data", "Tensor of rank r >= 1.", "T")
-    .Input(
-        1,
-        "indices",
-        "Tensor of int32/int64 indices, of any rank q.",
-        "Tind")
-    .Output(0, "output", "Tensor of rank q + (r - 1).", "T")
-    .TypeConstraint(
-        "T",
-        OpSchema::all_tensor_types(),
-        "Constrain input and output types to any tensor type.")
-    .TypeConstraint(
-        "Tind",
-        {"tensor(int32)", "tensor(int64)"},
-        "Constrain indices to integer types")
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      propagateElemTypeFromInputToOutput(ctx, 0, 0);
-      if (!hasNInputShapes(ctx, 2)) {
-        return;
-      }
+ONNX_OPERATOR_SET_SCHEMA(
+    Gather,
+    1,
+    OpSchema()
+        .SetDoc(Gather_ver1_doc)
+        .Attr(
+            "axis",
+            "Which axis to gather on, defaults to 0. Negative value means "
+            "counting dimensions from the back. Accepted range in [-r, r-1]",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Input(0, "data", "Tensor of rank r >= 1.", "T")
+        .Input(
+            1,
+            "indices",
+            "Tensor of int32/int64 indices, of any rank q.",
+            "Tind")
+        .Output(0, "output", "Tensor of rank q + (r - 1).", "T")
+        .TypeConstraint(
+            "T",
+            OpSchema::all_tensor_types(),
+            "Constrain input and output types to any tensor type.")
+        .TypeConstraint(
+            "Tind",
+            {"tensor(int32)", "tensor(int64)"},
+            "Constrain indices to integer types")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          if (!hasNInputShapes(ctx, 2)) {
+            return;
+          }
 
-      int r = ctx.getInputType(0)->tensor_type().shape().dim_size();
-      int q = ctx.getInputType(1)->tensor_type().shape().dim_size();
+          int r = ctx.getInputType(0)->tensor_type().shape().dim_size();
+          int q = ctx.getInputType(1)->tensor_type().shape().dim_size();
 
-      int out_rank = q + r - 1;
+          int out_rank = q + r - 1;
 
-      if (out_rank == 0) {
-        ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
-      }
-      for (int i = 0; i < out_rank; ++i) {
-        ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim();
-      }
-    }));
+          if (out_rank == 0) {
+            ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
+          }
+          for (int i = 0; i < out_rank; ++i) {
+            ctx.getOutputType(0)
+                ->mutable_tensor_type()
+                ->mutable_shape()
+                ->add_dim();
+          }
+        }));
 
-static const char * Squeeze_ver1_doc = R"DOC(
+static const char* Squeeze_ver1_doc = R"DOC(
 Remove single-dimensional entries from the shape of a tensor.
 Takes a  parameter `axes` with a list of axes to squeeze.
 If an axis is selected with shape entry not equal to one, an error is raised.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Squeeze, 1, OpSchema()
-    .Attr(
-        "axes",
-        "List of positive integers, indicate the dimensions to squeeze.",
-        AttributeProto::INTS)
-    .SetDoc(Squeeze_ver1_doc)
-    .Input(0, "data", "Tensors with at least max(dims) dimensions.", "T")
-    .Output(0, "squeezed", "Reshaped tensor with same data as input.", "T")
-    .TypeConstraint(
-        "T",
-        OpSchema::all_tensor_types(),
-        "Constrain input and output types to any tensor type.")
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      propagateElemTypeFromInputToOutput(ctx, 0, 0);
-      if (!hasNInputShapes(ctx, 1)) {
-        return;
-      }
+ONNX_OPERATOR_SET_SCHEMA(
+    Squeeze,
+    1,
+    OpSchema()
+        .Attr(
+            "axes",
+            "List of positive integers, indicate the dimensions to squeeze.",
+            AttributeProto::INTS)
+        .SetDoc(Squeeze_ver1_doc)
+        .Input(0, "data", "Tensors with at least max(dims) dimensions.", "T")
+        .Output(0, "squeezed", "Reshaped tensor with same data as input.", "T")
+        .TypeConstraint(
+            "T",
+            OpSchema::all_tensor_types(),
+            "Constrain input and output types to any tensor type.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          if (!hasNInputShapes(ctx, 1)) {
+            return;
+          }
 
-      std::vector<int64_t> axes;
-      if (!getRepeatedAttribute(ctx, "axes", axes)) {
-        return;
-      }
+          std::vector<int64_t> axes;
+          if (!getRepeatedAttribute(ctx, "axes", axes)) {
+            return;
+          }
 
-      if (!ctx.getInputType(0)->tensor_type().has_shape()) {
-        return;
-      }
+          if (!ctx.getInputType(0)->tensor_type().has_shape()) {
+            return;
+          }
 
-      ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
+          ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
 
-      for (int i = 0, j = 0;
-           i < ctx.getInputType(0)->tensor_type().shape().dim_size();
-           ++i) {
-        if (static_cast<size_t>(j) < axes.size() && axes[j] == i) {
-          ++j;
-        } else {
-          *ctx.getOutputType(0)
-               ->mutable_tensor_type()
-               ->mutable_shape()
-               ->add_dim() = ctx.getInputType(0)->tensor_type().shape().dim(i);
-        }
-      }
-    }));
+          for (int i = 0, j = 0;
+               i < ctx.getInputType(0)->tensor_type().shape().dim_size();
+               ++i) {
+            if (static_cast<size_t>(j) < axes.size() && axes[j] == i) {
+              ++j;
+            } else {
+              *ctx.getOutputType(0)
+                   ->mutable_tensor_type()
+                   ->mutable_shape()
+                   ->add_dim() =
+                  ctx.getInputType(0)->tensor_type().shape().dim(i);
+            }
+          }
+        }));
 
-static const char * Unsqueeze_ver1_doc = R"DOC(
+static const char* Unsqueeze_ver1_doc = R"DOC(
 Insert single-dimensional entries to the shape of a tensor.
 Takes one required argument `axes`, a list of dimensions that will be inserted.
 Dimension indices in `axes` are as seen in the output tensor. For example:
@@ -602,67 +644,72 @@ Dimension indices in `axes` are as seen in the output tensor. For example:
   Unsqueeze(tensor, axes=[0, 4]) has shape [1, 3, 4, 5, 1]
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Unsqueeze, 1, OpSchema()
-    .Attr(
-        "axes",
-        "List of positive integers, indicate the dimensions to be inserted",
-        AttributeProto::INTS)
-    .SetDoc(Unsqueeze_ver1_doc)
-    .Input(0, "data", "Original tensor", "T")
-    .Output(0, "expanded", "Reshaped tensor with same data as input.", "T")
-    .TypeConstraint(
-        "T",
-        OpSchema::all_tensor_types(),
-        "Constrain input and output types to any tensor type.")
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      propagateElemTypeFromInputToOutput(ctx, 0, 0);
-      if (!hasNInputShapes(ctx, 1)) {
-        return;
-      }
+ONNX_OPERATOR_SET_SCHEMA(
+    Unsqueeze,
+    1,
+    OpSchema()
+        .Attr(
+            "axes",
+            "List of positive integers, indicate the dimensions to be inserted",
+            AttributeProto::INTS)
+        .SetDoc(Unsqueeze_ver1_doc)
+        .Input(0, "data", "Original tensor", "T")
+        .Output(0, "expanded", "Reshaped tensor with same data as input.", "T")
+        .TypeConstraint(
+            "T",
+            OpSchema::all_tensor_types(),
+            "Constrain input and output types to any tensor type.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          if (!hasNInputShapes(ctx, 1)) {
+            return;
+          }
 
-      std::vector<int64_t> axes;
-      if (!getRepeatedAttribute(ctx, "axes", axes)) {
-        return;
-      }
-      std::sort(axes.begin(), axes.end());
+          std::vector<int64_t> axes;
+          if (!getRepeatedAttribute(ctx, "axes", axes)) {
+            return;
+          }
+          std::sort(axes.begin(), axes.end());
 
-      if (!ctx.getInputType(0)->tensor_type().has_shape()) {
-        return;
-      }
+          if (!ctx.getInputType(0)->tensor_type().has_shape()) {
+            return;
+          }
 
-      ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
+          ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
 
-      int j = 0;
-      for (int i = 0; i < ctx.getInputType(0)->tensor_type().shape().dim_size();
-           ++i) {
-        while (static_cast<size_t>(j) < axes.size() &&
-               axes[j] ==
-                   ctx.getOutputType(0)->tensor_type().shape().dim_size()) {
-          ctx.getOutputType(0)
-              ->mutable_tensor_type()
-              ->mutable_shape()
-              ->add_dim()
-              ->set_dim_value(1);
-          ++j;
-        }
-        *ctx.getOutputType(0)
-             ->mutable_tensor_type()
-             ->mutable_shape()
-             ->add_dim() = ctx.getInputType(0)->tensor_type().shape().dim(i);
-      }
-      while (static_cast<size_t>(j) < axes.size() &&
-             axes[j] ==
-                 ctx.getOutputType(0)->tensor_type().shape().dim_size()) {
-        ctx.getOutputType(0)
-            ->mutable_tensor_type()
-            ->mutable_shape()
-            ->add_dim()
-            ->set_dim_value(1);
-        ++j;
-      }
-    }));
+          int j = 0;
+          for (int i = 0;
+               i < ctx.getInputType(0)->tensor_type().shape().dim_size();
+               ++i) {
+            while (static_cast<size_t>(j) < axes.size() &&
+                   axes[j] ==
+                       ctx.getOutputType(0)->tensor_type().shape().dim_size()) {
+              ctx.getOutputType(0)
+                  ->mutable_tensor_type()
+                  ->mutable_shape()
+                  ->add_dim()
+                  ->set_dim_value(1);
+              ++j;
+            }
+            *ctx.getOutputType(0)
+                 ->mutable_tensor_type()
+                 ->mutable_shape()
+                 ->add_dim() =
+                ctx.getInputType(0)->tensor_type().shape().dim(i);
+          }
+          while (static_cast<size_t>(j) < axes.size() &&
+                 axes[j] ==
+                     ctx.getOutputType(0)->tensor_type().shape().dim_size()) {
+            ctx.getOutputType(0)
+                ->mutable_tensor_type()
+                ->mutable_shape()
+                ->add_dim()
+                ->set_dim_value(1);
+            ++j;
+          }
+        }));
 
-static const char * Pad_ver2_doc = R"DOC(
+static const char* Pad_ver2_doc = R"DOC(
 Given `data` tensor, pads, mode, and value.
 Example:
   Insert 0 pads to the beginning of the second dimension.
@@ -681,238 +728,259 @@ Example:
   ]
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Pad, 2, OpSchema()
-    .Attr(
-        "pads",
-        "List of integers indicating the number of padding elements to add or remove (if negative) "
-        "at the beginning and end of each axis. For 2D it is the number of pixels. "
-        "`pads` rank should be double of the input's rank. `pads` format should be as follow "
-        "[x1_begin, x2_begin...x1_end, x2_end,...], where xi_begin the number of pixels "
-        "added at the beginning of axis `i` and xi_end, the number of pixels added at "
-        "the end of axis `i`.",
-        AttributeProto::INTS)
-    .Attr(
-        "mode",
-        "Three modes: constant(default), reflect, edge",
-        AttributeProto::STRING,
-        std::string("constant"))
-    .Attr(
-        "value",
-        "One float, indicates the value to be filled, default is 0",
-        AttributeProto::FLOAT,
-        0.0f)
-    .SetDoc(Pad_ver2_doc)
-    .Input(0, "data", "Input tensor.", "T")
-    .Output(0, "output", "Tensor after padding.", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.")
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      propagateElemTypeFromInputToOutput(ctx, 0, 0);
-      if (!hasNInputShapes(ctx, 1)) {
-        return;
-      }
+ONNX_OPERATOR_SET_SCHEMA(
+    Pad,
+    2,
+    OpSchema()
+        .Attr(
+            "pads",
+            "List of integers indicating the number of padding elements to add or remove (if negative) "
+            "at the beginning and end of each axis. For 2D it is the number of pixels. "
+            "`pads` rank should be double of the input's rank. `pads` format should be as follow "
+            "[x1_begin, x2_begin...x1_end, x2_end,...], where xi_begin the number of pixels "
+            "added at the beginning of axis `i` and xi_end, the number of pixels added at "
+            "the end of axis `i`.",
+            AttributeProto::INTS)
+        .Attr(
+            "mode",
+            "Three modes: constant(default), reflect, edge",
+            AttributeProto::STRING,
+            std::string("constant"))
+        .Attr(
+            "value",
+            "One float, indicates the value to be filled, default is 0",
+            AttributeProto::FLOAT,
+            0.0f)
+        .SetDoc(Pad_ver2_doc)
+        .Input(0, "data", "Input tensor.", "T")
+        .Output(0, "output", "Tensor after padding.", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          if (!hasNInputShapes(ctx, 1)) {
+            return;
+          }
 
-      auto& input_shape = ctx.getInputType(0)->tensor_type().shape();
+          auto& input_shape = ctx.getInputType(0)->tensor_type().shape();
 
-      std::vector<int64_t> pads;
-      if (!getRepeatedAttribute(ctx, "pads", pads))
-        fail_shape_inference("Attribute value for pads is required");
-      if (pads.size() !=
-              static_cast<size_t>(input_shape.dim_size() * 2)) {
-        fail_shape_inference("Attribute pads has incorrect length");;
-      }
+          std::vector<int64_t> pads;
+          if (!getRepeatedAttribute(ctx, "pads", pads))
+            fail_shape_inference("Attribute value for pads is required");
+          if (pads.size() != static_cast<size_t>(input_shape.dim_size() * 2)) {
+            fail_shape_inference("Attribute pads has incorrect length");
+            ;
+          }
 
-      ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
+          ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
 
-      for (size_t i = 0;
-           (int64_t)i < input_shape.dim_size();
-           ++i) {
-        auto* newdim = ctx.getOutputType(0)
-                           ->mutable_tensor_type()
-                           ->mutable_shape()
-                           ->add_dim();
-        if (ctx.getInputType(0)
-                ->tensor_type()
-                .shape()
-                .dim((int)i)
-                .has_dim_value()) {
-          newdim->set_dim_value(
-              ctx.getInputType(0)
-                  ->tensor_type()
-                  .shape()
-                  .dim((int)i)
-                  .dim_value() +
-              pads[i] + pads[input_shape.dim_size() + i]);
-        } else if (pads[i] + pads[input_shape.dim_size() + i] == 0) {
-          *newdim = input_shape.dim((int)i);
-        }
-      }
-    }));
+          for (size_t i = 0; (int64_t)i < input_shape.dim_size(); ++i) {
+            auto* newdim = ctx.getOutputType(0)
+                               ->mutable_tensor_type()
+                               ->mutable_shape()
+                               ->add_dim();
+            if (ctx.getInputType(0)
+                    ->tensor_type()
+                    .shape()
+                    .dim((int)i)
+                    .has_dim_value()) {
+              newdim->set_dim_value(
+                  ctx.getInputType(0)
+                      ->tensor_type()
+                      .shape()
+                      .dim((int)i)
+                      .dim_value() +
+                  pads[i] + pads[input_shape.dim_size() + i]);
+            } else if (pads[i] + pads[input_shape.dim_size() + i] == 0) {
+              *newdim = input_shape.dim((int)i);
+            }
+          }
+        }));
 
-static const char * SpaceToDepth_ver1_doc = R"DOC(SpaceToDepth rearranges blocks of spatial data into depth. More specifically,
+static const char* SpaceToDepth_ver1_doc =
+    R"DOC(SpaceToDepth rearranges blocks of spatial data into depth. More specifically,
 this op outputs a copy of the input tensor where values from the height and width dimensions
 are moved to the depth dimension.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(SpaceToDepth, 1, OpSchema()
-    .Attr(
-        "blocksize",
-        "Blocks of [blocksize, blocksize] are moved.",
-        AttributeProto::INT)
-    .SetDoc(SpaceToDepth_ver1_doc)
-    .Input(
-        0,
-        "input",
-        "Input tensor of [N,C,H,W], where N is the batch axis, C is the channel or depth"
-        ", H is the height and W is the width.",
-        "T")
-    .Output(
-        0,
-        "output",
-        "Output tensor of [N, C * blocksize * blocksize, H/blocksize, W/blocksize].",
-        "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input types to float tensors.")
-	.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-		propagateElemTypeFromInputToOutput(ctx, 0, 0);
-		auto blocksize = getAttribute(ctx, "blocksize", 0);
-		if (blocksize <= 0)
+ONNX_OPERATOR_SET_SCHEMA(
+    SpaceToDepth,
+    1,
+    OpSchema()
+        .Attr(
+            "blocksize",
+            "Blocks of [blocksize, blocksize] are moved.",
+            AttributeProto::INT)
+        .SetDoc(SpaceToDepth_ver1_doc)
+        .Input(
+            0,
+            "input",
+            "Input tensor of [N,C,H,W], where N is the batch axis, C is the channel or depth"
+            ", H is the height and W is the width.",
+            "T")
+        .Output(
+            0,
+            "output",
+            "Output tensor of [N, C * blocksize * blocksize, H/blocksize, W/blocksize].",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input types to float tensors.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          auto blocksize = getAttribute(ctx, "blocksize", 0);
+          if (blocksize <= 0)
             fail_shape_inference("Blocksize must be positive");
-		if (hasInputShape(ctx, 0)) {
-			auto& input_shape = getInputShape(ctx, 0);
-			if (input_shape.dim_size() == 4) {
-				// TODO: Clarify what behavior should be if H or W is not a multiple of blocksize.
-				updateOutputShape(ctx, 0, {
-					input_shape.dim(0),
-					input_shape.dim(1) * (blocksize * blocksize),
-					input_shape.dim(2) / blocksize,
-					input_shape.dim(3) / blocksize
-				});
-			} else
-                fail_shape_inference("Input tensor must be 4-dimensional");
-		}
-    }));
+          if (hasInputShape(ctx, 0)) {
+            auto& input_shape = getInputShape(ctx, 0);
+            if (input_shape.dim_size() == 4) {
+              // TODO: Clarify what behavior should be if H or W is not a
+              // multiple of blocksize.
+              updateOutputShape(
+                  ctx,
+                  0,
+                  {input_shape.dim(0),
+                   input_shape.dim(1) * (blocksize * blocksize),
+                   input_shape.dim(2) / blocksize,
+                   input_shape.dim(3) / blocksize});
+            } else
+              fail_shape_inference("Input tensor must be 4-dimensional");
+          }
+        }));
 
-static const char * DepthToSpace_ver1_doc = R"DOC(DepthToSpace rearranges (permutes) data from depth into blocks of spatial data.
+static const char* DepthToSpace_ver1_doc =
+    R"DOC(DepthToSpace rearranges (permutes) data from depth into blocks of spatial data.
 This is the reverse transformation of SpaceToDepth. More specifically, this op outputs a copy of
 the input tensor where values from the depth dimension are moved in spatial blocks to the height
 and width dimensions.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(DepthToSpace, 1, OpSchema()
-    .Attr(
-        "blocksize",
-        "Blocks of [blocksize, blocksize] are moved.",
-        AttributeProto::INT)
-    .SetDoc(DepthToSpace_ver1_doc)
-    .Input(
-        0,
-        "input",
-        "Input tensor of [N,C,H,W], where N is the batch axis, C is the channel or depth"
-        ", H is the height and W is the width.",
-        "T")
-    .Output(
-        0,
-        "output",
-        "Output tensor of [N, C/(blocksize * blocksize), H * blocksize, W * blocksize].",
-        "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input types to float tensors.")
-	.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-		propagateElemTypeFromInputToOutput(ctx, 0, 0);
-		auto blocksize = getAttribute(ctx, "blocksize", 0);
-		if (blocksize <= 0)
+ONNX_OPERATOR_SET_SCHEMA(
+    DepthToSpace,
+    1,
+    OpSchema()
+        .Attr(
+            "blocksize",
+            "Blocks of [blocksize, blocksize] are moved.",
+            AttributeProto::INT)
+        .SetDoc(DepthToSpace_ver1_doc)
+        .Input(
+            0,
+            "input",
+            "Input tensor of [N,C,H,W], where N is the batch axis, C is the channel or depth"
+            ", H is the height and W is the width.",
+            "T")
+        .Output(
+            0,
+            "output",
+            "Output tensor of [N, C/(blocksize * blocksize), H * blocksize, W * blocksize].",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input types to float tensors.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          auto blocksize = getAttribute(ctx, "blocksize", 0);
+          if (blocksize <= 0)
             fail_shape_inference("Blocksize must be positive");
-		if (hasInputShape(ctx, 0)) {
-			auto& input_shape = getInputShape(ctx, 0);
-			if (input_shape.dim_size() == 4) {
-				// TODO: Clarify what behavior should be if C is not a multiple of blocksize*blocksize.
-				updateOutputShape(ctx, 0, {
-					input_shape.dim(0),
-					input_shape.dim(1) / (blocksize * blocksize),
-					input_shape.dim(2) * blocksize,
-					input_shape.dim(3) * blocksize
-				});
-			} else
-                fail_shape_inference("Input tensor must be 4-dimensional");
-		}
-	}));
+          if (hasInputShape(ctx, 0)) {
+            auto& input_shape = getInputShape(ctx, 0);
+            if (input_shape.dim_size() == 4) {
+              // TODO: Clarify what behavior should be if C is not a multiple of
+              // blocksize*blocksize.
+              updateOutputShape(
+                  ctx,
+                  0,
+                  {input_shape.dim(0),
+                   input_shape.dim(1) / (blocksize * blocksize),
+                   input_shape.dim(2) * blocksize,
+                   input_shape.dim(3) * blocksize});
+            } else
+              fail_shape_inference("Input tensor must be 4-dimensional");
+          }
+        }));
 
-static const char * Tile_ver6_doc = R"DOC(Constructs a tensor by tiling a given tensor.
+static const char* Tile_ver6_doc =
+    R"DOC(Constructs a tensor by tiling a given tensor.
 This is the same as function `tile` in Numpy, but no broadcast.
 For example A = [[1, 2], [3, 4]], B = [1, 2], tile(A, B) = [[1, 2, 1, 2], [3, 4, 3, 4]]
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Tile, 6, OpSchema()
-    .SetDoc(Tile_ver6_doc)
-    .Input(0, "input", "Input tensor of any shape.", "T")
-    .Input(
-        1,
-        "repeats",
-        "1D int64 tensor of the same length as input's dimension number, "
-        "includes numbers of repeated copies along input's dimensions.",
-        "T1")
-    .Output(
-        0,
-        "output",
-        "Output tensor of the same dimension and type as tensor input. "
-        "output_dim[i] = input_dim[i] * repeats[i]",
-        "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output's types to float tensors.")
-    .TypeConstraint(
-        "T1",
-        {"tensor(int64)"},
-        "Constrain repeat's type to int64 tensors.")
-	.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-	    propagateElemTypeFromInputToOutput(ctx, 0, 0);
-		// Only rank of output can be inferred. We can do better if second input is
-		// a constant, but this requires extending InferenceContext interface to
-		// get values of constant inputs.
-     }));
+ONNX_OPERATOR_SET_SCHEMA(
+    Tile,
+    6,
+    OpSchema()
+        .SetDoc(Tile_ver6_doc)
+        .Input(0, "input", "Input tensor of any shape.", "T")
+        .Input(
+            1,
+            "repeats",
+            "1D int64 tensor of the same length as input's dimension number, "
+            "includes numbers of repeated copies along input's dimensions.",
+            "T1")
+        .Output(
+            0,
+            "output",
+            "Output tensor of the same dimension and type as tensor input. "
+            "output_dim[i] = input_dim[i] * repeats[i]",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output's types to float tensors.")
+        .TypeConstraint(
+            "T1",
+            {"tensor(int64)"},
+            "Constrain repeat's type to int64 tensors.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          // Only rank of output can be inferred. We can do better if second
+          // input is a constant, but this requires extending InferenceContext
+          // interface to get values of constant inputs.
+        }));
 
-static const char * Upsample_ver7_doc = R"DOC(
+static const char* Upsample_ver7_doc = R"DOC(
 Upsample the input tensor.
 Each dimension value of the output tensor is:
   output_dimension = floor(input_dimension * scale).
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Upsample, 7, OpSchema()
-    .Attr(
-        "scales",
-        "The scale array along each dimension. It takes value greater than or equal to 1."
-        " The number of elements of 'scales' should be the same as the rank of input 'X'.",
-        AttributeProto::FLOATS)
-    .Attr(
-        "mode",
-        "Two interpolation modes: nearest (default), and linear (including bilinear, trilinear, etc)",
-        AttributeProto::STRING,
-        std::string("nearest"))
-    .Input(0, "X", "N-D tensor", "T")
-    .Output(0, "Y", "N-D tensor after resizing", "T")
-    .TypeConstraint(
-        "T",
-        OpSchema::all_tensor_types(),
-        "Constrain input/output types to all tensor types.")
-    .SetDoc(Upsample_ver7_doc));
+ONNX_OPERATOR_SET_SCHEMA(
+    Upsample,
+    7,
+    OpSchema()
+        .Attr(
+            "scales",
+            "The scale array along each dimension. It takes value greater than or equal to 1."
+            " The number of elements of 'scales' should be the same as the rank of input 'X'.",
+            AttributeProto::FLOATS)
+        .Attr(
+            "mode",
+            "Two interpolation modes: nearest (default), and linear (including bilinear, trilinear, etc)",
+            AttributeProto::STRING,
+            std::string("nearest"))
+        .Input(0, "X", "N-D tensor", "T")
+        .Output(0, "Y", "N-D tensor after resizing", "T")
+        .TypeConstraint(
+            "T",
+            OpSchema::all_tensor_types(),
+            "Constrain input/output types to all tensor types.")
+        .SetDoc(Upsample_ver7_doc));
 
-ONNX_OPERATOR_SET_SCHEMA(Identity, 1, OpSchema()
-.SetDoc("Identity operator")
-.Input(0, "input", "Input tensor", "T")
-.Output(
-	0,
-	"output",
-	"Tensor to copy input into.",
-	"T")
-	.TypeConstraint("T", OpSchema::all_tensor_types(),
-		"Constrain input and output types to all tensor types.")
-	.TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
-}
+ONNX_OPERATOR_SET_SCHEMA(
+    Identity,
+    1,
+    OpSchema()
+        .SetDoc("Identity operator")
+        .Input(0, "input", "Input tensor", "T")
+        .Output(0, "output", "Tensor to copy input into.", "T")
+        .TypeConstraint(
+            "T",
+            OpSchema::all_tensor_types(),
+            "Constrain input and output types to all tensor types.")
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+} // namespace ONNX_NAMESPACE

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -5,17 +5,19 @@
 
 #include <algorithm>
 
-using namespace ONNX_NAMESPACE;
+namespace ONNX_NAMESPACE
+{
 
-ONNX_OPERATOR_SCHEMA(Cast)
-    .SinceVersion(6)
-    .SetDoc(R"DOC(
+static const char * Cast_ver6_doc = R"DOC(
 The operator casts the elements of a given input tensor to a data type
 specified by the 'to' argument and returns an output tensor of the same size in
 the converted type. The 'to' argument must be one of the data types specified
 in the 'DataType' enum field in the TensorProto message.
 NOTE: Casting to and from strings is not supported yet.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Cast, 6, OpSchema()
+    .SetDoc(Cast_ver6_doc)
     .Attr(
         "to",
         "The data type to which the elements of the input tensor are cast."
@@ -65,20 +67,20 @@ NOTE: Casting to and from strings is not supported yet.
         return;
       }
       propagateShapeFromInputToOutput(ctx, 0, 0);
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(Reshape)
-    .SinceVersion(6)
-    .SetDoc(R"DOC(
+static const char * Reshape_ver5_doc = R"DOC(
 Reshape the input tensor similar to numpy.reshape.
 First input is the data tensor, second input is a shape tensor which specifies the output shape. It outputs the reshaped tensor.
 At most one dimension of the new shape can be -1. In this case, the value is
 inferred from the size of the tensor and the remaining dimensions. A dimension
 could also be 0, in which case the actual dimension value is unchanged (i.e. taken
-from the input tensor).)DOC")
+from the input tensor).)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Reshape, 5, OpSchema()
+    .SetDoc(Reshape_ver5_doc)
     .Input(0, "data", "An input tensor.", "T")
     .Input(1, "shape", "Specified shape for output.", "tensor(int64)")
-    .SinceVersion(5)
     .Output(0, "reshaped", "Reshaped data.", "T")
     .TypeConstraint(
         "T",
@@ -86,12 +88,14 @@ from the input tensor).)DOC")
         "Constrain input and output types to float tensors.")
     .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       propagateElemTypeFromInputToOutput(ctx, 0, 0);
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(Shape)
-    .SetDoc(R"DOC(
+static const char * Shape_ver1_doc = R"DOC(
 Takes a tensor as input and outputs an 1D int64 tensor containing the shape of the input tensor.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Shape, 1, OpSchema()
+    .SetDoc(Shape_ver1_doc)
     .Input(0, "data", "An input tensor.", "T")
     .Output(0, "shape", "Shape of the input tensor", "T1")
     .TypeConstraint(
@@ -127,12 +131,14 @@ Takes a tensor as input and outputs an 1D int64 tensor containing the shape of t
             ->set_dim_value(
                 ctx.getInputType(0)->tensor_type().shape().dim_size());
       }
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(Size)
-    .SetDoc(R"DOC(
+static const char * Size_ver1_doc = R"DOC(
 Takes a tensor as input and outputs a int64 scalar that equals to the total number of elements of the input tensor.
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Size, 1, OpSchema()
+    .SetDoc(Size_ver1_doc)
     .Input(0, "data", "An input tensor.", "T")
     .Output(0, "size", "Total number of elements of the input tensor", "T1")
     .TypeConstraint(
@@ -156,10 +162,9 @@ Takes a tensor as input and outputs a int64 scalar that equals to the total numb
       ctx.getOutputType(0)->mutable_tensor_type()->set_elem_type(
           TensorProto::INT64);
       ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(Concat)
-    .SinceVersion(4)
+ONNX_OPERATOR_SET_SCHEMA(Concat, 4, OpSchema()
     .Attr("axis", "Which axis to concat on", AttributeProto::INT)
     .SetDoc("Concatenate a list of tensors into a single tensor")
     .Input(
@@ -225,10 +230,14 @@ ONNX_OPERATOR_SCHEMA(Concat)
       if (all_lengths_known) {
         output_shape->mutable_dim(axis)->set_dim_value(total_length);
       }
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(Split)
-    .SinceVersion(2)
+static const char * Split_ver2_doc = R"DOC(Split a tensor into a list of tensors, along the specified
+'axis'. Lengths of the parts can be specified using argument 'split'.
+Otherwise, the tensor is split to equal sized parts.
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Split, 2, OpSchema()
     .Input(0, "input", "The tensor to split", "T")
     .Output(
         0,
@@ -246,10 +255,7 @@ ONNX_OPERATOR_SCHEMA(Split)
         AttributeProto::INT,
         static_cast<int64_t>(0))
     .Attr("split", "length of each output", AttributeProto::INTS, OPTIONAL)
-    .SetDoc(R"DOC(Split a tensor into a list of tensors, along the specified
-'axis'. Lengths of the parts can be specified using argument 'split'.
-Otherwise, the tensor is split to equal sized parts.
-)DOC")
+    .SetDoc(Split_ver2_doc)
     .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       for (int i = 0; i < static_cast<int>(ctx.getNumOutputs()); ++i) {
         propagateElemTypeFromInputToOutput(ctx, 0, i);
@@ -292,10 +298,9 @@ Otherwise, the tensor is split to equal sized parts.
               ->set_dim_value(split[i]);
         }
       }
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(Slice)
-    .SetDoc(R"DOC(
+static const char * Slice_ver1_doc = R"DOC(
 Produces a slice of the input tensor along multiple axes. Similar to numpy:
 https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html
 Slices uses `axes`, `starts` and `ends` attributes to specify the start and end
@@ -327,7 +332,10 @@ Example 2:
   result = [
       [2, 3, 4],
   ]
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Slice, 1, OpSchema()
+    .SetDoc(Slice_ver1_doc)
     .Input(0, "data", "Tensor of data to extract slices from.", "T")
     .Attr(
         "axes",
@@ -408,14 +416,16 @@ Example 2:
           *newdim = ctx.getInputType(0)->tensor_type().shape().dim((int)i);
         }
       }
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(Transpose)
-    .SetDoc(R"DOC(
+static const char * Transpose_ver1_doc = R"DOC(
 Transpose the input tensor similar to numpy.transpose. For example, when
 perm=(1, 0, 2), given an input tensor of shape (1, 2, 3), the output shape
 will be (2, 1, 3).
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Transpose, 1, OpSchema()
+    .SetDoc(Transpose_ver1_doc)
     .Attr(
         "perm",
         "A list of integers. By default, reverse the dimensions, "
@@ -448,10 +458,9 @@ will be (2, 1, 3).
         appendSingleDimCopiedFromInputTypeToOutputType(
             ctx, 0, 0, static_cast<size_t>(perm[i]));
       }
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(Gather)
-    .SetDoc(R"DOC(
+static const char * Gather_ver1_doc = R"DOC(
 Given `data` tensor of rank r >= 1, and `indices` tensor of rank q, gather
 entries of the axis dimension of `data` (by default outer-most one as axis=0) indexed by `indices`, and concatenates
 them in an output tensor of rank q + (r - 1).
@@ -492,7 +501,10 @@ Example 2:
           [4.5, 5.9],
       ],
   ]
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Gather, 1, OpSchema()
+    .SetDoc(Gather_ver1_doc)
     .Attr(
         "axis",
         "Which axis to gather on, defaults to 0. Negative value means "
@@ -531,18 +543,20 @@ Example 2:
       for (int i = 0; i < out_rank; ++i) {
         ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim();
       }
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(Squeeze)
+static const char * Squeeze_ver1_doc = R"DOC(
+Remove single-dimensional entries from the shape of a tensor.
+Takes a  parameter `axes` with a list of axes to squeeze.
+If an axis is selected with shape entry not equal to one, an error is raised.
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Squeeze, 1, OpSchema()
     .Attr(
         "axes",
         "List of positive integers, indicate the dimensions to squeeze.",
         AttributeProto::INTS)
-    .SetDoc(R"DOC(
-Remove single-dimensional entries from the shape of a tensor.
-Takes a  parameter `axes` with a list of axes to squeeze.
-If an axis is selected with shape entry not equal to one, an error is raised.
-)DOC")
+    .SetDoc(Squeeze_ver1_doc)
     .Input(0, "data", "Tensors with at least max(dims) dimensions.", "T")
     .Output(0, "squeezed", "Reshaped tensor with same data as input.", "T")
     .TypeConstraint(
@@ -578,20 +592,22 @@ If an axis is selected with shape entry not equal to one, an error is raised.
                ->add_dim() = ctx.getInputType(0)->tensor_type().shape().dim(i);
         }
       }
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(Unsqueeze)
-    .Attr(
-        "axes",
-        "List of positive integers, indicate the dimensions to be inserted",
-        AttributeProto::INTS)
-    .SetDoc(R"DOC(
+static const char * Unsqueeze_ver1_doc = R"DOC(
 Insert single-dimensional entries to the shape of a tensor.
 Takes one required argument `axes`, a list of dimensions that will be inserted.
 Dimension indices in `axes` are as seen in the output tensor. For example:
   Given a tensor such that tensor with shape [3, 4, 5], then
   Unsqueeze(tensor, axes=[0, 4]) has shape [1, 3, 4, 5, 1]
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Unsqueeze, 1, OpSchema()
+    .Attr(
+        "axes",
+        "List of positive integers, indicate the dimensions to be inserted",
+        AttributeProto::INTS)
+    .SetDoc(Unsqueeze_ver1_doc)
     .Input(0, "data", "Original tensor", "T")
     .Output(0, "expanded", "Reshaped tensor with same data as input.", "T")
     .TypeConstraint(
@@ -644,10 +660,28 @@ Dimension indices in `axes` are as seen in the output tensor. For example:
             ->set_dim_value(1);
         ++j;
       }
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(Pad)
-    .SinceVersion(2)
+static const char * Pad_ver2_doc = R"DOC(
+Given `data` tensor, pads, mode, and value.
+Example:
+  Insert 0 pads to the beginning of the second dimension.
+  data = [
+      [1.0, 1.2],
+      [2.3, 3.4],
+      [4.5, 5.7],
+  ]
+  pads = [0, 2, 0, 0]
+  output = [
+      [
+          [0.0, 0.0, 1.0, 1.2],
+          [0.0, 0.0, 2.3, 3.4],
+          [0.0, 0.0, 4.5, 5.7],
+      ],
+  ]
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Pad, 2, OpSchema()
     .Attr(
         "pads",
         "List of integers indicating the number of padding elements to add or remove (if negative) "
@@ -667,24 +701,7 @@ ONNX_OPERATOR_SCHEMA(Pad)
         "One float, indicates the value to be filled, default is 0",
         AttributeProto::FLOAT,
         0.0f)
-    .SetDoc(R"DOC(
-Given `data` tensor, pads, mode, and value.
-Example:
-  Insert 0 pads to the beginning of the second dimension.
-  data = [
-      [1.0, 1.2],
-      [2.3, 3.4],
-      [4.5, 5.7],
-  ]
-  pads = [0, 2, 0, 0]
-  output = [
-      [
-          [0.0, 0.0, 1.0, 1.2],
-          [0.0, 0.0, 2.3, 3.4],
-          [0.0, 0.0, 4.5, 5.7],
-      ],
-  ]
-)DOC")
+    .SetDoc(Pad_ver2_doc)
     .Input(0, "data", "Input tensor.", "T")
     .Output(0, "output", "Tensor after padding.", "T")
     .TypeConstraint(
@@ -732,18 +749,19 @@ Example:
           *newdim = input_shape.dim((int)i);
         }
       }
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(SpaceToDepth)
+static const char * SpaceToDepth_ver1_doc = R"DOC(SpaceToDepth rearranges blocks of spatial data into depth. More specifically,
+this op outputs a copy of the input tensor where values from the height and width dimensions
+are moved to the depth dimension.
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(SpaceToDepth, 1, OpSchema()
     .Attr(
         "blocksize",
         "Blocks of [blocksize, blocksize] are moved.",
         AttributeProto::INT)
-    .SetDoc(
-        R"DOC(SpaceToDepth rearranges blocks of spatial data into depth. More specifically,
-this op outputs a copy of the input tensor where values from the height and width dimensions
-are moved to the depth dimension.
-)DOC")
+    .SetDoc(SpaceToDepth_ver1_doc)
     .Input(
         0,
         "input",
@@ -777,19 +795,20 @@ are moved to the depth dimension.
 			} else
                 fail_shape_inference("Input tensor must be 4-dimensional");
 		}
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(DepthToSpace)
+static const char * DepthToSpace_ver1_doc = R"DOC(DepthToSpace rearranges (permutes) data from depth into blocks of spatial data.
+This is the reverse transformation of SpaceToDepth. More specifically, this op outputs a copy of
+the input tensor where values from the depth dimension are moved in spatial blocks to the height
+and width dimensions.
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(DepthToSpace, 1, OpSchema()
     .Attr(
         "blocksize",
         "Blocks of [blocksize, blocksize] are moved.",
         AttributeProto::INT)
-    .SetDoc(
-        R"DOC(DepthToSpace rearranges (permutes) data from depth into blocks of spatial data.
-This is the reverse transformation of SpaceToDepth. More specifically, this op outputs a copy of
-the input tensor where values from the depth dimension are moved in spatial blocks to the height
-and width dimensions.
-)DOC")
+    .SetDoc(DepthToSpace_ver1_doc)
     .Input(
         0,
         "input",
@@ -823,14 +842,15 @@ and width dimensions.
 			} else
                 fail_shape_inference("Input tensor must be 4-dimensional");
 		}
-	});
+	}));
 
-ONNX_OPERATOR_SCHEMA(Tile)
-	.SinceVersion(6)
-    .SetDoc(R"DOC(Constructs a tensor by tiling a given tensor.
+static const char * Tile_ver6_doc = R"DOC(Constructs a tensor by tiling a given tensor.
 This is the same as function `tile` in Numpy, but no broadcast.
 For example A = [[1, 2], [3, 4]], B = [1, 2], tile(A, B) = [[1, 2, 1, 2], [3, 4, 3, 4]]
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Tile, 6, OpSchema()
+    .SetDoc(Tile_ver6_doc)
     .Input(0, "input", "Input tensor of any shape.", "T")
     .Input(
         1,
@@ -857,10 +877,15 @@ For example A = [[1, 2], [3, 4]], B = [1, 2], tile(A, B) = [[1, 2, 1, 2], [3, 4,
 		// Only rank of output can be inferred. We can do better if second input is
 		// a constant, but this requires extending InferenceContext interface to
 		// get values of constant inputs.
-     });
+     }));
 
-ONNX_OPERATOR_SCHEMA(Upsample)
-	.SinceVersion(7)
+static const char * Upsample_ver7_doc = R"DOC(
+Upsample the input tensor.
+Each dimension value of the output tensor is:
+  output_dimension = floor(input_dimension * scale).
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Upsample, 7, OpSchema()
     .Attr(
         "scales",
         "The scale array along each dimension. It takes value greater than or equal to 1."
@@ -877,13 +902,9 @@ ONNX_OPERATOR_SCHEMA(Upsample)
         "T",
         OpSchema::all_tensor_types(),
         "Constrain input/output types to all tensor types.")
-    .SetDoc(R"DOC(
-Upsample the input tensor.
-Each dimension value of the output tensor is:
-  output_dimension = floor(input_dimension * scale).
-)DOC");
+    .SetDoc(Upsample_ver7_doc));
 
-ONNX_OPERATOR_SCHEMA(Identity)
+ONNX_OPERATOR_SET_SCHEMA(Identity, 1, OpSchema()
 .SetDoc("Identity operator")
 .Input(0, "input", "Input tensor", "T")
 .Output(
@@ -893,4 +914,5 @@ ONNX_OPERATOR_SCHEMA(Identity)
 	"T")
 	.TypeConstraint("T", OpSchema::all_tensor_types(),
 		"Constrain input and output types to all tensor types.")
-	.TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
+	.TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+}

--- a/onnx/defs/tensor/old.cc
+++ b/onnx/defs/tensor/old.cc
@@ -3,112 +3,121 @@
 
 #include "onnx/defs/schema.h"
 
-namespace ONNX_NAMESPACE
-{
-  static const char * Cast_ver1_doc =R"DOC(
+namespace ONNX_NAMESPACE {
+static const char* Cast_ver1_doc = R"DOC(
 The operator casts the elements of a given input tensor to a data type
 specified by the 'to' argument and returns an output tensor of the same size in
 the converted type. The 'to' argument must be one of the data types specified
 in the 'DataType' enum field in the TensorProto message.
 NOTE: Casting to and from strings is not supported yet.
 )DOC";
-  
 
-ONNX_OPERATOR_SET_SCHEMA(Cast, 1, OpSchema()
-    .SetDoc(Cast_ver1_doc)
-    .Attr(
-        "to",
-        "The data type to which the elements of the input tensor are cast."
-        "Strictly must be one of the types from DataType enum in TensorProto",
-        AttributeProto::STRING)
-    .Input(0, "input", "Input tensor to be cast.", "T1")
-    .Output(
-        0,
-        "output",
-        "Output tensor with the same shape as input with type "
-        "specified by the 'to' argument",
-        "T2")
-    .TypeConstraint(
-        "T1",
-        {"tensor(float16)",
-         "tensor(float)",
-         "tensor(double)",
-         "tensor(int8)",
-         "tensor(int16)",
-         "tensor(int32)",
-         "tensor(int64)",
-         "tensor(uint8)",
-         "tensor(uint16)",
-         "tensor(uint32)",
-         "tensor(uint64)",
-         "tensor(bool)"},
-        "Constrain input types. Casting from strings and complex are not supported.")
-    .TypeConstraint(
-        "T2",
-        {"tensor(float16)",
-         "tensor(float)",
-         "tensor(double)",
-         "tensor(int8)",
-         "tensor(int16)",
-         "tensor(int32)",
-         "tensor(int64)",
-         "tensor(uint8)",
-         "tensor(uint16)",
-         "tensor(uint32)",
-         "tensor(uint64)",
-         "tensor(bool)"},
-        "Constrain output types. Casting to strings and complex are not supported."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Cast,
+    1,
+    OpSchema()
+        .SetDoc(Cast_ver1_doc)
+        .Attr(
+            "to",
+            "The data type to which the elements of the input tensor are cast."
+            "Strictly must be one of the types from DataType enum in TensorProto",
+            AttributeProto::STRING)
+        .Input(0, "input", "Input tensor to be cast.", "T1")
+        .Output(
+            0,
+            "output",
+            "Output tensor with the same shape as input with type "
+            "specified by the 'to' argument",
+            "T2")
+        .TypeConstraint(
+            "T1",
+            {"tensor(float16)",
+             "tensor(float)",
+             "tensor(double)",
+             "tensor(int8)",
+             "tensor(int16)",
+             "tensor(int32)",
+             "tensor(int64)",
+             "tensor(uint8)",
+             "tensor(uint16)",
+             "tensor(uint32)",
+             "tensor(uint64)",
+             "tensor(bool)"},
+            "Constrain input types. Casting from strings and complex are not supported.")
+        .TypeConstraint(
+            "T2",
+            {"tensor(float16)",
+             "tensor(float)",
+             "tensor(double)",
+             "tensor(int8)",
+             "tensor(int16)",
+             "tensor(int32)",
+             "tensor(int64)",
+             "tensor(uint8)",
+             "tensor(uint16)",
+             "tensor(uint32)",
+             "tensor(uint64)",
+             "tensor(bool)"},
+            "Constrain output types. Casting to strings and complex are not supported."));
 
-static const char * Concat_ver1_doc = R"DOC(Concatenate a list of tensors into a single tensor)DOC";
+static const char* Concat_ver1_doc =
+    R"DOC(Concatenate a list of tensors into a single tensor)DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Concat, 1, OpSchema()
-    .Attr(
-        "axis",
-        "Which axis to concat on.  Default value is 1.",
-        AttributeProto::INT,
-        OPTIONAL)
-    .SetDoc(Concat_ver1_doc)
-    .Input(
-        0,
-        "inputs",
-        "List of tensors for concatenation",
-        "T",
-        OpSchema::Variadic)
-    .Output(0, "concat_result", "Concatenated tensor", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Concat,
+    1,
+    OpSchema()
+        .Attr(
+            "axis",
+            "Which axis to concat on.  Default value is 1.",
+            AttributeProto::INT,
+            OPTIONAL)
+        .SetDoc(Concat_ver1_doc)
+        .Input(
+            0,
+            "inputs",
+            "List of tensors for concatenation",
+            "T",
+            OpSchema::Variadic)
+        .Output(0, "concat_result", "Concatenated tensor", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain output types to float tensors."));
 
-static const char * Split_ver1_doc = R"DOC(Split a tensor into a list of tensors, along the specified
+static const char* Split_ver1_doc =
+    R"DOC(Split a tensor into a list of tensors, along the specified
 'axis'. The lengths of the split can be specified using argument 'axis' or
 optional second input blob to the operator. Otherwise, the tensor is split
 to equal sized parts.
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Split, 1, OpSchema()
-    .Input(0, "input", "The tensor to split", "T")
-    .Input(
-        1,
-        "split",
-        "Optional list of output lengths (see also arg 'split')",
-        "T",
-        OpSchema::Optional)
-    .Output(
-        0,
-        "outputs...",
-        "One or more outputs forming list of tensors after splitting",
-        "T",
-        OpSchema::Variadic)
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input types to float tensors.")
-    .Attr("axis", "Which axis to split on", AttributeProto::INT, OPTIONAL)
-    .Attr("split", "length of each output", AttributeProto::INTS, OPTIONAL)
-    .SetDoc(Split_ver1_doc));
+ONNX_OPERATOR_SET_SCHEMA(
+    Split,
+    1,
+    OpSchema()
+        .Input(0, "input", "The tensor to split", "T")
+        .Input(
+            1,
+            "split",
+            "Optional list of output lengths (see also arg 'split')",
+            "T",
+            OpSchema::Optional)
+        .Output(
+            0,
+            "outputs...",
+            "One or more outputs forming list of tensors after splitting",
+            "T",
+            OpSchema::Variadic)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input types to float tensors.")
+        .Attr("axis", "Which axis to split on", AttributeProto::INT, OPTIONAL)
+        .Attr("split", "length of each output", AttributeProto::INTS, OPTIONAL)
+        .SetDoc(Split_ver1_doc));
 
-static const char * Pad_ver1_doc = R"DOC(
+static const char* Pad_ver1_doc = R"DOC(
 Given `data` tensor, paddings, mode, and value.
 
 Example:
@@ -130,35 +139,38 @@ Example:
   ]
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Pad, 1, OpSchema()
-    .Attr(
-        "paddings",
-        "List of integers indicate the padding element count at the "
-        "beginning and end of each axis, for 2D it is the number of pixel. "
-        "`paddings` rank should be double of the input's rank. `paddings` format should be as follow "
-        "[x1_begin, x2_begin...x1_end, x2_end,...], where xi_begin the number of pixels "
-        "added at the beginning of axis `i` and xi_end, the number of pixels added at "
-        "the end of axis `i`.",
-        AttributeProto::INTS)
-    .Attr(
-        "mode",
-        "Three modes: constant(default), reflect, edge",
-        AttributeProto::STRING,
-        std::string("constant"))
-    .Attr(
-        "value",
-        "One float, indicates the value to be filled, default is 0",
-        AttributeProto::FLOAT,
-        0.0f)
-    .SetDoc(Pad_ver1_doc)
-    .Input(0, "data", "Input tensor.", "T")
-    .Output(0, "output", "Tensor after padding.", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Pad,
+    1,
+    OpSchema()
+        .Attr(
+            "paddings",
+            "List of integers indicate the padding element count at the "
+            "beginning and end of each axis, for 2D it is the number of pixel. "
+            "`paddings` rank should be double of the input's rank. `paddings` format should be as follow "
+            "[x1_begin, x2_begin...x1_end, x2_end,...], where xi_begin the number of pixels "
+            "added at the beginning of axis `i` and xi_end, the number of pixels added at "
+            "the end of axis `i`.",
+            AttributeProto::INTS)
+        .Attr(
+            "mode",
+            "Three modes: constant(default), reflect, edge",
+            AttributeProto::STRING,
+            std::string("constant"))
+        .Attr(
+            "value",
+            "One float, indicates the value to be filled, default is 0",
+            AttributeProto::FLOAT,
+            0.0f)
+        .SetDoc(Pad_ver1_doc)
+        .Input(0, "data", "Input tensor.", "T")
+        .Output(0, "output", "Tensor after padding.", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * Reshape_ver1_doc = R"DOC(
+static const char* Reshape_ver1_doc = R"DOC(
 Reshape the input tensor similar to numpy.reshape.
 It takes a tensor as input and an argument `shape`. It outputs the reshaped tensor.
 At most one dimension of the new shape can be -1. In this case, the value is
@@ -166,25 +178,28 @@ inferred from the size of the tensor and the remaining dimensions. A dimension
 could also be 0, in which case the actual dimension value is unchanged (i.e. taken
 from the input tensor).)DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Reshape, 1, OpSchema()
-    .SetDoc(Reshape_ver1_doc)
-    .Attr("shape", "New shape", AttributeProto::INTS, OPTIONAL)
-    // This attribute was added via AllowConsumed API in OpSchema.
-    // After removing the API, we're now using the Attr API to simulate the old
-    // definition.
-    .Attr(
-        "consumed_inputs",
-        "legacy optimization attribute.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Input(0, "data", "An input tensor.", "T")
-    .Output(0, "reshaped", "Reshaped data.", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors."));
+ONNX_OPERATOR_SET_SCHEMA(
+    Reshape,
+    1,
+    OpSchema()
+        .SetDoc(Reshape_ver1_doc)
+        .Attr("shape", "New shape", AttributeProto::INTS, OPTIONAL)
+        // This attribute was added via AllowConsumed API in OpSchema.
+        // After removing the API, we're now using the Attr API to simulate the
+        // old definition.
+        .Attr(
+            "consumed_inputs",
+            "legacy optimization attribute.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Input(0, "data", "An input tensor.", "T")
+        .Output(0, "reshaped", "Reshaped data.", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input and output types to float tensors."));
 
-static const char * Upsample_ver1_doc = R"DOC(
+static const char* Upsample_ver1_doc = R"DOC(
 Upsample the input tensor.
 The width and height of the output tensor are:
   output_width = floor(input_width * width_scale),
@@ -207,56 +222,66 @@ Example:
   ]]]
 )DOC";
 
-ONNX_OPERATOR_SET_SCHEMA(Tile, 1, OpSchema()
-    .SetDoc("Repeat the elements of a tensor along an axis.")
-    .Input(0, "input", "Input tensor of any shape.", "T")
-    .Input(
-        1,
-        "tiles",
-        "Number of repeated copies to make of the input tensor.",
-        "T")
-    .Input(2, "axis", "Axis along which to repeat.", "T")
-    .Output(0, "output", "Output tensor of same shape and type as input.", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input types to float tensors.")
-    .TypeConstraint(
-        "T1",
-        {"tensor(int64)"},
-        "Constrain tiles and axis's type to int64 tensors.")
-	.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-	    propagateElemTypeFromInputToOutput(ctx, 0, 0);
-		// Only rank of output can be inferred. We can do better if second input is
-		// a constant, but this requires extending InferenceContext interface to
-		// get values of constant inputs.
-     }));
+ONNX_OPERATOR_SET_SCHEMA(
+    Tile,
+    1,
+    OpSchema()
+        .SetDoc("Repeat the elements of a tensor along an axis.")
+        .Input(0, "input", "Input tensor of any shape.", "T")
+        .Input(
+            1,
+            "tiles",
+            "Number of repeated copies to make of the input tensor.",
+            "T")
+        .Input(2, "axis", "Axis along which to repeat.", "T")
+        .Output(
+            0,
+            "output",
+            "Output tensor of same shape and type as input.",
+            "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain input types to float tensors.")
+        .TypeConstraint(
+            "T1",
+            {"tensor(int64)"},
+            "Constrain tiles and axis's type to int64 tensors.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          // Only rank of output can be inferred. We can do better if second
+          // input is a constant, but this requires extending InferenceContext
+          // interface to get values of constant inputs.
+        }));
 
-ONNX_OPERATOR_SET_SCHEMA(Upsample, 1, OpSchema()
-    .SetSupportLevel(OpSchema::SupportType::EXPERIMENTAL)
-    .Attr(
-        "width_scale",
-        "The scale along width dimension. It takes value greater than or equal to 1.",
-        AttributeProto::FLOAT)
-    .Attr(
-        "height_scale",
-        "The scale along height dimension. It takes value greater than or equal to 1.",
-        AttributeProto::FLOAT)
-    .Attr(
-        "mode",
-        "Two interpolation modes: nearest(default), bilinear",
-        AttributeProto::STRING,
-        std::string("nearest"))
-    .Input(0, "X", "4-D tensor, [N,C,H,W]", "T")
-    .Output(0, "Y", "4-D tensor after resizing, [N,C,H,W]", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(bool)",
-         "tensor(int32)",
-         "tensor(int64)",
-         "tensor(float16)",
-         "tensor(float)",
-         "tensor(double)"},
-        "Constrain output types to bool, int32, int64, float16, float, double tensors.")
-    .SetDoc(Upsample_ver1_doc));
-}
+ONNX_OPERATOR_SET_SCHEMA(
+    Upsample,
+    1,
+    OpSchema()
+        .SetSupportLevel(OpSchema::SupportType::EXPERIMENTAL)
+        .Attr(
+            "width_scale",
+            "The scale along width dimension. It takes value greater than or equal to 1.",
+            AttributeProto::FLOAT)
+        .Attr(
+            "height_scale",
+            "The scale along height dimension. It takes value greater than or equal to 1.",
+            AttributeProto::FLOAT)
+        .Attr(
+            "mode",
+            "Two interpolation modes: nearest(default), bilinear",
+            AttributeProto::STRING,
+            std::string("nearest"))
+        .Input(0, "X", "4-D tensor, [N,C,H,W]", "T")
+        .Output(0, "Y", "4-D tensor after resizing, [N,C,H,W]", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(bool)",
+             "tensor(int32)",
+             "tensor(int64)",
+             "tensor(float16)",
+             "tensor(float)",
+             "tensor(double)"},
+            "Constrain output types to bool, int32, int64, float16, float, double tensors.")
+        .SetDoc(Upsample_ver1_doc));
+} // namespace ONNX_NAMESPACE

--- a/onnx/defs/tensor/old.cc
+++ b/onnx/defs/tensor/old.cc
@@ -3,16 +3,19 @@
 
 #include "onnx/defs/schema.h"
 
-using namespace ONNX_NAMESPACE;
-
-ONNX_OPERATOR_SCHEMA(Cast)
-    .SetDoc(R"DOC(
+namespace ONNX_NAMESPACE
+{
+  static const char * Cast_ver1_doc =R"DOC(
 The operator casts the elements of a given input tensor to a data type
 specified by the 'to' argument and returns an output tensor of the same size in
 the converted type. The 'to' argument must be one of the data types specified
 in the 'DataType' enum field in the TensorProto message.
 NOTE: Casting to and from strings is not supported yet.
-)DOC")
+)DOC";
+  
+
+ONNX_OPERATOR_SET_SCHEMA(Cast, 1, OpSchema()
+    .SetDoc(Cast_ver1_doc)
     .Attr(
         "to",
         "The data type to which the elements of the input tensor are cast."
@@ -54,15 +57,17 @@ NOTE: Casting to and from strings is not supported yet.
          "tensor(uint32)",
          "tensor(uint64)",
          "tensor(bool)"},
-        "Constrain output types. Casting to strings and complex are not supported.");
+        "Constrain output types. Casting to strings and complex are not supported."));
 
-ONNX_OPERATOR_SCHEMA(Concat)
+static const char * Concat_ver1_doc = R"DOC(Concatenate a list of tensors into a single tensor)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Concat, 1, OpSchema()
     .Attr(
         "axis",
         "Which axis to concat on.  Default value is 1.",
         AttributeProto::INT,
         OPTIONAL)
-    .SetDoc("Concatenate a list of tensors into a single tensor")
+    .SetDoc(Concat_ver1_doc)
     .Input(
         0,
         "inputs",
@@ -73,10 +78,15 @@ ONNX_OPERATOR_SCHEMA(Concat)
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain output types to float tensors.");
+        "Constrain output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Split)
-    .SinceVersion(1)
+static const char * Split_ver1_doc = R"DOC(Split a tensor into a list of tensors, along the specified
+'axis'. The lengths of the split can be specified using argument 'axis' or
+optional second input blob to the operator. Otherwise, the tensor is split
+to equal sized parts.
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Split, 1, OpSchema()
     .Input(0, "input", "The tensor to split", "T")
     .Input(
         1,
@@ -96,34 +106,9 @@ ONNX_OPERATOR_SCHEMA(Split)
         "Constrain input types to float tensors.")
     .Attr("axis", "Which axis to split on", AttributeProto::INT, OPTIONAL)
     .Attr("split", "length of each output", AttributeProto::INTS, OPTIONAL)
-    .SetDoc(R"DOC(Split a tensor into a list of tensors, along the specified
-'axis'. The lengths of the split can be specified using argument 'axis' or
-optional second input blob to the operator. Otherwise, the tensor is split
-to equal sized parts.
-)DOC");
+    .SetDoc(Split_ver1_doc));
 
-ONNX_OPERATOR_SCHEMA(Pad)
-    .SinceVersion(1)
-    .Attr(
-        "paddings",
-        "List of integers indicate the padding element count at the "
-        "beginning and end of each axis, for 2D it is the number of pixel. "
-        "`paddings` rank should be double of the input's rank. `paddings` format should be as follow "
-        "[x1_begin, x2_begin...x1_end, x2_end,...], where xi_begin the number of pixels "
-        "added at the beginning of axis `i` and xi_end, the number of pixels added at "
-        "the end of axis `i`.",
-        AttributeProto::INTS)
-    .Attr(
-        "mode",
-        "Three modes: constant(default), reflect, edge",
-        AttributeProto::STRING,
-        std::string("constant"))
-    .Attr(
-        "value",
-        "One float, indicates the value to be filled, default is 0",
-        AttributeProto::FLOAT,
-        0.0f)
-    .SetDoc(R"DOC(
+static const char * Pad_ver1_doc = R"DOC(
 Given `data` tensor, paddings, mode, and value.
 
 Example:
@@ -143,22 +128,46 @@ Example:
           [0.0, 0.0, 4.5, 5.7],
       ],
   ]
-)DOC")
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Pad, 1, OpSchema()
+    .Attr(
+        "paddings",
+        "List of integers indicate the padding element count at the "
+        "beginning and end of each axis, for 2D it is the number of pixel. "
+        "`paddings` rank should be double of the input's rank. `paddings` format should be as follow "
+        "[x1_begin, x2_begin...x1_end, x2_end,...], where xi_begin the number of pixels "
+        "added at the beginning of axis `i` and xi_end, the number of pixels added at "
+        "the end of axis `i`.",
+        AttributeProto::INTS)
+    .Attr(
+        "mode",
+        "Three modes: constant(default), reflect, edge",
+        AttributeProto::STRING,
+        std::string("constant"))
+    .Attr(
+        "value",
+        "One float, indicates the value to be filled, default is 0",
+        AttributeProto::FLOAT,
+        0.0f)
+    .SetDoc(Pad_ver1_doc)
     .Input(0, "data", "Input tensor.", "T")
     .Output(0, "output", "Tensor after padding.", "T")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Reshape)
-    .SetDoc(R"DOC(
+static const char * Reshape_ver1_doc = R"DOC(
 Reshape the input tensor similar to numpy.reshape.
 It takes a tensor as input and an argument `shape`. It outputs the reshaped tensor.
 At most one dimension of the new shape can be -1. In this case, the value is
 inferred from the size of the tensor and the remaining dimensions. A dimension
 could also be 0, in which case the actual dimension value is unchanged (i.e. taken
-from the input tensor).)DOC")
+from the input tensor).)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Reshape, 1, OpSchema()
+    .SetDoc(Reshape_ver1_doc)
     .Attr("shape", "New shape", AttributeProto::INTS, OPTIONAL)
     // This attribute was added via AllowConsumed API in OpSchema.
     // After removing the API, we're now using the Attr API to simulate the old
@@ -173,10 +182,33 @@ from the input tensor).)DOC")
     .TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."));
 
-ONNX_OPERATOR_SCHEMA(Tile)
-    .SetDoc(R"DOC(Repeat the elements of a tensor along an axis.)DOC")
+static const char * Upsample_ver1_doc = R"DOC(
+Upsample the input tensor.
+The width and height of the output tensor are:
+  output_width = floor(input_width * width_scale),
+  output_height = floor(input_height * height_scale).
+Example:
+  Given `data` tensor, width_scale, height_scale, mode,
+  Upsample the input 4-D tensor in nearest mode:
+  data = [[[
+      [1, 2],
+      [3, 4]
+  ]]]
+  width_scale = 2
+  height_scale = 2
+  mode = "nearest"
+  output = [[[
+      [1, 1, 2, 2],
+      [1, 1, 2, 2],
+      [3, 3, 4, 4],
+      [3, 3, 4, 4]
+  ]]]
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(Tile, 1, OpSchema()
+    .SetDoc("Repeat the elements of a tensor along an axis.")
     .Input(0, "input", "Input tensor of any shape.", "T")
     .Input(
         1,
@@ -198,9 +230,9 @@ ONNX_OPERATOR_SCHEMA(Tile)
 		// Only rank of output can be inferred. We can do better if second input is
 		// a constant, but this requires extending InferenceContext interface to
 		// get values of constant inputs.
-     });
+     }));
 
-ONNX_OPERATOR_SCHEMA(Upsample)
+ONNX_OPERATOR_SET_SCHEMA(Upsample, 1, OpSchema()
     .SetSupportLevel(OpSchema::SupportType::EXPERIMENTAL)
     .Attr(
         "width_scale",
@@ -226,25 +258,5 @@ ONNX_OPERATOR_SCHEMA(Upsample)
          "tensor(float)",
          "tensor(double)"},
         "Constrain output types to bool, int32, int64, float16, float, double tensors.")
-    .SetDoc(R"DOC(
-Upsample the input tensor.
-The width and height of the output tensor are:
-  output_width = floor(input_width * width_scale),
-  output_height = floor(input_height * height_scale).
-Example:
-  Given `data` tensor, width_scale, height_scale, mode,
-  Upsample the input 4-D tensor in nearest mode:
-  data = [[[
-      [1, 2],
-      [3, 4]
-  ]]]
-  width_scale = 2
-  height_scale = 2
-  mode = "nearest"
-  output = [[[
-      [1, 1, 2, 2],
-      [1, 1, 2, 2],
-      [3, 3, 4, 4],
-      [3, 3, 4, 4]
-  ]]]
-)DOC");
+    .SetDoc(Upsample_ver1_doc));
+}

--- a/onnx/defs/traditionalml/defs.cc
+++ b/onnx/defs/traditionalml/defs.cc
@@ -3,13 +3,15 @@
 
 #include "onnx/defs/schema.h"
 
-using namespace ONNX_NAMESPACE;
 #ifdef ONNX_ML
-ONNX_OPERATOR_SCHEMA(ArrayFeatureExtractor)
-    .SetDomain("ai.onnx.ml")
-    .SetDoc(R"DOC(
+namespace ONNX_NAMESPACE
+{
+static const char * ArrayFeatureExtractor_ver1_doc = R"DOC(
     Select a subset of the data X based on the indices provided Y.
-)DOC")
+)DOC";
+
+ONNX_ML_OPERATOR_SET_SCHEMA(ArrayFeatureExtractor, 1, OpSchema()
+    .SetDoc(ArrayFeatureExtractor_ver1_doc)
     .Input(0, "X", "Data to be selected", "T")
     .Input(
         1,
@@ -24,13 +26,14 @@ ONNX_OPERATOR_SCHEMA(ArrayFeatureExtractor)
          "tensor(int64)",
          "tensor(int32)",
          "tensor(string)"},
-        "allowed types.");
+        "allowed types."));
 
-ONNX_OPERATOR_SCHEMA(Binarizer)
-    .SetDomain("ai.onnx.ml")
-    .SetDoc(R"DOC(
+static const char * Binarizer_ver1_doc = R"DOC(
     Makes values 1 or 0 based on a single threshold.
-)DOC")
+)DOC";
+
+ONNX_ML_OPERATOR_SET_SCHEMA(Binarizer, 1, OpSchema()
+    .SetDoc(Binarizer_ver1_doc)
     .Input(0, "X", "Data to be binarized", "T")
     .Output(0, "Y", "Binarized output data", "T")
     .TypeConstraint(
@@ -41,15 +44,16 @@ ONNX_OPERATOR_SCHEMA(Binarizer)
         "threshold",
         "Values greater than this are set to 1, else set to 0",
         AttributeProto::FLOAT,
-        0.f);
+        0.f));
 
-ONNX_OPERATOR_SCHEMA(CastMap)
-    .SetDomain("ai.onnx.ml")
-    .SetDoc(R"DOC(
+static const char * CastMap_ver1_doc = R"DOC(
     Converts a map to a tensor.  Map key must be int64 and the values will be ordered
     in ascending order based on this key.  Supports dense packing or sparse packing.
     If using sparse packing, the key cannot exceed the max_map-1 value.
-)DOC")
+)DOC";
+
+ONNX_ML_OPERATOR_SET_SCHEMA(CastMap, 1, OpSchema()
+    .SetDoc(CastMap_ver1_doc)
     .Input(0, "X", "Data to be encoded", "T1")
     .Output(0, "Y", "encoded output data", "T2")
     .TypeConstraint(
@@ -90,12 +94,9 @@ ONNX_OPERATOR_SCHEMA(CastMap)
       } else if (0 == cast_to.compare("TO_STRING")) {
         output_type->set_elem_type(TensorProto::STRING);
       }
-    });
+    }));
 
-
-ONNX_OPERATOR_SCHEMA(CategoryMapper)
-    .SetDomain("ai.onnx.ml")
-    .SetDoc(R"DOC(
+static const char * CategoryMapper_ver1_doc = R"DOC(
     Convert strings to int64s and vice versa.
     Takes in a map to use for the conversion.
     The index position in the strings and ints repeated inputs
@@ -104,7 +105,10 @@ ONNX_OPERATOR_SCHEMA(CategoryMapper)
     This behavior is triggered based on which default value is set.
     If the string default value is set, it will convert ints to strings.
     If the int default value is set, it will convert strings to ints.
-)DOC")
+)DOC";
+
+ONNX_ML_OPERATOR_SET_SCHEMA(CategoryMapper, 1, OpSchema()
+    .SetDoc(CategoryMapper_ver1_doc)
     .Input(0, "X", "Input data", "T1")
     .Output(
         0,
@@ -147,11 +151,9 @@ ONNX_OPERATOR_SCHEMA(CategoryMapper)
       } else if (TensorProto::INT64 == input_elem_type) {
         output_elem_type->set_elem_type(TensorProto::STRING);
       }
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(DictVectorizer)
-    .SetDomain("ai.onnx.ml")
-    .SetDoc(R"DOC(
+static const char * DictVectorizer_ver1_doc = R"DOC(
     Uses an index mapping to convert a dictionary to an array.
     The output array will be equal in length to the index mapping vector parameter.
     All keys in the input dictionary must be present in the index mapping vector.
@@ -161,7 +163,10 @@ ONNX_OPERATOR_SCHEMA(DictVectorizer)
     zero in the output array.  Use either string_vocabulary or int64_vocabulary, not both.
     For example: if the ``string_vocabulary`` parameter is set to ``["a", "c", "b", "z"]``,
     then an input of ``{"a": 4, "c": 8}`` will produce an output of ``[4, 8, 0, 0]``.
-    )DOC")
+    )DOC";
+
+ONNX_ML_OPERATOR_SET_SCHEMA(DictVectorizer, 1, OpSchema()
+    .SetDoc(DictVectorizer_ver1_doc)
     .Input(0, "X", "The input dictionary", "T1")
     .Output(0, "Y", "The tensor", "T2")
     .TypeConstraint(
@@ -195,17 +200,18 @@ ONNX_OPERATOR_SCHEMA(DictVectorizer)
                                  .elem_type();
       auto output_elem_type = ctx.getOutputType(0)->mutable_tensor_type();
       output_elem_type->set_elem_type(input_elem_type);
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(Imputer)
-    .SetDomain("ai.onnx.ml")
-    .SetDoc(R"DOC(
+static const char * Imputer_ver1_doc = R"DOC(
     Replace imputs that equal replaceValue/s  with  imputeValue/s.
     All other inputs are copied to the output unchanged.
     This op is used to replace missing values where we know what a missing value looks like.
     Only one of imputed_value_floats or imputed_value_int64s should be used.
     The size can be 1 element, which will be reused, or the size of the feature set F in input N,F
-)DOC")
+)DOC";
+
+ONNX_ML_OPERATOR_SET_SCHEMA(Imputer, 1, OpSchema()
+    .SetDoc(Imputer_ver1_doc)
     .Input(0, "X", "Data to be imputed", "T")
     .Output(0, "Y", "Imputed output data", "T")
     .TypeConstraint(
@@ -231,15 +237,16 @@ ONNX_OPERATOR_SCHEMA(Imputer)
         "replaced_value_int64",
         "value that needs replacing",
         AttributeProto::INT,
-        static_cast<int64_t>(0));
+        static_cast<int64_t>(0)));
 
-ONNX_OPERATOR_SCHEMA(LabelEncoder)
-    .SetDomain("ai.onnx.ml")
-    .SetDoc(R"DOC(
+static const char * LabelEncoder_ver1_doc = R"DOC(
     Convert class label to their integral type and vice versa.
     In both cases the operator is instantiated with the list of class strings.
     The integral value of the string is the index position in the list.
-)DOC")
+)DOC";
+
+ONNX_ML_OPERATOR_SET_SCHEMA(LabelEncoder, 1, OpSchema()
+    .SetDoc(LabelEncoder_ver1_doc)
     .Input(0, "X", "Data to be encoded", "T1")
     .Output(0, "Y", "Encoded output data", "T2")
     .TypeConstraint(
@@ -273,13 +280,14 @@ ONNX_OPERATOR_SCHEMA(LabelEncoder)
       } else if (TensorProto::INT64 == input_elem_type) {
         output_elem_type->set_elem_type(TensorProto::STRING);
       }
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(LinearClassifier)
-    .SetDomain("ai.onnx.ml")
-    .SetDoc(R"DOC(
+static const char * LinearClassifier_ver1_doc = R"DOC(
     Linear classifier prediction (choose class)
-)DOC")
+)DOC";
+
+ONNX_ML_OPERATOR_SET_SCHEMA(LinearClassifier, 1, OpSchema()
+    .SetDoc(LinearClassifier_ver1_doc)
     .Input(0, "X", "Data to be classified", "T1")
     .Output(0, "Y", "Classification outputs (one class per example", "T2")
     .Output(
@@ -332,18 +340,19 @@ ONNX_OPERATOR_SCHEMA(LinearClassifier)
       } else {
         output_elem_type->set_elem_type(TensorProto::INT64);
       }
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(LinearRegressor)
-    .SetDomain("ai.onnx.ml")
-    .SetDoc(R"DOC(
+static const char * LinearRegressor_ver1_doc = R"DOC(
     Generalized linear regression evaluation.
     If targets is set to 1 (default) then univariate regression is performed.
     If targets is set to M then M sets of coefficients must be passed in as a sequence
     and M results will be output for each input n in N.
     Coefficients are of the same length as an n, and coefficients for each target are contiguous.
     Intercepts are optional but if provided must match the number of targets.
-)DOC")
+)DOC";
+
+ONNX_ML_OPERATOR_SET_SCHEMA(LinearRegressor, 1, OpSchema()
+    .SetDoc(LinearRegressor_ver1_doc)
     .Input(0, "X", "Data to be regressed", "T")
     .Output(
         0,
@@ -373,17 +382,18 @@ ONNX_OPERATOR_SCHEMA(LinearRegressor)
         "targets",
         "total number of regression targets (default is 1)",
         AttributeProto::INT,
-        static_cast<int64_t>(1));
+        static_cast<int64_t>(1)));
 
-ONNX_OPERATOR_SCHEMA(Normalizer)
-    .SetDomain("ai.onnx.ml")
-    .SetDoc(R"DOC(
+static const char * Normalizer_ver1_doc = R"DOC(
     Normalize the input.  There are three normalization modes,
     which have the corresponding formulas:
     Max .. math::     max(x_i)
     L1  .. math::  z = ||x||_1 = \sum_{i=1}^{n} |x_i|
     L2  .. math::  z = ||x||_2 = \sqrt{\sum_{i=1}^{n} x_i^2}
-)DOC")
+)DOC";
+
+ONNX_ML_OPERATOR_SET_SCHEMA(Normalizer, 1, OpSchema()
+    .SetDoc(Normalizer_ver1_doc)
     .Input(0, "X", "Data to be encoded", "T")
     .Output(0, "Y", "encoded output data", "tensor(float)")
     .TypeConstraint(
@@ -394,11 +404,9 @@ ONNX_OPERATOR_SCHEMA(Normalizer)
         "norm",
         "enum 'MAX', 'L1', 'L2'",
         AttributeProto::STRING,
-        std::string("MAX"));
+        std::string("MAX")));
 
-ONNX_OPERATOR_SCHEMA(OneHotEncoder)
-    .SetDomain("ai.onnx.ml")
-    .SetDoc(R"DOC(
+static const char * OneHotEncoder_ver1_doc = R"DOC(
     Replace the inputs with an array of ones and zeros, where the only
     one is the zero-based category that was passed in.  The total category count
     will determine the length of the vector. For example if we pass a
@@ -410,7 +418,10 @@ ONNX_OPERATOR_SCHEMA(OneHotEncoder)
 
     If the input is a tensor of float, int32, or double, the data will be cast
     to int64s and the cats_int64s category list will be used for the lookups.
-)DOC")
+)DOC";
+
+ONNX_ML_OPERATOR_SET_SCHEMA(OneHotEncoder, 1, OpSchema()
+    .SetDoc(OneHotEncoder_ver1_doc)
     .Input(0, "X", "Data to be encoded", "T")
     .Output(0, "Y", "encoded output data", "tensor(float)")
     .TypeConstraint(
@@ -435,13 +446,14 @@ ONNX_OPERATOR_SCHEMA(OneHotEncoder)
         "zeros",
         "if true and category is not present, will return all zeros, if false and missing category, operator will return false. Default is true (1).",
         AttributeProto::INT,
-        static_cast<int64_t>(1));
+        static_cast<int64_t>(1)));
 
-ONNX_OPERATOR_SCHEMA(Scaler)
-    .SetDomain("ai.onnx.ml")
-    .SetDoc(R"DOC(
+static const char * Scaler_ver1_doc = R"DOC(
     Rescale input data, for example to standardize features by removing the mean and scaling to unit variance.
-)DOC")
+)DOC";
+
+ONNX_ML_OPERATOR_SET_SCHEMA(Scaler, 1, OpSchema()
+    .SetDoc(Scaler_ver1_doc)
     .Input(0, "X", "Data to be scaled", "T")
     .Output(0, "Y", "Scaled output data", "tensor(float)")
     .TypeConstraint(
@@ -457,13 +469,14 @@ ONNX_OPERATOR_SCHEMA(Scaler)
         "offset",
         "first, offset by this, must be same length as scale",
         AttributeProto::FLOATS,
-        OPTIONAL);
+        OPTIONAL));
 
-ONNX_OPERATOR_SCHEMA(SVMClassifier)
-    .SetDomain("ai.onnx.ml")
-    .SetDoc(R"DOC(
+static const char * SVMClassifier_ver1_doc = R"DOC(
     SVM classifier prediction
-)DOC")
+)DOC";
+
+ONNX_ML_OPERATOR_SET_SCHEMA(SVMClassifier, 1, OpSchema()
+    .SetDoc(SVMClassifier_ver1_doc)
     .Input(0, "X", "Data to be classified", "T1")
     .Output(0, "Y", "Classification outputs (one class per example)", "T2")
     .Output(
@@ -529,13 +542,14 @@ ONNX_OPERATOR_SCHEMA(SVMClassifier)
       } else {
         output_elem_type->set_elem_type(TensorProto::INT64);
       }
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(SVMRegressor)
-    .SetDomain("ai.onnx.ml")
-    .SetDoc(R"DOC(
+static const char * SVMRegressor_ver1_doc = R"DOC(
     SVM regression prediction and one-class svm anomaly detection
-)DOC")
+)DOC";
+
+ONNX_ML_OPERATOR_SET_SCHEMA(SVMRegressor, 1, OpSchema()
+    .SetDoc(SVMRegressor_ver1_doc)
     .Input(0, "X", "Data to be regressed", "T")
     .Output(
         0,
@@ -581,11 +595,9 @@ ONNX_OPERATOR_SCHEMA(SVMRegressor)
         "post eval transform for score, enum NONE, SOFTMAX, LOGISTIC, SOFTMAX_ZERO, PROBIT",
         AttributeProto::STRING,
         std::string("NONE"))
-    .Attr("rho", "", AttributeProto::FLOATS, OPTIONAL);
+    .Attr("rho", "", AttributeProto::FLOATS, OPTIONAL));
 
-ONNX_OPERATOR_SCHEMA(TreeEnsembleClassifier)
-    .SetDomain("ai.onnx.ml")
-    .SetDoc(R"DOC(
+static const char * TreeEnsembleClassifier_ver1_doc = R"DOC(
     Tree Ensemble classifier.  Returns the top class for each input in N.
     All args with nodes_ are fields of a tuple of tree nodes, and
     it is assumed they are the same length, and an index i will decode the
@@ -597,7 +609,10 @@ ONNX_OPERATOR_SCHEMA(TreeEnsembleClassifier)
     It is expected that either classlabels_strings or classlabels_int64s
     will be passed and the class_ids are an index into this list.
     Mode enum is BRANCH_LEQ, BRANCH_LT, BRANCH_GTE, BRANCH_GT, BRANCH_EQ, BRANCH_NEQ, LEAF
-)DOC")
+)DOC";
+
+ONNX_ML_OPERATOR_SET_SCHEMA(TreeEnsembleClassifier, 1, OpSchema()
+    .SetDoc(TreeEnsembleClassifier_ver1_doc)
     .Input(0, "X", "Input N,F", "T1")
     .Output(0, "Y", "N, Top class for each point", "T2")
     .Output(
@@ -705,11 +720,9 @@ ONNX_OPERATOR_SCHEMA(TreeEnsembleClassifier)
       } else {
         output_elem_type->set_elem_type(TensorProto::INT64);
       }
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(TreeEnsembleRegressor)
-    .SetDomain("ai.onnx.ml")
-    .SetDoc(R"DOC(
+static const char * TreeEnsembleRegressor_ver1_doc = R"DOC(
     Tree Ensemble regressor.  Returns the regressed values for each input in N.
     All args with nodes_ are fields of a tuple of tree nodes, and
     it is assumed they are the same length, and an index i will decode the
@@ -720,7 +733,10 @@ ONNX_OPERATOR_SCHEMA(TreeEnsembleRegressor)
     the associated target_weights index.
     All trees must have their node ids start at 0 and increment by 1.
     Mode enum is BRANCH_LEQ, BRANCH_LT, BRANCH_GTE, BRANCH_GT, BRANCH_EQ, BRANCH_NEQ, LEAF
-)DOC")
+)DOC";
+
+ONNX_ML_OPERATOR_SET_SCHEMA(TreeEnsembleRegressor, 1, OpSchema()
+    .SetDoc(TreeEnsembleRegressor_ver1_doc)
     .Input(0, "X", "Input N,F", "T")
     .Output(0, "Y", "N classes", "tensor(float)")
     .TypeConstraint(
@@ -807,18 +823,19 @@ ONNX_OPERATOR_SCHEMA(TreeEnsembleRegressor)
         "base_values",
         "base values for regression, added to final score, size must be the same as n_outputs or can be left unassigned (assumed 0)",
         AttributeProto::FLOATS,
-        OPTIONAL);
+        OPTIONAL));
 
-ONNX_OPERATOR_SCHEMA(ZipMap)
-    .SetDomain("ai.onnx.ml")
-    .SetDoc(R"DOC(
+static const char * ZipMap_ver1_doc = R"DOC(
     Makes a map from the input and the attributes.
     Assumes input 0 are the values, and the keys are specified by the attributes.
     Must provide keys in either classlabels_strings or classlabels_int64s (but not both).
     Input 0 may have a batch size larger than 1,
     but each input in the batch must be the size of the keys specified by the attributes.
     The order of the input and attributes determines the key-value mapping.
-)DOC")
+)DOC";
+
+ONNX_ML_OPERATOR_SET_SCHEMA(ZipMap, 1, OpSchema()
+    .SetDoc(ZipMap_ver1_doc)
     .Input(0, "X", "The input values", "tensor(float)")
     .Output(0, "Z", "The output map", "T")
     .TypeConstraint(
@@ -855,11 +872,9 @@ ONNX_OPERATOR_SCHEMA(ZipMap)
       if (result && !classlabels_int64s.empty()) {
         output_map_type->set_key_type(TensorProto::INT64);
       }
-    });
+    }));
 
-ONNX_OPERATOR_SCHEMA(FeatureVectorizer)
-    .SetDomain("ai.onnx.ml")
-    .SetDoc(R"DOC(
+static const char * FeatureVectorizer_ver1_doc = R"DOC(
     Concatenates input features into one continuous output of floats.
     inputdimensions is the size of each input feature.
     Inputs will be written to the output in the order of the input arguments.
@@ -867,7 +882,10 @@ ONNX_OPERATOR_SCHEMA(FeatureVectorizer)
     If an input tensor is longer than its matching input dimension, the additional input will be ignored.
     Input tensors must all be of the same type. Use Cast as needed.  
     Input tensors must all be of the same batch size.
-)DOC")
+)DOC";
+
+ONNX_ML_OPERATOR_SET_SCHEMA(FeatureVectorizer, 1, OpSchema()
+    .SetDoc(FeatureVectorizer_ver1_doc)
     .Input(0, "X", "ordered input tensors", "T1", OpSchema::Variadic)
     .Output(
         0,
@@ -882,6 +900,7 @@ ONNX_OPERATOR_SCHEMA(FeatureVectorizer)
         "inputdimensions",
         "the size of each input in the input list",
         AttributeProto::INTS,
-        OPTIONAL);
-
+        OPTIONAL));
+          
+}
 #endif

--- a/onnx/defs/traditionalml/defs.cc
+++ b/onnx/defs/traditionalml/defs.cc
@@ -4,99 +4,110 @@
 #include "onnx/defs/schema.h"
 
 #ifdef ONNX_ML
-namespace ONNX_NAMESPACE
-{
-static const char * ArrayFeatureExtractor_ver1_doc = R"DOC(
+namespace ONNX_NAMESPACE {
+static const char* ArrayFeatureExtractor_ver1_doc = R"DOC(
     Select a subset of the data X based on the indices provided Y.
 )DOC";
 
-ONNX_ML_OPERATOR_SET_SCHEMA(ArrayFeatureExtractor, 1, OpSchema()
-    .SetDoc(ArrayFeatureExtractor_ver1_doc)
-    .Input(0, "X", "Data to be selected", "T")
-    .Input(
-        1,
-        "Y",
-        "The index values to select as a int64 tensor",
-        "tensor(int64)")
-    .Output(0, "Z", "Selected output data as an array", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float)",
-         "tensor(double)",
-         "tensor(int64)",
-         "tensor(int32)",
-         "tensor(string)"},
-        "allowed types."));
+ONNX_ML_OPERATOR_SET_SCHEMA(
+    ArrayFeatureExtractor,
+    1,
+    OpSchema()
+        .SetDoc(ArrayFeatureExtractor_ver1_doc)
+        .Input(0, "X", "Data to be selected", "T")
+        .Input(
+            1,
+            "Y",
+            "The index values to select as a int64 tensor",
+            "tensor(int64)")
+        .Output(0, "Z", "Selected output data as an array", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float)",
+             "tensor(double)",
+             "tensor(int64)",
+             "tensor(int32)",
+             "tensor(string)"},
+            "allowed types."));
 
-static const char * Binarizer_ver1_doc = R"DOC(
+static const char* Binarizer_ver1_doc = R"DOC(
     Makes values 1 or 0 based on a single threshold.
 )DOC";
 
-ONNX_ML_OPERATOR_SET_SCHEMA(Binarizer, 1, OpSchema()
-    .SetDoc(Binarizer_ver1_doc)
-    .Input(0, "X", "Data to be binarized", "T")
-    .Output(0, "Y", "Binarized output data", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)"},
-        "allowed types.")
-    .Attr(
-        "threshold",
-        "Values greater than this are set to 1, else set to 0",
-        AttributeProto::FLOAT,
-        0.f));
+ONNX_ML_OPERATOR_SET_SCHEMA(
+    Binarizer,
+    1,
+    OpSchema()
+        .SetDoc(Binarizer_ver1_doc)
+        .Input(0, "X", "Data to be binarized", "T")
+        .Output(0, "Y", "Binarized output data", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float)",
+             "tensor(double)",
+             "tensor(int64)",
+             "tensor(int32)"},
+            "allowed types.")
+        .Attr(
+            "threshold",
+            "Values greater than this are set to 1, else set to 0",
+            AttributeProto::FLOAT,
+            0.f));
 
-static const char * CastMap_ver1_doc = R"DOC(
+static const char* CastMap_ver1_doc = R"DOC(
     Converts a map to a tensor.  Map key must be int64 and the values will be ordered
     in ascending order based on this key.  Supports dense packing or sparse packing.
     If using sparse packing, the key cannot exceed the max_map-1 value.
 )DOC";
 
-ONNX_ML_OPERATOR_SET_SCHEMA(CastMap, 1, OpSchema()
-    .SetDoc(CastMap_ver1_doc)
-    .Input(0, "X", "Data to be encoded", "T1")
-    .Output(0, "Y", "encoded output data", "T2")
-    .TypeConstraint(
-        "T1",
-        {"map(int64, string)", "map(int64, float)"},
-        " allowed input types.")
-    .TypeConstraint(
-        "T2",
-        {"tensor(string)", "tensor(float)", "tensor(int64)"},
-        " allowed output types.")
-    .Attr(
-        "cast_to",
-        "what type of tensor to cast the input to, enum 'TO_FLOAT','TO_STRING','TO_INT64', default is 'TO_FLOAT'",
-        AttributeProto::STRING,
-        std::string("TO_FLOAT"))
-    .Attr(
-        "map_form",
-        "whether to only output as many values as are in the input, or position the input based on using the key of the map as the index of the output (sparse), enum 'DENSE', 'SPARSE', default is 'DENSE'",
-        AttributeProto::STRING,
-        std::string("DENSE"))
-    .Attr(
-        "max_map",
-        "if map_form packing is SPARSE, what is the total length of each output in N (max index value)",
-        AttributeProto::INT,
-        static_cast<int64_t>(1))
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      auto cast_to_attr = ctx.getAttribute("cast_to");
-      auto output_type = ctx.getOutputType(0)->mutable_tensor_type();
-      if (nullptr == cast_to_attr) {
-        output_type->set_elem_type(TensorProto::FLOAT);
-        return;
-      }
-      auto& cast_to = cast_to_attr->s();
-      if (0 == cast_to.compare("TO_FLOAT")) {
-        output_type->set_elem_type(TensorProto::FLOAT);
-      } else if (0 == cast_to.compare("TO_INT64")) {
-        output_type->set_elem_type(TensorProto::INT64);
-      } else if (0 == cast_to.compare("TO_STRING")) {
-        output_type->set_elem_type(TensorProto::STRING);
-      }
-    }));
+ONNX_ML_OPERATOR_SET_SCHEMA(
+    CastMap,
+    1,
+    OpSchema()
+        .SetDoc(CastMap_ver1_doc)
+        .Input(0, "X", "Data to be encoded", "T1")
+        .Output(0, "Y", "encoded output data", "T2")
+        .TypeConstraint(
+            "T1",
+            {"map(int64, string)", "map(int64, float)"},
+            " allowed input types.")
+        .TypeConstraint(
+            "T2",
+            {"tensor(string)", "tensor(float)", "tensor(int64)"},
+            " allowed output types.")
+        .Attr(
+            "cast_to",
+            "what type of tensor to cast the input to, enum 'TO_FLOAT','TO_STRING','TO_INT64', default is 'TO_FLOAT'",
+            AttributeProto::STRING,
+            std::string("TO_FLOAT"))
+        .Attr(
+            "map_form",
+            "whether to only output as many values as are in the input, or position the input based on using the key of the map as the index of the output (sparse), enum 'DENSE', 'SPARSE', default is 'DENSE'",
+            AttributeProto::STRING,
+            std::string("DENSE"))
+        .Attr(
+            "max_map",
+            "if map_form packing is SPARSE, what is the total length of each output in N (max index value)",
+            AttributeProto::INT,
+            static_cast<int64_t>(1))
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          auto cast_to_attr = ctx.getAttribute("cast_to");
+          auto output_type = ctx.getOutputType(0)->mutable_tensor_type();
+          if (nullptr == cast_to_attr) {
+            output_type->set_elem_type(TensorProto::FLOAT);
+            return;
+          }
+          auto& cast_to = cast_to_attr->s();
+          if (0 == cast_to.compare("TO_FLOAT")) {
+            output_type->set_elem_type(TensorProto::FLOAT);
+          } else if (0 == cast_to.compare("TO_INT64")) {
+            output_type->set_elem_type(TensorProto::INT64);
+          } else if (0 == cast_to.compare("TO_STRING")) {
+            output_type->set_elem_type(TensorProto::STRING);
+          }
+        }));
 
-static const char * CategoryMapper_ver1_doc = R"DOC(
+static const char* CategoryMapper_ver1_doc = R"DOC(
     Convert strings to int64s and vice versa.
     Takes in a map to use for the conversion.
     The index position in the strings and ints repeated inputs
@@ -107,53 +118,56 @@ static const char * CategoryMapper_ver1_doc = R"DOC(
     If the int default value is set, it will convert strings to ints.
 )DOC";
 
-ONNX_ML_OPERATOR_SET_SCHEMA(CategoryMapper, 1, OpSchema()
-    .SetDoc(CategoryMapper_ver1_doc)
-    .Input(0, "X", "Input data", "T1")
-    .Output(
-        0,
-        "Y",
-        "Output data, if strings are input, then output is int64s, and vice versa.",
-        "T2")
-    .TypeConstraint(
-        "T1",
-        {"tensor(string)", "tensor(int64)"},
-        " allowed types.")
-    .TypeConstraint(
-        "T2",
-        {"tensor(string)", "tensor(int64)"},
-        " allowed types.")
-    .Attr(
-        "cats_strings",
-        "strings part of the input map, must be same size and the ints",
-        AttributeProto::STRINGS,
-        OPTIONAL)
-    .Attr(
-        "cats_int64s",
-        "ints part of the input map, must be same size and the strings",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "default_string",
-        "string value to use if the int is not in the map",
-        AttributeProto::STRING,
-        std::string("_Unused"))
-    .Attr(
-        "default_int64",
-        "int value to use if the string is not in the map",
-        AttributeProto::INT,
-        static_cast<int64_t>(-1))
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      auto input_elem_type = ctx.getInputType(0)->tensor_type().elem_type();
-      auto output_elem_type = ctx.getOutputType(0)->mutable_tensor_type();
-      if (TensorProto::STRING == input_elem_type) {
-        output_elem_type->set_elem_type(TensorProto::INT64);
-      } else if (TensorProto::INT64 == input_elem_type) {
-        output_elem_type->set_elem_type(TensorProto::STRING);
-      }
-    }));
+ONNX_ML_OPERATOR_SET_SCHEMA(
+    CategoryMapper,
+    1,
+    OpSchema()
+        .SetDoc(CategoryMapper_ver1_doc)
+        .Input(0, "X", "Input data", "T1")
+        .Output(
+            0,
+            "Y",
+            "Output data, if strings are input, then output is int64s, and vice versa.",
+            "T2")
+        .TypeConstraint(
+            "T1",
+            {"tensor(string)", "tensor(int64)"},
+            " allowed types.")
+        .TypeConstraint(
+            "T2",
+            {"tensor(string)", "tensor(int64)"},
+            " allowed types.")
+        .Attr(
+            "cats_strings",
+            "strings part of the input map, must be same size and the ints",
+            AttributeProto::STRINGS,
+            OPTIONAL)
+        .Attr(
+            "cats_int64s",
+            "ints part of the input map, must be same size and the strings",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "default_string",
+            "string value to use if the int is not in the map",
+            AttributeProto::STRING,
+            std::string("_Unused"))
+        .Attr(
+            "default_int64",
+            "int value to use if the string is not in the map",
+            AttributeProto::INT,
+            static_cast<int64_t>(-1))
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          auto input_elem_type = ctx.getInputType(0)->tensor_type().elem_type();
+          auto output_elem_type = ctx.getOutputType(0)->mutable_tensor_type();
+          if (TensorProto::STRING == input_elem_type) {
+            output_elem_type->set_elem_type(TensorProto::INT64);
+          } else if (TensorProto::INT64 == input_elem_type) {
+            output_elem_type->set_elem_type(TensorProto::STRING);
+          }
+        }));
 
-static const char * DictVectorizer_ver1_doc = R"DOC(
+static const char* DictVectorizer_ver1_doc = R"DOC(
     Uses an index mapping to convert a dictionary to an array.
     The output array will be equal in length to the index mapping vector parameter.
     All keys in the input dictionary must be present in the index mapping vector.
@@ -165,44 +179,50 @@ static const char * DictVectorizer_ver1_doc = R"DOC(
     then an input of ``{"a": 4, "c": 8}`` will produce an output of ``[4, 8, 0, 0]``.
     )DOC";
 
-ONNX_ML_OPERATOR_SET_SCHEMA(DictVectorizer, 1, OpSchema()
-    .SetDoc(DictVectorizer_ver1_doc)
-    .Input(0, "X", "The input dictionary", "T1")
-    .Output(0, "Y", "The tensor", "T2")
-    .TypeConstraint(
-        "T1",
-        {"map(string, int64)",
-         "map(int64, string)",
-         "map(int64, float)",
-         "map(int64, double)",
-         "map(string, float)",
-         "map(string, double)"},
-        " allowed types.")
-    .TypeConstraint(
-        "T2",
-        {"tensor(int64)", "tensor(float)", "tensor(double)", "tensor(string)"},
-        " allowed types.")
-    .Attr(
-        "string_vocabulary",
-        "The vocabulary vector",
-        AttributeProto::STRINGS,
-        OPTIONAL)
-    .Attr(
-        "int64_vocabulary",
-        "The vocabulary vector",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      auto input_elem_type = ctx.getInputType(0)
-                                 ->map_type()
-                                 .value_type()
-                                 .tensor_type()
-                                 .elem_type();
-      auto output_elem_type = ctx.getOutputType(0)->mutable_tensor_type();
-      output_elem_type->set_elem_type(input_elem_type);
-    }));
+ONNX_ML_OPERATOR_SET_SCHEMA(
+    DictVectorizer,
+    1,
+    OpSchema()
+        .SetDoc(DictVectorizer_ver1_doc)
+        .Input(0, "X", "The input dictionary", "T1")
+        .Output(0, "Y", "The tensor", "T2")
+        .TypeConstraint(
+            "T1",
+            {"map(string, int64)",
+             "map(int64, string)",
+             "map(int64, float)",
+             "map(int64, double)",
+             "map(string, float)",
+             "map(string, double)"},
+            " allowed types.")
+        .TypeConstraint(
+            "T2",
+            {"tensor(int64)",
+             "tensor(float)",
+             "tensor(double)",
+             "tensor(string)"},
+            " allowed types.")
+        .Attr(
+            "string_vocabulary",
+            "The vocabulary vector",
+            AttributeProto::STRINGS,
+            OPTIONAL)
+        .Attr(
+            "int64_vocabulary",
+            "The vocabulary vector",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          auto input_elem_type = ctx.getInputType(0)
+                                     ->map_type()
+                                     .value_type()
+                                     .tensor_type()
+                                     .elem_type();
+          auto output_elem_type = ctx.getOutputType(0)->mutable_tensor_type();
+          output_elem_type->set_elem_type(input_elem_type);
+        }));
 
-static const char * Imputer_ver1_doc = R"DOC(
+static const char* Imputer_ver1_doc = R"DOC(
     Replace imputs that equal replaceValue/s  with  imputeValue/s.
     All other inputs are copied to the output unchanged.
     This op is used to replace missing values where we know what a missing value looks like.
@@ -210,139 +230,154 @@ static const char * Imputer_ver1_doc = R"DOC(
     The size can be 1 element, which will be reused, or the size of the feature set F in input N,F
 )DOC";
 
-ONNX_ML_OPERATOR_SET_SCHEMA(Imputer, 1, OpSchema()
-    .SetDoc(Imputer_ver1_doc)
-    .Input(0, "X", "Data to be imputed", "T")
-    .Output(0, "Y", "Imputed output data", "T")
-    .TypeConstraint(
-        "T",
-        {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)"},
-        " allowed types.")
-    .Attr(
-        "imputed_value_floats",
-        "value to change to",
-        AttributeProto::FLOATS,
-        OPTIONAL)
-    .Attr(
-        "replaced_value_float",
-        "value that needs replacing",
-        AttributeProto::FLOAT,
-        0.f)
-    .Attr(
-        "imputed_value_int64s",
-        "value to change to",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "replaced_value_int64",
-        "value that needs replacing",
-        AttributeProto::INT,
-        static_cast<int64_t>(0)));
+ONNX_ML_OPERATOR_SET_SCHEMA(
+    Imputer,
+    1,
+    OpSchema()
+        .SetDoc(Imputer_ver1_doc)
+        .Input(0, "X", "Data to be imputed", "T")
+        .Output(0, "Y", "Imputed output data", "T")
+        .TypeConstraint(
+            "T",
+            {"tensor(float)",
+             "tensor(double)",
+             "tensor(int64)",
+             "tensor(int32)"},
+            " allowed types.")
+        .Attr(
+            "imputed_value_floats",
+            "value to change to",
+            AttributeProto::FLOATS,
+            OPTIONAL)
+        .Attr(
+            "replaced_value_float",
+            "value that needs replacing",
+            AttributeProto::FLOAT,
+            0.f)
+        .Attr(
+            "imputed_value_int64s",
+            "value to change to",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "replaced_value_int64",
+            "value that needs replacing",
+            AttributeProto::INT,
+            static_cast<int64_t>(0)));
 
-static const char * LabelEncoder_ver1_doc = R"DOC(
+static const char* LabelEncoder_ver1_doc = R"DOC(
     Convert class label to their integral type and vice versa.
     In both cases the operator is instantiated with the list of class strings.
     The integral value of the string is the index position in the list.
 )DOC";
 
-ONNX_ML_OPERATOR_SET_SCHEMA(LabelEncoder, 1, OpSchema()
-    .SetDoc(LabelEncoder_ver1_doc)
-    .Input(0, "X", "Data to be encoded", "T1")
-    .Output(0, "Y", "Encoded output data", "T2")
-    .TypeConstraint(
-        "T1",
-        {"tensor(string)", "tensor(int64)"},
-        " allowed types.")
-    .TypeConstraint(
-        "T2",
-        {"tensor(string)", "tensor(int64)"},
-        " allowed types.")
-    .Attr(
-        "classes_strings",
-        "List of class label strings to be encoded as int64s",
-        AttributeProto::STRINGS,
-        OPTIONAL)
-    .Attr(
-        "default_int64",
-        "Default value if not in class list as int64",
-        AttributeProto::INT,
-        static_cast<int64_t>(-1))
-    .Attr(
-        "default_string",
-        "Default value if not in class list as string",
-        AttributeProto::STRING,
-        std::string("_Unused"))
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      auto input_elem_type = ctx.getInputType(0)->tensor_type().elem_type();
-      auto output_elem_type = ctx.getOutputType(0)->mutable_tensor_type();
-      if (TensorProto::STRING == input_elem_type) {
-        output_elem_type->set_elem_type(TensorProto::INT64);
-      } else if (TensorProto::INT64 == input_elem_type) {
-        output_elem_type->set_elem_type(TensorProto::STRING);
-      }
-    }));
+ONNX_ML_OPERATOR_SET_SCHEMA(
+    LabelEncoder,
+    1,
+    OpSchema()
+        .SetDoc(LabelEncoder_ver1_doc)
+        .Input(0, "X", "Data to be encoded", "T1")
+        .Output(0, "Y", "Encoded output data", "T2")
+        .TypeConstraint(
+            "T1",
+            {"tensor(string)", "tensor(int64)"},
+            " allowed types.")
+        .TypeConstraint(
+            "T2",
+            {"tensor(string)", "tensor(int64)"},
+            " allowed types.")
+        .Attr(
+            "classes_strings",
+            "List of class label strings to be encoded as int64s",
+            AttributeProto::STRINGS,
+            OPTIONAL)
+        .Attr(
+            "default_int64",
+            "Default value if not in class list as int64",
+            AttributeProto::INT,
+            static_cast<int64_t>(-1))
+        .Attr(
+            "default_string",
+            "Default value if not in class list as string",
+            AttributeProto::STRING,
+            std::string("_Unused"))
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          auto input_elem_type = ctx.getInputType(0)->tensor_type().elem_type();
+          auto output_elem_type = ctx.getOutputType(0)->mutable_tensor_type();
+          if (TensorProto::STRING == input_elem_type) {
+            output_elem_type->set_elem_type(TensorProto::INT64);
+          } else if (TensorProto::INT64 == input_elem_type) {
+            output_elem_type->set_elem_type(TensorProto::STRING);
+          }
+        }));
 
-static const char * LinearClassifier_ver1_doc = R"DOC(
+static const char* LinearClassifier_ver1_doc = R"DOC(
     Linear classifier prediction (choose class)
 )DOC";
 
-ONNX_ML_OPERATOR_SET_SCHEMA(LinearClassifier, 1, OpSchema()
-    .SetDoc(LinearClassifier_ver1_doc)
-    .Input(0, "X", "Data to be classified", "T1")
-    .Output(0, "Y", "Classification outputs (one class per example", "T2")
-    .Output(
-        1,
-        "Z",
-        "Classification scores (N,E - one score for each class, for each example",
-        "tensor(float)")
-    .TypeConstraint(
-        "T1",
-        {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)"},
-        " allowed types.")
-    .TypeConstraint(
-        "T2",
-        {"tensor(string)", "tensor(int64)"},
-        " allowed types.")
-    .Attr("coefficients", "weights of the model(s)", AttributeProto::FLOATS)
-    .Attr(
-        "intercepts",
-        "weights of the intercepts (if used)",
-        AttributeProto::FLOATS,
-        OPTIONAL)
-    .Attr(
-        "multi_class",
-        "whether to do OvR or multinomial (0=OvR and is default)",
-        AttributeProto::INT,
-        static_cast<int64_t>(0))
-    .Attr(
-        "classlabels_strings",
-        "class labels if using string labels",
-        AttributeProto::STRINGS,
-        OPTIONAL)
-    .Attr(
-        "classlabels_ints",
-        "class labels if using int labels",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "post_transform",
-        "enum NONE, SOFTMAX, LOGISTIC, SOFTMAX_ZERO, PROBIT",
-        AttributeProto::STRING,
-        std::string("NONE"))
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      std::vector<std::string> label_strs;
-      auto result =
-          getRepeatedAttribute(ctx, "classlabels_strings", label_strs);
-      bool using_strings = (result && !label_strs.empty());
-      auto output_elem_type = ctx.getOutputType(0)->mutable_tensor_type();
-      if (using_strings) {
-        output_elem_type->set_elem_type(TensorProto::STRING);
-      } else {
-        output_elem_type->set_elem_type(TensorProto::INT64);
-      }
-    }));
+ONNX_ML_OPERATOR_SET_SCHEMA(
+    LinearClassifier,
+    1,
+    OpSchema()
+        .SetDoc(LinearClassifier_ver1_doc)
+        .Input(0, "X", "Data to be classified", "T1")
+        .Output(0, "Y", "Classification outputs (one class per example", "T2")
+        .Output(
+            1,
+            "Z",
+            "Classification scores (N,E - one score for each class, for each example",
+            "tensor(float)")
+        .TypeConstraint(
+            "T1",
+            {"tensor(float)",
+             "tensor(double)",
+             "tensor(int64)",
+             "tensor(int32)"},
+            " allowed types.")
+        .TypeConstraint(
+            "T2",
+            {"tensor(string)", "tensor(int64)"},
+            " allowed types.")
+        .Attr("coefficients", "weights of the model(s)", AttributeProto::FLOATS)
+        .Attr(
+            "intercepts",
+            "weights of the intercepts (if used)",
+            AttributeProto::FLOATS,
+            OPTIONAL)
+        .Attr(
+            "multi_class",
+            "whether to do OvR or multinomial (0=OvR and is default)",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Attr(
+            "classlabels_strings",
+            "class labels if using string labels",
+            AttributeProto::STRINGS,
+            OPTIONAL)
+        .Attr(
+            "classlabels_ints",
+            "class labels if using int labels",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "post_transform",
+            "enum NONE, SOFTMAX, LOGISTIC, SOFTMAX_ZERO, PROBIT",
+            AttributeProto::STRING,
+            std::string("NONE"))
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          std::vector<std::string> label_strs;
+          auto result =
+              getRepeatedAttribute(ctx, "classlabels_strings", label_strs);
+          bool using_strings = (result && !label_strs.empty());
+          auto output_elem_type = ctx.getOutputType(0)->mutable_tensor_type();
+          if (using_strings) {
+            output_elem_type->set_elem_type(TensorProto::STRING);
+          } else {
+            output_elem_type->set_elem_type(TensorProto::INT64);
+          }
+        }));
 
-static const char * LinearRegressor_ver1_doc = R"DOC(
+static const char* LinearRegressor_ver1_doc = R"DOC(
     Generalized linear regression evaluation.
     If targets is set to 1 (default) then univariate regression is performed.
     If targets is set to M then M sets of coefficients must be passed in as a sequence
@@ -351,40 +386,46 @@ static const char * LinearRegressor_ver1_doc = R"DOC(
     Intercepts are optional but if provided must match the number of targets.
 )DOC";
 
-ONNX_ML_OPERATOR_SET_SCHEMA(LinearRegressor, 1, OpSchema()
-    .SetDoc(LinearRegressor_ver1_doc)
-    .Input(0, "X", "Data to be regressed", "T")
-    .Output(
-        0,
-        "Y",
-        "Regression outputs (one per target, per example",
-        "tensor(float)")
-    .TypeConstraint(
-        "T",
-        {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)"},
-        " allowed types.")
-    .Attr(
-        "post_transform",
-        "enum NONE, SOFTMAX, LOGISTIC, SOFTMAX_ZERO, PROBIT",
-        AttributeProto::STRING,
-        std::string("NONE"))
-    .Attr(
-        "coefficients",
-        "weights of the model(s)",
-        AttributeProto::FLOATS,
-        OPTIONAL)
-    .Attr(
-        "intercepts",
-        "weights of the intercepts (if used)",
-        AttributeProto::FLOATS,
-        OPTIONAL)
-    .Attr(
-        "targets",
-        "total number of regression targets (default is 1)",
-        AttributeProto::INT,
-        static_cast<int64_t>(1)));
+ONNX_ML_OPERATOR_SET_SCHEMA(
+    LinearRegressor,
+    1,
+    OpSchema()
+        .SetDoc(LinearRegressor_ver1_doc)
+        .Input(0, "X", "Data to be regressed", "T")
+        .Output(
+            0,
+            "Y",
+            "Regression outputs (one per target, per example",
+            "tensor(float)")
+        .TypeConstraint(
+            "T",
+            {"tensor(float)",
+             "tensor(double)",
+             "tensor(int64)",
+             "tensor(int32)"},
+            " allowed types.")
+        .Attr(
+            "post_transform",
+            "enum NONE, SOFTMAX, LOGISTIC, SOFTMAX_ZERO, PROBIT",
+            AttributeProto::STRING,
+            std::string("NONE"))
+        .Attr(
+            "coefficients",
+            "weights of the model(s)",
+            AttributeProto::FLOATS,
+            OPTIONAL)
+        .Attr(
+            "intercepts",
+            "weights of the intercepts (if used)",
+            AttributeProto::FLOATS,
+            OPTIONAL)
+        .Attr(
+            "targets",
+            "total number of regression targets (default is 1)",
+            AttributeProto::INT,
+            static_cast<int64_t>(1)));
 
-static const char * Normalizer_ver1_doc = R"DOC(
+static const char* Normalizer_ver1_doc = R"DOC(
     Normalize the input.  There are three normalization modes,
     which have the corresponding formulas:
     Max .. math::     max(x_i)
@@ -392,21 +433,27 @@ static const char * Normalizer_ver1_doc = R"DOC(
     L2  .. math::  z = ||x||_2 = \sqrt{\sum_{i=1}^{n} x_i^2}
 )DOC";
 
-ONNX_ML_OPERATOR_SET_SCHEMA(Normalizer, 1, OpSchema()
-    .SetDoc(Normalizer_ver1_doc)
-    .Input(0, "X", "Data to be encoded", "T")
-    .Output(0, "Y", "encoded output data", "tensor(float)")
-    .TypeConstraint(
-        "T",
-        {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)"},
-        " allowed types.")
-    .Attr(
-        "norm",
-        "enum 'MAX', 'L1', 'L2'",
-        AttributeProto::STRING,
-        std::string("MAX")));
+ONNX_ML_OPERATOR_SET_SCHEMA(
+    Normalizer,
+    1,
+    OpSchema()
+        .SetDoc(Normalizer_ver1_doc)
+        .Input(0, "X", "Data to be encoded", "T")
+        .Output(0, "Y", "encoded output data", "tensor(float)")
+        .TypeConstraint(
+            "T",
+            {"tensor(float)",
+             "tensor(double)",
+             "tensor(int64)",
+             "tensor(int32)"},
+            " allowed types.")
+        .Attr(
+            "norm",
+            "enum 'MAX', 'L1', 'L2'",
+            AttributeProto::STRING,
+            std::string("MAX")));
 
-static const char * OneHotEncoder_ver1_doc = R"DOC(
+static const char* OneHotEncoder_ver1_doc = R"DOC(
     Replace the inputs with an array of ones and zeros, where the only
     one is the zero-based category that was passed in.  The total category count
     will determine the length of the vector. For example if we pass a
@@ -420,184 +467,205 @@ static const char * OneHotEncoder_ver1_doc = R"DOC(
     to int64s and the cats_int64s category list will be used for the lookups.
 )DOC";
 
-ONNX_ML_OPERATOR_SET_SCHEMA(OneHotEncoder, 1, OpSchema()
-    .SetDoc(OneHotEncoder_ver1_doc)
-    .Input(0, "X", "Data to be encoded", "T")
-    .Output(0, "Y", "encoded output data", "tensor(float)")
-    .TypeConstraint(
-        "T",
-        {"tensor(string)",
-         "tensor(int64)",
-         "tensor(int32)",
-         "tensor(float)",
-         "tensor(double)"},
-        " allowed types.")
-    .Attr(
-        "cats_int64s",
-        "list of categories, ints",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "cats_strings",
-        "list of categories, strings",
-        AttributeProto::STRINGS,
-        OPTIONAL)
-    .Attr(
-        "zeros",
-        "if true and category is not present, will return all zeros, if false and missing category, operator will return false. Default is true (1).",
-        AttributeProto::INT,
-        static_cast<int64_t>(1)));
+ONNX_ML_OPERATOR_SET_SCHEMA(
+    OneHotEncoder,
+    1,
+    OpSchema()
+        .SetDoc(OneHotEncoder_ver1_doc)
+        .Input(0, "X", "Data to be encoded", "T")
+        .Output(0, "Y", "encoded output data", "tensor(float)")
+        .TypeConstraint(
+            "T",
+            {"tensor(string)",
+             "tensor(int64)",
+             "tensor(int32)",
+             "tensor(float)",
+             "tensor(double)"},
+            " allowed types.")
+        .Attr(
+            "cats_int64s",
+            "list of categories, ints",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "cats_strings",
+            "list of categories, strings",
+            AttributeProto::STRINGS,
+            OPTIONAL)
+        .Attr(
+            "zeros",
+            "if true and category is not present, will return all zeros, if false and missing category, operator will return false. Default is true (1).",
+            AttributeProto::INT,
+            static_cast<int64_t>(1)));
 
-static const char * Scaler_ver1_doc = R"DOC(
+static const char* Scaler_ver1_doc = R"DOC(
     Rescale input data, for example to standardize features by removing the mean and scaling to unit variance.
 )DOC";
 
-ONNX_ML_OPERATOR_SET_SCHEMA(Scaler, 1, OpSchema()
-    .SetDoc(Scaler_ver1_doc)
-    .Input(0, "X", "Data to be scaled", "T")
-    .Output(0, "Y", "Scaled output data", "tensor(float)")
-    .TypeConstraint(
-        "T",
-        {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)"},
-        " allowed types.")
-    .Attr(
-        "scale",
-        "second, multiply by this, can be length of features or length 1",
-        AttributeProto::FLOATS,
-        OPTIONAL)
-    .Attr(
-        "offset",
-        "first, offset by this, must be same length as scale",
-        AttributeProto::FLOATS,
-        OPTIONAL));
+ONNX_ML_OPERATOR_SET_SCHEMA(
+    Scaler,
+    1,
+    OpSchema()
+        .SetDoc(Scaler_ver1_doc)
+        .Input(0, "X", "Data to be scaled", "T")
+        .Output(0, "Y", "Scaled output data", "tensor(float)")
+        .TypeConstraint(
+            "T",
+            {"tensor(float)",
+             "tensor(double)",
+             "tensor(int64)",
+             "tensor(int32)"},
+            " allowed types.")
+        .Attr(
+            "scale",
+            "second, multiply by this, can be length of features or length 1",
+            AttributeProto::FLOATS,
+            OPTIONAL)
+        .Attr(
+            "offset",
+            "first, offset by this, must be same length as scale",
+            AttributeProto::FLOATS,
+            OPTIONAL));
 
-static const char * SVMClassifier_ver1_doc = R"DOC(
+static const char* SVMClassifier_ver1_doc = R"DOC(
     SVM classifier prediction
 )DOC";
 
-ONNX_ML_OPERATOR_SET_SCHEMA(SVMClassifier, 1, OpSchema()
-    .SetDoc(SVMClassifier_ver1_doc)
-    .Input(0, "X", "Data to be classified", "T1")
-    .Output(0, "Y", "Classification outputs (one class per example)", "T2")
-    .Output(
-        1,
-        "Z",
-        "Class scores (one per class per example), if prob_a and prob_b are provided they are probabilities for each class otherwise they are raw scores.",
-        "tensor(float)")
-    .TypeConstraint(
-        "T1",
-        {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)"},
-        " allowed types.")
-    .TypeConstraint(
-        "T2",
-        {"tensor(string)", "tensor(int64)"},
-        " allowed types.")
-    .Attr(
-        "kernel_type",
-        "enum LINEAR, POLY, RBF, SIGMOID, defaults to linear",
-        AttributeProto::STRING,
-        std::string("LINEAR"))
-    .Attr(
-        "kernel_params",
-        "Tensor of 3 elements containing gamma, coef0, degree in that order.  Zero if unused for the kernel.",
-        AttributeProto::FLOATS,
-        OPTIONAL)
-    .Attr("vectors_per_class", "", AttributeProto::INTS, OPTIONAL)
-    .Attr("support_vectors", "", AttributeProto::FLOATS, OPTIONAL)
-    .Attr("coefficients", "", AttributeProto::FLOATS, OPTIONAL)
-    .Attr(
-        "prob_a",
-        "First set of probability coefficients",
-        AttributeProto::FLOATS,
-        OPTIONAL)
-    .Attr(
-        "prob_b",
-        "Second set of probability coefficients, must be same size as prob_a, if these are provided then output Z are probability estimates.",
-        AttributeProto::FLOATS,
-        OPTIONAL)
-    .Attr("rho", "", AttributeProto::FLOATS, OPTIONAL)
-    .Attr(
-        "post_transform",
-        "post eval transform for score, enum NONE, SOFTMAX, LOGISTIC, SOFTMAX_ZERO, PROBIT",
-        AttributeProto::STRING,
-        std::string("NONE"))
-    .Attr(
-        "classlabels_strings",
-        "class labels if using string labels",
-        AttributeProto::STRINGS,
-        OPTIONAL)
-    .Attr(
-        "classlabels_ints",
-        "class labels if using int labels",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      std::vector<std::string> label_strs;
-      auto result =
-          getRepeatedAttribute(ctx, "classlabels_strings", label_strs);
-      bool using_strings = (result && !label_strs.empty());
-      auto output_elem_type = ctx.getOutputType(0)->mutable_tensor_type();
-      if (using_strings) {
-        output_elem_type->set_elem_type(TensorProto::STRING);
-      } else {
-        output_elem_type->set_elem_type(TensorProto::INT64);
-      }
-    }));
+ONNX_ML_OPERATOR_SET_SCHEMA(
+    SVMClassifier,
+    1,
+    OpSchema()
+        .SetDoc(SVMClassifier_ver1_doc)
+        .Input(0, "X", "Data to be classified", "T1")
+        .Output(0, "Y", "Classification outputs (one class per example)", "T2")
+        .Output(
+            1,
+            "Z",
+            "Class scores (one per class per example), if prob_a and prob_b are provided they are probabilities for each class otherwise they are raw scores.",
+            "tensor(float)")
+        .TypeConstraint(
+            "T1",
+            {"tensor(float)",
+             "tensor(double)",
+             "tensor(int64)",
+             "tensor(int32)"},
+            " allowed types.")
+        .TypeConstraint(
+            "T2",
+            {"tensor(string)", "tensor(int64)"},
+            " allowed types.")
+        .Attr(
+            "kernel_type",
+            "enum LINEAR, POLY, RBF, SIGMOID, defaults to linear",
+            AttributeProto::STRING,
+            std::string("LINEAR"))
+        .Attr(
+            "kernel_params",
+            "Tensor of 3 elements containing gamma, coef0, degree in that order.  Zero if unused for the kernel.",
+            AttributeProto::FLOATS,
+            OPTIONAL)
+        .Attr("vectors_per_class", "", AttributeProto::INTS, OPTIONAL)
+        .Attr("support_vectors", "", AttributeProto::FLOATS, OPTIONAL)
+        .Attr("coefficients", "", AttributeProto::FLOATS, OPTIONAL)
+        .Attr(
+            "prob_a",
+            "First set of probability coefficients",
+            AttributeProto::FLOATS,
+            OPTIONAL)
+        .Attr(
+            "prob_b",
+            "Second set of probability coefficients, must be same size as prob_a, if these are provided then output Z are probability estimates.",
+            AttributeProto::FLOATS,
+            OPTIONAL)
+        .Attr("rho", "", AttributeProto::FLOATS, OPTIONAL)
+        .Attr(
+            "post_transform",
+            "post eval transform for score, enum NONE, SOFTMAX, LOGISTIC, SOFTMAX_ZERO, PROBIT",
+            AttributeProto::STRING,
+            std::string("NONE"))
+        .Attr(
+            "classlabels_strings",
+            "class labels if using string labels",
+            AttributeProto::STRINGS,
+            OPTIONAL)
+        .Attr(
+            "classlabels_ints",
+            "class labels if using int labels",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          std::vector<std::string> label_strs;
+          auto result =
+              getRepeatedAttribute(ctx, "classlabels_strings", label_strs);
+          bool using_strings = (result && !label_strs.empty());
+          auto output_elem_type = ctx.getOutputType(0)->mutable_tensor_type();
+          if (using_strings) {
+            output_elem_type->set_elem_type(TensorProto::STRING);
+          } else {
+            output_elem_type->set_elem_type(TensorProto::INT64);
+          }
+        }));
 
-static const char * SVMRegressor_ver1_doc = R"DOC(
+static const char* SVMRegressor_ver1_doc = R"DOC(
     SVM regression prediction and one-class svm anomaly detection
 )DOC";
 
-ONNX_ML_OPERATOR_SET_SCHEMA(SVMRegressor, 1, OpSchema()
-    .SetDoc(SVMRegressor_ver1_doc)
-    .Input(0, "X", "Data to be regressed", "T")
-    .Output(
-        0,
-        "Y",
-        "Regression outputs (one score per target per example)",
-        "tensor(float)")
-    .TypeConstraint(
-        "T",
-        {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)"},
-        " allowed types.")
-    .Attr(
-        "kernel_type",
-        "enum LINEAR, POLY, RBF, SIGMOID, defaults to linear",
-        AttributeProto::STRING,
-        std::string("LINEAR"))
-    .Attr(
-        "kernel_params",
-        "Tensor of 3 elements containing gamma, coef0, degree in that order.  Zero if unused for the kernel.",
-        AttributeProto::FLOATS,
-        OPTIONAL)
-    .Attr(
-        "support_vectors",
-        "chosen support vectors",
-        AttributeProto::FLOATS,
-        OPTIONAL)
-    .Attr(
-        "one_class",
-        "bool whether the regression is a one class svm or not, defaults to false",
-        AttributeProto::INT,
-        static_cast<int64_t>(0))
-    .Attr(
-        "coefficients",
-        "support vector coefficients",
-        AttributeProto::FLOATS,
-        OPTIONAL)
-    .Attr(
-        "n_supports",
-        "number of support vectors",
-        AttributeProto::INT,
-        static_cast<int64_t>(0))
-    .Attr(
-        "post_transform",
-        "post eval transform for score, enum NONE, SOFTMAX, LOGISTIC, SOFTMAX_ZERO, PROBIT",
-        AttributeProto::STRING,
-        std::string("NONE"))
-    .Attr("rho", "", AttributeProto::FLOATS, OPTIONAL));
+ONNX_ML_OPERATOR_SET_SCHEMA(
+    SVMRegressor,
+    1,
+    OpSchema()
+        .SetDoc(SVMRegressor_ver1_doc)
+        .Input(0, "X", "Data to be regressed", "T")
+        .Output(
+            0,
+            "Y",
+            "Regression outputs (one score per target per example)",
+            "tensor(float)")
+        .TypeConstraint(
+            "T",
+            {"tensor(float)",
+             "tensor(double)",
+             "tensor(int64)",
+             "tensor(int32)"},
+            " allowed types.")
+        .Attr(
+            "kernel_type",
+            "enum LINEAR, POLY, RBF, SIGMOID, defaults to linear",
+            AttributeProto::STRING,
+            std::string("LINEAR"))
+        .Attr(
+            "kernel_params",
+            "Tensor of 3 elements containing gamma, coef0, degree in that order.  Zero if unused for the kernel.",
+            AttributeProto::FLOATS,
+            OPTIONAL)
+        .Attr(
+            "support_vectors",
+            "chosen support vectors",
+            AttributeProto::FLOATS,
+            OPTIONAL)
+        .Attr(
+            "one_class",
+            "bool whether the regression is a one class svm or not, defaults to false",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Attr(
+            "coefficients",
+            "support vector coefficients",
+            AttributeProto::FLOATS,
+            OPTIONAL)
+        .Attr(
+            "n_supports",
+            "number of support vectors",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Attr(
+            "post_transform",
+            "post eval transform for score, enum NONE, SOFTMAX, LOGISTIC, SOFTMAX_ZERO, PROBIT",
+            AttributeProto::STRING,
+            std::string("NONE"))
+        .Attr("rho", "", AttributeProto::FLOATS, OPTIONAL));
 
-static const char * TreeEnsembleClassifier_ver1_doc = R"DOC(
+static const char* TreeEnsembleClassifier_ver1_doc = R"DOC(
     Tree Ensemble classifier.  Returns the top class for each input in N.
     All args with nodes_ are fields of a tuple of tree nodes, and
     it is assumed they are the same length, and an index i will decode the
@@ -611,118 +679,124 @@ static const char * TreeEnsembleClassifier_ver1_doc = R"DOC(
     Mode enum is BRANCH_LEQ, BRANCH_LT, BRANCH_GTE, BRANCH_GT, BRANCH_EQ, BRANCH_NEQ, LEAF
 )DOC";
 
-ONNX_ML_OPERATOR_SET_SCHEMA(TreeEnsembleClassifier, 1, OpSchema()
-    .SetDoc(TreeEnsembleClassifier_ver1_doc)
-    .Input(0, "X", "Input N,F", "T1")
-    .Output(0, "Y", "N, Top class for each point", "T2")
-    .Output(
-        1,
-        "Z",
-        "N,E the class score for each class, for each point",
-        "tensor(float)")
-    .TypeConstraint(
-        "T1",
-        {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)"},
-        " allowed types.")
-    .TypeConstraint(
-        "T2",
-        {"tensor(string)", "tensor(int64)"},
-        " allowed types.")
-    .Attr(
-        "nodes_treeids",
-        "tree id for this node",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "nodes_nodeids",
-        "node id for this node, node ids may restart at zero for each tree (but not required).",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "nodes_featureids",
-        "feature id for this node",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "nodes_values",
-        "thresholds to do the splitting on for this node.",
-        AttributeProto::FLOATS,
-        OPTIONAL)
-    .Attr("nodes_hitrates", "", AttributeProto::FLOATS, OPTIONAL)
-    .Attr(
-        "nodes_modes",
-        "enum of behavior for this node 'BRANCH_LEQ', 'BRANCH_LT', 'BRANCH_GTE', 'BRANCH_GT', 'BRANCH_EQ', 'BRANCH_NEQ', 'LEAF'",
-        AttributeProto::STRINGS,
-        OPTIONAL)
-    .Attr(
-        "nodes_truenodeids",
-        "child node if expression is true",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "nodes_falsenodeids",
-        "child node if expression is false",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "nodes_missing_value_tracks_true",
-        "for each node, decide if the value is missing (nan) then use true branch, this field can be left unset and will assume false for all nodes",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "class_treeids",
-        "tree that this node is in",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "class_nodeids",
-        "node id that this weight is for",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "class_ids",
-        "index of the class list that this weight is for",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "class_weights",
-        "the weight for the class in class_id",
-        AttributeProto::FLOATS,
-        OPTIONAL)
-    .Attr(
-        "classlabels_strings",
-        "class labels if using string labels",
-        AttributeProto::STRINGS,
-        OPTIONAL)
-    .Attr(
-        "classlabels_int64s",
-        "class labels if using int labels",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "post_transform",
-        "post eval transform for score, enum NONE, SOFTMAX, LOGISTIC, SOFTMAX_ZERO, PROBIT",
-        AttributeProto::STRING,
-        std::string("NONE"))
-    .Attr(
-        "base_values",
-        "base values for classification, added to final class score, size must be the same as classes or can be left unassigned (assumed 0)",
-        AttributeProto::FLOATS,
-        OPTIONAL)
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      std::vector<std::string> label_strs;
-      auto result =
-          getRepeatedAttribute(ctx, "classlabels_strings", label_strs);
-      bool using_strings = (result && !label_strs.empty());
-      auto output_elem_type = ctx.getOutputType(0)->mutable_tensor_type();
-      if (using_strings) {
-        output_elem_type->set_elem_type(TensorProto::STRING);
-      } else {
-        output_elem_type->set_elem_type(TensorProto::INT64);
-      }
-    }));
+ONNX_ML_OPERATOR_SET_SCHEMA(
+    TreeEnsembleClassifier,
+    1,
+    OpSchema()
+        .SetDoc(TreeEnsembleClassifier_ver1_doc)
+        .Input(0, "X", "Input N,F", "T1")
+        .Output(0, "Y", "N, Top class for each point", "T2")
+        .Output(
+            1,
+            "Z",
+            "N,E the class score for each class, for each point",
+            "tensor(float)")
+        .TypeConstraint(
+            "T1",
+            {"tensor(float)",
+             "tensor(double)",
+             "tensor(int64)",
+             "tensor(int32)"},
+            " allowed types.")
+        .TypeConstraint(
+            "T2",
+            {"tensor(string)", "tensor(int64)"},
+            " allowed types.")
+        .Attr(
+            "nodes_treeids",
+            "tree id for this node",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "nodes_nodeids",
+            "node id for this node, node ids may restart at zero for each tree (but not required).",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "nodes_featureids",
+            "feature id for this node",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "nodes_values",
+            "thresholds to do the splitting on for this node.",
+            AttributeProto::FLOATS,
+            OPTIONAL)
+        .Attr("nodes_hitrates", "", AttributeProto::FLOATS, OPTIONAL)
+        .Attr(
+            "nodes_modes",
+            "enum of behavior for this node 'BRANCH_LEQ', 'BRANCH_LT', 'BRANCH_GTE', 'BRANCH_GT', 'BRANCH_EQ', 'BRANCH_NEQ', 'LEAF'",
+            AttributeProto::STRINGS,
+            OPTIONAL)
+        .Attr(
+            "nodes_truenodeids",
+            "child node if expression is true",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "nodes_falsenodeids",
+            "child node if expression is false",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "nodes_missing_value_tracks_true",
+            "for each node, decide if the value is missing (nan) then use true branch, this field can be left unset and will assume false for all nodes",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "class_treeids",
+            "tree that this node is in",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "class_nodeids",
+            "node id that this weight is for",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "class_ids",
+            "index of the class list that this weight is for",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "class_weights",
+            "the weight for the class in class_id",
+            AttributeProto::FLOATS,
+            OPTIONAL)
+        .Attr(
+            "classlabels_strings",
+            "class labels if using string labels",
+            AttributeProto::STRINGS,
+            OPTIONAL)
+        .Attr(
+            "classlabels_int64s",
+            "class labels if using int labels",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "post_transform",
+            "post eval transform for score, enum NONE, SOFTMAX, LOGISTIC, SOFTMAX_ZERO, PROBIT",
+            AttributeProto::STRING,
+            std::string("NONE"))
+        .Attr(
+            "base_values",
+            "base values for classification, added to final class score, size must be the same as classes or can be left unassigned (assumed 0)",
+            AttributeProto::FLOATS,
+            OPTIONAL)
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          std::vector<std::string> label_strs;
+          auto result =
+              getRepeatedAttribute(ctx, "classlabels_strings", label_strs);
+          bool using_strings = (result && !label_strs.empty());
+          auto output_elem_type = ctx.getOutputType(0)->mutable_tensor_type();
+          if (using_strings) {
+            output_elem_type->set_elem_type(TensorProto::STRING);
+          } else {
+            output_elem_type->set_elem_type(TensorProto::INT64);
+          }
+        }));
 
-static const char * TreeEnsembleRegressor_ver1_doc = R"DOC(
+static const char* TreeEnsembleRegressor_ver1_doc = R"DOC(
     Tree Ensemble regressor.  Returns the regressed values for each input in N.
     All args with nodes_ are fields of a tuple of tree nodes, and
     it is assumed they are the same length, and an index i will decode the
@@ -735,97 +809,107 @@ static const char * TreeEnsembleRegressor_ver1_doc = R"DOC(
     Mode enum is BRANCH_LEQ, BRANCH_LT, BRANCH_GTE, BRANCH_GT, BRANCH_EQ, BRANCH_NEQ, LEAF
 )DOC";
 
-ONNX_ML_OPERATOR_SET_SCHEMA(TreeEnsembleRegressor, 1, OpSchema()
-    .SetDoc(TreeEnsembleRegressor_ver1_doc)
-    .Input(0, "X", "Input N,F", "T")
-    .Output(0, "Y", "N classes", "tensor(float)")
-    .TypeConstraint(
-        "T",
-        {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)"},
-        " allowed types.")
-    .Attr(
-        "nodes_treeids",
-        "tree id for this node",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "nodes_nodeids",
-        "node id for this node, node ids must restart at zero for each tree and increase sequentially.",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "nodes_featureids",
-        "feature id for this node",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "nodes_values",
-        "thresholds to do the splitting on for this node.",
-        AttributeProto::FLOATS,
-        OPTIONAL)
-    .Attr(
-        "nodes_hitrates",
-        "popularity of the node, used for performance and may be omitted",
-        AttributeProto::FLOATS,
-        OPTIONAL)
-    .Attr(
-        "nodes_modes",
-        "enum of behavior for this node as enum of BRANCH_LEQ, BRANCH_LT, BRANCH_GTE, BRANCH_GT, BRANCH_EQ, BRANCH_NEQ, LEAF",
-        AttributeProto::STRINGS,
-        OPTIONAL)
-    .Attr(
-        "nodes_truenodeids",
-        "child node if expression is true",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "nodes_falsenodeids",
-        "child node if expression is false",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "nodes_missing_value_tracks_true",
-        "for each node, decide if the value is missing (nan) then use true branch, this field can be left unset and will assume false for all nodes",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "target_treeids",
-        "tree that this node is in",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "target_nodeids",
-        "node id that this weight is for",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "target_ids",
-        "index of the class list that this weight is for",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .Attr(
-        "target_weights",
-        "the weight for the class in target_id",
-        AttributeProto::FLOATS,
-        OPTIONAL)
-    .Attr("n_targets", "total number of targets", AttributeProto::INT, OPTIONAL)
-    .Attr(
-        "post_transform",
-        "post eval transform for score, enum NONE, SOFTMAX, LOGISTIC, SOFTMAX_ZERO, PROBIT",
-        AttributeProto::STRING,
-        std::string("NONE"))
-    .Attr(
-        "aggregate_function",
-        " enum, how to aggregate leaf values within a target, AVERAGE,SUM,MIN,MAX",
-        AttributeProto::STRING,
-        std::string("SUM"))
-    .Attr(
-        "base_values",
-        "base values for regression, added to final score, size must be the same as n_outputs or can be left unassigned (assumed 0)",
-        AttributeProto::FLOATS,
-        OPTIONAL));
+ONNX_ML_OPERATOR_SET_SCHEMA(
+    TreeEnsembleRegressor,
+    1,
+    OpSchema()
+        .SetDoc(TreeEnsembleRegressor_ver1_doc)
+        .Input(0, "X", "Input N,F", "T")
+        .Output(0, "Y", "N classes", "tensor(float)")
+        .TypeConstraint(
+            "T",
+            {"tensor(float)",
+             "tensor(double)",
+             "tensor(int64)",
+             "tensor(int32)"},
+            " allowed types.")
+        .Attr(
+            "nodes_treeids",
+            "tree id for this node",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "nodes_nodeids",
+            "node id for this node, node ids must restart at zero for each tree and increase sequentially.",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "nodes_featureids",
+            "feature id for this node",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "nodes_values",
+            "thresholds to do the splitting on for this node.",
+            AttributeProto::FLOATS,
+            OPTIONAL)
+        .Attr(
+            "nodes_hitrates",
+            "popularity of the node, used for performance and may be omitted",
+            AttributeProto::FLOATS,
+            OPTIONAL)
+        .Attr(
+            "nodes_modes",
+            "enum of behavior for this node as enum of BRANCH_LEQ, BRANCH_LT, BRANCH_GTE, BRANCH_GT, BRANCH_EQ, BRANCH_NEQ, LEAF",
+            AttributeProto::STRINGS,
+            OPTIONAL)
+        .Attr(
+            "nodes_truenodeids",
+            "child node if expression is true",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "nodes_falsenodeids",
+            "child node if expression is false",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "nodes_missing_value_tracks_true",
+            "for each node, decide if the value is missing (nan) then use true branch, this field can be left unset and will assume false for all nodes",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "target_treeids",
+            "tree that this node is in",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "target_nodeids",
+            "node id that this weight is for",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "target_ids",
+            "index of the class list that this weight is for",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .Attr(
+            "target_weights",
+            "the weight for the class in target_id",
+            AttributeProto::FLOATS,
+            OPTIONAL)
+        .Attr(
+            "n_targets",
+            "total number of targets",
+            AttributeProto::INT,
+            OPTIONAL)
+        .Attr(
+            "post_transform",
+            "post eval transform for score, enum NONE, SOFTMAX, LOGISTIC, SOFTMAX_ZERO, PROBIT",
+            AttributeProto::STRING,
+            std::string("NONE"))
+        .Attr(
+            "aggregate_function",
+            " enum, how to aggregate leaf values within a target, AVERAGE,SUM,MIN,MAX",
+            AttributeProto::STRING,
+            std::string("SUM"))
+        .Attr(
+            "base_values",
+            "base values for regression, added to final score, size must be the same as n_outputs or can be left unassigned (assumed 0)",
+            AttributeProto::FLOATS,
+            OPTIONAL));
 
-static const char * ZipMap_ver1_doc = R"DOC(
+static const char* ZipMap_ver1_doc = R"DOC(
     Makes a map from the input and the attributes.
     Assumes input 0 are the values, and the keys are specified by the attributes.
     Must provide keys in either classlabels_strings or classlabels_int64s (but not both).
@@ -834,47 +918,50 @@ static const char * ZipMap_ver1_doc = R"DOC(
     The order of the input and attributes determines the key-value mapping.
 )DOC";
 
-ONNX_ML_OPERATOR_SET_SCHEMA(ZipMap, 1, OpSchema()
-    .SetDoc(ZipMap_ver1_doc)
-    .Input(0, "X", "The input values", "tensor(float)")
-    .Output(0, "Z", "The output map", "T")
-    .TypeConstraint(
-        "T",
-        {"seq(map(string, float))", "seq(map(int64, float))"},
-        " allowed types.")
-    .Attr(
-        "classlabels_strings",
-        "keys if using string keys",
-        AttributeProto::STRINGS,
-        OPTIONAL)
-    .Attr(
-        "classlabels_int64s",
-        "keys if using int keys",
-        AttributeProto::INTS,
-        OPTIONAL)
-    .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-      std::vector<std::string> classlabels_strings;
-      bool result =
-          getRepeatedAttribute(ctx, "classlabels_strings", classlabels_strings);
-      auto output_map_type = ctx.getOutputType(0)
-                                 ->mutable_sequence_type()
-                                 ->mutable_elem_type()
-                                 ->mutable_map_type();
-      output_map_type->mutable_value_type()
-          ->mutable_tensor_type()
-          ->set_elem_type(TensorProto::FLOAT);
-      if (result && !classlabels_strings.empty()) {
-        output_map_type->set_key_type(TensorProto::STRING);
-      }
-      std::vector<int64_t> classlabels_int64s;
-      result =
-          getRepeatedAttribute(ctx, "classlabels_int64s", classlabels_int64s);
-      if (result && !classlabels_int64s.empty()) {
-        output_map_type->set_key_type(TensorProto::INT64);
-      }
-    }));
+ONNX_ML_OPERATOR_SET_SCHEMA(
+    ZipMap,
+    1,
+    OpSchema()
+        .SetDoc(ZipMap_ver1_doc)
+        .Input(0, "X", "The input values", "tensor(float)")
+        .Output(0, "Z", "The output map", "T")
+        .TypeConstraint(
+            "T",
+            {"seq(map(string, float))", "seq(map(int64, float))"},
+            " allowed types.")
+        .Attr(
+            "classlabels_strings",
+            "keys if using string keys",
+            AttributeProto::STRINGS,
+            OPTIONAL)
+        .Attr(
+            "classlabels_int64s",
+            "keys if using int keys",
+            AttributeProto::INTS,
+            OPTIONAL)
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          std::vector<std::string> classlabels_strings;
+          bool result = getRepeatedAttribute(
+              ctx, "classlabels_strings", classlabels_strings);
+          auto output_map_type = ctx.getOutputType(0)
+                                     ->mutable_sequence_type()
+                                     ->mutable_elem_type()
+                                     ->mutable_map_type();
+          output_map_type->mutable_value_type()
+              ->mutable_tensor_type()
+              ->set_elem_type(TensorProto::FLOAT);
+          if (result && !classlabels_strings.empty()) {
+            output_map_type->set_key_type(TensorProto::STRING);
+          }
+          std::vector<int64_t> classlabels_int64s;
+          result = getRepeatedAttribute(
+              ctx, "classlabels_int64s", classlabels_int64s);
+          if (result && !classlabels_int64s.empty()) {
+            output_map_type->set_key_type(TensorProto::INT64);
+          }
+        }));
 
-static const char * FeatureVectorizer_ver1_doc = R"DOC(
+static const char* FeatureVectorizer_ver1_doc = R"DOC(
     Concatenates input features into one continuous output of floats.
     inputdimensions is the size of each input feature.
     Inputs will be written to the output in the order of the input arguments.
@@ -884,23 +971,29 @@ static const char * FeatureVectorizer_ver1_doc = R"DOC(
     Input tensors must all be of the same batch size.
 )DOC";
 
-ONNX_ML_OPERATOR_SET_SCHEMA(FeatureVectorizer, 1, OpSchema()
-    .SetDoc(FeatureVectorizer_ver1_doc)
-    .Input(0, "X", "ordered input tensors", "T1", OpSchema::Variadic)
-    .Output(
-        0,
-        "Y",
-        "Output array, in same order as Input, as floats",
-        "tensor(float)")
-    .TypeConstraint(
-        "T1",
-        {"tensor(int32)", "tensor(int64)", "tensor(float)", "tensor(double)"},
-        " Allowed input types")
-    .Attr(
-        "inputdimensions",
-        "the size of each input in the input list",
-        AttributeProto::INTS,
-        OPTIONAL));
-          
-}
+ONNX_ML_OPERATOR_SET_SCHEMA(
+    FeatureVectorizer,
+    1,
+    OpSchema()
+        .SetDoc(FeatureVectorizer_ver1_doc)
+        .Input(0, "X", "ordered input tensors", "T1", OpSchema::Variadic)
+        .Output(
+            0,
+            "Y",
+            "Output array, in same order as Input, as floats",
+            "tensor(float)")
+        .TypeConstraint(
+            "T1",
+            {"tensor(int32)",
+             "tensor(int64)",
+             "tensor(float)",
+             "tensor(double)"},
+            " Allowed input types")
+        .Attr(
+            "inputdimensions",
+            "the size of each input in the input list",
+            AttributeProto::INTS,
+            OPTIONAL));
+
+} // namespace ONNX_NAMESPACE
 #endif

--- a/onnx/shape_inference/implementation.h
+++ b/onnx/shape_inference/implementation.h
@@ -142,7 +142,9 @@ void mergeShapesAndTypes(
   }
 }
 
-void InferShapes(ModelProto& m, const ISchemaRegistry *schema_registry = OpSchemaRegistry::Instance()) {
+void InferShapes(
+    ModelProto& m,
+    const ISchemaRegistry* schema_registry = OpSchemaRegistry::Instance()) {
   std::unordered_map<std::string, int> opset_imports;
   for (const auto& opset_import : m.opset_import()) {
     opset_imports[opset_import.domain()] =
@@ -174,7 +176,7 @@ void InferShapes(ModelProto& m, const ISchemaRegistry *schema_registry = OpSchem
     auto domain_version = dit->second;
 
     const auto schema =
-      schema_registry->GetSchema(n.op_type(), domain_version, n.domain());
+        schema_registry->GetSchema(n.op_type(), domain_version, n.domain());
     if (!schema) {
       continue;
     }

--- a/onnx/shape_inference/implementation.h
+++ b/onnx/shape_inference/implementation.h
@@ -142,7 +142,7 @@ void mergeShapesAndTypes(
   }
 }
 
-void InferShapes(ModelProto& m) {
+void InferShapes(ModelProto& m, const ISchemaRegistry *schema_registry = OpSchemaRegistry::Instance()) {
   std::unordered_map<std::string, int> opset_imports;
   for (const auto& opset_import : m.opset_import()) {
     opset_imports[opset_import.domain()] =
@@ -174,7 +174,7 @@ void InferShapes(ModelProto& m) {
     auto domain_version = dit->second;
 
     const auto schema =
-        OpSchemaRegistry::Schema(n.op_type(), domain_version, n.domain());
+      schema_registry->GetSchema(n.op_type(), domain_version, n.domain());
     if (!schema) {
       continue;
     }


### PR DESCRIPTION
This changes how operator schema are registered and used by ONNX. 

The motivation for this change is two-fold.  First, it transfers policy to the consumer for which operator schema and versions of those schema will be registered.  Second, it avoids a pattern of static object usage which can cause downstream compilation and performance issues.

Before this change, schema are registered using a macro (ONNX_OPERATOR_SCHEMA) which populates a static map.  This PR changes these macros to implement methods constructing the schema.  It also exposes functions that iterate across schema in different operator sets.

By default, the static registration map is populated with the operator sets on first use.  Callers can also disable this and populate the map manually.  Finally they can implement ISchemaRegistry, and request this be  which is used instead of the static map.

So that consumers may generate code with calls to the new registration functions, the macros are now always called from the ONNNX namespace.  The codebase was previously inconsistent on using either this or the global namespace.  The objects defined in this macro also use a naming convention, which includes the name, domain, and version which reflects the operator set within which it was first defined.  This affects the macro syntax and removes the need to use __COUNTER__ for uniqueness.  
