### PR TITLE
Change function ownership to ONNX

### DIFF
--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -8,9 +8,9 @@
 #include "onnx/defs/function.h"
 #include "onnx/defs/schema.h"
 #include "onnx/optimizer/optimize.h"
-#include "onnx/version_converter/convert.h"
 #include "onnx/py_utils.h"
 #include "onnx/shape_inference/implementation.h"
+#include "onnx/version_converter/convert.h"
 
 namespace ONNX_NAMESPACE {
 namespace py = pybind11;
@@ -153,7 +153,7 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
       "get_all_functions",
       [](const std::string& domain)
           -> std::unordered_map<std::string, std::vector<py::bytes>> {
-        std::multimap<std::string, std::unique_ptr<FunctionProto>> temp_ptr_map;
+        std::multimap<std::string, const FunctionProto*> temp_ptr_map;
         std::unordered_map<std::string, std::vector<py::bytes>> temp_map;
         FunctionBuilderRegistry& function_registry =
             FunctionBuilderRegistry::OnnxInstance();
@@ -172,7 +172,7 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
                 "Failed to serilize registered function for '" + iter->first +
                 "'!");
           }
-          temp_map[iter->first].emplace_back(py::bytes(std::move(bytes)));
+          temp_map[iter->first].emplace_back(py::bytes(bytes));
         }
         return temp_map;
       });
@@ -261,17 +261,17 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
   optimizer.def("get_available_passes", &optimization::GetAvailablePasses);
 
   // Submodule `version_converter`
