### PR TITLE
Fix the input numbers for max, min, mean, sum

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -8034,11 +8034,13 @@ This version of the operator has been available since version 7 of the default O
 
 This version of the operator has been available since version 8 of the default ONNX operator set.
 
-#### Inputs (1 - &#8734;)
+#### Inputs (2 - &#8734;)
 
 <dl>
-<dt><tt>data_0</tt> (variadic) : T</dt>
-<dd>List of tensors for max.</dd>
+<dt><tt>data_0</tt> : T</dt>
+<dd>First input tensor</dd>
+<dt><tt>data_1</tt> (variadic) : T</dt>
+<dd>List of tensors including the remaining inputs for max.</dd>
 </dl>
 
 #### Outputs
@@ -8065,11 +8067,13 @@ This version of the operator has been available since version 8 of the default O
 
 This version of the operator has been available since version 8 of the default ONNX operator set.
 
-#### Inputs (1 - &#8734;)
+#### Inputs (2 - &#8734;)
 
 <dl>
-<dt><tt>data_0</tt> (variadic) : T</dt>
-<dd>List of tensors for mean.</dd>
+<dt><tt>data_0</tt> : T</dt>
+<dd>First input tensor</dd>
+<dt><tt>data_1</tt> (variadic) : T</dt>
+<dd>List of tensors including the remaining inputs for mean.</dd>
 </dl>
 
 #### Outputs
@@ -8096,11 +8100,13 @@ This version of the operator has been available since version 8 of the default O
 
 This version of the operator has been available since version 8 of the default ONNX operator set.
 
-#### Inputs (1 - &#8734;)
+#### Inputs (2 - &#8734;)
 
 <dl>
-<dt><tt>data_0</tt> (variadic) : T</dt>
-<dd>List of tensors for min.</dd>
+<dt><tt>data_0</tt> : T</dt>
+<dd>First input tensor</dd>
+<dt><tt>data_1</tt> (variadic) : T</dt>
+<dd>List of tensors including the remaining inputs for min.</dd>
 </dl>
 
 #### Outputs
@@ -8127,11 +8133,13 @@ This version of the operator has been available since version 8 of the default O
 
 This version of the operator has been available since version 8 of the default ONNX operator set.
 
-#### Inputs (1 - &#8734;)
+#### Inputs (2 - &#8734;)
 
 <dl>
-<dt><tt>data_0</tt> (variadic) : T</dt>
-<dd>List of tensors for sum.</dd>
+<dt><tt>data_0</tt> : T</dt>
+<dd>First input tensor</dd>
+<dt><tt>data_1</tt> (variadic) : T</dt>
+<dd>List of tensors including the remaining inputs for sum.</dd>
 </dl>
 
 #### Outputs

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -4941,11 +4941,13 @@ This version of the operator has been available since version 8 of the default O
 
 Other versions of this operator: <a href="Changelog.md#Max-1">Max-1</a>, <a href="Changelog.md#Max-6">Max-6</a>
 
-#### Inputs (1 - &#8734;)
+#### Inputs (2 - &#8734;)
 
 <dl>
-<dt><tt>data_0</tt> (variadic) : T</dt>
-<dd>List of tensors for max.</dd>
+<dt><tt>data_0</tt> : T</dt>
+<dd>First input tensor</dd>
+<dt><tt>data_1</tt> (variadic) : T</dt>
+<dd>List of tensors including the remaining inputs for max.</dd>
 </dl>
 
 #### Outputs
@@ -5446,11 +5448,13 @@ This version of the operator has been available since version 8 of the default O
 
 Other versions of this operator: <a href="Changelog.md#Mean-1">Mean-1</a>, <a href="Changelog.md#Mean-6">Mean-6</a>
 
-#### Inputs (1 - &#8734;)
+#### Inputs (2 - &#8734;)
 
 <dl>
-<dt><tt>data_0</tt> (variadic) : T</dt>
-<dd>List of tensors for mean.</dd>
+<dt><tt>data_0</tt> : T</dt>
+<dd>First input tensor</dd>
+<dt><tt>data_1</tt> (variadic) : T</dt>
+<dd>List of tensors including the remaining inputs for mean.</dd>
 </dl>
 
 #### Outputs
@@ -5519,11 +5523,13 @@ This version of the operator has been available since version 8 of the default O
 
 Other versions of this operator: <a href="Changelog.md#Min-1">Min-1</a>, <a href="Changelog.md#Min-6">Min-6</a>
 
-#### Inputs (1 - &#8734;)
+#### Inputs (2 - &#8734;)
 
 <dl>
-<dt><tt>data_0</tt> (variadic) : T</dt>
-<dd>List of tensors for min.</dd>
+<dt><tt>data_0</tt> : T</dt>
+<dd>First input tensor</dd>
+<dt><tt>data_1</tt> (variadic) : T</dt>
+<dd>List of tensors including the remaining inputs for min.</dd>
 </dl>
 
 #### Outputs
@@ -9477,11 +9483,13 @@ This version of the operator has been available since version 8 of the default O
 
 Other versions of this operator: <a href="Changelog.md#Sum-1">Sum-1</a>, <a href="Changelog.md#Sum-6">Sum-6</a>
 
-#### Inputs (1 - &#8734;)
+#### Inputs (2 - &#8734;)
 
 <dl>
-<dt><tt>data_0</tt> (variadic) : T</dt>
-<dd>List of tensors for sum.</dd>
+<dt><tt>data_0</tt> : T</dt>
+<dd>First input tensor</dd>
+<dt><tt>data_1</tt> (variadic) : T</dt>
+<dd>List of tensors including the remaining inputs for sum.</dd>
 </dl>
 
 #### Outputs

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -494,8 +494,7 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
 std::function<void(OpSchema&)> ElementwiseMultiOpDocGenerator(const char* name) {
-  return [=](OpSchema& schema) {
-    std::string doc = R"DOC(
+  return [=](OpSchema& schema) { std::string doc = R"DOC(
 Element-wise {name} of each of the input tensors (with Numpy-style broadcasting support).
 All inputs and outputs must have the same data type.
 {broadcast_doc}
@@ -506,7 +505,13 @@ All inputs and outputs must have the same data type.
     schema.Input(
         0,
         "data_0",
-        "List of tensors for " + std::string(name) + ".",
+        "First input tensor",
+        "T");
+    schema.Input(
+        1,
+        "data_1",
+        "List of tensors including the remaining inputs for "
+        + std::string(name) + ".",
         "T",
         OpSchema::Variadic);
     schema.Output(0, name, "Output tensor.", "T");


### PR DESCRIPTION
Like mentioned in https://github.com/onnx/onnx/issues/1172, Operator `Max`, `Min, `Sum`, and `Mean` should at least have two inputs. Even numpy does not support one input case. I would consider this as a schema bug, let's fix it.