### PR TITLE
Fix compiler warnings on unhandled bfloat16 switch case

### DIFF
--- a/onnx/common/ir_pb_converter.cc
+++ b/onnx/common/ir_pb_converter.cc
@@ -27,6 +27,7 @@ Tensor tensorProtoToTensor(const ONNX_NAMESPACE::TensorProto & tp) {
     break;
   }
   case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16:
+  case ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16:
   case ONNX_NAMESPACE::TensorProto_DataType_BOOL:
   case ONNX_NAMESPACE::TensorProto_DataType_INT8:
   case ONNX_NAMESPACE::TensorProto_DataType_INT16:
@@ -355,6 +356,7 @@ void encodeTensor(ONNX_NAMESPACE::TensorProto * p, const Tensor & tensor) {
     break;
   }
   case ONNX_NAMESPACE::TensorProto_DataType_FLOAT16:
+  case ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16:
   case ONNX_NAMESPACE::TensorProto_DataType_BOOL:
   case ONNX_NAMESPACE::TensorProto_DataType_INT8:
   case ONNX_NAMESPACE::TensorProto_DataType_INT16:


### PR DESCRIPTION
/Users/travis/build/onnx/onnx/onnx/common/ir_pb_converter.cc:20:10: warning: enumeration value 'TensorProto_DataType_BFLOAT16' not handled in switch [-Wswitch]