### PR TITLE
Operator set versioning - tighten wording regarding breaking changes

### DIFF
--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -69,27 +69,19 @@ ONNX is defined such that the IR can evolve independently from the set of operat
 
 A given operator is identified by a three-tuple: `(domain, op_type, and op_version)`. This is written as `domain.op_type:op_version` in prose (e.g., `com.acme.FastConv:3`).  Nodes in graphs always refer to operators by their three-part identifier.
 
-The semantics of an operator MAY be extended in a backwards-compatible
-way without requiring the `op_version` of an operator to be increased.
-A backwards compatible semantics change is defined to be a change to
-operator semantics such that all operator definitions which were defined
-in the previous operator definition have exactly same semantics as
-in the previous version.  The following are examples of
-backwards-compatible extensions:
+If the semantics of an operator are changed, you MUST create a new operator; the `op_version` of the new
+operator id MUST be greater than any extant `op_version` for the
+`domain`. The following changes would be considered breaking:
 
-* Adding an optional attribute, such that when the attribute is omitted,
-  the semantics are identical.
+* Adding/removing/renaming an attribute, even an optional attribute such that when the attribute is omitted,
+  the semantics are identical to a previous operator.
 
-* Adding an optional input, such that when the input is omitted, the
-  semantics are identical.
+* Adding/removing/renaming input or output, even when optional.
+
+The following are not breaking:
 
 * Clarifications of specification ambiguities to match prevailing
   implementation practice.
-
-If the semantics of an operator is changed in a backwards-incompatible
-way, you MUST create a new operator; the `op_version` of the new
-operator id MUST be greater than any extant `op_version` for the
-`domain`.
 
 > In practice, this means that BC-breaking changes in the ONNX
 > repository require contributors to follow the following three steps:

--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -67,21 +67,24 @@ ISSUE: define type compatibility rules either here or under model versioning - p
 
 ONNX is defined such that the IR can evolve independently from the set of operators. In ONNX, operators represent both the signature and semantics of a given operation.  Operators are abstract interfaces in that they do not imply a specific implementation; rather, they are simply the contract between a model author and the implementations that model may execute on.
 
-A given operator is identified by a three-tuple: `(domain, op_type, and op_version)`. This is written as `domain.op_type:op_version` in prose (e.g., `com.acme.FastConv:3`).  Nodes in graphs always refer to operators by their three-part identifier.
+A given operator is identified by a three-tuple: `(domain, op_type, and op_version)`. This is written as `domain.op_type:op_version` in prose (e.g., `com.acme.FastConv:3`).  Nodes in graphs always refer to operators by their three-part identifier. Breaking opset changes include:
 
-If the semantics of an operator are changed, you MUST create a new operator; the `op_version` of the new
-operator id MUST be greater than any extant `op_version` for the
-`domain`. The following changes would be considered breaking:
+* Adding/removing/renaming an attribute. This even includes the case of adding a new optional attribute, where omitting the attribute would imply a default value yielding semantics identical to the previous operator version.
 
-* Adding/removing/renaming an attribute, even an optional attribute such that when the attribute is omitted,
-  the semantics are identical to a previous operator.
+* Adding/removing/reordering inputs or outputs.
 
-* Adding/removing/renaming input or output, even when optional.
+* Adding/removing types supported by inputs and outputs, and changing types used by attributes.
+
+* Supporting new behavior even when the existing parameter signature is otherwise identical (e.g. implicitly supporting tensor broadcasting in the Mean operator).
 
 The following are not breaking:
 
 * Clarifications of specification ambiguities to match prevailing
   implementation practice.
+
+If the semantics of an operator or function are changed, you MUST create a new operator; the `op_version` of the new
+operator id MUST be greater than any extant `op_version` for the
+`domain`.
 
 > In practice, this means that BC-breaking changes in the ONNX
 > repository require contributors to follow the following three steps:


### PR DESCRIPTION
It is highly desirable for model loaders to quickly gauge their compatibility with the operators in a model when loading it and to reliably know that they can compute correct results. The current wording though for op set versioning is unclear regarding optional attributes, which makes it sound like it's legal to add a new attribute to an operator without updating the version number so long as (a) it's marked optional, and (b) it's absence would yield the same behavior as the earlier version of the operator. This is okay when the attribute *is* missing, but it would be bad for the model loader when the new attribute is present as the execution would think that it could successfully process a model and all operators in it, only to yield incorrect results because it was unaware of a newly added attribute that it should have considered.

So, any parameter additions which affect behavior, optional or not, should increment the operator version. Unlike some other file formats which can afford more lenient fallback in the results presented to the user (e.g. color SVG fonts falling back to black&white glyph outlines or JPEG-HDR falling back to LDR gamut), ML must either have a clear up-front failure or should have correct results (e.g. the difference between a 75% chance vs 5% of cancer diagnosis matters).

This tightens wording to include:
- attribute additions/changes/removals
- tensor additions/removals/reorderings.
- data type additions/removals. Previously, type additions which didn't affect behavior were just considered documentation updates, without incrementing the op version, but it's desirable to know type compatibility immediately.