### PR TITLE
Fix build error caused by using std::set without including corresponding header

### DIFF
--- a/onnx/optimizer/passes/lift_lexical_references.h
+++ b/onnx/optimizer/passes/lift_lexical_references.h
@@ -77,8 +77,8 @@ struct LiftLexicalReferences : public OptimizePass {
   using ValueTable = std::unordered_map<std::string, Value*>;
   using EnvStack = std::vector<ValueTable>;
 
-  std::set<std::string> liftReferences(Graph* g, EnvStack *es) {
-    std::set<std::string> unresolved_references;
+  std::unordered_set<std::string> liftReferences(Graph* g, EnvStack *es) {
+    std::unordered_set<std::string> unresolved_references;
     es->push_back(ValueTable());
     for (auto &inp : g->inputs()) {
       es->back()[inp->uniqueName()] = inp;
@@ -97,7 +97,7 @@ struct LiftLexicalReferences : public OptimizePass {
         }
       }
 
-      std::set<std::string> local_unresolved;
+      std::unordered_set<std::string> local_unresolved;
       if (n->kind() == ONNX_NAMESPACE::kLoop) {
         auto *body_graph = n->g(ONNX_NAMESPACE::kbody).get();
         local_unresolved = liftReferences(body_graph, es);


### PR DESCRIPTION
```
/home/travis/build/onnx/onnx/onnx/optimizer/passes/lift_lexical_references.h:80:3: error: ‘set’ in namespace ‘std’ does not name a type
   std::set<std::string> liftReferences(Graph* g, EnvStack *es) {
```