### PR TITLE
Implemented shape inference for Gather

### DIFF
--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -706,23 +706,13 @@ ONNX_OPERATOR_SET_SCHEMA(
             ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
           }
           for (int i = 0; i < out_rank; ++i) {
-            auto* newdim = ctx.getOutputType(0)
+            *ctx.getOutputType(0)
                 ->mutable_tensor_type()
                 ->mutable_shape()
-                ->add_dim();
-            const auto& dim =
+                ->add_dim() =
                 (i < axis) ? data_shape.dim(i) :                             // i < axis < r
                 (i >= axis && i < axis + q) ? indices_shape.dim(i - axis) :  // i - axis < q
                 data_shape.dim(i - q + 1);                                   // i < out_rank < q + r - 1
-            if (dim.has_dim_value()) {
-              newdim->set_dim_value(dim.dim_value());
-            }
-            if (dim.has_dim_param()) {
-              newdim->set_dim_param(dim.dim_param());
-            }
-            if (dim.has_denotation()) {
-              newdim->set_denotation(dim.denotation());
-            }
           }
         }));
 

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -706,14 +706,23 @@ ONNX_OPERATOR_SET_SCHEMA(
             ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
           }
           for (int i = 0; i < out_rank; ++i) {
-            ctx.getOutputType(0)
+            auto* newdim = ctx.getOutputType(0)
                 ->mutable_tensor_type()
                 ->mutable_shape()
-                ->add_dim()
-                ->set_dim_value(
-                (i < axis) ? data_shape.dim(i).dim_value() :                             // i < axis < r
-                (i >= axis && i < axis + q) ? indices_shape.dim(i - axis).dim_value() :  // i - axis < q
-                data_shape.dim(i - q + 1).dim_value());                                  // i < out_rank < q + r - 1
+                ->add_dim();
+            const auto& dim =
+                (i < axis) ? data_shape.dim(i) :                             // i < axis < r
+                (i >= axis && i < axis + q) ? indices_shape.dim(i - axis) :  // i - axis < q
+                data_shape.dim(i - q + 1);                                   // i < out_rank < q + r - 1
+            if (dim.has_dim_value()) {
+              newdim->set_dim_value(dim.dim_value());
+            }
+            if (dim.has_dim_param()) {
+              newdim->set_dim_param(dim.dim_param());
+            }
+            if (dim.has_denotation()) {
+              newdim->set_denotation(dim.denotation());
+            }
           }
         }));
 

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -239,11 +239,19 @@ class TestShapeInference(unittest.TestCase):
 
     def test_gather(self):  # type: () -> None
         graph = self._make_graph(
-            [('x', TensorProto.FLOAT, (3, 2)),
+            [('x', TensorProto.FLOAT, (4, 3)),
              ('i', TensorProto.INT64, (2,))],
             [make_node("Gather", ['x', 'i'], ['y'])],
             [])
-        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (None, None))])  # type: ignore
+        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (2, 3))])  # type: ignore
+
+    def test_gather_axis1(self):  # type: () -> None
+        graph = self._make_graph(
+            [('x', TensorProto.FLOAT, (4, 3, 5)),
+             ('i', TensorProto.INT64, (1, 2))],
+            [make_node("Gather", ['x', 'i'], ['y'], axis=1)],
+            [])
+        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (4, 1, 2, 5))])  # type: ignore
 
     def test_gather_into_scalar(self):  # type: () -> None
         graph = self._make_graph(


### PR DESCRIPTION
For `data_shape = [d0, d1, ..., d{r-1}]` and`indices_shape = [s0, s1, ..., s{q-1}]`, the output shape is `[d0, ..., d{axis-1}, s0, ..., s{q-1}, d{axis+1}, ..., d{r-1}]`.