### PR TITLE
Fall back to build with 3.5.2 protobuf on Windows CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ install:
 
 before_build:
 - cmd: SET PATH=%CONDA_PREFIX%;%CONDA_PREFIX%\Scripts;%PATH%
-- cmd: conda install -y -c conda-forge protobuf numpy
+- cmd: conda install -y -c conda-forge protobuf=3.5.2 numpy
 - cmd: pip install pytest-cov nbval
 
 build_script:


### PR DESCRIPTION
Will do more investigation on the issue with 3.6 (#1485 ). 
Lets use 3.5.1 for CI right now. 