### PR TITLE
Clean memory when failed test

### DIFF
--- a/onnx/backend/test/cpp/driver_test.cc
+++ b/onnx/backend/test/cpp/driver_test.cc
@@ -20,17 +20,6 @@
 #define ONNXIFI_TESTDATA_EPS 1e-5
 #endif
 
-#define ASSERT_MEMORYSAFE_SUCCESS(X, isGraphInitialized)  \
-  {                                                       \
-    onnxStatus sta = X;                                   \
-    if (sta != ONNXIFI_STATUS_SUCCESS) {                  \
-      if (isGraphInitialized) {                           \
-        lib.onnxReleaseGraph(graph);                      \
-      }                                                   \
-    }                                                     \
-    ASSERT_EQ(sta, ONNXIFI_STATUS_SUCCESS);               \
-  }
-
 const float onnxifi_testdata_eps = ONNXIFI_TESTDATA_EPS;
 
 template <typename T>
@@ -52,6 +41,7 @@ class ONNXCppDriverTest
     protos_ = t.proto_test_data_;
     model_ = t.model_;
   }
+
   uint64_t GetDescriptorSize(const onnxTensorDescriptorV1* t) {
     uint64_t d_size = 1;
     for (int i = 0; i < t->dimensions; i++) {
@@ -59,6 +49,19 @@ class ONNXCppDriverTest
     }
     return d_size;
   }
+
+  void GtestAssertMemorySafeSuccess(
+      onnxStatus x,
+      onnxGraph* graph_pointer,
+      onnxifi_library& lib) {
+    if (x != ONNXIFI_STATUS_SUCCESS) {
+      if (graph_pointer != NULL) {
+        lib.onnxReleaseGraph(*graph_pointer);
+      }
+    }
+    ASSERT_EQ(x, ONNXIFI_STATUS_SUCCESS);
+  }
+
   bool IsUnsupported(onnxStatus s, std::string& msg) {
     if (s == ONNXIFI_STATUS_UNSUPPORTED_VERSION) {
       msg = "Unsupported version of ONNX or operator.";
@@ -210,8 +213,8 @@ class ONNXCppDriverTest
         GTEST_SKIP();
         return;
       }
-      ASSERT_MEMORYSAFE_SUCCESS(is_compatible, false);
-      ASSERT_MEMORYSAFE_SUCCESS(
+      GtestAssertMemorySafeSuccess(is_compatible, NULL, lib);
+      GtestAssertMemorySafeSuccess(
           lib.onnxInitGraph(
               backend,
               NULL,
@@ -220,7 +223,8 @@ class ONNXCppDriverTest
               weightCount,
               weightDescriptors_pointer,
               &graph),
-          false);
+          NULL,
+          lib);
       for (const auto& proto_test_data : protos_) {
         std::vector<onnxTensorDescriptorV1> input_descriptor, output_descriptor,
             result_descriptor;
@@ -235,8 +239,7 @@ class ONNXCppDriverTest
               ONNX_NAMESPACE::testing::ProtoToOnnxTensorDescriptor(output));
           onnxTensorDescriptorV1 result;
           result.tag = ONNXIFI_TAG_TENSOR_DESCRIPTOR_V1;
-          std::string name_string =
-              "output_" + ONNX_NAMESPACE::to_string(output_count);
+          std::string name_string = output_descriptor[output_count - 1].name;
           result.name = name_string.c_str();
           result.dataType = output.data_type();
           result.memoryType = ONNXIFI_MEMORY_TYPE_CPU;
@@ -248,35 +251,41 @@ class ONNXCppDriverTest
           result.buffer = (onnxPointer)raw_data.data();
           result_descriptor.emplace_back(std::move(result));
         }
-        ASSERT_MEMORYSAFE_SUCCESS(
+        GtestAssertMemorySafeSuccess(
             lib.onnxSetGraphIO(
                 graph,
                 input_descriptor.size(),
                 input_descriptor.data(),
                 result_descriptor.size(),
                 result_descriptor.data()),
-            true);
+            &graph,
+            lib);
 
         onnxMemoryFenceV1 inputFence, outputFence;
         inputFence.tag = ONNXIFI_TAG_MEMORY_FENCE_V1;
         outputFence.tag = ONNXIFI_TAG_MEMORY_FENCE_V1;
         inputFence.type = ONNXIFI_SYNCHRONIZATION_EVENT;
         outputFence.type = ONNXIFI_SYNCHRONIZATION_EVENT;
-
-        ASSERT_MEMORYSAFE_SUCCESS(
-            lib.onnxRunGraph(graph, &inputFence, &outputFence), true);
-        ASSERT_MEMORYSAFE_SUCCESS(lib.onnxWaitEvent(outputFence.event), true);
+        GtestAssertMemorySafeSuccess(
+            lib.onnxInitEvent(backend, &inputFence.event), &graph, lib);
+        GtestAssertMemorySafeSuccess(
+            lib.onnxInitEvent(backend, &outputFence.event), &graph, lib);
+        GtestAssertMemorySafeSuccess(
+            lib.onnxSignalEvent(inputFence.event), &graph, lib);
+        GtestAssertMemorySafeSuccess(
+            lib.onnxRunGraph(graph, &inputFence, &outputFence), &graph, lib);
+        GtestAssertMemorySafeSuccess(
+            lib.onnxWaitEvent(outputFence.event), &graph, lib);
         for (int i = 0; i < output_descriptor.size(); i++) {
           auto output_size = GetDescriptorSize(&output_descriptor[i]);
           for (int j = 0; j < output_size; j++) {
             EXPECT_EQ(
                 IsDescriptorEqual(output_descriptor[i], result_descriptor[i]),
                 true);
-            ;
           }
         }
       }
-      ASSERT_MEMORYSAFE_SUCCESS(lib.onnxReleaseGraph(graph), false);
+      GtestAssertMemorySafeSuccess(lib.onnxReleaseGraph(graph), NULL, lib);
     }
   }
 };

--- a/onnx/backend/test/cpp/driver_test.cc
+++ b/onnx/backend/test/cpp/driver_test.cc
@@ -20,15 +20,15 @@
 #define ONNXIFI_TESTDATA_EPS 1e-5
 #endif
 
-#define ASSERT_MEMORYSAFE_SUCCESS(X, isGraphInitialized) \
-  {                                                      \
-    onnxStatus sta = X;                                  \
-    if (sta != ONNXIFI_STATUS_SUCCESS) {                 \
-      if (isGraphInitialized) {                          \
-        lib.onnxReleaseGraph(graph);                     \
-      }                                                  \
-    }                                                    \
-    ASSERT_EQ(sta, ONNXIFI_STATUS_SUCCESS);              \
+#define ASSERT_MEMORYSAFE_SUCCESS(X, isGraphInitialized)  \
+  {                                                       \
+    onnxStatus sta = X;                                   \
+    if (sta != ONNXIFI_STATUS_SUCCESS) {                  \
+      if (isGraphInitialized) {                           \
+        lib.onnxReleaseGraph(graph);                      \
+      }                                                   \
+    }                                                     \
+    ASSERT_EQ(sta, ONNXIFI_STATUS_SUCCESS);               \
   }
 
 const float onnxifi_testdata_eps = ONNXIFI_TESTDATA_EPS;


### PR DESCRIPTION
Right now, we dont clean when our test failed, which may cause memory leaking.
In this pr we introduced a macro to handle the clean up in test driver.
We also updated the testing process in onnxifi test driver, fixed a few bug of not using signal.