### PR TITLE
Fix tensor checker

### DIFF
--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -151,8 +151,10 @@ void check_tensor(const TensorProto& tensor, const CheckerContext& /*ctx*/) {
         break;
 
       case TensorProto::INT32:
-      case TensorProto::UINT8:
+      case TensorProto::INT16:
+      case TensorProto::INT8:
       case TensorProto::UINT16:
+      case TensorProto::UINT8:
       case TensorProto::BOOL:
       case TensorProto::FLOAT16:
       case TensorProto::BFLOAT16:
@@ -235,10 +237,10 @@ void check_attribute(
   // In proto3, when the value to be set is type default value (say 0 for int),
   // used_fields may be 0.
   if (used_fields > 1) {
-    fail_check(
-        "Attribute (name: ",
-        attr.name(),
-        ") should not contain more than one value field.");
+	  fail_check(
+		  "Attribute (name: ",
+		  attr.name(),
+		  ") should not contain more than one value field.");
   }
 
   if (!ctx.is_main_graph()) {

--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -127,6 +127,7 @@ void check_tensor(const TensorProto& tensor, const CheckerContext& /*ctx*/) {
     }
     return;
   } else {
+    bool isChecked = false;
 #define check_field(field)               \
   if (nelem != 0 && !has_##field) {      \
     fail_check(                          \
@@ -137,7 +138,8 @@ void check_tensor(const TensorProto& tensor, const CheckerContext& /*ctx*/) {
         "' instead of '",                \
         value_field,                     \
         "'");                            \
-  }
+  }                                      \
+  isChecked = true;
 
     switch (tensor.data_type()) {
       case TensorProto::FLOAT:
@@ -174,7 +176,12 @@ void check_tensor(const TensorProto& tensor, const CheckerContext& /*ctx*/) {
         check_field(string_data);
         break;
 
-      default:
+      case TensorProto::UNDEFINED:
+        // Fail afterwards
+        break;
+
+    }
+    if (!isChecked) {
         fail_check(
             "Unrecognized data_type (tensor name: ",
             tensor.name(),


### PR DESCRIPTION
Having an initializer of type int16, int8 or uint8 will make the model fail the model-checker although it is valid.

This is caused by missing switch cases which this fixes.

Note that issues like this could be detected automatically by CI if `-Wall -Werror` was used and `default` is not used in the switch handling. I include a commit ("Remove default case...") to do the latter and opened an issue (#1538) for the former.