### PR TITLE
Enforce writing type hints.

### DIFF
--- a/onnx/backend/test/case/node/reducel1.py
+++ b/onnx/backend/test/case/node/reducel1.py
@@ -13,7 +13,7 @@ from . import expect
 class ReduceL1(Base):
 
     @staticmethod
-    def export_do_not_keepdims():
+    def export_do_not_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = [2]
         keepdims = 0
@@ -45,7 +45,7 @@ class ReduceL1(Base):
             name='test_reduce_l1_do_not_keepdims_random')
 
     @staticmethod
-    def export_keepdims():
+    def export_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = [2]
         keepdims = 1
@@ -77,7 +77,7 @@ class ReduceL1(Base):
             name='test_reduce_l1_keep_dims_random')
 
     @staticmethod
-    def export_default_axes_keepdims():
+    def export_default_axes_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = None
         keepdims = 1

--- a/onnx/backend/test/case/node/reducel2.py
+++ b/onnx/backend/test/case/node/reducel2.py
@@ -13,7 +13,7 @@ from . import expect
 class ReduceL2(Base):
 
     @staticmethod
-    def export_do_not_keepdims():
+    def export_do_not_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = [2]
         keepdims = 0
@@ -49,7 +49,7 @@ class ReduceL2(Base):
             name='test_reduce_l2_do_not_keepdims_random')
 
     @staticmethod
-    def export_keepdims():
+    def export_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = [2]
         keepdims = 1
@@ -84,7 +84,7 @@ class ReduceL2(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_l2_keep_dims_random')
 
     @staticmethod
-    def export_default_axes_keepdims():
+    def export_default_axes_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = None
         keepdims = 1

--- a/onnx/backend/test/case/node/reducelogsumexp.py
+++ b/onnx/backend/test/case/node/reducelogsumexp.py
@@ -13,7 +13,7 @@ from . import expect
 class ReduceLogSumExp(Base):
 
     @staticmethod
-    def export_do_not_keepdims():
+    def export_do_not_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 0
@@ -47,7 +47,7 @@ class ReduceLogSumExp(Base):
             name='test_reduce_log_sum_exp_do_not_keepdims_random')
 
     @staticmethod
-    def export_keepdims():
+    def export_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 1
@@ -83,7 +83,7 @@ class ReduceLogSumExp(Base):
               name='test_reduce_log_sum_exp_keepdims_random')
 
     @staticmethod
-    def export_default_axes_keepdims():
+    def export_default_axes_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = None
         keepdims = 1

--- a/onnx/backend/test/case/node/reducemax.py
+++ b/onnx/backend/test/case/node/reducemax.py
@@ -13,7 +13,7 @@ from . import expect
 class ReduceMax(Base):
 
     @staticmethod
-    def export_do_not_keepdims():
+    def export_do_not_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 0
@@ -41,7 +41,7 @@ class ReduceMax(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_max_do_not_keepdims_random')
 
     @staticmethod
-    def export_keepdims():
+    def export_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 1
@@ -69,7 +69,7 @@ class ReduceMax(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_max_keepdims_random')
 
     @staticmethod
-    def export_default_axes_keepdims():
+    def export_default_axes_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = None
         keepdims = 1

--- a/onnx/backend/test/case/node/reducemean.py
+++ b/onnx/backend/test/case/node/reducemean.py
@@ -13,7 +13,7 @@ from . import expect
 class ReduceMean(Base):
 
     @staticmethod
-    def export_do_not_keepdims():
+    def export_do_not_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 0
@@ -41,7 +41,7 @@ class ReduceMean(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_mean_do_not_keepdims_random')
 
     @staticmethod
-    def export_keepdims():
+    def export_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 1
@@ -69,7 +69,7 @@ class ReduceMean(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_mean_keepdims_random')
 
     @staticmethod
-    def export_default_axes_keepdims():
+    def export_default_axes_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = None
         keepdims = 1

--- a/onnx/backend/test/case/node/reducemin.py
+++ b/onnx/backend/test/case/node/reducemin.py
@@ -13,7 +13,7 @@ from . import expect
 class ReduceMin(Base):
 
     @staticmethod
-    def export_do_not_keepdims():
+    def export_do_not_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 0
@@ -41,7 +41,7 @@ class ReduceMin(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_min_do_not_keepdims_random')
 
     @staticmethod
-    def export_keepdims():
+    def export_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 1
@@ -68,7 +68,7 @@ class ReduceMin(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_min_keepdims_random')
 
     @staticmethod
-    def export_default_axes_keepdims():
+    def export_default_axes_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = None
         keepdims = 1

--- a/onnx/backend/test/case/node/reduceprod.py
+++ b/onnx/backend/test/case/node/reduceprod.py
@@ -13,7 +13,7 @@ from . import expect
 class ReduceProd(Base):
 
     @staticmethod
-    def export_do_not_keepdims():
+    def export_do_not_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 0
@@ -40,7 +40,7 @@ class ReduceProd(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_prod_do_not_keepdims_random')
 
     @staticmethod
-    def export_keepdims():
+    def export_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 1
@@ -67,7 +67,7 @@ class ReduceProd(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_prod_keepdims_random')
 
     @staticmethod
-    def export_default_axes_keepdims():
+    def export_default_axes_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = None
         keepdims = 1

--- a/onnx/backend/test/case/node/reducesum.py
+++ b/onnx/backend/test/case/node/reducesum.py
@@ -13,7 +13,7 @@ from . import expect
 class ReduceSum(Base):
 
     @staticmethod
-    def export_do_not_keepdims():
+    def export_do_not_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 0
@@ -41,7 +41,7 @@ class ReduceSum(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_sum_do_not_keepdims_random')
 
     @staticmethod
-    def export_keepdims():
+    def export_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 1
@@ -69,7 +69,7 @@ class ReduceSum(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_sum_keepdims_random')
 
     @staticmethod
-    def export_default_axes_keepdims():
+    def export_default_axes_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = None
         keepdims = 1

--- a/onnx/backend/test/case/node/reducesumsquare.py
+++ b/onnx/backend/test/case/node/reducesumsquare.py
@@ -13,7 +13,7 @@ from . import expect
 class ReduceSumSquare(Base):
 
     @staticmethod
-    def export_do_not_keepdims():
+    def export_do_not_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 0
@@ -41,7 +41,7 @@ class ReduceSumSquare(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_sum_square_do_not_keepdims_random')
 
     @staticmethod
-    def export_keepdims():
+    def export_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 1
@@ -69,7 +69,7 @@ class ReduceSumSquare(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_sum_square_keepdims_random')
 
     @staticmethod
-    def export_default_axes_keepdims():
+    def export_default_axes_keepdims():  # type: () -> None
         shape = [3, 2, 2]
         axes = None
         keepdims = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,11 +49,16 @@ warn_incomplete_stub = True
 check_untyped_defs = True
 disallow_any_generics = True
 no_implicit_optional = True
-# TODO disallow_untyped_defs = True
 # TODO disallow_incomplete_defs = True
 # TODO disallow_subclassing_any = True
 disallow_untyped_decorators = True
 warn_unused_configs = True
+
+[mypy-onnx.*]
+disallow_untyped_defs = True
+
+[mypy-tools.*]
+disallow_untyped_defs = True
 
 # Ignore errors in setup.py
 [mypy-setup]


### PR DESCRIPTION
Only look at last commit, the rest is in PR #991  .

This changes the mypy config so that untyped functions are disallowed. So in future, if someone writes python code, they're forced to write type hints and I won't have to play catch up again.