### PR TITLE
Add auxiliary property list argument to onnxInitGraph

### DIFF
--- a/onnx/onnxifi_dummy.c
+++ b/onnx/onnxifi_dummy.c
@@ -53,7 +53,7 @@ onnxGetBackendCompatibility(
 
 ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI onnxInitBackend(
     onnxBackendID backendID,
-    const uint64_t* auxpropertiesList,
+    const uint64_t* auxPropertiesList,
     onnxBackend* backend) {
   if (backend == NULL) {
     return ONNXIFI_STATUS_INVALID_POINTER;
@@ -93,6 +93,7 @@ onnxReleaseEvent(onnxEvent event) {
 
 ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI onnxInitGraph(
     onnxBackend backend,
+    const uint64_t* auxPropertiesList,
     size_t onnxModelSize,
     const void* onnxModel,
     uint32_t weightCount,

--- a/onnx/test/cpp/onnxifi_backend_test.cc
+++ b/onnx/test/cpp/onnxifi_backend_test.cc
@@ -49,7 +49,9 @@ TEST(OnnxifiLoadTest, OnnxifiDummyBackend) {
       backendID, onnxModelSize, onnxModel));
 
   // Testing onnxInitBackend
-  uint64_t auxpropertiesList = 0;
+  const uint64_t backendProperties[] = {
+      ONNXIFI_BACKEND_PROPERTY_NONE
+  };
   EXPECT_EQ_OSS(
       dummy_backend.onnxInitBackend(backendID, &auxpropertiesList, &backend));
 
@@ -71,8 +73,12 @@ TEST(OnnxifiLoadTest, OnnxifiDummyBackend) {
   // Testing onnxInitGraph
   uint32_t weightCount = 1;
   onnxTensorDescriptorV1 weightDescriptors;
+  const uint64_t graphProperties[] = {
+      ONNXIFI_GRAPH_PROPERTY_NONE
+  };
   EXPECT_EQ_OSS(dummy_backend.onnxInitGraph(
       backend,
+      graphProperties,
       onnxModelSize,
       &onnxModel,
       weightCount,


### PR DESCRIPTION
This is needed to support per-graph accuracy specification and similar external attributes.

Attn: @yinghai, @varunjain99, @bddppq, @zrphercule: this is a breaking change