### PR TITLE
Fix undefined ONNX_API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,7 +286,7 @@ if (MSVC)
 else()
   set(ONNX_API_DEFINE "-DONNX_API=")
 endif()
-target_compile_definitions(onnx_proto PRIVATE ${ONNX_API_DEFINE})
+target_compile_definitions(onnx_proto PUBLIC ${ONNX_API_DEFINE})
 
 if(ONNX_USE_LITE_PROTO)
   if(TARGET protobuf::libprotobuf-lite)


### PR DESCRIPTION
https://github.com/onnx/onnx/pull/1407 added `ONNX_API` as `PRIVATE`. For upstream project which uses ONNX, if they include `onnx.pb.h`, compilation will fail due to undefined `ONNX_API`. This PR fixes it by propagating the definition. 