### PR TITLE
Move the definition of the singleton DomainToVersionRange to .cc file

### DIFF
--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -722,6 +722,11 @@ std::ostream& operator<<(std::ostream& out, const OpSchema& schema) {
   return out;
 }
 
+OpSchemaRegistry::DomainToVersionRange& OpSchemaRegistry::DomainToVersionRange::Instance() {
+  static DomainToVersionRange domain_to_version_range;
+  return domain_to_version_range;
+};
+
 // Private method used by OpSchemaRegisterOnce and OpSchemaRegistry::map()
 OpName_Domain_Version_Schema_Map&
 OpSchemaRegistry::GetMapWithoutEnsuringRegistration() {

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -624,10 +624,7 @@ class OpSchemaRegistry final : public ISchemaRegistry {
       map_[domain] = std::make_pair(min_version, max_version);
     }
 
-    static DomainToVersionRange& Instance() {
-      static DomainToVersionRange domain_to_version_range;
-      return domain_to_version_range;
-    }
+    static DomainToVersionRange& Instance();
 
    private:
     // Key: domain. Value: <lowest version, highest version> pair.


### PR DESCRIPTION
Putting it in a header file causes multiple instances of DomainToVersionRange existing in different libs