### PR TITLE
Better way to enable mypy in test/ and tools/ folder.

### DIFF
--- a/onnx/test/__init__.pyi
+++ b/onnx/test/__init__.pyi
@@ -1,0 +1,2 @@
+# This file needs to be here to enable mypy type checking for this folder.
+# It doesn't make this a python module for installation purposes as a __init__.pyi would.

--- a/tools/__init__.pyi
+++ b/tools/__init__.pyi
@@ -1,0 +1,2 @@
+# This file needs to be here to enable mypy type checking for this folder.
+# It doesn't make this a python module for installation purposes as a __init__.py would.

--- a/tools/mypy-onnx.py
+++ b/tools/mypy-onnx.py
@@ -7,22 +7,10 @@ import os
 def main():  # type: () -> None
     try:
         root_folder = os.path.realpath(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-        source_folder = os.path.join(root_folder, "onnx/test")
         os.chdir(root_folder)
 
         subprocess.check_call(["mypy", "."])
         subprocess.check_call(["mypy", "--py2", "."])
-
-        # Since test cases aren't a python package (missing __init__.py),
-        # mypy ignores them. Explicitly call mypy with these files.
-
-        # Enumerate py and pyi files, they're listed without file extension
-        py_files = [os.path.relpath(os.path.join(dirpath, f), root_folder)
-                   for dirpath, dirnames, files in os.walk(source_folder)
-                   for f in files if f.endswith('.py')]
-
-        subprocess.check_call(["mypy"] + py_files)
-        subprocess.check_call(["mypy", "--py2"] + py_files)
 
         exit(0)
     except subprocess.CalledProcessError:


### PR DESCRIPTION
Before, we had this custom script running mypy on all files in the onnx/test folder. This is, however, not a great solution.

I figured out that I can add a `__init__.pyi` file to the folder, which makes it a python module in respect to mypy, but not in respect to installation (i.e. users are still not able to import the module and it's not part of the pypi distribution). Seems this is a better way.