### PR TITLE
Add instructions for non root install from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ git submodule update --init --recursive
 python setup.py install
 ```
 
+You can run the commands above in a virtual environment such as virtualenv if you are not logged in as root.
+
 Note: When installing in a non-Anaconda environment, make sure to install the Protobuf compiler before running the pip installation of onnx. For example, on Ubuntu:
 
 ```


### PR DESCRIPTION
The install from source code is trying to create
files in /usr/local/bin where a non root user might
not have write permissions. The fix is to provide
instructions for non root users to avoid getting
'error: [Errno 13] Permission denied'.