### PR TITLE
[ONNXIFI]Reliable memory of shape in test driver

### DIFF
--- a/onnx/backend/test/cpp/driver_test.cc
+++ b/onnx/backend/test/cpp/driver_test.cc
@@ -175,7 +175,10 @@ class ONNXCppDriverTest
     return true;
   }
 
+  // A memory pool of shape information of onnxTensorDescriptorV1 used in this
+  // test driver.
   std::vector<std::vector<uint64_t>> shape_pool;
+  // A memory pool of raw_data of backend output in onnxTensorDescriptorV1.
   std::vector<std::vector<uint8_t>> data_pool;
 
   void RunAndVerify(

--- a/onnx/onnxifi_utils.cc
+++ b/onnx/onnxifi_utils.cc
@@ -4,7 +4,8 @@ namespace ONNX_NAMESPACE {
 namespace testing {
 
 onnxTensorDescriptorV1 ProtoToOnnxTensorDescriptor(
-    const ONNX_NAMESPACE::TensorProto& proto_tensor) {
+    const ONNX_NAMESPACE::TensorProto& proto_tensor,
+    std::vector<std::vector<uint64_t>>& shape_pool) {
   onnxTensorDescriptorV1 onnx_tensor;
   onnx_tensor.tag = ONNXIFI_TAG_TENSOR_DESCRIPTOR_V1;
   onnx_tensor.name = proto_tensor.name().c_str();
@@ -12,8 +13,9 @@ onnxTensorDescriptorV1 ProtoToOnnxTensorDescriptor(
   onnx_tensor.memoryType = ONNXIFI_MEMORY_TYPE_CPU;
   std::vector<uint64_t> shape_values(
       proto_tensor.dims().begin(), proto_tensor.dims().end());
-  onnx_tensor.dimensions = (uint32_t)shape_values.size();
-  onnx_tensor.shape = shape_values.data();
+  shape_pool.emplace_back(std::move(shape_values));
+  onnx_tensor.dimensions = (uint32_t)shape_pool.back().size();
+  onnx_tensor.shape = shape_pool.back().data();
   onnx_tensor.buffer = (onnxPointer)proto_tensor.raw_data().data();
   return onnx_tensor;
 }

--- a/onnx/onnxifi_utils.h
+++ b/onnx/onnxifi_utils.h
@@ -9,6 +9,7 @@ namespace ONNX_NAMESPACE {
 namespace testing {
 
 onnxTensorDescriptorV1 ProtoToOnnxTensorDescriptor(
-    const ONNX_NAMESPACE::TensorProto& proto_tensor);
+    const ONNX_NAMESPACE::TensorProto& proto_tensor,
+    std::vector<std::vector<uint64_t>>& shape_pool);
 } // namespace testing
 } // namespace ONNX_NAMESPACE


### PR DESCRIPTION
We didnt use persistent memory in test driver, which may cause memory leaking.