### PR TITLE
add script to count shape inference implementations

### DIFF
--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -38,6 +38,7 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
       .def_property_readonly("attributes", &OpSchema::attributes)
       .def_property_readonly("inputs", &OpSchema::inputs)
       .def_property_readonly("outputs", &OpSchema::outputs)
+      .def_property_readonly("has_type_and_shape_inference_function", &OpSchema::has_type_and_shape_inference_function)
       .def_property_readonly(
           "type_constraints", &OpSchema::typeConstraintParams)
       .def_static(

--- a/onnx/defs/gen_shape_inference_information.py
+++ b/onnx/defs/gen_shape_inference_information.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from onnx import defs
+
+def main():
+    # domain -> support level -> name -> [schema]
+    with_inference = []
+    without_inference = []
+    for schema in defs.get_all_schemas():
+        domain, name, has_inference = schema.domain, schema.name, schema.has_type_and_shape_inference_function
+        if has_inference:
+            with_inference.append((domain, name))
+        else:
+            without_inference.append((domain, name))
+    print(len(with_inference), 'operators have a type/shape inference function.')
+    print(len(without_inference), 'do not. These are:')
+    for domain, name in sorted(without_inference):
+        print(domain, name)
+
+if __name__ == '__main__':
+    main()

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -202,7 +202,7 @@ class OpSchema final {
   // any structs used from ir.h
   OpSchema& TypeAndShapeInferenceFunction(InferenceFunction inferenceFunction);
   InferenceFunction GetTypeAndShapeInferenceFunction() const {
-    return tensor_inference_function_;
+    return tensor_inference_function_ ? tensor_inference_function_ : dummyInferenceFunction;
   }
 
   // Set the support level for the op schema.
@@ -434,6 +434,10 @@ class OpSchema final {
     return max_output_;
   }
 
+  bool has_type_and_shape_inference_function() const {
+    return tensor_inference_function_;
+  }
+
  private:
   friend class OpSchemaRegistry;
 
@@ -467,7 +471,7 @@ class OpSchema final {
   OperatorSetVersion since_version_ = 1;
   std::function<bool(int)> num_inputs_allowed_ = [](int) { return true; };
   std::function<bool(int)> num_outputs_allowed_ = [](int) { return true; };
-  InferenceFunction tensor_inference_function_ = [](InferenceContext&) {};
+  InferenceFunction tensor_inference_function_ = nullptr;
 };
 
 // Map type to store operator schemas. The format is,

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -17,6 +17,10 @@ struct InferenceContext {
 
 typedef void (*InferenceFunction)(InferenceContext&);
 
+// This no-op inference function is used for operators without an
+// inference implementation.
+inline void dummyInferenceFunction(InferenceContext&) { };
+
 template <typename T>
 inline bool getRepeatedAttribute(
     InferenceContext& ctx,


### PR DESCRIPTION
at the moment, this outputs

```
103 operators have a type/shape inference function.
12 do not. These are:
 ATen
 ConvTranspose
 Crop
 FC
 GRU
 GRUUnit
 If
 LSTM
 Loop
 LoopIndexTensor
 RNN
 Upsample
```