### PR TITLE
minor fix to scan documentation

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -8180,7 +8180,7 @@ This version of the operator has been available since version 8 of the default O
 
 ### <a name="Scan-8"></a>**Scan-8**</a>
 
-  Scan can be used to iterate over (specified axes of) one or more scan_input tensors,
+  Scan can be used to iterate over one or more scan_input tensors,
   constructing zero or more scan_output tensors. It combines ideas from general recurrences,
   functional programming constructs such as scan, fold, map, and zip and is intended to enable
   generalizations of RNN-like constructs for sequence-to-sequence processing.

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -8755,7 +8755,7 @@ for test_name, shape in test_cases.items():
 
 ### <a name="Scan"></a><a name="scan">**Scan**</a>
 
-  Scan can be used to iterate over (specified axes of) one or more scan_input tensors,
+  Scan can be used to iterate over one or more scan_input tensors,
   constructing zero or more scan_output tensors. It combines ideas from general recurrences,
   functional programming constructs such as scan, fold, map, and zip and is intended to enable
   generalizations of RNN-like constructs for sequence-to-sequence processing.

--- a/onnx/defs/controlflow/defs.cc
+++ b/onnx/defs/controlflow/defs.cc
@@ -194,7 +194,7 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint("B", {"bool"}, "Only bool"));
 
 static const char* scan_ver1_doc = R"DOC(
-Scan can be used to iterate over (specified axes of) one or more scan_input tensors,
+Scan can be used to iterate over one or more scan_input tensors,
 constructing zero or more scan_output tensors. It combines ideas from general recurrences,
 functional programming constructs such as scan, fold, map, and zip and is intended to enable
 generalizations of RNN-like constructs for sequence-to-sequence processing.


### PR DESCRIPTION
Drop the words "specified axes of" from the documentation of scan op. (This refers to a outdated version.)