### PR TITLE
Domain exists in GraphProto but not in Node

### DIFF
--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -1144,6 +1144,7 @@ inline Node::Node(Graph * graph_, NodeKind kind_) :
   graph_(graph_),
   stage_(graph_->new_node_stage_),
   has_name_(false),
+  has_domain_(false),
   has_doc_string_(false) {
   graph_->all_nodes.emplace(this);
 }

--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -409,6 +409,8 @@ private:
   size_t stage_;
   bool has_name_;
   std::string name_;
+  bool has_domain_;
+  std::string domain_;
   bool has_doc_string_;
   std::string doc_string_;
 
@@ -425,6 +427,16 @@ public:
   void setName(std::string name) {
     has_name_ = true;
     name_ = std::move(name);
+  }
+  bool has_domain() {
+    return has_domain_;
+  }
+  const std::string& domain() const {
+    return domain_;
+  }
+  void setDomain(std::string domain) {
+    has_domain_ = true;
+    domain_ = std::move(domain);
   }
   bool has_doc_string() const {
     return has_doc_string_;

--- a/onnx/common/ir_pb_converter.cc
+++ b/onnx/common/ir_pb_converter.cc
@@ -252,6 +252,9 @@ std::unique_ptr<Graph> graphProtoToGraph(const ONNX_NAMESPACE::GraphProto& gp, b
     if (np.has_name()) {
       n->setName(np.name());
     }
+    if (np.has_domain()) {
+      n->setDomain(np.domain());
+    }
   }
 
   for (auto n : g->nodes()) {
@@ -527,6 +530,9 @@ void encodeGraph(GraphProto * p_g, const std::shared_ptr<Graph> & g) {
     }
     if (node->has_name()) {
       p_n->set_name(node->name());
+    }
+    if (node->has_domain()) {
+      p_n->set_domain(node->domain());
     }
   }
 


### PR DESCRIPTION
We noticed that after optimizing a model that node domains were stripped out. After investigating we noticed that the domain was not loaded from the GraphProto. After this change optimizing a model will not lose the node domains.

**Summary of changes:**
Added domain_ member to the Node class, plus setter/getters
Modified graphProtoToGraph to copy across the domain
Modified  encodeGraph(GraphProto * p_g, const std::shared_ptr<Graph> & g) to copy the domain back into the GraphProto node.