### PR TITLE
Add missing include for using std::floor

### DIFF
--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -4,6 +4,7 @@
 #include "onnx/defs/schema.h"
 
 #include <algorithm>
+#include <cmath>
 
 namespace ONNX_NAMESPACE {
 static const char* Cast_ver6_doc = R"DOC(


### PR DESCRIPTION
#1320 
```
error: 'floor' is not a member of 'std'
```