### PR TITLE
[ONNXIFI]Make TEST_P be able to show the test case name directly

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ install:
 
 before_build:
 - cmd: SET PATH=%CONDA_PREFIX%;%CONDA_PREFIX%\Scripts;%PATH%
-- cmd: conda install -y -c conda-forge protobuf numpy
+- cmd: conda install -y -c conda-forge protobuf=3.5.2 numpy
 - cmd: pip install pytest-cov nbval
 
 build_script:

--- a/onnx/backend/test/cpp/driver/test_driver.cc
+++ b/onnx/backend/test/cpp/driver/test_driver.cc
@@ -37,11 +37,14 @@ void TestDriver::SetDefaultDir(const std::string& s) {
  *	It is possible that case_dir is not a dir.
  *	But it does not affect the result.
  */
-void TestDriver::FetchSingleTestCase(const std::string& case_dir) {
+void TestDriver::FetchSingleTestCase(
+    const std::string& case_dir,
+    const std::string& test_case_name) {
   std::string model_name = case_dir;
   model_name += "model.onnx";
   if (FileExists(model_name)) {
     UnsolvedTestCase test_case;
+    test_case.test_case_name_ = test_case_name;
     test_case.model_filename_ = model_name;
     test_case.model_dirname_ = case_dir;
     for (int case_count = 0;; case_count++) {
@@ -97,10 +100,10 @@ bool TestDriver::FetchAllTestCases(const std::string& target) {
   } else {
     try {
       do {
-        std::string entry_dname = file.name;
+        std::string entry_dname = file.name, full_entry_dname;
         if (entry_dname != "." && entry_dname != "..") {
-          entry_dname = target_dir + "/" + entry_dname + "/";
-          FetchSingleTestCase(entry_dname);
+          full_entry_dname = target_dir + "/" + entry_dname + "/";
+          FetchSingleTestCase(full_entry_dname, entry_dname);
         }
       } while (_findnext(lf, &file) == 0);
     } catch (const std::exception& e) {
@@ -133,10 +136,10 @@ bool TestDriver::FetchAllTestCases(const std::string& target) {
           break;
         }
       }
-      std::string entry_dname = entry->d_name;
+      std::string full_entry_dname, entry_dname = entry->d_name;
       if (entry_dname != "." && entry_dname != "..") {
-        entry_dname = target_dir + "/" + entry_dname + "/";
-        FetchSingleTestCase(entry_dname);
+        full_entry_dname = target_dir + "/" + entry_dname + "/";
+        FetchSingleTestCase(full_entry_dname, entry_dname);
       }
     }
   } catch (const std::exception& e) {
@@ -191,6 +194,7 @@ ResolvedTestCase LoadSingleTestCase(const UnsolvedTestCase& t) {
   ResolvedTestCase st;
   std::string raw_model;
   LoadSingleFile(t.model_filename_, raw_model);
+  st.test_case_name_ = t.test_case_name_;
   ONNX_NAMESPACE::ParseProtoFromBytes(
       &st.model_, raw_model.c_str(), raw_model.size());
 

--- a/onnx/backend/test/cpp/driver/test_driver.cc
+++ b/onnx/backend/test/cpp/driver/test_driver.cc
@@ -100,7 +100,8 @@ bool TestDriver::FetchAllTestCases(const std::string& target) {
   } else {
     try {
       do {
-        std::string entry_dname = file.name, full_entry_dname;
+        std::string entry_dname = file.name;
+        std::string full_entry_dname;
         if (entry_dname != "." && entry_dname != "..") {
           full_entry_dname = target_dir + "/" + entry_dname + "/";
           FetchSingleTestCase(full_entry_dname, entry_dname);
@@ -136,7 +137,8 @@ bool TestDriver::FetchAllTestCases(const std::string& target) {
           break;
         }
       }
-      std::string full_entry_dname, entry_dname = entry->d_name;
+      std::string full_entry_dname;
+      std::string entry_dname = entry->d_name;
       if (entry_dname != "." && entry_dname != "..") {
         full_entry_dname = target_dir + "/" + entry_dname + "/";
         FetchSingleTestCase(full_entry_dname, entry_dname);

--- a/onnx/backend/test/cpp/driver/test_driver.h
+++ b/onnx/backend/test/cpp/driver/test_driver.h
@@ -44,7 +44,7 @@ struct UnsolvedTestCase {
         test_data_(test_data) {}
 
   UnsolvedTestCase() {}
-
+  std::string test_case_name_;
   std::string model_filename_;
   std::string model_dirname_;
   std::vector<UnsolvedTestData> test_data_;
@@ -70,6 +70,7 @@ struct ResolvedTestData {
 struct ResolvedTestCase {
   ONNX_NAMESPACE::ModelProto model_;
   std::vector<ResolvedTestData> proto_test_data_;
+  std::string test_case_name_;
 };
 
 /**
@@ -101,7 +102,9 @@ class TestDriver {
    *	Regular file(s): input_X.pb, store one input tensor.
    *	Regular file(s): output_X.pb, store one output tensor.
    */
-  void FetchSingleTestCase(const std::string& case_dir);
+  void FetchSingleTestCase(
+      const std::string& case_dir,
+      const std::string& test_case_name);
 };
 
 std::vector<UnsolvedTestCase> GetTestCase();

--- a/onnx/backend/test/cpp/driver_test.cc
+++ b/onnx/backend/test/cpp/driver_test.cc
@@ -40,7 +40,7 @@ class ONNXCppDriverTest
     std::string operator()(const testing::TestParamInfo<T>& t) const {
       auto test_case =
           static_cast<ONNX_NAMESPACE::testing::ResolvedTestCase>(t.param);
-      return test_case.model_.graph().name();
+      return test_case.test_case_name_;
     }
   };
 

--- a/onnx/backend/test/cpp/driver_test.cc
+++ b/onnx/backend/test/cpp/driver_test.cc
@@ -40,6 +40,13 @@ class ONNXCppDriverTest
     std::string operator()(const testing::TestParamInfo<T>& t) const {
       auto test_case =
           static_cast<ONNX_NAMESPACE::testing::ResolvedTestCase>(t.param);
+      /**
+       *  We pick folder name instead of model.graph().name as test case name
+       * here mostly for two reasons:
+       *  1. Name of proto graph can be empty or ruined.
+       *  2. Compares to the complex logic of protobuf, folder name is easier to
+       * parse, to modify and to use.
+       */
       return test_case.test_case_name_;
     }
   };

--- a/onnx/backend/test/cpp/driver_test.cc
+++ b/onnx/backend/test/cpp/driver_test.cc
@@ -31,8 +31,19 @@ class CompareOnnxifiData {
         ((x - y) < onnxifi_testdata_eps);
   }
 };
+
 class ONNXCppDriverTest
     : public testing::TestWithParam<ONNX_NAMESPACE::testing::ResolvedTestCase> {
+ public:
+  struct PrintToStringParamName {
+    template <class T>
+    std::string operator()(const testing::TestParamInfo<T>& t) const {
+      auto test_case =
+          static_cast<ONNX_NAMESPACE::testing::ResolvedTestCase>(t.param);
+      return test_case.model_.graph().name();
+    }
+  };
+
  protected:
   std::vector<ONNX_NAMESPACE::testing::ResolvedTestData> protos_;
   ONNX_NAMESPACE::ModelProto model_;
@@ -213,7 +224,6 @@ class ONNXCppDriverTest
       }
       std::string serialized_model;
       model_.SerializeToString(&serialized_model);
-      std::cout << model_.graph().name() << std::endl;
       auto is_compatible = lib.onnxGetBackendCompatibility(
           backendID, serialized_model.size(), serialized_model.data());
       std::string error_msg;
@@ -346,7 +356,9 @@ TEST_P(ONNXCppDriverTest, ONNXCppDriverUnitTest){
     RunAndVerify(lib, backend, NULL);
   }
 }
+
 INSTANTIATE_TEST_CASE_P(
     ONNXCppAllTest,
     ONNXCppDriverTest,
-    testing::ValuesIn(GetTestCases()));
+    testing::ValuesIn(GetTestCases()),
+    ONNXCppDriverTest::PrintToStringParamName());


### PR DESCRIPTION
Before:
[ RUN      ] ONNXCppAllTest/ONNXCppDriverTest.ONNXCppDriverUnitTest/1
[       OK ] ONNXCppAllTest/ONNXCppDriverTest.ONNXCppDriverUnitTest/1
[ RUN      ] ONNXCppAllTest/ONNXCppDriverTest.ONNXCppDriverUnitTest/2
[       OK ] ONNXCppAllTest/ONNXCppDriverTest.ONNXCppDriverUnitTest/2

After:
[ RUN      ] ONNXCppAllTest/ONNXCppDriverTest.ONNXCppDriverUnitTest/test_maxpool_2d_strides
[       OK ] ONNXCppAllTest/ONNXCppDriverTest.ONNXCppDriverUnitTest/test_maxpool_2d_strides 
[ RUN      ] ONNXCppAllTest/ONNXCppDriverTest.ONNXCppDriverUnitTest/test_conv_with_strides_padding
[       OK ] ONNXCppAllTest/ONNXCppDriverTest.ONNXCppDriverUnitTest/test_conv_with_strides_padding

