### PR TITLE
Change Function registry flow; Get rid of whole-archive in compile

### DIFF
--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -26,5 +26,19 @@ function(add_onnx_global_defines target)
   if(ONNX_USE_LITE_PROTO)
     target_compile_definitions(${target} PUBLIC "ONNX_USE_LITE_PROTO=1")
   endif()
+endfunction()
 
+function(add_whole_archive_flag lib output_var)
+  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    set(${output_var} -Wl,-force_load,$<TARGET_FILE:${lib}> PARENT_SCOPE)
+  elseif(MSVC)
+    # In MSVC, we will add whole archive in default.
+    set(${output_var} -WHOLEARCHIVE:$<SHELL_PATH:$<TARGET_FILE:${lib}>>
+        PARENT_SCOPE)
+  else()
+    # Assume everything else is like gcc
+    set(${output_var}
+        "-Wl,--whole-archive $<TARGET_FILE:${lib}> -Wl,--no-whole-archive"
+        PARENT_SCOPE)
+  endif()
 endfunction()

--- a/cmake/unittest.cmake
+++ b/cmake/unittest.cmake
@@ -6,32 +6,16 @@ include(${ONNX_ROOT}/cmake/Utils.cmake)
 
 find_package(Threads)
 
-function(add_whole_archive_flag lib output_var)
-  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-    set(${output_var} -Wl,-force_load,$<TARGET_FILE:${lib}> PARENT_SCOPE)
-  elseif(MSVC)
-    # In MSVC, we will add whole archive in default.
-    set(${output_var} -WHOLEARCHIVE:$<SHELL_PATH:$<TARGET_FILE:${lib}>>
-        PARENT_SCOPE)
-  else()
-    # Assume everything else is like gcc
-    set(${output_var}
-        "-Wl,--whole-archive $<TARGET_FILE:${lib}> -Wl,--no-whole-archive"
-        PARENT_SCOPE)
-  endif()
-endfunction()
-
 set(${UT_NAME}_libs ${googletest_STATIC_LIBRARIES})
 set(${ONNXIFI_TEST_DRIVER}_libs ${googletest_STATIC_LIBRARIES})
 
-add_whole_archive_flag(onnx tmp)
-list(APPEND ${UT_NAME}_libs ${tmp})
+list(APPEND ${UT_NAME}_libs onnx)
 list(APPEND ${UT_NAME}_libs onnx_proto)
 list(APPEND ${UT_NAME}_libs onnxifi_loader)
 list(APPEND ${UT_NAME}_libs onnxifi)
 list(APPEND ${UT_NAME}_libs ${PROTOBUF_LIBRARIES})
 
-list(APPEND ${ONNXIFI_TEST_DRIVER}_libs ${tmp})
+list(APPEND ${ONNXIFI_TEST_DRIVER}_libs onnx)
 list(APPEND ${ONNXIFI_TEST_DRIVER}_libs onnx_proto)
 list(APPEND ${ONNXIFI_TEST_DRIVER}_libs onnxifi_loader)
 list(APPEND ${ONNXIFI_TEST_DRIVER}_libs ${PROTOBUF_LIBRARIES})

--- a/onnx/defs/experiments/experiments_functions.cc
+++ b/onnx/defs/experiments/experiments_functions.cc
@@ -4,8 +4,8 @@
 #include "onnx/common/constants.h"
 #include "onnx/common/model_helpers.h"
 #include "onnx/defs/function.h"
-using namespace ONNX_NAMESPACE;
 
