### PR TITLE
fix onnx checker to support proto3 models.

### DIFF
--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -229,7 +229,7 @@ void check_attribute(
 	  fail_check(
 		  "Attribute (name: ",
 		  attr.name(),
-		  ") should contain less than one value field.");
+		  ") should not contain more than one value field.");
   }
 
   if (!ctx.is_main_graph()) {

--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -223,20 +223,23 @@ void check_attribute(
 #undef check_singular_field
 #undef check_repeated_field
 
-  if (ctx.is_main_graph()) {
-    if (used_fields != 1) {
-      fail_check(
-          "Attribute (name: ",
-          attr.name(),
-          ") should contain one and only one value field.");
-    }
-  } else {
+  // Normally, used_fields is expected to be 1.
+  // In proto3, when the value to be set is type default value (say 0 for int), used_fields may be 0.
+  if (used_fields > 1) {
+	  fail_check(
+		  "Attribute (name: ",
+		  attr.name(),
+		  ") should contain less than one value field.");
+  }
+
+  if (!ctx.is_main_graph()) {
     // It's an attribute of a node in function body.
-    if (used_fields != 1 && (used_fields != 0 || !attr.has_ref_attr_name())) {
+    if (attr.has_ref_attr_name() && used_fields != 0) {
+	  // The attribute proto is supposed to refer to data outside and does not have its own value field set.
       fail_check(
           "Attribute (name: ",
           attr.name(),
-          ") should contain one value field or refer to attribute declared in function.");
+          ") should refer to attribute in parent node.");
     }
   }
 


### PR DESCRIPTION
In proto3 models, if the attribute value is set to be the default value (say 0 for int), it will not really have the value set, then used_fields will be 0. We'd relax the checker logic to pass such models. 