### PR TITLE
Initialise weights and input with random values. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,6 +378,15 @@ endif()
 add_library(onnxifi INTERFACE)
 target_include_directories(onnxifi INTERFACE onnx)
 
+# ---[ ONNXIFI loader
+add_library(onnxifi_loader STATIC onnx/onnxifi_loader.c)
+# Users of ONNX backend API would compile it with their toolchain,
+# so it is implemented in standard C89 for maximum compatibility
+set_target_properties(onnxifi_loader PROPERTIES
+  C_STANDARD 90
+  C_EXTENSIONS NO)
+target_link_libraries(onnxifi_loader PUBLIC onnxifi)
+target_include_directories(onnxifi_loader PUBLIC onnx)
 
 install(TARGETS onnx onnx_proto
     DESTINATION lib)

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -4644,7 +4644,8 @@ This version of the operator has been available since version 1 of the default O
 
   Remove single-dimensional entries from the shape of a tensor.
   Takes a  parameter `axes` with a list of axes to squeeze.
-  If an axis is selected with shape entry not equal to one, an error is raised.
+  If `axes` is not provided, all the single dimensions will be removed from
+  the shape. If an axis is selected with shape entry not equal to one, an error is raised.
 
 #### Version
 
@@ -4653,7 +4654,7 @@ This version of the operator has been available since version 1 of the default O
 #### Attributes
 
 <dl>
