### PR TITLE
Remove default value for 'dtype' attribute in ConstantLike op.

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -8358,8 +8358,8 @@ This version of the operator has been available since version 9 of the default O
 #### Attributes
 
 <dl>
-<dt><tt>dtype</tt> : int (default is 1)</dt>
-<dd>(Optional) The data type for the elements of the output tensor. If not specified,the data type of the input tensor T1 is used. If input tensor T1 is also notspecified, then type defaults to 'float'.</dd>
+<dt><tt>dtype</tt> : int</dt>
+<dd>(Optional) The data type for the elements of the output tensor. If not specified,the data type of the input tensor T1 is used. If input tensor T1 is also not specified, then output tensor type defaults to 'float'.</dd>
 <dt><tt>shape</tt> : list of ints</dt>
 <dd>(Optional) The shape of the output tensor. If input tensor T1 is provided, then 'shape' attribute is ignored and the output follows the shape of the input. One of either input tensor T1 or 'shape' attribute must be provided.</dd>
 <dt><tt>value</tt> : float (default is 0.0)</dt>

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -1799,8 +1799,8 @@ This version of the operator has been available since version 9 of the default O
 #### Attributes
 
 <dl>
-<dt><tt>dtype</tt> : int (default is 1)</dt>
-<dd>(Optional) The data type for the elements of the output tensor. If not specified,the data type of the input tensor T1 is used. If input tensor T1 is also notspecified, then type defaults to 'float'.</dd>
+<dt><tt>dtype</tt> : int</dt>
+<dd>(Optional) The data type for the elements of the output tensor. If not specified,the data type of the input tensor T1 is used. If input tensor T1 is also not specified, then output tensor type defaults to 'float'.</dd>
 <dt><tt>shape</tt> : list of ints</dt>
 <dd>(Optional) The shape of the output tensor. If input tensor T1 is provided, then 'shape' attribute is ignored and the output follows the shape of the input. One of either input tensor T1 or 'shape' attribute must be provided.</dd>
 <dt><tt>value</tt> : float (default is 0.0)</dt>

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -113,7 +113,14 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(bool)"},
              "Constrain output types. Strings and complex are not supported.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-          propagateElemTypeFromAttributeToOutput(ctx, "dtype", 0);
+          if (ctx.getAttribute("dtype") != nullptr) {
+            propagateElemTypeFromAttributeToOutput(ctx, "dtype", 0);
+          }
+          else {
+            if (hasNInputShapes(ctx, 1)) {
+              propagateElemTypeFromInputToOutput(ctx, 0, 0);
+            }
+          }
           if (hasNInputShapes(ctx, 1)) {
             propagateShapeFromInputToOutput(ctx, 0, 0);
           }

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -59,10 +59,10 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Attr(
             "dtype",
             "(Optional) The data type for the elements of the output tensor. If not specified,"
-            "the data type of the input tensor T1 is used. If input tensor T1 is also not" 
-            "specified, then type defaults to 'float'.",
+            "the data type of the input tensor T1 is used. If input tensor T1 is also not " 
+            "specified, then output tensor type defaults to 'float'.",
             AttributeProto::INT,
-            static_cast<int64_t>(TensorProto::FLOAT))
+            OPTIONAL)
         .Attr(
             "shape",
             "(Optional) The shape of the output tensor. If input tensor T1 is provided, then"


### PR DESCRIPTION
This is a bug in the spec of `ConstantLike` op. The spec says that if `dtype` is not specified then the type of the input tensor should be used as the output tensor type. But currently, with the default value specified for this op, this attribute will always be _present_, and therefore, it is contrary to the spec. With this fix the default value is removed, which will allow the `dtype` attribute to be absent, in which case the input tensor type can be used for output type. 

Since this op was checked in very recently (less than two weeks ago), I am not updating the opset for this change.