### PR TITLE
Correcting links in OpsetVersionConverter.md

### DIFF
--- a/docs/OpsetVersionConverter.md
+++ b/docs/OpsetVersionConverter.md
@@ -21,7 +21,7 @@ conversion methods, dependent on the nature of relevant breaking changes.
 
 The version converter may be invoked either via C++ or Python. The Python API
 is described, with example,
-[here](docs/PythonAPIOverview.md#converting-opset-version-of-an-onnx-model).
+[here](/docs/PythonAPIOverview.md#converting-version-of-an-onnx-model-within-default-domain-aionnx).
 
 The C++ API consists of a single function
 
@@ -36,14 +36,14 @@ which accepts an input `ModelProto`, the initial opset version of the model,
 and the target opset verison, and which returns a new `ModelProto` which 
 is the result of apply all relevant adapters between initial_version and
 target_version. For a list of available passes, see 
-[convert.h](onnx/version_converter/convert.h).
+[convert.h](/onnx/version_converter/convert.h).
 
 Implementing Adapters
 
 You can implement a new adapter by subclassing `Adapter`, and registering 
 your new adapter with `VersionConverter::registerAdapter()`. Adapters operate 
-on an in-memory graph representation defined in [ir.h](onnx/common/ir.h). 
-There are a number of examples in the [adapters](onnx/version_converter/adapters) 
+on an in-memory graph representation defined in [ir.h](/onnx/common/ir.h). 
+There are a number of examples in the [adapters](/onnx/version_converter/adapters) 
 directory.
 
 If your adapter applies in the default domain, please consider adding it


### PR DESCRIPTION
Appended a "/" to fix the outbound links from the OpsetVersionConverter.md page.