### PR TITLE
Add index check for Transpose's type inference function

### DIFF
--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -1106,7 +1106,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           int rank = static_cast<int>(input_shape.dim_size());
           int axis = static_cast<int>(getAttribute(ctx, "axis", 1));
           if (axis > rank || axis < 0) {
-            fail_type_inference(
+            fail_shape_inference(
                 "Invalid value(" , axis , ") for attribute 'axis'");
           }
           // TODO: is the operation defined for input-rank < 2?

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -73,7 +73,7 @@ void convPoolTypeAndShapeInference(
   std::vector<int64_t> pads;
   if (getRepeatedAttribute(ctx, "pads", pads)) {
     if (pads.size() != n_input_dims * 2) {
-      fail_shape_inference("Attribute pads has incorrect size");;
+      fail_shape_inference("Attribute pads has incorrect size");
     }
   } else {
     pads.assign(n_input_dims * 2, 0);
@@ -82,7 +82,7 @@ void convPoolTypeAndShapeInference(
   std::vector<int64_t> strides;
   if (getRepeatedAttribute(ctx, "strides", strides)) {
     if (strides.size() != n_input_dims) {
-      fail_shape_inference("Attribute strides has incorrect size");;
+      fail_shape_inference("Attribute strides has incorrect size");
     }
   } else {
     strides.assign(n_input_dims, 1);
@@ -91,10 +91,10 @@ void convPoolTypeAndShapeInference(
   std::vector<int64_t> kernel_shape;
   if (getRepeatedAttribute(ctx, "kernel_shape", kernel_shape)) {
     if (kernel_shape.size() != n_input_dims) {
-      fail_shape_inference("Attribute kernel_shape has incorrect size");;
+      fail_shape_inference("Attribute kernel_shape has incorrect size");
     }
   } else if (require_kernel_shape) {
-    fail_shape_inference("Attribute kernel_shape must be specified");;
+    fail_shape_inference("Attribute kernel_shape must be specified");
   } else {
     auto second_input_shape = ctx.getInputType(1)->tensor_type().shape();
     for (int i = 2; i < second_input_shape.dim_size(); ++i) {
@@ -1100,19 +1100,21 @@ ONNX_OPERATOR_SET_SCHEMA(
             static_cast<int64_t>(1))
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
-          if (hasInputShape(ctx, 0)) {
-            auto& input_shape = getInputShape(ctx, 0);
-            int rank = static_cast<int>(input_shape.dim_size());
-            int axis = static_cast<int>(getAttribute(ctx, "axis", 1));
-            if (axis > rank)
-              axis = rank;
-            // TODO: is the operation defined for input-rank < 2?
-            updateOutputShape(
-                ctx,
-                0,
-                {multiplyDims(input_shape, 0, axis),
-                 multiplyDims(input_shape, axis, rank)});
+          if (!hasInputShape(ctx, 0))
+            return;
+          auto& input_shape = getInputShape(ctx, 0);
+          int rank = static_cast<int>(input_shape.dim_size());
+          int axis = static_cast<int>(getAttribute(ctx, "axis", 1));
+          if (axis > rank || axis < 0) {
+            fail_type_inference(
+                "Invalid value(" , axis , ") for attribute 'axis'");
           }
+          // TODO: is the operation defined for input-rank < 2?
+          updateOutputShape(
+              ctx,
+              0,
+              {multiplyDims(input_shape, 0, axis),
+               multiplyDims(input_shape, axis, rank)});
         }));
 
 static const char* LRN_ver1_doc = R"DOC(

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -113,6 +113,9 @@ inline TensorShapeProto::Dimension operator/(TensorShapeProto::Dimension dim1, i
   return result;
 }
 
+//if from >= upto_exclusive, return 1.
+//Caller must make sure upto_exclusive is less than or equal to shape.size()
+//Caller must make sure from>=0
 inline TensorShapeProto::Dimension multiplyDims(const TensorShapeProto& shape, int from, int upto_exclusive) {
   TensorShapeProto::Dimension dim;
   dim.set_dim_value(1);
@@ -170,6 +173,7 @@ inline const TensorShapeProto& getInputShape(InferenceContext& ctx, size_t n) {
   return ctx.getInputType(n)->tensor_type().shape();
 }
 
+//Caller must make sure fromDimIndex is strictly less than shape.dim_size()
 inline void appendSingleDimCopiedFromInputTypeToOutputType(
     InferenceContext& ctx,
     size_t inputIndex,


### PR DESCRIPTION
@gramalingam Before passing an index to protobuf's repeated field, you must check if the index is valid first.  Otherwise, it's a security issue. 