### PR TITLE
Better error message if protoc isn't found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,9 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP NAME SRCS HDRS ROOT_DIR DEPEND)
         endif()
       endif()
     endif()
+    if (NOT ONNX_PROTOC_EXECUTABLE)
+        message(FATAL_ERROR "Protobuf compiler not found")
+    endif()
     add_custom_command (
       OUTPUT "${OUTPUT_PB_SRC}"
              "${OUTPUT_PB_HEADER}"


### PR DESCRIPTION
Protobuf compiler wasn't found on my system, which caused the cmake ONNX_PROTOC_EXECUTABLE to be not set, and what should have been a command like `protoc onnx.proto ...` became `onnx.proto ...`. The error message was then `onnx.proto: Permission denied` which was quite unhelpful and took me some time to track down.

This PR improves the error message for this case.