-  auto version_converter = onnx_cpp2py_export.def_submodule("version_converter");
+  auto version_converter =
+      onnx_cpp2py_export.def_submodule("version_converter");
   version_converter.doc() = "VersionConverter submodule";
 
   version_converter.def(
-      "convert_version",
-      [](const py::bytes& bytes, const py::int_ target) {
+      "convert_version", [](const py::bytes& bytes, const py::int_ target) {
         ModelProto proto{};
         ParseProtoFromPyBytes(&proto, bytes);
         shape_inference::InferShapes(proto);
-        auto const result = version_conversion::ConvertVersion(std::move(proto),
-          target);
+        auto const result =
+            version_conversion::ConvertVersion(std::move(proto), target);
         std::string out;
         result.SerializeToString(&out);
         return py::bytes(out);

--- a/onnx/defs/function.cc
+++ b/onnx/defs/function.cc
@@ -97,13 +97,14 @@ Common::Status FunctionBuilderRegistry::GetFunctions(
       (RegisterOnnxFunctionBuilder(), false);
 #endif
 
-  const std::multimap<std::string, std::unique_ptr<FunctionProto>>&
-      function_name_map = domain_functions_map.at(domain);
-  for (auto iter = function_name_map.begin(); iter != function_name_map.end();
-       ++iter) {
-    function_set->emplace(iter->first, iter->second.get());
+  auto function_name_map_iter = domain_functions_map.find(domain);
+  if (function_name_map_iter != domain_functions_map.end()) {
+    for (auto iter = function_name_map_iter->second.begin();
+         iter != function_name_map_iter->second.end();
+         ++iter) {
+      function_set->emplace(iter->first, iter->second.get());
+    }
   }
-
   return Common::Status::OK();
 }
 

--- a/onnx/defs/function.cc
+++ b/onnx/defs/function.cc
@@ -99,7 +99,7 @@ Common::Status FunctionBuilderRegistry::GetFunctions(
 
   const std::multimap<std::string, std::unique_ptr<FunctionProto>>&
       function_name_map = domain_functions_map.at(domain);
-  for (auto& iter = function_name_map.begin(); iter != function_name_map.end();
+  for (auto iter = function_name_map.begin(); iter != function_name_map.end();
        ++iter) {
     function_set->emplace(iter->first, iter->second.get());
   }

--- a/onnx/defs/function.cc
+++ b/onnx/defs/function.cc
@@ -31,6 +31,52 @@ Common::Status FunctionBuilderRegistry::Register(
     const FunctionBuilder& function_builder) {
   std::lock_guard<std::mutex> lock(mutex_);
   function_builders.push_back(function_builder);
+  std::unique_ptr<FunctionProto> function_proto;
+  auto status = function_builder.GetBuildFunction()(&function_proto);
+  if (!status.IsOK()) {
+    return status;
+  }
+
+  CheckerContext ctx;
+  std::unordered_map<std::string, int> op_set;
+  auto version_range =
+      OpSchemaRegistry::DomainToVersionRange::Instance().Map().at(
+          function_builder.GetDomain());
+  if (function_proto->since_version() > version_range.second ||
+      function_proto->since_version() < version_range.first) {
+    fail_check("Invalid function version in '", function_proto->name(), "'");
+  }
+  op_set.insert(
+      {function_builder.GetDomain(), (int)function_proto->since_version()});
+  ctx.set_opset_imports(op_set);
+  ctx.set_is_main_graph(false);
+  LexicalScopeContext lex_ctx;
+  try {
+    check_function(*function_proto, ctx, lex_ctx);
+  } catch (ValidationError& ex) {
+    return Common::Status(Common::CHECKER, Common::INVALID_PROTOBUF, ex.what());
+  }
+
+  auto& func_name = function_proto->name();
+  // Check no op version conflicts.
+  auto range =
+      domain_functions_map[function_builder.GetDomain()].equal_range(func_name);
+  for (auto i = range.first; i != range.second; ++i) {
+    auto version = i->second->since_version();
+    if (function_proto->since_version() == version) {
+      return Common::Status(
+          Common::CHECKER,
+          Common::FAIL,
+          ONNX_NAMESPACE::MakeString(
+              "A function (",
+              func_name,
+              ") with version (",
+              version,
+              ") has already been registered."));
+    }
+  }
+  domain_functions_map[function_builder.GetDomain()].emplace(
+      func_name, std::move(function_proto));
   return Common::Status::OK();
 }
 
@@ -38,8 +84,7 @@ Common::Status FunctionBuilderRegistry::Register(
 Common::Status FunctionBuilderRegistry::GetFunctions(
     const std::string& domain,
     /*out*/
-    std::multimap<std::string, std::unique_ptr<FunctionProto>>* function_set)
-    const {
+    std::multimap<std::string, const FunctionProto*>* function_set) const {
   if (nullptr == function_set) {
     return Common::Status(
         Common::CHECKER,
@@ -48,74 +93,30 @@ Common::Status FunctionBuilderRegistry::GetFunctions(
   }
 
 #ifndef __ONNX_DISABLE_STATIC_REGISTRATION
-  static bool functionBuilder_registerer = (RegisterOnnxFunctionBuilder(), false);
+  static bool functionBuilder_registerer =
+      (RegisterOnnxFunctionBuilder(), false);
 #endif
 
-  for (auto func_builder : function_builders) {
-    if (func_builder.GetDomain() != domain) {
-      continue;
-    }
-    std::unique_ptr<FunctionProto> function_proto;
-    auto status = func_builder.GetBuildFunction()(&function_proto);
-    if (!status.IsOK()) {
-      return status;
-    }
-
-    CheckerContext ctx;
-    std::unordered_map<std::string, int> op_set;
-    auto version_range =
-        OpSchemaRegistry::DomainToVersionRange::Instance().Map().at(
-            func_builder.GetDomain());
-    if (function_proto->since_version() > version_range.second ||
-        function_proto->since_version() < version_range.first) {
-      fail_check("Invalid function version in '", function_proto->name(), "'");
-    }
-    op_set.insert(
-        {func_builder.GetDomain(), (int)function_proto->since_version()});
-    ctx.set_opset_imports(op_set);
-    ctx.set_is_main_graph(false);
-    LexicalScopeContext lex_ctx;
-    try {
-      check_function(*function_proto, ctx, lex_ctx);
-    } catch (ValidationError& ex) {
-      return Common::Status(
-          Common::CHECKER, Common::INVALID_PROTOBUF, ex.what());
-    }
-
-    auto& func_name = function_proto->name();
-    // Check no op version conflicts.
-    auto range = function_set->equal_range(func_name);
-    for (auto i = range.first; i != range.second; ++i) {
-      auto version = i->second->since_version();
-      if (function_proto->since_version() == version) {
-        // There's already a function with same name/since_version registered.
-        return Common::Status(
-            Common::CHECKER,
-            Common::FAIL,
-            ONNX_NAMESPACE::MakeString(
-                "A function (",
-                func_name,
-                ") with version (",
-                version,
-                ") has already been registered."));
-      }
-    }
-    function_set->emplace(func_name, std::move(function_proto));
+  const std::multimap<std::string, std::unique_ptr<FunctionProto>>&
+      function_name_map = domain_functions_map.at(domain);
+  for (auto& iter = function_name_map.begin(); iter != function_name_map.end();
+       ++iter) {
+    function_set->emplace(iter->first, iter->second.get());
   }
 
   return Common::Status::OK();
 }
 
-std::unique_ptr<FunctionProto> FunctionBuilderRegistry::GetFunction(
+const FunctionProto* FunctionBuilderRegistry::GetFunction(
     const std::string& func_name,
     const int maxInclusiveVersion,
     const std::string& domain) const {
-  std::multimap<std::string, std::unique_ptr<FunctionProto>> funcs;
+  std::multimap<std::string, const FunctionProto*> funcs;
   auto status = GetFunctions(domain, &funcs);
   if (!status.IsOK()) {
     return nullptr;
   }
-  std::map<int, std::unique_ptr<FunctionProto>> version_to_func;
+  std::map<int, const FunctionProto*> version_to_func;
   auto range = funcs.equal_range(func_name);
   for (auto i = range.first; i != range.second; ++i) {
     version_to_func[static_cast<int>(i->second->since_version())] =
@@ -134,7 +135,7 @@ std::unique_ptr<FunctionProto> FunctionBuilderRegistry::GetFunction(
     // The <pos> version is greater than specified version.
     pos--;
   }
-  return std::move(pos->second);
+  return pos->second;
 }
 
 FunctionBuilderRegistry& FunctionBuilderRegistry::OnnxInstance() {

--- a/onnx/defs/function.h
+++ b/onnx/defs/function.h
@@ -31,7 +31,7 @@ class IFunctionBuilderRegistry {
  public:
   virtual ~IFunctionBuilderRegistry() = default;
 
-  virtual std::unique_ptr<FunctionProto> GetFunction(
+  virtual const FunctionProto* GetFunction(
       const std::string& func_name,
       const int maxInclusiveVersion,
       const std::string& domain = ONNX_DOMAIN) const = 0;
@@ -47,10 +47,9 @@ class FunctionBuilderRegistry : public IFunctionBuilderRegistry {
   Common::Status GetFunctions(
       const std::string& domain,
       /*out*/
-      std::multimap<std::string, std::unique_ptr<FunctionProto>>* function_set)
-      const;
+      std::multimap<std::string, const FunctionProto*>* function_set) const;
 
-  std::unique_ptr<FunctionProto> GetFunction(
+  const FunctionProto* GetFunction(
       const std::string& func_name,
       const int maxInclusiveVersion,
       const std::string& domain = ONNX_DOMAIN) const override;
@@ -59,6 +58,10 @@ class FunctionBuilderRegistry : public IFunctionBuilderRegistry {
 
  private:
   std::vector<FunctionBuilder> function_builders;
+  std::unordered_map<
+      std::string,
+      std::multimap<std::string, std::unique_ptr<FunctionProto>>>
+      domain_functions_map;
   std::mutex mutex_;
 };
 

--- a/onnx/defs/function.h
+++ b/onnx/defs/function.h
@@ -5,6 +5,7 @@
 
 #include <mutex>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "onnx/common/constants.h"

--- a/onnx/test/cpp/function_get_test.cc
+++ b/onnx/test/cpp/function_get_test.cc
@@ -6,7 +6,7 @@
 namespace ONNX_NAMESPACE {
 namespace Test {
 TEST(FunctionAPITest, Get_All_Functions) {
-  std::multimap<std::string, std::unique_ptr<FunctionProto>> temp_map;
+  std::multimap<std::string, const FunctionProto*> temp_map;
   FunctionBuilderRegistry& function_registry =
       FunctionBuilderRegistry::OnnxInstance();
   Common::Status status =


### PR DESCRIPTION
This avoids redundant copies of functionproto returned to any API users.