### PR TITLE
Fix ONNX_NAMESPACE definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,6 @@ option(ONNX_BUILD_TESTS "Build ONNX C++ APIs Tests" OFF)
 option(ONNX_USE_LITE_PROTO "Use lite protobuf instead of full." OFF)
 option(ONNXIFI_DUMMY_BACKEND "Use dummy backend in onnxifi test driver." OFF)
 
-set(ONNX_NAMESPACE "onnx" CACHE STRING "onnx namespace")
-
 # Set C++11 as standard for the whole project
 if(NOT MSVC)
   set(CMAKE_CXX_STANDARD 11)
@@ -45,6 +43,13 @@ if(NOT MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
   endif()
+endif()
+
+if(ONNX_NAMESPACE)
+  set(MY_ONNX_NAMESPACE "-DONNX_NAMESPACE=${ONNX_NAMESPACE}")
+else()
+  set(ONNX_NAMESPACE "onnx")
+  set(MY_ONNX_NAMESPACE "-DONNX_NAMESPACE=onnx")
 endif()
 
 if(ONNX_BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,11 +45,8 @@ if(NOT MSVC)
   endif()
 endif()
 
-if(ONNX_NAMESPACE)
-  set(MY_ONNX_NAMESPACE "-DONNX_NAMESPACE=${ONNX_NAMESPACE}")
-else()
+if(NOT ONNX_NAMESPACE)
   set(ONNX_NAMESPACE "onnx")
-  set(MY_ONNX_NAMESPACE "-DONNX_NAMESPACE=onnx")
 endif()
 
 if(ONNX_BUILD_TESTS)


### PR DESCRIPTION
When downstream project includes onnx, it usually sets ONNX_NAMESPACE to avoid protobuf conflicts, for example https://github.com/pytorch/glow/blob/21cf654a0192924d8d9415d1577caef7d0af3114/lib/Importer/CMakeLists.txt#L6-L13. 

In ONNX CMakefile, if we do `set(ONNX_NAMESPACE "onnx" CACHE STRING "onnx namespace")`, it will ignore previous set ONNX_NAMESPACE because of `CACHE`. Quote
> The code ‘set(FOO “x”)’ sets the normal variable ‘FOO’. It does not touch the cache, but it will hide any existing cache value ‘FOO’.
>
>The code ‘set(FOO “x” CACHE …)’ checks for ‘FOO’ in the cache, ignoring any normal variable of the same name. If ‘FOO’ is in the cache then nothing happens to either the normal variable or the cache variable. If ‘FOO’ is not in the cache, then it is added to the cache.

From https://cmake.org/cmake/help/v3.0/command/set.html. 

So it's better that we revert to the previous `if (NOT ONNX_NAMESPACE)` check. 

Test Plan:
With the patch, I was able to compile Glow with correct `ONNX_NAMESPACE`.