### PR TITLE
Remove/replace /MX with /WX for MSVC build. Was typo in a previous ch…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,10 +250,6 @@ else()
   target_link_libraries(onnx_proto PUBLIC ${PROTOBUF_LIBRARIES})
 endif()
 
-if(MSVC)
-  target_compile_options(onnx_proto PRIVATE /WX-)
-endif()
-
 add_library(onnx ${onnx_src})
 target_include_directories(onnx PUBLIC ${ONNX_ROOT} "${CMAKE_CURRENT_BINARY_DIR}")
 target_link_libraries(onnx PUBLIC onnx_proto)
@@ -300,9 +296,10 @@ if(BUILD_ONNX_PYTHON)
     target_link_libraries(onnx_cpp2py_export PRIVATE ${PYTHON_LIBRARIES})
     target_compile_options(onnx_cpp2py_export PRIVATE
       /MP
-      /MX
+      /WX
       /wd4800 # disable warning type' : forcing value to bool 'true' or 'false' (performance warning)
       /wd4503 # identifier' : decorated name length exceeded, name was truncated
+      /wd4146 # unary minus operator applied to unsigned type, result still unsigned from include\google\protobuf\wire_format_lite.h
       )
     target_compile_options(onnx_cpp2py_export PRIVATE /MT)
   endif()
@@ -332,11 +329,11 @@ endif()
 if (MSVC)
     target_compile_options(onnx_proto PRIVATE
         /MP
-        /MX
+        /WX
+        /wd4146 # unary minus operator applied to unsigned type, result still unsigned: include\google\protobuf\wire_format_lite.h
     )
     target_compile_options(onnx PRIVATE
         /MP
-        /MX
         /WX
         /wd4800 # disable warning type' : forcing value to bool 'true' or 'false' (performance warning)
         /wd4503 # identifier' : decorated name length exceeded, name was truncated

--- a/cmake/unittest.cmake
+++ b/cmake/unittest.cmake
@@ -52,6 +52,12 @@ function(AddTest)
     target_compile_options(${_UT_TARGET} PRIVATE /MT)
   endif()
 
+  if(MSVC)
+    target_compile_options(${_UT_TARGET} PRIVATE
+      /wd4146 # unary minus operator applied to unsigned type, result still unsigned from include\google\protobuf\wire_format_lite.h
+    )
+  endif()
+  
   set(TEST_ARGS)
   if (ONNX_GENERATE_TEST_REPORTS)
     # generate a report file next to the test program

--- a/onnx/shape_inference/implementation.h
+++ b/onnx/shape_inference/implementation.h
@@ -71,9 +71,7 @@ void checkShapesAndTypes(
       existingType.elem_type() != inferredType.elem_type()) {
     std::stringstream ss;
     ss << "Inferred elem type differs from existing elem type: ("
-       << inferredType.elem_type()
-       << ") vs ("
-       << existingType.elem_type()
+       << inferredType.elem_type() << ") vs (" << existingType.elem_type()
        << ")";
     throw std::runtime_error(ss.str());
   }
@@ -85,27 +83,20 @@ void checkShapesAndTypes(
   if (inferredType.shape().dim_size() != existingType.shape().dim_size()) {
     std::stringstream ss;
     ss << "Inferred shape and existing shape differ in rank: ("
-       << inferredType.shape().dim_size()
-       << ") vs ("
-       << existingType.shape().dim_size()
-       << ")";
+       << inferredType.shape().dim_size() << ") vs ("
+       << existingType.shape().dim_size() << ")";
     throw std::runtime_error(ss.str());
   }
 
   for (int i = 0; i < inferredType.shape().dim_size(); ++i) {
     const auto& inferredDim = inferredType.shape().dim(i);
     const auto& existingDim = existingType.shape().dim(i);
-    if (inferredDim.has_dim_value() &&
-        existingDim.has_dim_value() &&
+    if (inferredDim.has_dim_value() && existingDim.has_dim_value() &&
         inferredDim.dim_value() != existingDim.dim_value()) {
       std::stringstream ss;
-      ss << "Inferred shape and existing shape differ in dimension "
-         << i
-         << ": ("
-         << inferredDim.dim_value()
-         << ") vs ("
-         << existingDim.dim_value()
-         << ")";
+      ss << "Inferred shape and existing shape differ in dimension " << i
+         << ": (" << inferredDim.dim_value() << ") vs ("
+         << existingDim.dim_value() << ")";
       throw std::runtime_error(ss.str());
     }
   }
@@ -182,12 +173,13 @@ void InferShapes(
     }
 
     InferenceContextImpl ctx(n, valueTypesByName);
-	try {
+    try {
       schema->GetTypeAndShapeInferenceFunction()(ctx);
-	} catch (ONNX_NAMESPACE::InferenceError& ex) {
-	  // Continue with inference for remaining nodes
-	  continue;
-	}
+    } catch (const ONNX_NAMESPACE::InferenceError& ex) {
+      (void)ex;
+      // Continue with inference for remaining nodes
+      continue;
+    }
 
     for (int i = 0; i < n.output_size(); ++i) {
       if (!ctx.getOutputType(i)->has_tensor_type()) {
@@ -196,7 +188,8 @@ void InferShapes(
       const auto& inferredType = ctx.getOutputType(i)->tensor_type();
 
       // Bail out early if shape inference does nothing useful.
-      if (inferredType.elem_type() == TensorProto::UNDEFINED && !inferredType.has_shape()) {
+      if (inferredType.elem_type() == TensorProto::UNDEFINED &&
+          !inferredType.has_shape()) {
         continue;
       }
 


### PR DESCRIPTION
https://github.com/onnx/onnx/issues/1093

Fix typo where /WX (all warnings) was replaced with /MX (unknown flag0
Add ignore of compile warning C4146 from protobuf so build is warning free.