+namespace ONNX_NAMESPACE {
 static Common::Status BuildMVN(std::unique_ptr<FunctionProto>* func_proto) {
   if (nullptr == func_proto) {
     return Common::Status(
@@ -171,5 +171,11 @@ static Common::Status BuildMVN(std::unique_ptr<FunctionProto>* func_proto) {
   return Common::Status::OK();
 }
 
-ONNX_FUNCTION(
+ONNX_FUNCTION_BUILD(
+    MeanVarianceNormalization,
+    9,
     FunctionBuilder().SetDomain(ONNX_DOMAIN).SetBuildFunction(BuildMVN));
+
+} // namespace ONNX_NAMESPACE
+// ONNX_FUNCTION(
+//    FunctionBuilder().SetDomain(ONNX_DOMAIN).SetBuildFunction(BuildMVN));

--- a/onnx/defs/experiments/experiments_functions.cc
+++ b/onnx/defs/experiments/experiments_functions.cc
@@ -177,5 +177,3 @@ ONNX_FUNCTION_BUILD(
     FunctionBuilder().SetDomain(ONNX_DOMAIN).SetBuildFunction(BuildMVN));
 
 } // namespace ONNX_NAMESPACE
-// ONNX_FUNCTION(
-//    FunctionBuilder().SetDomain(ONNX_DOMAIN).SetBuildFunction(BuildMVN));

--- a/onnx/defs/function.cc
+++ b/onnx/defs/function.cc
@@ -47,15 +47,8 @@ Common::Status FunctionBuilderRegistry::GetFunctions(
         "function_set should not be nullptr.");
   }
 
-  class FunctionBuilderRegisterer {
-   public:
-    FunctionBuilderRegisterer() {
-      RegisterOnnxFunctionBuilder();
-    }
-  };
-
 #ifndef __ONNX_DISABLE_STATIC_REGISTRATION
-  static FunctionBuilderRegisterer functionBuilder_registerer;
+  static bool functionBuilder_registerer = (RegisterOnnxFunctionBuilder(), false);
 #endif
 
   for (auto func_builder : function_builders) {

--- a/onnx/defs/function.cc
+++ b/onnx/defs/function.cc
@@ -229,8 +229,4 @@ void FunctionExpandHelper(
   }
 }
 
-void RegisterOneFunctionBuilder(FunctionBuilder&& func_builder) {
-  ONNX_FUNCTION(func_builder);
-};
-
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/function.cc
+++ b/onnx/defs/function.cc
@@ -228,4 +228,9 @@ void FunctionExpandHelper(
     }
   }
 }
+
+void RegisterOneFunctionBuilder(FunctionBuilder&& func_builder) {
+  ONNX_FUNCTION(func_builder);
+};
+
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/function.cc
+++ b/onnx/defs/function.cc
@@ -3,6 +3,7 @@
 
 #include "onnx/defs/function.h"
 #include "onnx/checker.h"
+#include "onnx/defs/operator_sets.h"
 #include "onnx/defs/schema.h"
 #include "onnx/string_utils.h"
 
@@ -45,6 +46,17 @@ Common::Status FunctionBuilderRegistry::GetFunctions(
         Common::INVALID_ARGUMENT,
         "function_set should not be nullptr.");
   }
