### PR TITLE
Print protobuf type stubs warning to stderr

### DIFF
--- a/tools/protoc-gen-mypy.py
+++ b/tools/protoc-gen-mypy.py
@@ -22,7 +22,7 @@ try:
     import six
     from google.protobuf.compiler import plugin_pb2 as plugin  # type: ignore
 except ImportError as e:
-    print('Failed to generate mypy stubs: {}'.format(e))
+    sys.stderr.write('Failed to generate mypy stubs: {}\n'.format(e))
     sys.exit(0)
 
 MYPY = False


### PR DESCRIPTION
output printed to stdout needs to follow the protobuf format