### PR TITLE
[Don't Merge/Review]Enable float16 in onnxifi backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,8 @@ if(NOT MSVC)
   endif()
 endif()
 
+list(APPEND CMAKE_MODULE_PATH ${ONNX_ROOT}/cmake/external)
 if(ONNX_BUILD_TESTS)
-  list(APPEND CMAKE_MODULE_PATH ${ONNX_ROOT}/cmake/external)
   include(googletest)
 endif()
 


### PR DESCRIPTION
Add fp16 as submodule and enable it in onnxifi backend.
Blocked by #1290 
Don't review or merge it until 1290 merged.