### PR TITLE
Do not generate protobuf python type stubs if protobuf python package is not installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ project(onnx C CXX)
 option(ONNX_BUILD_BENCHMARKS "Build ONNX micro-benchmarks" OFF)
 
 option(BUILD_ONNX_PYTHON "Build Python binaries" OFF)
+option(ONNX_GEN_PB_TYPE_STUBS "Generate protobuf python type stubs" ON)
 option(ONNX_WERROR "Build with Werror" OFF)
 option(ONNX_COVERAGE "Build with coverage instrumentation" OFF)
 
@@ -172,9 +173,11 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP NAME SRCS HDRS ROOT_DIR DEPEND)
     set(PROTOC_ARGS ${GENERATED_PROTO} -I ${OUTPUT_PROTO_DIR} --cpp_out ${ONNX_DLLEXPORT_STR}${OUTPUT_PROTO_DIR})
     if(BUILD_ONNX_PYTHON)
       list(APPEND PROTOC_ARGS --python_out ${ONNX_DLLEXPORT_STR}${OUTPUT_PROTO_DIR})
-      if(NOT WIN32)
-        # Haven't figured out how to generate mypy stubs on Windows yet
-        list(APPEND PROTOC_ARGS --plugin protoc-gen-mypy=${ROOT_DIR}/tools/protoc-gen-mypy.py --mypy_out ${ONNX_DLLEXPORT_STR}${OUTPUT_PROTO_DIR})
+      if(ONNX_GEN_PB_TYPE_STUBS)
+        if(NOT WIN32)
+          # Haven't figured out how to generate mypy stubs on Windows yet
+          list(APPEND PROTOC_ARGS --plugin protoc-gen-mypy=${ROOT_DIR}/tools/protoc-gen-mypy.py --mypy_out ${ONNX_DLLEXPORT_STR}${OUTPUT_PROTO_DIR})
+        endif()
       endif()
     endif()
     add_custom_command (

--- a/setup.py
+++ b/setup.py
@@ -156,6 +156,12 @@ class cmake_build(setuptools.Command):
                 '-DONNX_NAMESPACE={}'.format(ONNX_NAMESPACE),
                 '-DPY_EXT_SUFFIX={}'.format(sysconfig.get_config_var('EXT_SUFFIX') or ''),
             ]
+
+            try:
+                import google.protobuf
+            except ImportError:
+                cmake_args.append('-DONNX_GEN_PB_TYPE_STUBS=OFF')
+
             if COVERAGE:
                 cmake_args.append('-DONNX_COVERAGE=ON')
             if COVERAGE or DEBUG:

--- a/setup.py
+++ b/setup.py
@@ -156,12 +156,6 @@ class cmake_build(setuptools.Command):
                 '-DONNX_NAMESPACE={}'.format(ONNX_NAMESPACE),
                 '-DPY_EXT_SUFFIX={}'.format(sysconfig.get_config_var('EXT_SUFFIX') or ''),
             ]
-
-            try:
-                import google.protobuf
-            except ImportError:
-                cmake_args.append('-DONNX_GEN_PB_TYPE_STUBS=OFF')
-
             if COVERAGE:
                 cmake_args.append('-DONNX_COVERAGE=ON')
             if COVERAGE or DEBUG:

--- a/tools/protoc-gen-mypy.py
+++ b/tools/protoc-gen-mypy.py
@@ -17,9 +17,13 @@ import sys
 from collections import defaultdict
 from contextlib import contextmanager
 
-import google.protobuf.descriptor_pb2 as d_typed  # type: ignore
-import six
-from google.protobuf.compiler import plugin_pb2 as plugin  # type: ignore
+try:
+    import google.protobuf.descriptor_pb2 as d_typed  # type: ignore
+    import six
+    from google.protobuf.compiler import plugin_pb2 as plugin  # type: ignore
+except ImportError as e:
+    print('Failed to generate mypy stubs: {}'.format(e))
+    sys.exit(0)
 
 MYPY = False
 if MYPY:


### PR DESCRIPTION
type stubs should not be a hard requirements for users