+
+  class FunctionBuilderRegisterer {
+   public:
+    FunctionBuilderRegisterer() {
+      RegisterOnnxFunctionBuilder();
+    }
+  };
+
+#ifndef __ONNX_DISABLE_STATIC_REGISTRATION
+  static FunctionBuilderRegisterer functionBuilder_registerer;
+#endif
 
   for (auto func_builder : function_builders) {
     if (func_builder.GetDomain() != domain) {

--- a/onnx/defs/function.h
+++ b/onnx/defs/function.h
@@ -97,9 +97,7 @@ void RegisterFunctionBuilder() {
   static Common::Status function_builder_##counter##_status = \
       FunctionBuilderRegistry::OnnxInstance().Register(function_builder);
 
-inline void RegisterOneFunctionBuilder(FunctionBuilder&& func_builder) {
-  ONNX_FUNCTION(func_builder);
-};
+void RegisterOneFunctionBuilder(FunctionBuilder&& func_builder); 
 
 // Helper function to expand a function node given the function proto
 void FunctionExpandHelper(

--- a/onnx/defs/function.h
+++ b/onnx/defs/function.h
@@ -129,6 +129,6 @@ void FunctionExpandHelper(
 //  return Status::OK();
 //}
 //
-// ONNX_FUNCTION(FunctionBuilder().SetDomain("").SetBuildFunction(BuildFc));
+// ONNX_FUNCTION_BUILD(Name, Ver, FunctionBuilder().SetDomain("").SetBuildFunction(BuildFc));
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/function.h
+++ b/onnx/defs/function.h
@@ -81,12 +81,6 @@ FunctionBuilder GetFunctionBuilder();
     return build_func;                                                        \
   }
 
-// Registers all function builder of a given operator set
-template <class T>
-void RegisterFunctionBuilder() {
-  T::ForEachFunctionBuilder(RegisterOneFunctionBuilder);
-};
-
 #define ONNX_FUNCTION(function_builder) \
   ONNX_FUNCTION_UNIQ_HELPER(__COUNTER__, function_builder)
 
@@ -97,7 +91,15 @@ void RegisterFunctionBuilder() {
   static Common::Status function_builder_##counter##_status = \
       FunctionBuilderRegistry::OnnxInstance().Register(function_builder);
 
-void RegisterOneFunctionBuilder(FunctionBuilder&& func_builder); 
+inline void RegisterOneFunctionBuilder(FunctionBuilder&& func_builder) { 
+  ONNX_FUNCTION(func_builder); 
+}
+
+// Registers all function builder of a given operator set
+template <class T>
+void RegisterFunctionBuilder() {
+  T::ForEachFunctionBuilder(RegisterOneFunctionBuilder);
+};
 
 // Helper function to expand a function node given the function proto
 void FunctionExpandHelper(

--- a/onnx/defs/function.h
+++ b/onnx/defs/function.h
@@ -69,11 +69,9 @@ FunctionBuilder GetFunctionBuilder();
   name##_##domain##_ver##ver
 
 #define ONNX_FUNCTION_BUILD(name, ver, build_func) \
-  ONNX_FUNCTION_BUILD_HELPER(                      \
-      __COUNTER__, name, Onnx, ONNX_DOMAIN, ver, build_func)
+  ONNX_FUNCTION_BUILD_HELPER(name, Onnx, ONNX_DOMAIN, ver, build_func)
 
-#define ONNX_FUNCTION_BUILD_HELPER(                                           \
-    counter, name, domain, domain_str, ver, build_func)                       \
+#define ONNX_FUNCTION_BUILD_HELPER(name, domain, domain_str, ver, build_func) \
   class ONNX_FUNCTION_BUILDER_CLASS_NAME(domain, ver, name);                  \
   template <>                                                                 \
   FunctionBuilder                                                             \
@@ -91,8 +89,8 @@ FunctionBuilder GetFunctionBuilder();
   static Common::Status function_builder_##counter##_status = \
       FunctionBuilderRegistry::OnnxInstance().Register(function_builder);
 
-inline void RegisterOneFunctionBuilder(FunctionBuilder&& func_builder) { 
-  ONNX_FUNCTION(func_builder); 
+inline void RegisterOneFunctionBuilder(FunctionBuilder&& func_builder) {
+  ONNX_FUNCTION(func_builder);
 }
 
 // Registers all function builder of a given operator set
@@ -129,6 +127,7 @@ void FunctionExpandHelper(
 //  return Status::OK();
 //}
 //
-// ONNX_FUNCTION_BUILD(Name, Ver, FunctionBuilder().SetDomain("").SetBuildFunction(BuildFc));
+// ONNX_FUNCTION_BUILD(Name, Ver,
+// FunctionBuilder().SetDomain("").SetBuildFunction(BuildFc));
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/operator_sets.h
+++ b/onnx/defs/operator_sets.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "onnx/defs/function.h"
 #include "onnx/defs/schema.h"
 
 namespace ONNX_NAMESPACE {
@@ -471,16 +472,24 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, DynamicSlice);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, EyeLike);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, Greater);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, Less);
+class ONNX_FUNCTION_BUILDER_CLASS_NAME(Onnx, 9, MeanVarianceNormalization);
 
 // Iterate over schema from ai.onnx version 9
 class OpSet_Onnx_ver9 {
  public:
   static void ForEachSchema(std::function<void(OpSchema&&)> fn) {
-    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, ConstantLike)>());
-    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, DynamicSlice)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 9, ConstantLike)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(
+           Onnx, 9, DynamicSlice)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, EyeLike)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, Greater)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, Less)>());
+  }
+  static void ForEachFunctionBuilder(
+      std::function<void(FunctionBuilder&&)> fn) {
+    fn(GetFunctionBuilder<ONNX_FUNCTION_BUILDER_CLASS_NAME(
+           Onnx, 9, MeanVarianceNormalization)>());
   }
 };
 
@@ -496,5 +505,7 @@ inline void RegisterOnnxOperatorSetSchema() {
   RegisterOpSetSchema<OpSet_Onnx_ver9>();
 }
 
-
+inline void RegisterOnnxFunctionBuilder() {
+  RegisterFunctionBuilder<OpSet_Onnx_ver9>();
+}
 } // namespace ONNX_NAMESPACE


### PR DESCRIPTION
* Change Function registry flow into the Opschema registering way.
* Get rid of whole-archive during compiling