### PR TITLE
Remove duplicate op LpNormalization

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2513,44 +2513,6 @@ This version of the operator has been available since version 1 of the default O
 <dd>Indices</dd>
 </dl>
 
-### <a name="LpNormalization-1"></a>**LpNormalization-1**</a>
-
-  Given a matrix, apply Lp-normalization along the provided axis.
-
-#### Version
-
-This version of the operator has been available since version 1 of the default ONNX operator set.
-
-#### Attributes
-
-<dl>
-<dt><tt>axis</tt> : int</dt>
-<dd>(int64, default -1) the axis on which to apply normalization, -1 mean last axis.</dd>
-<dt><tt>p</tt> : int</dt>
-<dd>(int64, default 2) the order of the normalization, only 1 or 2 are supported.</dd>
-</dl>
-
-#### Inputs
-
-<dl>
-<dt><tt>input</tt> : T</dt>
-<dd>Input matrix</dd>
-</dl>
-
-#### Outputs
-
-<dl>
-<dt><tt>output</tt> : T</dt>
-<dd>Matrix after normalization</dd>
-</dl>
-
-#### Type Constraints
-
-<dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
-</dl>
-
 ### <a name="LpPool-1"></a>**LpPool-1**</a>
 
   LpPool consumes an input tensor X and applies Lp pooling across the

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -47,7 +47,6 @@
   * <a href="#Less">Less</a>
   * <a href="#Log">Log</a>
   * <a href="#LogSoftmax">LogSoftmax</a>
-  * <a href="#LpNormalization">LpNormalization</a>
   * <a href="#LpPool">LpPool</a>
   * <a href="#MatMul">MatMul</a>
   * <a href="#Max">Max</a>
@@ -4610,45 +4609,6 @@ expect(node, inputs=[x], outputs=[y],
 ```
 
 </details>
-
-
-### <a name="LpNormalization"></a><a name="lpnormalization">**LpNormalization**</a>
-
-  Given a matrix, apply Lp-normalization along the provided axis.
-
-#### Version
-
-This version of the operator has been available since version 1 of the default ONNX operator set.
-
-#### Attributes
-
-<dl>
-<dt><tt>axis</tt> : int</dt>
-<dd>(int64, default -1) the axis on which to apply normalization, -1 mean last axis.</dd>
-<dt><tt>p</tt> : int</dt>
-<dd>(int64, default 2) the order of the normalization, only 1 or 2 are supported.</dd>
-</dl>
-
-#### Inputs
-
-<dl>
-<dt><tt>input</tt> : T</dt>
-<dd>Input matrix</dd>
-</dl>
-
-#### Outputs
-
-<dl>
-<dt><tt>output</tt> : T</dt>
-<dd>Matrix after normalization</dd>
-</dl>
-
-#### Type Constraints
-
-<dl>
-<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
-<dd>Constrain input and output types to float tensors.</dd>
-</dl>
 
 
 ### <a name="LpPool"></a><a name="lppool">**LpPool**</a>

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -5,7 +5,7 @@
 * [Overall Test Coverage](#overall-test-coverage)
 # Node Test Coverage
 ## Summary
-Node tests have covered 88/100 (0.88%) common operators.
+Node tests have covered 88/99 (0.89%) common operators.
 
 Node tests have covered 1/15 (0.07%) experimental operators.
 
@@ -5326,9 +5326,6 @@ expect(node, inputs=[x, y], outputs=[z],
 
 
 ### GlobalLpPool (call for test cases)
-
-
-### LpNormalization (call for test cases)
 
 
 ### LpPool (call for test cases)

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -1020,35 +1020,6 @@ ONNX_OPERATOR_SET_SCHEMA(
           propagateShapeAndTypeFromFirstInput(ctx);
         }));
 
-static const char* LpNormalization_ver1_doc = R"DOC(
-Given a matrix, apply Lp-normalization along the provided axis.
-)DOC";
-
-ONNX_OPERATOR_SET_SCHEMA(
-    LpNormalization,
-    1,
-    OpSchema()
-        .Input(0, "input", "Input matrix", "T")
-        .Output(0, "output", "Matrix after normalization", "T")
-        .TypeConstraint(
-            "T",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .SetDoc(LpNormalization_ver1_doc)
-        .Attr(
-            "axis",
-            "(int64, default -1) the axis on which to apply normalization, -1 mean last axis.",
-            AttributeProto::INT,
-            static_cast<int64_t>(-1))
-        .Attr(
-            "p",
-            "(int64, default 2) the order of the normalization, only 1 or 2 are supported.",
-            AttributeProto::INT,
-            static_cast<int64_t>(2))
-        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-          propagateShapeAndTypeFromFirstInput(ctx);
-        }));
-
 static const char* Dropout_ver7_doc = R"DOC(
 Dropout takes one input data (Tensor<float>) and produces two Tensor outputs,
 output (Tensor<float>) and mask (Tensor<bool>). Depending on whether it is in

--- a/onnx/defs/operator_sets.h
+++ b/onnx/defs/operator_sets.h
@@ -57,7 +57,6 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Log);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LogSoftmax);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Loop);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LoopIndexTensor);
-class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LpNormalization);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LpPool);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, MatMul);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Max);
@@ -183,8 +182,6 @@ class OpSet_Onnx_ver1 {
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Loop)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
            Onnx, 1, LoopIndexTensor)>());
-    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
-           Onnx, 1, LpNormalization)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, LpPool)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, MatMul)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 1, Max)>());

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -809,13 +809,6 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (2, 3, 2, 2))])
 
-    def test_lp_norm(self):  # type: () -> None
-        graph = self._make_graph(
-            [('x', TensorProto.FLOAT, (3, 4, 5, 6, 7))],
-            [make_node('LpNormalization', ['x'], ['out'])],
-            [])
-        self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.FLOAT, (3, 4, 5, 6, 7))])
-
     def test_instance_norm(self):  # type: () -> None
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4, 5, 6, 7)),


### PR DESCRIPTION
LpNormalization is applying the Lp Normalization along specified axis (axes). The definition should be quite similar to the `norm` op in [tensorflow](https://www.tensorflow.org/api_docs/python/tf/norm) and `lpnorm` in [pytorch](https://github.com/pytorch/pytorch/blob/master/caffe2/operators/lpnorm_op.cc#L6).

After some research, I found we already have equivalent operators in ONNX, i.e., ReduceL1 and ReduceL2. So, let's remove unused and duplicate operator `LpNormalization`.