### PR TITLE
Fix googletest building when using ninja

### DIFF
--- a/cmake/external/googletest.cmake
+++ b/cmake/external/googletest.cmake
@@ -27,4 +27,5 @@ ExternalProject_Add(googletest
         -DBUILD_GMOCK:BOOL=OFF
         -DBUILD_GTEST:BOOL=ON
         -Dgtest_force_shared_crt:BOOL=OFF
+    BUILD_BYPRODUCTS ${googletest_STATIC_LIBRARIES}
 )


### PR DESCRIPTION
googletest target cannot be found when using ninja to build onnx.
this pr fixed it by adding BUILD_BYPRODUCTS macro.