### PR TITLE
move macro ONNXIFI_DUMMY_LIBRARY to onnxifi_dummy.h

### DIFF
--- a/onnx/onnxifi.h
+++ b/onnx/onnxifi.h
@@ -15,14 +15,6 @@ extern "C" {
 #define ONNXIFI_ABI
 #endif
 
-#if defined(__APPLE__)
-#define ONNXIFI_DUMMY_LIBRARY "libonnxifi_dummy.dylib"
-#elif defined(_WIN32)
-#define ONNXIFI_DUMMY_LIBRARY L"onnxifi_dummy.dll"
-#else
-#define ONNXIFI_DUMMY_LIBRARY "libonnxifi_dummy.so"
-#endif
-
 #ifndef ONNXIFI_PUBLIC
 #if defined(__ELF__)
 #define ONNXIFI_PUBLIC __attribute__((__visibility__("default")))

--- a/onnx/onnxifi.h
+++ b/onnx/onnxifi.h
@@ -15,6 +15,14 @@ extern "C" {
 #define ONNXIFI_ABI
 #endif
 
+#if defined(__APPLE__)
+#define ONNXIFI_DUMMY_LIBRARY "libonnxifi_dummy.dylib"
+#elif defined(_WIN32)
+#define ONNXIFI_DUMMY_LIBRARY L"onnxifi_dummy.dll"
+#else
+#define ONNXIFI_DUMMY_LIBRARY "libonnxifi_dummy.so"
+#endif
+
 #ifndef ONNXIFI_PUBLIC
 #if defined(__ELF__)
 #define ONNXIFI_PUBLIC __attribute__((__visibility__("default")))

--- a/onnx/onnxifi_dummy.h
+++ b/onnx/onnxifi_dummy.h
@@ -1,0 +1,7 @@
+#if defined(__APPLE__)
+#define ONNXIFI_DUMMY_LIBRARY "libonnxifi_dummy.dylib"
+#elif defined(_WIN32)
+#define ONNXIFI_DUMMY_LIBRARY L"onnxifi_dummy.dll"
+#else
+#define ONNXIFI_DUMMY_LIBRARY "libonnxifi_dummy.so"
+#endif

--- a/onnx/test/cpp/onnxifi_backend_test.cc
+++ b/onnx/test/cpp/onnxifi_backend_test.cc
@@ -4,15 +4,6 @@
 #include "onnx/onnxifi_loader.h"
 #include "onnx/onnxifi.h"
 
-#if defined(__APPLE__)
-#define ONNXIFI_DUMMY_LIBRARY "libonnxifi_dummy.dylib"
-#elif defined(_WIN32)
-#define ONNXIFI_DUMMY_LIBRARY L"onnxifi_dummy.dll"
-#else
-#define ONNXIFI_DUMMY_LIBRARY "libonnxifi_dummy.so"
-#endif
-
-
 namespace ONNX_NAMESPACE
 {
 	namespace Test

--- a/onnx/test/cpp/onnxifi_backend_test.cc
+++ b/onnx/test/cpp/onnxifi_backend_test.cc
@@ -3,6 +3,7 @@
 #include "gtest/gtest.h"
 #include "onnx/onnxifi_loader.h"
 #include "onnx/onnxifi.h"
+#include "onnx/onnxifi_dummy.h"
 
 namespace ONNX_NAMESPACE
 {


### PR DESCRIPTION
This macro is used in cpp test driver sample.