### PR TITLE
Honor visibility options when compiled as a static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(NOT CMAKE_BUILD_TYPE)
       "Choose the type of build from: Debug Release RelWithDebInfo MinSizeRel Coverage."
     FORCE)
 endif()
-cmake_policy(SET CMP0063 NEW)
+#cmake_policy(SET CMP0063 NEW)
 
 # Project
 project(onnx C CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(NOT CMAKE_BUILD_TYPE)
       "Choose the type of build from: Debug Release RelWithDebInfo MinSizeRel Coverage."
     FORCE)
 endif()
-#cmake_policy(SET CMP0063 NEW)
+cmake_policy(SET CMP0063 NEW)
 
 # Project
 project(onnx C CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ if(NOT CMAKE_BUILD_TYPE)
       "Choose the type of build from: Debug Release RelWithDebInfo MinSizeRel Coverage."
     FORCE)
 endif()
+cmake_policy(SET CMP0063 NEW)
 
 # Project
 project(onnx C CXX)


### PR DESCRIPTION
When compiled as static library and included as a lib in other project, current cmake OLD behavior won't honor the visibility settings from the outer projects, resulting in warning in linking. This fixes it. 