### PR TITLE
Use vector instead of set to keep the order of the opt passes

### DIFF
--- a/onnx/optimizer/pass_manager.cc
+++ b/onnx/optimizer/pass_manager.cc
@@ -10,7 +10,7 @@ GeneralPassManager::~GeneralPassManager() {
   this->passes.clear();
 }
 void GeneralPassManager::add(std::shared_ptr<Pass> pass) {
-  this->passes.insert(pass);
+  this->passes.push_back(std::move(pass));
 }
 
 std::shared_ptr<PassManagerAnalysis> GeneralPassManager::run(Graph& graph) {

--- a/onnx/optimizer/pass_manager.h
+++ b/onnx/optimizer/pass_manager.h
@@ -35,7 +35,7 @@ class GeneralPassManager : public PassManager {
   std::shared_ptr<PassManagerAnalysis> run(Graph& graph) override;
 
  protected:
-  std::set<std::shared_ptr<Pass>> passes;
+  std::vector<std::shared_ptr<Pass>> passes;
 };
 
 // Exhibits the same behavior as GeneralPassManager but will instead check

--- a/onnx/optimizer/pass_manager.h
+++ b/onnx/optimizer/pass_manager.h
@@ -2,7 +2,7 @@
 // ATTENTION: The code in this file is highly EXPERIMENTAL.
 // Adventurous users should note that the APIs will probably change.
 
-#include <set>
+#include <vector>
 #include "onnx/optimizer/pass.h"
 #include "onnx/optimizer/passes/eliminate_deadend.h"
 
@@ -35,6 +35,9 @@ class GeneralPassManager : public PassManager {
   std::shared_ptr<PassManagerAnalysis> run(Graph& graph) override;
 
  protected:
+  // use vector here to ensure the order of the passes
+  // for some pass, order is critical, for example,
+  // split_init and split_predict should be the last in the list
   std::vector<std::shared_ptr<Pass>> passes;
 };
 


### PR DESCRIPTION
Use set is dangerous. The order is important for some passes. Use vector to replace set.