### PR TITLE
[ONNXIFI]Maintain Gtest main.cc argument 

### DIFF
--- a/onnx/backend/test/cpp/test_main.cc
+++ b/onnx/backend/test/cpp/test_main.cc
@@ -2,11 +2,12 @@
 #include "gtest_utils.h"
 
 GTEST_API_ int main(int argc, char** argv) {
-  if (argc != 2) {
+  if (argc < 2) {
     std::cerr << "target directory must be given!" << std::endl;
     return EXIT_FAILURE;
   }
-  std::string target_dir = argv[1];
+  argc--;
+  std::string target_dir = argv[argc];
   auto testcases = ONNX_NAMESPACE::testing::LoadAllTestCases(target_dir);
   GetTestCases() = testcases;
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Not to ruin gtest argument by always assuming the last argument to be the data target dir