### PR TITLE
Fixup handling of captured values as graph outputs

### DIFF
--- a/onnx/common/ir_pb_converter.cc
+++ b/onnx/common/ir_pb_converter.cc
@@ -277,6 +277,16 @@ std::unique_ptr<Graph> graphProtoToGraph(const ONNX_NAMESPACE::GraphProto& gp, b
   }
 
   for (int i = 0; i < gp.output_size(); i++) {
+    if (!value_by_name_of.count(gp.output(i).name()) && nested) {
+      // Same captured value logic as above. We can consider outputs of a
+      // graph to be "inputs" of a dummy "output" node. The same lexical
+      // scoping rules are valid here, thus we need to add a dummy node
+      // in the case of an undefined reference
+      auto * undef = g->create(kCaptured, 1);
+      g->appendNode(undef);
+      undef->outputs()[0]->setUniqueName(gp.output(i).name());
+      value_by_name_of[gp.output(i).name()] = undef->outputs()[0];
+    }
     value_by_name_of[gp.output(i).name()]->setElemType(gp.output(i).type().tensor_type().elem_type());
     value_by_name_of[gp.output(i).name()]->setSizes(tensorShapeProtoToDimensions(gp.output(i).type().tensor_type().shape()));
     g->registerOutput(value_by_name_of[gp.output(i).name()]);


### PR DESCRIPTION
This situation occurs, for example, in code like this:

```
x = 3
if foo:
  x = 4
```

Notice there is no textual `else` branch, but in the graph we will have an empty `else` graph on the `If` node with the original value of `x` as the output. In this case, this is value in an enclosing scope that's used as a graph output, so we need to replicate the dummy node logic for graph outputs as well.