-<dt><tt>axes</tt> : list of ints (required)</dt>
+<dt><tt>axes</tt> : list of ints</dt>
 <dd>List of positive integers, indicate the dimensions to squeeze.</dd>
 </dl>
 

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -9162,7 +9162,8 @@ expect(node, inputs=[x], outputs=[y],
 
   Remove single-dimensional entries from the shape of a tensor.
   Takes a  parameter `axes` with a list of axes to squeeze.
-  If an axis is selected with shape entry not equal to one, an error is raised.
+  If `axes` is not provided, all the single dimensions will be removed from
+  the shape. If an axis is selected with shape entry not equal to one, an error is raised.
 
 #### Version
 
@@ -9171,7 +9172,7 @@ This version of the operator has been available since version 1 of the default O
 #### Attributes
 
 <dl>
-<dt><tt>axes</tt> : list of ints (required)</dt>
+<dt><tt>axes</tt> : list of ints</dt>
 <dd>List of positive integers, indicate the dimensions to squeeze.</dd>
 </dl>
 

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -4150,12 +4150,10 @@ Other versions of this operator: <a href="Changelog.md#LSTM-1">LSTM-1</a>
 <summary>defaults</summary>
 
 ```python
-input = np.array([[[1., 2.], [3., 4.], [5., 6.]]]).astype(np.float32)
-
 input_size = 2
+batch_size = 4
 hidden_size = 3
-weight_scale = 0.1
-number_of_gates = 4
+input  = LSTM_Helper.get_random([1, batch_size, input_size])
 
 node = onnx.helper.make_node(
     'LSTM',
@@ -4164,8 +4162,8 @@ node = onnx.helper.make_node(
     hidden_size=hidden_size
 )
 
-W = weight_scale * np.ones((1, number_of_gates * hidden_size, input_size)).astype(np.float32)
-R = weight_scale * np.ones((1, number_of_gates * hidden_size, hidden_size)).astype(np.float32)
+W = LSTM_Helper.get_random([1, LSTM_Helper.number_of_gates * hidden_size, input_size])
+R = LSTM_Helper.get_random([1, LSTM_Helper.number_of_gates * hidden_size, hidden_size])
 
 lstm = LSTM_Helper(X=input, W=W, R=R)
 _, Y_h = lstm.step()
@@ -4179,13 +4177,11 @@ expect(node, inputs=[input, W, R], outputs=[Y_h.astype(np.float32)], name='test_
 <summary>initial_bias</summary>
 
 ```python
-input = np.array([[[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]]).astype(np.float32)
-
 input_size = 3
+batch_size = 3
 hidden_size = 4
-weight_scale = 0.1
 custom_bias = 0.1
-number_of_gates = 4
+input  = LSTM_Helper.get_random([1, batch_size, input_size])
 
 node = onnx.helper.make_node(
     'LSTM',
@@ -4194,12 +4190,12 @@ node = onnx.helper.make_node(
     hidden_size=hidden_size
 )
 
-W = weight_scale * np.ones((1, number_of_gates * hidden_size, input_size)).astype(np.float32)
-R = weight_scale * np.ones((1, number_of_gates * hidden_size, hidden_size)).astype(np.float32)
+W = LSTM_Helper.get_random([1, LSTM_Helper.number_of_gates * hidden_size, input_size])
+R = LSTM_Helper.get_random([1, LSTM_Helper.number_of_gates * hidden_size, hidden_size])
 
 # Adding custom bias
-W_B = custom_bias * np.ones((1, number_of_gates * hidden_size)).astype(np.float32)
-R_B = np.zeros((1, number_of_gates * hidden_size)).astype(np.float32)
+W_B = LSTM_Helper.get_random([1, LSTM_Helper.number_of_gates*hidden_size])
+R_B = np.zeros((1, LSTM_Helper.number_of_gates * hidden_size)).astype(np.float32)
 B = np.concatenate((W_B, R_B), 1)
 
 lstm = LSTM_Helper(X=input, W=W, R=R, B=B)
@@ -4214,13 +4210,10 @@ expect(node, inputs=[input, W, R, B], outputs=[Y_h.astype(np.float32)], name='te
 <summary>peepholes</summary>
 
 ```python
-input = np.array([[[1., 2., 3., 4.], [5., 6., 7., 8.]]]).astype(np.float32)
-
 input_size = 4
+batch_size = 2
 hidden_size = 3
-weight_scale = 0.1
-number_of_gates = 4
-number_of_peepholes = 3
+input  = np.random.rand(1, batch_size, input_size).astype(np.float32)
 
 node = onnx.helper.make_node(
     'LSTM',
@@ -4230,14 +4223,13 @@ node = onnx.helper.make_node(
 )
 
 # Initializing Inputs
-W = weight_scale * np.ones((1, number_of_gates * hidden_size, input_size)).astype(np.float32)
-R = weight_scale * np.ones((1, number_of_gates * hidden_size, hidden_size)).astype(np.float32)
-B = np.zeros((1, 2 * number_of_gates * hidden_size)).astype(np.float32)
+W = LSTM_Helper.get_random([1, LSTM_Helper.number_of_gates * hidden_size, input_size])
+R = LSTM_Helper.get_random([1, LSTM_Helper.number_of_gates * hidden_size, hidden_size])
+B = np.zeros((1, 2 * LSTM_Helper.number_of_gates * hidden_size)).astype(np.float32)
 seq_lens = np.repeat(input.shape[0], input.shape[1]).astype(np.int32)
 init_h = np.zeros((1, input.shape[1], hidden_size)).astype(np.float32)
 init_c = np.zeros((1, input.shape[1], hidden_size)).astype(np.float32)
-P = weight_scale * np.ones((1, number_of_peepholes * hidden_size)).astype(np.float32)
-
+P = LSTM_Helper.get_random([1, LSTM_Helper.number_of_peepholes*hidden_size]);
 lstm = LSTM_Helper(X=input, W=W, R=R, B=B, P=P, initial_c=init_c, initial_h=init_h)
 _, Y_h = lstm.step()
 expect(node, inputs=[input, W, R, B, seq_lens, init_h, init_c, P], outputs=[Y_h.astype(np.float32)],

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -2112,12 +2112,10 @@ There are 3 test cases, listed as following:
 <summary>defaults</summary>
 
 ```python
-input = np.array([[[1., 2.], [3., 4.], [5., 6.]]]).astype(np.float32)
-
 input_size = 2
+batch_size = 4
 hidden_size = 3
-weight_scale = 0.1
-number_of_gates = 4
+input  = LSTM_Helper.get_random([1, batch_size, input_size])
 
 node = onnx.helper.make_node(
     'LSTM',
@@ -2126,8 +2124,8 @@ node = onnx.helper.make_node(
     hidden_size=hidden_size
 )
 
-W = weight_scale * np.ones((1, number_of_gates * hidden_size, input_size)).astype(np.float32)
-R = weight_scale * np.ones((1, number_of_gates * hidden_size, hidden_size)).astype(np.float32)
+W = LSTM_Helper.get_random([1, LSTM_Helper.number_of_gates * hidden_size, input_size])
+R = LSTM_Helper.get_random([1, LSTM_Helper.number_of_gates * hidden_size, hidden_size])
 
 lstm = LSTM_Helper(X=input, W=W, R=R)
 _, Y_h = lstm.step()
@@ -2139,13 +2137,11 @@ expect(node, inputs=[input, W, R], outputs=[Y_h.astype(np.float32)], name='test_
 <summary>initial_bias</summary>
 
 ```python
-input = np.array([[[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]]).astype(np.float32)
-
 input_size = 3
+batch_size = 3
 hidden_size = 4
-weight_scale = 0.1
 custom_bias = 0.1
-number_of_gates = 4
+input  = LSTM_Helper.get_random([1, batch_size, input_size])
 
 node = onnx.helper.make_node(
     'LSTM',
@@ -2154,12 +2150,12 @@ node = onnx.helper.make_node(
     hidden_size=hidden_size
 )
 
-W = weight_scale * np.ones((1, number_of_gates * hidden_size, input_size)).astype(np.float32)
-R = weight_scale * np.ones((1, number_of_gates * hidden_size, hidden_size)).astype(np.float32)
+W = LSTM_Helper.get_random([1, LSTM_Helper.number_of_gates * hidden_size, input_size])
+R = LSTM_Helper.get_random([1, LSTM_Helper.number_of_gates * hidden_size, hidden_size])
 
 # Adding custom bias
-W_B = custom_bias * np.ones((1, number_of_gates * hidden_size)).astype(np.float32)
-R_B = np.zeros((1, number_of_gates * hidden_size)).astype(np.float32)
+W_B = LSTM_Helper.get_random([1, LSTM_Helper.number_of_gates*hidden_size])
+R_B = np.zeros((1, LSTM_Helper.number_of_gates * hidden_size)).astype(np.float32)
 B = np.concatenate((W_B, R_B), 1)
 
 lstm = LSTM_Helper(X=input, W=W, R=R, B=B)
@@ -2172,13 +2168,10 @@ expect(node, inputs=[input, W, R, B], outputs=[Y_h.astype(np.float32)], name='te
 <summary>peepholes</summary>
 
 ```python
-input = np.array([[[1., 2., 3., 4.], [5., 6., 7., 8.]]]).astype(np.float32)
-
 input_size = 4
+batch_size = 2
 hidden_size = 3
-weight_scale = 0.1
-number_of_gates = 4
-number_of_peepholes = 3
+input  = np.random.rand(1, batch_size, input_size).astype(np.float32)
 
 node = onnx.helper.make_node(
     'LSTM',
@@ -2188,14 +2181,13 @@ node = onnx.helper.make_node(
 )
 
 # Initializing Inputs
-W = weight_scale * np.ones((1, number_of_gates * hidden_size, input_size)).astype(np.float32)
-R = weight_scale * np.ones((1, number_of_gates * hidden_size, hidden_size)).astype(np.float32)
-B = np.zeros((1, 2 * number_of_gates * hidden_size)).astype(np.float32)
+W = LSTM_Helper.get_random([1, LSTM_Helper.number_of_gates * hidden_size, input_size])
+R = LSTM_Helper.get_random([1, LSTM_Helper.number_of_gates * hidden_size, hidden_size])
+B = np.zeros((1, 2 * LSTM_Helper.number_of_gates * hidden_size)).astype(np.float32)
 seq_lens = np.repeat(input.shape[0], input.shape[1]).astype(np.int32)
 init_h = np.zeros((1, input.shape[1], hidden_size)).astype(np.float32)
 init_c = np.zeros((1, input.shape[1], hidden_size)).astype(np.float32)
-P = weight_scale * np.ones((1, number_of_peepholes * hidden_size)).astype(np.float32)
-
+P = LSTM_Helper.get_random([1, LSTM_Helper.number_of_peepholes*hidden_size]);
 lstm = LSTM_Helper(X=input, W=W, R=R, B=B, P=P, initial_c=init_c, initial_h=init_h)
 _, Y_h = lstm.step()
 expect(node, inputs=[input, W, R, B, seq_lens, init_h, init_c, P], outputs=[Y_h.astype(np.float32)],

--- a/onnx/backend/test/case/node/lstm.py
+++ b/onnx/backend/test/case/node/lstm.py
@@ -89,7 +89,7 @@ class LSTM_Helper():
 
 
     @staticmethod
-    def get_random(shape, scale = 1.0):
+    def get_random(shape, scale = 1.0):  # type: ignore
         """ 
         return float 32 array with values uniformly sampled from [-scale, scale)
         """

--- a/onnx/backend/test/case/node/lstm.py
+++ b/onnx/backend/test/case/node/lstm.py
@@ -40,10 +40,14 @@ class LSTM_Helper():
             hidden_size = params[R].shape[-1]
             batch_size = params[X].shape[1]
 
-            b = params[B] if B in params else np.zeros(2 * self.number_of_gates * hidden_size, dtype=np.float32)
-            p = params[P] if P in params else np.zeros(self.number_of_peepholes * hidden_size, dtype=np.float32)
-            h_0 = params[H_0] if H_0 in params else np.zeros((batch_size, hidden_size), dtype=np.float32)
-            c_0 = params[C_0] if C_0 in params else np.zeros((batch_size, hidden_size), dtype=np.float32)
+            b = params[B] if B in params else np.zeros(
+                2 * self.number_of_gates * hidden_size, dtype=np.float32)
+            p = params[P] if P in params else np.zeros(
+                self.number_of_peepholes * hidden_size, dtype=np.float32)
+            h_0 = params[H_0] if H_0 in params else np.zeros(
+                (batch_size, hidden_size), dtype=np.float32)
+            c_0 = params[C_0] if C_0 in params else np.zeros(
+                (batch_size, hidden_size), dtype=np.float32)
 
             self.X = params[X]
             self.W = params[W]
@@ -70,8 +74,8 @@ class LSTM_Helper():
         H_t = self.H_0
         C_t = self.C_0
         for x in np.split(self.X, self.X.shape[0], axis=0):
-            gates = np.dot(x, np.transpose(self.W)) + np.dot(H_t, np.transpose(self.R)) + np.add(
-                *np.split(self.B, 2))
+            gates = np.dot(x, np.transpose(self.W)) + np.dot(
+                H_t, np.transpose(self.R)) + np.add(*np.split(self.B, 2))
             i, o, f, c = np.split(gates, 4, -1)
             i = self.f(i + p_i * C_t)
             f = self.f(f + p_f * C_t)
@@ -87,88 +91,108 @@ class LSTM_Helper():
             output = np.expand_dims(concatenated, 1)
         return output, h_list[-1]
 
-
     @staticmethod
-    def get_random(shape, scale = 1.0):  # type: ignore
-        """ 
+    def get_random(shape, scale=1.0):  # type: ignore
+        """
         return float 32 array with values uniformly sampled from [-scale, scale)
         """
-        return (scale * (2.*np.random.random_sample(shape) - 1.)).astype(np.float32)
+        return (scale * (2. * np.random.random_sample(shape) - 1.)).astype(np.float32)
 
 
 class LSTM(Base):
-
     @staticmethod
     def export_defaults():  # type: () -> None
         input_size = 2
         batch_size = 4
         hidden_size = 3
-        input  = LSTM_Helper.get_random([1, batch_size, input_size])
+        input = LSTM_Helper.get_random([1, batch_size, input_size])
 
         node = onnx.helper.make_node(
             'LSTM',
             inputs=['X', 'W', 'R'],
             outputs=['', 'Y'],
-            hidden_size=hidden_size
-        )
+            hidden_size=hidden_size)
 
-        W = LSTM_Helper.get_random([1, LSTM_Helper.number_of_gates * hidden_size, input_size])
-        R = LSTM_Helper.get_random([1, LSTM_Helper.number_of_gates * hidden_size, hidden_size])
+        W = LSTM_Helper.get_random(
+            [1, LSTM_Helper.number_of_gates * hidden_size, input_size])
+        R = LSTM_Helper.get_random(
+            [1, LSTM_Helper.number_of_gates * hidden_size, hidden_size])
 
         lstm = LSTM_Helper(X=input, W=W, R=R)
         _, Y_h = lstm.step()
-        expect(node, inputs=[input, W, R], outputs=[Y_h.astype(np.float32)], name='test_lstm_defaults')
+        expect(
+            node,
+            inputs=[input, W, R],
+            outputs=[Y_h.astype(np.float32)],
+            name='test_lstm_defaults')
 
     @staticmethod
     def export_initial_bias():  # type: () -> None
         input_size = 3
         batch_size = 3
         hidden_size = 4
-        custom_bias = 0.1
-        input  = LSTM_Helper.get_random([1, batch_size, input_size])
+        input = LSTM_Helper.get_random([1, batch_size, input_size])
 
         node = onnx.helper.make_node(
             'LSTM',
             inputs=['X', 'W', 'R', 'B'],
             outputs=['', 'Y'],
-            hidden_size=hidden_size
-        )
+            hidden_size=hidden_size)
 
-        W = LSTM_Helper.get_random([1, LSTM_Helper.number_of_gates * hidden_size, input_size])
-        R = LSTM_Helper.get_random([1, LSTM_Helper.number_of_gates * hidden_size, hidden_size])
+        W = LSTM_Helper.get_random(
+            [1, LSTM_Helper.number_of_gates * hidden_size, input_size])
+        R = LSTM_Helper.get_random(
+            [1, LSTM_Helper.number_of_gates * hidden_size, hidden_size])
 
         # Adding custom bias
-        W_B = LSTM_Helper.get_random([1, LSTM_Helper.number_of_gates*hidden_size])
-        R_B = np.zeros((1, LSTM_Helper.number_of_gates * hidden_size)).astype(np.float32)
+        W_B = LSTM_Helper.get_random(
+            [1, LSTM_Helper.number_of_gates * hidden_size])
+        R_B = np.zeros(
+            (1, LSTM_Helper.number_of_gates * hidden_size)).astype(np.float32)
         B = np.concatenate((W_B, R_B), 1)
 
         lstm = LSTM_Helper(X=input, W=W, R=R, B=B)
         _, Y_h = lstm.step()
-        expect(node, inputs=[input, W, R, B], outputs=[Y_h.astype(np.float32)], name='test_lstm_with_initial_bias')
+        expect(
+            node,
+            inputs=[input, W, R, B],
+            outputs=[Y_h.astype(np.float32)],
+            name='test_lstm_with_initial_bias')
 
     @staticmethod
     def export_peepholes():  # type: () -> None
         input_size = 4
         batch_size = 2
         hidden_size = 3
-        input  = np.random.rand(1, batch_size, input_size).astype(np.float32)
+        input = np.random.rand(1, batch_size, input_size).astype(np.float32)
 
         node = onnx.helper.make_node(
             'LSTM',
-            inputs=['X', 'W', 'R', 'B', 'sequence_lens', 'initial_h', 'initial_c', 'P'],
+            inputs=[
+                'X', 'W', 'R', 'B', 'sequence_lens', 'initial_h', 'initial_c',
+                'P'
+            ],
             outputs=['', 'Y'],
-            hidden_size=hidden_size
-        )
+            hidden_size=hidden_size)
 
         # Initializing Inputs
-        W = LSTM_Helper.get_random([1, LSTM_Helper.number_of_gates * hidden_size, input_size])
-        R = LSTM_Helper.get_random([1, LSTM_Helper.number_of_gates * hidden_size, hidden_size])
-        B = np.zeros((1, 2 * LSTM_Helper.number_of_gates * hidden_size)).astype(np.float32)
+        W = LSTM_Helper.get_random(
+            [1, LSTM_Helper.number_of_gates * hidden_size, input_size])
+        R = LSTM_Helper.get_random(
+            [1, LSTM_Helper.number_of_gates * hidden_size, hidden_size])
+        B = np.zeros(
+            (1,
+             2 * LSTM_Helper.number_of_gates * hidden_size)).astype(np.float32)
         seq_lens = np.repeat(input.shape[0], input.shape[1]).astype(np.int32)
         init_h = np.zeros((1, input.shape[1], hidden_size)).astype(np.float32)
         init_c = np.zeros((1, input.shape[1], hidden_size)).astype(np.float32)
-        P = LSTM_Helper.get_random([1, LSTM_Helper.number_of_peepholes*hidden_size]);
-        lstm = LSTM_Helper(X=input, W=W, R=R, B=B, P=P, initial_c=init_c, initial_h=init_h)
+        P = LSTM_Helper.get_random(
+            [1, LSTM_Helper.number_of_peepholes * hidden_size])
+        lstm = LSTM_Helper(
+            X=input, W=W, R=R, B=B, P=P, initial_c=init_c, initial_h=init_h)
         _, Y_h = lstm.step()
-        expect(node, inputs=[input, W, R, B, seq_lens, init_h, init_c, P], outputs=[Y_h.astype(np.float32)],
-               name='test_lstm_with_peepholes')
+        expect(
+            node,
+            inputs=[input, W, R, B, seq_lens, init_h, init_c, P],
+            outputs=[Y_h.astype(np.float32)],
+            name='test_lstm_with_peepholes')

--- a/onnx/common/ir_pb_converter.cc
+++ b/onnx/common/ir_pb_converter.cc
@@ -450,9 +450,7 @@ void encodeTypeProtoTensorType(ONNX_NAMESPACE::TypeProto_Tensor* tensor_type, Va
 }
 
 void encodeValueInfo(ONNX_NAMESPACE::ValueInfoProto* v, Value* n) {
-  if (n->has_unique_name()) {
-    v->set_name(value_name(n));
-  }
+  v->set_name(value_name(n));
   ONNX_NAMESPACE::TypeProto* t = v->mutable_type();
   ONNX_NAMESPACE::TypeProto_Tensor* tensor_type = t->mutable_tensor_type();
   encodeTypeProtoTensorType(tensor_type, n);

--- a/onnx/common/tensor.h
+++ b/onnx/common/tensor.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "onnx/onnx_pb.h"
-#include <math.h>
+#include <cmath>
 #include <numeric>
 #include <functional>
 #include <stdexcept>

--- a/onnx/common/tensor.h
+++ b/onnx/common/tensor.h
@@ -4,8 +4,17 @@
 #pragma once
 
 #include "onnx/onnx_pb.h"
+#include <math.h>
+#include <numeric>
+#include <functional>
+#include <stdexcept>
+
 
 namespace ONNX_NAMESPACE {
+
+class TensorError final : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
 
 struct Tensor final {
 private:
@@ -26,6 +35,15 @@ private:
 
   bool is_raw_data_;
   std::string raw_data_;
+
+  template<typename F, typename T>
+  void bin_func(F f, T* ptr, const T* a_ptr);
+
+  template<typename F, typename T>
+  void un_func(F f, T* ptr);
+
+  template<typename T>
+  void scale_dim(T* ptr, const T* s_ptr);
 
 public:
   Tensor()
@@ -109,6 +127,14 @@ public:
     raw_data_ = std::move(raw_data);
   }
 
+  void set_raw_data(const char* raw_data, size_t size) {
+    set_raw_data({raw_data, size});
+  }
+
+  void set_raw_data(const char* raw_data) {
+    set_raw_data(raw_data, raw_data_.size());
+  }
+
   bool is_segment() const {
     return is_segment_;
   }
@@ -139,6 +165,225 @@ public:
     has_name_ = true;
     name_ = std::move(name);
   }
+
+  bool is_raw_data() const {
+    return is_raw_data_;
+  }
+
+  //this += a
+  //Supported for
+  //FLOAT, BOOL, INT8, INT16, INT32, UINT8, UINT16, INT64,
+  //UINT32, UINT64, DOUBLE,
+  //TODO: Support for FLOAT16, COMPLEX64, COMPLEX128
+  void add(const Tensor& a);
+
+  //this -= a
+  //Supported for
+  //FLOAT, BOOL, INT8, INT16, INT32, UINT8, UINT16, INT64,
+  //UINT32, UINT64, DOUBLE
+  //TODO: Support for FLOAT16, COMPLEX64, COMPLEX128
+  void subtract(const Tensor& a);
+
+  //this *= a
+  //Supported for
+  //FLOAT, BOOL, INT8, INT16, INT32, UINT8, UINT16, INT64,
+  //UINT32, UINT64, DOUBLE
+  //TODO: Support for FLOAT16, COMPLEX64, COMPLEX128
+  void multiply(const Tensor& a);
+
+  //this /= a
+  //Supported for
+  //FLOAT, INT8, INT16, INT32, UINT8, UINT16, INT64,
+  //UINT32, UINT64, DOUBLE
+  //TODO: Support for FLOAT16, COMPLEX64, COMPLEX128
+  void divide(const Tensor& a);
+
+  //Element-wise square root of This
+  //Supported for
+  //FLOAT, DOUBLE,
+  //TODO: Support for FLOAT16
+  void sqrt();
+
+  //Element wise scaling of tensor s
+  //s is one dimensional, has size M, where M is size of first dimension of tensor
+  //s must have has data type corresponding to this
+  //Supported for
+  //FLOAT16, FLOAT, DOUBLE
+  void scale_by_first_dim(const Tensor& s);
 };
+
+#define CONST_DATA(owner, type, vec)                                           \
+  const type* owner##_const_data_ptr;                                          \
+  if (owner->is_raw_data())  {                                                 \
+    owner##_const_data_ptr = (const type*) owner->raw().c_str();               \
+  } else {                                                                     \
+    owner##_const_data_ptr = (const type*) owner->vec().data();                \
+  }                                                                            \
+
+
+#define DATA(owner, type, vec)                                                 \
+  type* owner##_data_ptr;                                                      \
+  std::vector<type> vals;                                                      \
+  if (owner->is_raw_data())  {                                                 \
+    for (size_t i = 0; i < raw_data_.size(); i += sizeof(type))  {             \
+        vals.push_back(*((const type*)(owner->raw().c_str() + i)));            \
+    }                                                                          \
+    owner##_data_ptr = (type*) vals.data();                                    \
+  } else {                                                                     \
+    owner##_data_ptr = (type*) owner->vec().data();                            \
+  }                                                                            \
+
+
+#define SET_RAW_DATA(ptr)                                                      \
+  if (is_raw_data_)  {                                                         \
+    set_raw_data((const char*)(ptr));                                          \
+  }                                                                            \
+
+
+
+template<typename F, typename T>
+inline void Tensor::bin_func(F f, T* ptr, const T* a_ptr) {
+  int64_t num_elements = std::accumulate(sizes_.begin(), sizes_.end(),
+                                        (int64_t) 1, std::multiplies<int64_t>());
+  for (int64_t i = 0; i < num_elements; ++i) {
+    ptr[i] = f(ptr[i], a_ptr[i]);
+  }
+  SET_RAW_DATA(ptr)
+}
+
+template<typename F, typename T>
+inline void Tensor::un_func(F f, T* ptr)  {
+  int64_t num_elements = std::accumulate(sizes_.begin(), sizes_.end(),
+                                        (int64_t) 1, std::multiplies<int64_t>());
+  for (int64_t i = 0; i < num_elements; ++i) {
+    ptr[i] = f(ptr[i]);
+  }
+  SET_RAW_DATA(ptr)
+}
+
+template<typename T>
+inline void Tensor::scale_dim(T* ptr, const T* s_ptr)  {
+  int64_t elems_per_first_dim = std::accumulate(sizes_.begin() + 1, sizes_.end(),
+                                              (int64_t) 1, std::multiplies<int64_t>());
+  int64_t first_dim_size = sizes_[0];
+  int64_t counter = 0;
+  for (int64_t i = 0; i < first_dim_size; ++i)  {
+    for (int64_t j = 0; j < elems_per_first_dim; ++j) {
+      ptr[counter++] *= s_ptr[i];
+    }
+  }
+  SET_RAW_DATA(ptr)
+}
+
+#define CALL_BIN_FUNC(type, vec, f)                                            \
+  DATA(this, type, vec)                                                        \
+  CONST_DATA(a, type, vec)                                                     \
+  bin_func(f<type>(), this_data_ptr, a_const_data_ptr);                        \
+
+
+
+#define APPLY_BINARY_FUNCTION(op_name, f)                                      \
+  inline void Tensor::op_name(const Tensor& a_tensor) {                        \
+    const Tensor* a = &a_tensor;                                               \
+    if (a->elem_type() != elem_type_) {                                        \
+      throw TensorError(std::string("Tensor types do not match.\nType ") +     \
+      ONNX_NAMESPACE::to_string(elem_type_) + std::string(" != Type ") +       \
+      ONNX_NAMESPACE::to_string(a->elem_type()));                              \
+    }                                                                          \
+    if (a->sizes() != sizes_) {                                                \
+      throw TensorError(std::string("Tensor sizes do not match."));            \
+    }                                                                          \
+    switch(elem_type_) {                                                       \
+      case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:  {                      \
+        CALL_BIN_FUNC(float, floats, f)                                        \
+        break;                                                                 \
+      }                                                                        \
+      case ONNX_NAMESPACE::TensorProto_DataType_BOOL:                          \
+      case ONNX_NAMESPACE::TensorProto_DataType_INT8:                          \
+      case ONNX_NAMESPACE::TensorProto_DataType_INT16:                         \
+      case ONNX_NAMESPACE::TensorProto_DataType_INT32:                         \
+      case ONNX_NAMESPACE::TensorProto_DataType_UINT8:                         \
+      case ONNX_NAMESPACE::TensorProto_DataType_UINT16:  {                     \
+        CALL_BIN_FUNC(int32_t, int32s, f)                                      \
+        break;                                                                 \
+      }                                                                        \
+      case ONNX_NAMESPACE::TensorProto_DataType_INT64:  {                      \
+        CALL_BIN_FUNC(int64_t, int64s, f)                                      \
+        break;                                                                 \
+      }                                                                        \
+      case ONNX_NAMESPACE::TensorProto_DataType_UINT32:                        \
+      case ONNX_NAMESPACE::TensorProto_DataType_UINT64:  {                     \
+        CALL_BIN_FUNC(uint64_t, uint64s, f)                                    \
+        break;                                                                 \
+      }                                                                        \
+      case ONNX_NAMESPACE::TensorProto_DataType_DOUBLE: {                      \
+        CALL_BIN_FUNC(double, doubles, f)                                      \
+        break;                                                                 \
+      }                                                                        \
+      default:                                                                 \
+        throw TensorError(std::string("Operation ") + std::string(#op_name) +  \
+        std::string(" not supported for data type ") +                         \
+        ONNX_NAMESPACE::to_string(elem_type_));                                \
+    }                                                                          \
+  }                                                                            \
+
+APPLY_BINARY_FUNCTION(add, std::plus)
+APPLY_BINARY_FUNCTION(subtract, std::minus)
+APPLY_BINARY_FUNCTION(multiply, std::multiplies)
+APPLY_BINARY_FUNCTION(divide, std::divides)
+
+#undef CALL_BIN_FUNC
+#undef APPLY_BINARY_FUNCTION
+
+inline void Tensor::sqrt() {
+  switch(elem_type_) {
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:  {
+      DATA(this, float, floats)
+      un_func<float (*)(float), float>(std::sqrt, this_data_ptr);
+      break;
+    }
+    case ONNX_NAMESPACE::TensorProto_DataType_DOUBLE: {
+      DATA(this, double, doubles)
+      un_func<double (*)(double), double>(std::sqrt, this_data_ptr);
+      break;
+    }
+    default:
+      throw TensorError(std::string("Operation sqrt not supported for data type ") +
+      ONNX_NAMESPACE::to_string(elem_type_));
+    }
+}
+
+inline void Tensor::scale_by_first_dim(const Tensor& s_tensor) {
+  const Tensor* s = &s_tensor;
+  ONNX_ASSERT(sizes_.size() > 1 && s->sizes().size() == 1 && s->sizes()[0] == sizes_[0]);
+  ONNX_ASSERT(s->elem_type() == elem_type_);
+
+  switch(elem_type_) {
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:  {
+      DATA(this, float, floats)
+      CONST_DATA(s, float, floats)
+      scale_dim<float>(this_data_ptr, s_const_data_ptr);
+      break;
+    }
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16: {
+      DATA(this, int32_t, int32s)
+      CONST_DATA(s, int32_t, int32s)
+      scale_dim<int32_t>(this_data_ptr, s_const_data_ptr);
+      break;
+    }
+    case ONNX_NAMESPACE::TensorProto_DataType_DOUBLE: {
+      DATA(this, double, doubles)
+      CONST_DATA(s, double, doubles)
+      scale_dim<double>(this_data_ptr, s_const_data_ptr);
+      break;
+    }
+    default:
+      throw TensorError(std::string("Operation scale_by_first_dim not supported for data type ") +
+      ONNX_NAMESPACE::to_string(elem_type_));
+    }
+}
+#undef CONST_DATA
+#undef DATA
+#undef SET_RAW_DATA
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -605,7 +605,8 @@ ONNX_OPERATOR_SET_SCHEMA(
 static const char* Squeeze_ver1_doc = R"DOC(
 Remove single-dimensional entries from the shape of a tensor.
 Takes a  parameter `axes` with a list of axes to squeeze.
-If an axis is selected with shape entry not equal to one, an error is raised.
+If `axes` is not provided, all the single dimensions will be removed from
+the shape. If an axis is selected with shape entry not equal to one, an error is raised.
 )DOC";
 
 ONNX_OPERATOR_SET_SCHEMA(
@@ -615,7 +616,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Attr(
             "axes",
             "List of positive integers, indicate the dimensions to squeeze.",
-            AttributeProto::INTS)
+            AttributeProto::INTS,
+            OPTIONAL)
         .SetDoc(Squeeze_ver1_doc)
         .Input(0, "data", "Tensors with at least max(dims) dimensions.", "T")
         .Output(0, "squeezed", "Reshaped tensor with same data as input.", "T")

--- a/onnx/onnxifi_loader.c
+++ b/onnx/onnxifi_loader.c
@@ -1,0 +1,237 @@
+#ifdef _WIN32
+#include <windows.h>
+#include <malloc.h> /* for _alloca */
+#else
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <alloca.h>
+#include <dlfcn.h>
+#endif
+
+#include <onnxifi_loader.h>
+
+/* ONNXIFI_LOADER_LOGGING macro enables/disables logging. Its OFF by default. */
+#ifndef ONNXIFI_LOADER_LOGGING
+#define ONNXIFI_LOADER_LOGGING 0
+#endif
+
+#if ONNXIFI_LOADER_LOGGING
+#if defined(__ANDROID__)
+#include <android/log.h>
+/* Tag used for logging on Android */
+#define ONNXIFI_LOADER_ANDROID_LOG_TAG "ONNX-LOADER"
+#else
+#include <stdio.h>
+#endif
+#endif
+
+#if defined(__APPLE__)
+#define ONNXIFI_LIBRARY_NAME "libonnxifi.dylib"
+#elif defined(_WIN32)
+#define ONNXIFI_LIBRARY_NAME L"onnxifi.dll"
+#else
+#define ONNXIFI_LIBRARY_NAME "libonnxifi.so"
+#endif
+
+/* Order must match declaration order in onnxifi_library structure */
+static const char onnxifi_function_names[] =
+    "onnxGetBackendIDs\0"
+    "onnxReleaseBackendID\0"
+    "onnxGetBackendInfo\0"
+    "onnxGetBackendCompatibility\0"
+    "onnxInitBackend\0"
+    "onnxReleaseBackend\0"
+    "onnxInitEvent\0"
+    "onnxSignalEvent\0"
+    "onnxWaitEvent\0"
+    "onnxReleaseEvent\0"
+    "onnxInitGraph\0"
+    "onnxSetGraphIO\0"
+    "onnxRunGraph\0"
+    "onnxReleaseGraph\0";
+
+/* Length of the longest function, including terminating null */
+#define ONNXIFI_FUNCTION_NAME_MAX sizeof("onnxGetBackendCompatibility")
+
+int ONNXIFI_ABI onnxifi_load(
+  uint32_t flags,
+#ifdef _WIN32
+  const wchar_t* path,
+#else
+  const char* path,
+#endif
+  const char* suffix,
+  struct onnxifi_library* onnx)
+{
+  size_t i;
+  const char* function_name;
+  char* buffer;
+  size_t buffer_length;
+  size_t suffix_length;
+#ifdef _WIN32
+  LPCSTR format_arguments[2];
+#endif
+
+  if (onnx == NULL) {
+    return 0;
+  }
+
+#ifdef _WIN32
+  ZeroMemory(onnx, sizeof(struct onnxifi_library));
+#else
+  memset(onnx, 0, sizeof(struct onnxifi_library));
+#endif
+  if (!(flags & ONNXIFI_LOADER_FLAG_VERSION_1_0)) {
+    /* Unknown ONNXIFI version requested */
+    return 0;
+  }
+
+  if (path == NULL) {
+    path = ONNXIFI_LIBRARY_NAME;
+  }
+  if (suffix == NULL) {
+    suffix = "";
+  }
+
+#ifdef _WIN32
+  buffer_length = ONNXIFI_FUNCTION_NAME_MAX + lstrlenA(suffix);
+  buffer = (char*) _alloca(buffer_length);
+#else
+  buffer_length = ONNXIFI_FUNCTION_NAME_MAX + strlen(suffix);
+  buffer = (char*) alloca(buffer_length);
+#endif
+
+#ifdef _WIN32
+  onnx->handle = (void*) LoadLibraryExW(path, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+#else
+  /* Clear libdl error state */
+  dlerror();
+  onnx->handle = dlopen(path, RTLD_NOW | RTLD_GLOBAL);
+#endif
+  if (onnx->handle == NULL) {
+#if ONNXIFI_LOADER_LOGGING
+#if defined(__ANDROID__)
+    __android_log_print(
+      ANDROID_LOG_ERROR,
+      ONNXIFI_LOADER_ANDROID_LOG_TAG,
+      "failed to load %s: %s",
+      path, dlerror());
+#elif defined(_WIN32)
+    fprintf(
+      stderr,
+      "Error: failed to load %S: error %u\n",
+      path, (unsigned long) GetLastError());
+#else
+    fprintf(stderr, "Error: failed to load %s: %s\n",
+      path, dlerror());
+#endif
+#endif /* ONNXIFI_LOADER_LOGGING */
+
+    goto failed;
+  }
+
+  function_name = onnxifi_function_names;
+  for (i = 0; i < ONNXIFI_LOADER_FUNCTION_COUNT; i++) {
+#ifdef _WIN32
+    format_arguments[0] = &function_name;
+    format_arguments[1] = &suffix;
+    FormatMessageA(
+      FORMAT_MESSAGE_FROM_STRING | FORMAT_MESSAGE_ARGUMENT_ARRAY,
+      "%1%2", 0 /* message id: ignored */, 0 /* language id: default */,
+      buffer, (DWORD) buffer_length, (va_list*) format_arguments);
+    onnx->functions[i] = GetProcAddress((HMODULE) onnx->handle, buffer);
+#else
+    snprintf(buffer, buffer_length, "%s%s", function_name, suffix);
+    onnx->functions[i] = dlsym(onnx->handle, buffer);
+#endif
+
+    if (onnx->functions[i] == NULL) {
+#if ONNXIFI_LOADER_LOGGING
+#if defined(__ANDROID__)
+      __android_log_print(
+        ANDROID_LOG_ERROR,
+        ONNXIFI_LOADER_ANDROID_LOG_TAG,
+        "failed to find function %s in %s: %s",
+        function_name,
+        ONNXIFI_LIBRARY_NAME,
+        dlerror());
+#elif defined(_WIN32)
+      fprintf(
+        stderr,
+        "Error: failed to find function %s in %s: error %u\n",
+        function_name,
+        ONNXIFI_LIBRARY_NAME,
+        (unsigned long) GetLastError());
+#else
+      fprintf(
+        stderr,
+        "Error: failed to find function %s in %s: %s\n",
+        function_name,
+        ONNXIFI_LIBRARY_NAME,
+        dlerror());
+#endif
+#endif /* ONNXIFI_LOADER_LOGGING */
+
+      goto failed;
+    }
+#ifdef _WIN32
+    function_name += lstrlenA(function_name);
+#else
+    function_name += strlen(function_name);
+#endif
+    /* Skip null-terminator */
+    function_name += 1;
+  }
+
+  onnx->flags = flags & ONNXIFI_LOADER_FLAG_VERSION_MASK;
+  return 1;
+
+failed:
+  onnxifi_unload(onnx);
+  return 0;
+}
+
+void ONNXIFI_ABI onnxifi_unload(struct onnxifi_library* onnx) {
+  if (onnx != NULL) {
+    if (onnx->handle != NULL) {
+#ifdef _WIN32
+      if (FreeLibrary((HMODULE) onnx->handle) == FALSE) {
+#if ONNXIFI_LOADER_LOGGING
+        fprintf(
+          stderr,
+          "Error: failed to unload library %s: error %u\n",
+          ONNXIFI_LIBRARY_NAME,
+          (unsigned long) GetLastError());
+#endif /* ONNXIFI_LOADER_LOGGING */
+      }
+#else /* !defined(_WIN32) */
+      /* Clear libdl error state */
+      dlerror();
+      if (dlclose(onnx->handle) != 0) {
+#if ONNXIFI_LOADER_LOGGING
+#if defined(__ANDROID__)
+        __android_log_print(
+          ANDROID_LOG_ERROR,
+          ONNXIFI_LOADER_ANDROID_LOG_TAG,
+          "failed to unload %s: %s",
+          ONNXIFI_LIBRARY_NAME,
+          dlerror());
+#else
+        fprintf(
+          stderr,
+          "Error: failed to unload %s: %s\n",
+          ONNXIFI_LIBRARY_NAME,
+          dlerror());
+#endif
+#endif /* ONNXIFI_LOADER_LOGGING */
+      }
+#endif /* !defined(_WIN32) */
+    }
+#ifdef _WIN32
+    ZeroMemory(onnx, sizeof(struct onnxifi_library));
+#else
+    memset(onnx, 0, sizeof(struct onnxifi_library));
+#endif
+  }
+}

--- a/onnx/onnxifi_loader.h
+++ b/onnx/onnxifi_loader.h
@@ -1,0 +1,106 @@
+#ifndef ONNXIFI_LOADER_H
+#define ONNXIFI_LOADER_H 1
+
+#include <onnxifi.h>
+
+#define ONNXIFI_LOADER_FUNCTION_COUNT 14
+
+#define ONNXIFI_LOADER_FLAG_VERSION_MASK 0xFF
+#define ONNXIFI_LOADER_FLAG_VERSION_1_0 0x01
+
+#ifndef ONNXIFI_HIDDEN
+#if defined(__ELF__)
+#define ONNXIFI_HIDDEN __attribute__((__visibility__("hidden")))
+#elif defined(__MACH__)
+#define ONNXIFI_HIDDEN __attribute__((__visibility__("hidden")))
+#else
+#define ONNXIFI_HIDDEN
+#endif
+#endif /* !defined(ONNXIFI_HIDDEN) */
+
+struct onnxifi_library {
+  /*
+   * Opaque handle for the loaded ONNXIFI library.
+   *
+   * Note: this is the value returned from LoadLibraryW (on Windows), or
+   * dlopen (on other operating systems and environments).
+   */
+  void* handle;
+  /*
+   * Options used for dynamic loading of the ONNXIFI library and its API
+   * functions. These are the options passed in flags parameter to onnxifi_load.
+   */
+  uint32_t flags;
+  union {
+    struct {
+      onnxGetBackendIDsFunction onnxGetBackendIDs;
+      onnxReleaseBackendIDFunction onnxReleaseBackendID;
+      onnxGetBackendInfoFunction onnxGetBackendInfo;
+      onnxGetBackendCompatibilityFunction onnxGetBackendCompatibility;
+      onnxInitBackendFunction onnxInitBackend;
+      onnxReleaseBackendFunction onnxReleaseBackend;
+      onnxInitEventFunction onnxInitEvent;
+      onnxSignalEventFunction onnxSignalEvent;
+      onnxWaitEventFunction onnxWaitEvent;
+      onnxReleaseEventFunction onnxReleaseEvent;
+      onnxInitGraphFunction onnxInitGraph;
+      onnxSetGraphIOFunction onnxSetGraphIO;
+      onnxRunGraphFunction onnxRunGraph;
+      onnxReleaseGraphFunction onnxReleaseGraph;
+    };
+    void* functions[ONNXIFI_LOADER_FUNCTION_COUNT];
+  };
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Dynamically load the ONNXIFI library.
+ *
+ * @param flags - options for dynamic loading of the ONNXIFI library.
+ *                The ONNXIFI_LOADER_FLAG_VERSION_MASK part of the flags
+ *                specifies which ONNX API function should be loaded. The only
+ *                currently supported value is ONNXIFI_LOADER_FLAG_VERSION_1_0.
+ * @param path - optional path to the ONNXIFI library to load.
+ *               If this argument is null, the default path is used.
+ * @param[in] suffix - optional suffix for names of ONNX Backend API functions.
+ *                     E.g. if this argument is "GAMMA", the loader will search
+ *                     for "onnxGetNumBackendsGAMMA", "onnxGetBackendInfoGAMMA",
+ *                     etc. functions in the loaded library.
+ *                     If this argument is null, an empty suffix is used.
+ * @param[out] library - the structure representing the dynamic library and
+ *                       its API functions. On success, this structure will
+ *                       be initialized with valid pointers to implentation.
+ *                       On failure, this structure will be zero-initialized.
+ *
+ * @return Non-zero if the function succeeds, or zero if the function fails.
+ */
+ONNXIFI_HIDDEN int ONNXIFI_ABI onnxifi_load(
+  uint32_t flags,
+#ifdef _WIN32
+  const wchar_t* path,
+#else
+  const char* path,
+#endif
+  const char* suffix,
+  struct onnxifi_library* library);
+
+/**
+ * Unload the dynamically loaded ONNXIFI library.
+ *
+ * @param[in,out] library - the structure representing the dynamic library and
+ *                          its API functions. If this structure is
+ *                          zero-initialized, the function does nothing.
+ *                          The function zero-initialized the structure before
+ *                          returning.
+ */
+ONNXIFI_HIDDEN void ONNXIFI_ABI onnxifi_unload(
+  struct onnxifi_library* library);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* !defined(ONNXIFI_LOADER_H) */

--- a/onnx/optimizer/optimize.h
+++ b/onnx/optimizer/optimize.h
@@ -17,6 +17,7 @@
 #include "onnx/optimizer/passes/lift_lexical_references.h"
 #include "onnx/optimizer/passes/nop.h"
 #include "onnx/optimizer/passes/split.h"
+#include "onnx/optimizer/passes/fuse_bn_into_conv.h"
 #include "onnx/proto_utils.h"
 
 namespace ONNX_NAMESPACE { namespace optimization {
@@ -40,6 +41,7 @@ struct Optimizer {
     _registerOptimizer<SplitInit>();
     _registerOptimizer<SplitPredict>();
     _registerOptimizer<LiftLexicalReferences>();
+    _registerOptimizer<FuseBNIntoConv>();
   }
 
   virtual ~Optimizer() = default;

--- a/onnx/optimizer/passes/extract_constant_to_initializer.h
+++ b/onnx/optimizer/passes/extract_constant_to_initializer.h
@@ -28,18 +28,8 @@ struct ExtractConstantToInitializer final : public OptimizePass {
       if (n->kind() == kConstant) {
         const auto name = n->output()->uniqueName();
         Tensor t = n->t(kvalue);
-
-        // add a new graph input
-        Value* input = graph.addInput();
-        input->setUniqueName(name);
-        input->setSizes({t.sizes().begin(), t.sizes().end()});
-        input->setElemType(t.elem_type());
-        n->output()->replaceAllUsesWith(input);
-
-        // copy the tensor to initializer
-        t.setName(name);
-        graph.addInitializer(std::move(t), name);
-
+        Value* new_init = graph.addInitializerAndInput(t, name);
+        n->output()->replaceAllUsesWith(new_init);
         it.destroyCurrent();
       }
     }

--- a/onnx/optimizer/passes/fuse_bn_into_conv.h
+++ b/onnx/optimizer/passes/fuse_bn_into_conv.h
@@ -1,0 +1,179 @@
+
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+// Before:
+//	 conv = Conv()
+//   bn = BatchNormalization()
+//
+// After:
+//	 bn is deleted
+//   new inputs/initializers to conv are added to graph
+//   any no longer used inputs/initializers are erased from graph
+//
+//	 this pass can handle the case satisfy all following conditions:
+//	   condition 1: Run in testing mode
+//     condition 2: Inputs 1 - 4 of bn are all initializer_size
+//     condition 3: Output of initial conv has no other uses
+//     condition 3: Currently works for only DOUBLE, FLOAT32 tensor types
+//
+// Formula for transformation
+// $$ X_{bn} = \frac{s(X - m)}{\sqrt{\sigma + \epsilon}} + b_{bn}$$
+// $$ X_{conv} = X * W + b_{conv} $$
+// thus, substituting $X$ with $X_{conv}$ in the BN equation we get:
+// $$X_{bn} = X * \frac{sW}{\sqrt{\sigma + \epsilon}} + \frac{s(b_{conv} - m)}{\sqrt{\sigma + \epsilon}} + b_{bn}$$
+// or
+// $$ W' = W\frac{s}{\sqrt{\sigma + \epsilon}}$$
+// $$ b' = (b_{conv} - m)\frac{s}{\sqrt{\sigma + \epsilon}} + b_{bn}$$
+
+#include "onnx/optimizer/passes/optimize_pass.h"
+
+namespace ONNX_NAMESPACE { namespace optimization {
+//TODO: Currently broken for complex values and float16
+struct FuseBNIntoConv final : public OptimizePass {
+  explicit FuseBNIntoConv()
+    : OptimizePass("fuse_bn_into_conv", API_TYPE::IR) {
+  }
+
+  void replace_inputs(Tensor& W, Tensor& b, Node* conv, Graph& graph) {
+    Value* new_W_value = graph.addInitializerAndInput(W);
+    Value* old_W_value = conv->inputs()[1];
+    conv->replaceInput(1, new_W_value);
+    if (old_W_value->uses().size() == 0) {
+      graph.eraseInitializerAndInput(old_W_value);
+    }
+
+    if (conv->inputs().size() == 3) {
+      Value* new_b_value = graph.addInitializerAndInput(b);
+      Value* old_b_value = conv->inputs()[2];
+      conv->replaceInput(2, new_b_value);
+      if (old_b_value->uses().size() == 0) {
+        graph.eraseInitializerAndInput(old_b_value);
+      }
+    } else {
+      Value* new_b_value = graph.addInitializerAndInput(b);
+      conv->addInput(new_b_value);
+    }
+  }
+
+  bool modify_conv(Node* conv, Node* bn, Graph& graph)  {
+    const auto& bn_inputs = bn->inputs();
+    const auto& conv_inputs = conv->inputs();
+    auto end_iter = graph.initializers().end();
+    auto s_iter = graph.getInitializer(bn_inputs[1]->uniqueName());
+    auto bbn_iter = graph.getInitializer(bn_inputs[2]->uniqueName());
+    auto m_iter = graph.getInitializer(bn_inputs[3]->uniqueName());
+    auto var_iter = graph.getInitializer(bn_inputs[4]->uniqueName());
+    auto W_iter = graph.getInitializer(conv_inputs[1]->uniqueName());
+    if (s_iter == end_iter || bbn_iter == end_iter || m_iter == end_iter ||
+        var_iter == end_iter || W_iter == end_iter) {
+      return false;
+    }
+
+    ONNX_ASSERT(s_iter->sizes().size() == 1);
+    ONNX_ASSERT(bbn_iter->sizes().size() == 1 && bbn_iter->sizes()[0] == s_iter->sizes()[0]);
+    ONNX_ASSERT(m_iter->sizes().size() == 1 && m_iter->sizes()[0] == s_iter->sizes()[0]);
+    ONNX_ASSERT(var_iter->sizes().size() == 1 && var_iter->sizes()[0] == s_iter->sizes()[0]);
+    ONNX_ASSERT(W_iter->sizes().size() > 2 && W_iter->sizes()[0] == s_iter->sizes()[0]);
+    ONNX_ASSERT(s_iter->elem_type() == bbn_iter->elem_type() &&
+                s_iter->elem_type() == m_iter->elem_type() &&
+                s_iter->elem_type() == var_iter->elem_type() &&
+                s_iter->elem_type() == W_iter->elem_type());
+    if (s_iter->elem_type() != ONNX_NAMESPACE::TensorProto_DataType_FLOAT &&
+        s_iter->elem_type() != ONNX_NAMESPACE::TensorProto_DataType_DOUBLE)  {
+      return false;
+    }
+
+    Tensor bc;
+    if (conv_inputs.size() == 3) {
+      auto bc_iter = graph.getInitializer(conv_inputs[2]->uniqueName());
+      if (bc_iter == end_iter) {
+        return false;
+      }
+      bc = *bc_iter;
+      ONNX_ASSERT(bc.sizes().size() == 1 && bc.sizes()[0] == s_iter->sizes()[0]);
+    }
+
+    Tensor s = *s_iter;
+    const Tensor& bbn = *bbn_iter;
+    const Tensor& m = *m_iter;
+    Tensor var = *var_iter;
+    Tensor W = *W_iter;
+    float epsilon = bn->hasAttribute(kepsilon) ? (float) bn->f(kepsilon) : 1e-5f;
+    Tensor eps;
+
+    #define DO_COMPUTATION(TENSOR_TYPE, vec)                                   \
+      eps.sizes().push_back(s.sizes()[0]);                                     \
+      eps.elem_type() = ONNX_NAMESPACE::TensorProto_DataType_##TENSOR_TYPE;    \
+      for (int64_t i = 0; i < eps.sizes()[0]; ++i)  {                          \
+        eps.vec().push_back(epsilon);                                          \
+      }                                                                        \
+      if (conv_inputs.size() != 3) {                                           \
+        bc.sizes().push_back(s.sizes()[0]);                                    \
+        bc.elem_type() = ONNX_NAMESPACE::TensorProto_DataType_##TENSOR_TYPE;   \
+        for (int64_t i = 0; i < eps.sizes()[0]; ++i)  {                        \
+          bc.vec().push_back(0.f);                                             \
+        }                                                                      \
+      }                                                                        \
+      var.add(eps);                                                            \
+      var.sqrt();                                                              \
+      s.divide(var);                                                           \
+      W.scale_by_first_dim(s);                                                 \
+      bc.subtract(m);                                                          \
+      bc.multiply(s);                                                          \
+      bc.add(bbn);                                                             \
+
+    switch(s.elem_type()) {
+      case ONNX_NAMESPACE::TensorProto_DataType_FLOAT: {
+        DO_COMPUTATION(FLOAT, floats)
+        break;
+      }
+      case ONNX_NAMESPACE::TensorProto_DataType_DOUBLE:
+      {
+        DO_COMPUTATION(DOUBLE, doubles)
+        break;
+      }
+      default:
+        return false;
+    }
+
+    replace_inputs(W, bc, conv, graph);
+    return true;
+  }
+
+  void fuse_bn_into_conv(Graph& graph) {
+
+    for (auto it = graph.begin(); it != graph.end(); ++it) {
+      auto* n = *it;
+      DescendOnGraphAttributes(n, [this](Graph& g){fuse_bn_into_conv(g);});
+      if (n->kind() == kBatchNormalization && n->inputs()[0]->node()->kind() == kConv) {
+        Node* bn = n;
+        Node* conv = n->inputs()[0]->node();
+        auto origInput = bn->inputs()[0];
+        if (origInput->uses().size() > 1 ||
+            bn->outputs().size() > 1 ||
+            !modify_conv(conv, bn, graph)) {
+          continue;
+        }
+        for (int i = 4; i >= 1; --i)  {
+          if (bn->inputs()[i]->uses().size() == 1) {
+            auto input = bn->inputs()[i];
+            bn->removeInput(i);
+            graph.eraseInitializerAndInput(input);
+          }
+        }
+        bn->output()->replaceAllUsesWith(origInput);
+        it.destroyCurrent();
+
+      }
+    }
+  }
+
+  void optimize(Graph& graph) override {
+    fuse_bn_into_conv(graph);
+  }
+};
+
+}} // namespace ONNX_NAMESPACE::optimization

--- a/onnx/test/optimizer_test.py
+++ b/onnx/test/optimizer_test.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 from onnx import checker, helper, ModelProto, TensorProto, GraphProto, NodeProto
 from typing import Sequence, Text, Tuple, List, Callable
+from onnx import numpy_helper
 
 import numpy as np  # type: ignore
 
@@ -706,6 +707,50 @@ class TestOptimizer(unittest.TestCase):
         assert optimized_model.graph.node[2].attribute[2].name == "__control_inputs"
         assert optimized_model.graph.node[2].attribute[2].strings[0] == b"X"
         assert optimized_model.graph.node[2].attribute[2].strings[1] == b"Y"
+
+    def test_fuse_bn_into_conv_simple(self):  # type: () -> None
+        for (tensor_type, np_type) in [(TensorProto.FLOAT, np.float32), (TensorProto.DOUBLE, np.float64)]:
+            conv = helper.make_node("Conv", ["X", "W", "B"], ["Y"])
+            bn = helper.make_node("BatchNormalization", ["Y", "scale", "b", "mean", "var"], ["Z"])
+
+            W = np.random.randn(3, 2, 5, 5).astype(np_type) + 2
+            B = np.random.randn(3,).astype(np_type) + 2
+            scale = np.random.randn(3,).astype(np_type) + 2
+            b = np.random.randn(3,).astype(np_type) + 2
+            mean = np.random.randn(3,).astype(np_type) + 2
+            var = np.random.randn(3,).astype(np_type) + 2
+
+            initializers = [
+                helper.make_tensor(name, tensor_type, npa.shape, npa.tobytes(), raw=True)
+                for name, npa in [('W', W), ('B', B), ('scale', scale), ('b', b), ('mean', mean), ('var', var)]
+            ]
+            graph = helper.make_graph(
+                [conv, bn],
+                "test",
+                [helper.make_tensor_value_info("X", tensor_type, (5, 2, 28, 28)),
+                 helper.make_tensor_value_info("W", tensor_type, (3, 2, 5, 5)),
+                 helper.make_tensor_value_info("B", tensor_type, (3,)),
+                 helper.make_tensor_value_info("scale", tensor_type, (3,)),
+                 helper.make_tensor_value_info("b", tensor_type, (3,)),
+                 helper.make_tensor_value_info("mean", tensor_type, (3,)),
+                 helper.make_tensor_value_info("var", tensor_type, (3,))],
+                [helper.make_tensor_value_info("Z", tensor_type, (3,))],
+                initializer=initializers,
+                value_info=[
+                    helper.make_tensor_value_info("Y", tensor_type, (3,))
+                ]
+            )
+            optimized_model = self._optimized(graph, ["fuse_bn_into_conv"])
+
+            self.assertEqual(len(optimized_model.graph.node), 1)
+            self.assertEqual(optimized_model.graph.node[0].op_type, 'Conv')
+            self.assertEqual(len(optimized_model.graph.initializer), 2)
+            new_W = numpy_helper.to_array(optimized_model.graph.initializer[0])
+            new_b = numpy_helper.to_array(optimized_model.graph.initializer[1])
+
+            f = scale / np.sqrt(var + 1e-5)
+            np.testing.assert_almost_equal((B - mean) * f + b, new_b)
+            np.testing.assert_almost_equal(W * f[:, np.newaxis, np.newaxis, np.newaxis], new_W)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Prior to this commit LSTM unit weights are initialized with 1. To make the test more robust, this commit initialises with uniform random values. Similarly for input data. Finally a cosmetic change: repeated code is removed. 