### PR TITLE
Use cmath instead of math.h

### DIFF
--- a/onnx/common/tensor.h
+++ b/onnx/common/tensor.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "onnx/onnx_pb.h"
-#include <math.h>
+#include <cmath>
 #include <numeric>
 #include <functional>
 #include <stdexcept>


### PR DESCRIPTION
Should fix issues with std I just saw in the pytorch builds. For example:

https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-linux-trusty-py3.6-gcc5.4-build/10549/console
```
/var/lib/jenkins/workspace/third_party/onnx/onnx/common/tensor.h:342:40: error: 'sqrt' is not a member of 'std'
```