### PR TITLE
Convert schema assert for duplicate type names to exception

### DIFF
--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -513,7 +513,10 @@ OpSchema& OpSchema::TypeConstraint(
     std::string type_str,
     std::vector<std::string> constraints,
     std::string description) {
-  assert(type_constraints_.end() == type_constraints_.find(type_str));
+  if (type_constraints_.end() != type_constraints_.find(type_str)) {
+    fail_schema("Duplicate type constraint name");
+  }
+
   DataTypeSet d;
   for (const auto& t : constraints) {
     d.insert(Utils::DataTypeUtils::ToType(t));


### PR DESCRIPTION
This converts a schema validation error from an assert to a normal SchemaError exception, which is more appropriate for callers consuming external schema.