### PR TITLE
[Optimization Pass] Add optimization pass eliminating nop Pad

### DIFF
--- a/onnx/common/interned_strings.h
+++ b/onnx/common/interned_strings.h
@@ -40,6 +40,7 @@ _(Tile) \
 _(SubConstant) \
 _(Scale) \
 _(Transpose) \
+_(Pad) \
 _(Reshape) \
 _(split) \
 _(chunk) \

--- a/onnx/examples/optimize_onnx.ipynb
+++ b/onnx/examples/optimize_onnx.ipynb
@@ -112,6 +112,7 @@
      "text": [
       "Available optimization passes:\n",
       "eliminate_identity\n",
+      "eliminate_nop_pad\n",
       "eliminate_nop_transpose\n",
       "eliminate_unused_initializer\n",
       "extract_constant_to_initializer\n",

--- a/onnx/optimizer.py
+++ b/onnx/optimizer.py
@@ -28,6 +28,7 @@ Supported pass names:
     -- nop
     -- eliminate_identity
     -- eliminate_nop_transpose
+    -- eliminate_nop_pad
     -- eliminate_unused_initializer
     -- fuse_consecutive_squeezes
     -- fuse_consecutive_transposes
@@ -41,6 +42,7 @@ get_available_passes = C.get_available_passes
 def optimize(model, passes=[]):  # type: (ModelProto, Sequence[Text]) -> ModelProto
     if len(passes) == 0:
         passes = ['eliminate_nop_transpose',
+                  'eliminate_nop_pad',
                   'fuse_consecutive_transposes',
                   'fuse_transpose_into_gemm']
     if not isinstance(model, ModelProto):

--- a/onnx/optimizer/optimize.h
+++ b/onnx/optimizer/optimize.h
@@ -8,6 +8,7 @@
 #include "onnx/common/stl_backports.h"
 #include "onnx/optimizer/passes/eliminate_identity.h"
 #include "onnx/optimizer/passes/eliminate_nop_transpose.h"
+#include "onnx/optimizer/passes/eliminate_nop_pad.h"
 #include "onnx/optimizer/passes/eliminate_unused_initializer.h"
 #include "onnx/optimizer/passes/extract_constant_to_initializer.h"
 #include "onnx/optimizer/passes/fuse_add_bias_into_conv.h"
@@ -29,6 +30,7 @@ struct Optimizer {
     // Register the optimization passes to the optimizer.
     registerOptimizer<EliminateIdentity>();
     registerOptimizer<EliminateNopTranspose>();
+    registerOptimizer<EliminateNopPad>();
     registerOptimizer<EliminateUnusedInitializer>();
     registerOptimizer<ExtractConstantToInitializer>();
     registerOptimizer<FuseConsecutiveSqueezes>();

--- a/onnx/optimizer/passes/eliminate_nop_pad.h
+++ b/onnx/optimizer/passes/eliminate_nop_pad.h
@@ -1,0 +1,41 @@
+// ATTENTION: The code in this file is highly EXPERIMENTAL.
+// Adventurous users should note that the APIs will probably change.
+
+#pragma once
+
+#include "onnx/optimizer/passes/optimize_pass.h"
+
+namespace ONNX_NAMESPACE { namespace optimization {
+
+struct EliminateNopPad final : public OptimizePass {
+  explicit EliminateNopPad()
+    : OptimizePass("eliminate_nop_pad", API_TYPE::IR) {
+  }
+
+  static bool is_nop_pad(const std::vector<int64_t> & pads) {
+    for (size_t i = 0; i < pads.size(); i++)
+      if (pads[i] > 0)
+        return false;
+    return true;
+  }
+
+  void eliminate_nop_pad(Graph& graph) {
+    for (auto it = graph.begin(); it != graph.end(); ++it) {
+      auto* n = *it;
+      DescendOnGraphAttributes(n, [this](Graph& g){eliminate_nop_pad(g);});
+      if (n->kind() == kPad && n->hasAttribute(kpads)) {
+        if (is_nop_pad(n->is(kpads))) {
+          n->output()->replaceAllUsesWith(n->input());
+          it.destroyCurrent();
+          continue;
+        }
+      }
+    }
+  }
+
+  void optimize(Graph& graph) override {
+    eliminate_nop_pad(graph);
+  }
+};
+
+}} // namespace ONNX_NAMESPACE::optimization


### PR DESCRIPTION
[Why]
A Pad layer with argument pads = zeros does nothing and should be removed.
Such a nop pad is observed when converting torchvision.resnet to onnx

[How]
* We mimic the optimization pass of nop_transpose and created the nop_pads optimizer.
* Test cases are added ensuring the correctness.