### PR TITLE
Move off the Xcode 9.3 beta image on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ matrix:
       language: python
       python: "3.6"
     - os: osx
-      osx_image: xcode9.3beta
+      osx_image: xcode9.3
       env: PYTHON_VERSION=python2
     - os: osx
-      osx_image: xcode9.3beta
+      osx_image: xcode9.3
       env: PYTHON_VERSION=python3
     - os: linux
       sudo: required
@@ -29,10 +29,10 @@ matrix:
       language: python
       python: "3.6"
     - os: osx
-      osx_image: xcode9.3beta
+      osx_image: xcode9.3
       env: PYTHON_VERSION=python2 ONNX_ML=1
     - os: osx
-      osx_image: xcode9.3beta
+      osx_image: xcode9.3
       env: PYTHON_VERSION=python3 ONNX_ML=1
 
 env:


### PR DESCRIPTION
We suggest you use the real image with Xcode 9.3 GM i.e. `osx_image: xcode9.3`