### PR TITLE
Do not export onnx symbols in the python extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,6 +345,8 @@ if(BUILD_ONNX_PYTHON)
     target_link_libraries(onnx_cpp2py_export
                           PRIVATE "-Wl,--whole-archive" $<TARGET_FILE:onnx>
                                   "-Wl,--no-whole-archive")
+    set_target_properties(onnx_cpp2py_export
+                          PROPERTIES LINK_FLAGS "-Wl,--exclude-libs,ALL")
   endif()
 
   target_link_libraries(onnx_cpp2py_export PRIVATE onnx)


### PR DESCRIPTION
~~Also fixed the issue of duplicating libonnx in the link command of onnx_cpp2py_export~~

Results of `nm -g .setuptools-cmake-build/onnx_cpp2py_export.so | wc -l`:
Before: 2677
After: 396
