### PR TITLE
[ONNXIFI]serialized model data in test driver, ir version is now corrected

### DIFF
--- a/onnx/backend/test/cpp/driver_test.cc
+++ b/onnx/backend/test/cpp/driver_test.cc
@@ -158,12 +158,14 @@ class ONNXCppDriverTest
                 model_.graph().initializer(0));
         weightDescriptors_pointer = &weightDescriptors;
       }
+      std::string serialized_model;
+      model_.SerializeToString(&serialized_model);
       EXPECT_EQ(
           lib.onnxInitGraph(
               backend,
               NULL,
-              sizeof(model_),
-              &model_,
+              serialized_model.size(),
+              serialized_model.c_str(),
               weightCount,
               weightDescriptors_pointer,
               &graph),


### PR DESCRIPTION
Bug: using unserialized model in test driver. It is now fixed.