### PR TITLE
[ONNXIFI]gtest:expect to assert

### DIFF
--- a/onnx/backend/test/cpp/driver_test.cc
+++ b/onnx/backend/test/cpp/driver_test.cc
@@ -165,7 +165,7 @@ class ONNXCppDriverTest
               backend,
               NULL,
               serialized_model.size(),
-              serialized_model.c_str(),
+              serialized_model.data(),
               weightCount,
               weightDescriptors_pointer,
               &graph),

--- a/onnx/backend/test/cpp/driver_test.cc
+++ b/onnx/backend/test/cpp/driver_test.cc
@@ -160,7 +160,7 @@ class ONNXCppDriverTest
       }
       std::string serialized_model;
       model_.SerializeToString(&serialized_model);
-      EXPECT_EQ(
+      ASSERT_EQ(
           lib.onnxInitGraph(
               backend,
               NULL,
@@ -197,7 +197,7 @@ class ONNXCppDriverTest
           result.buffer = (onnxPointer)raw_data.data();
           result_descriptor.emplace_back(std::move(result));
         }
-        EXPECT_EQ(
+        ASSERT_EQ(
             lib.onnxSetGraphIO(
                 graph,
                 input_descriptor.size(),
@@ -212,10 +212,10 @@ class ONNXCppDriverTest
         inputFence.type = ONNXIFI_SYNCHRONIZATION_EVENT;
         outputFence.type = ONNXIFI_SYNCHRONIZATION_EVENT;
 
-        EXPECT_EQ(
+        ASSERT_EQ(
             lib.onnxRunGraph(graph, &inputFence, &outputFence),
             ONNXIFI_STATUS_SUCCESS);
-        EXPECT_EQ(lib.onnxWaitEvent(outputFence.event), ONNXIFI_STATUS_SUCCESS);
+        ASSERT_EQ(lib.onnxWaitEvent(outputFence.event), ONNXIFI_STATUS_SUCCESS);
         for (int i = 0; i < output_descriptor.size(); i++) {
           auto output_size = GetDescriptorSize(&output_descriptor[i]);
           for (int j = 0; j < output_size; j++) {
@@ -226,7 +226,7 @@ class ONNXCppDriverTest
           }
         }
       }
-      EXPECT_EQ(lib.onnxReleaseGraph(graph), ONNXIFI_STATUS_SUCCESS);
+      ASSERT_EQ(lib.onnxReleaseGraph(graph), ONNXIFI_STATUS_SUCCESS);
     }
   }
 };
@@ -242,7 +242,7 @@ TEST_P(ONNXCppDriverTest, ONNXCppDriverUnitTest){
   onnxBackendID backendID = NULL;
   onnxBackend backend;
   if (!ONNXIFI_DUMMY_BACKEND) {
-    EXPECT_TRUE(onnxifi_load(1, NULL, &lib));
+    ASSERT_TRUE(onnxifi_load(1, NULL, &lib));
     size_t numBackends = 0;
     lib.onnxGetBackendIDs(&backendID, &numBackends);
     const uint64_t backendProperties[] = {ONNXIFI_BACKEND_PROPERTY_NONE};


### PR DESCRIPTION
Change the expect to assert for some tests in onnxifi test driver. This can prevent onnxifi test driver from crashing once model is not supported by backend.