### PR TITLE
type proto does not exactly match the type str,

### DIFF
--- a/onnx/defs/data_type_utils.cc
+++ b/onnx/defs/data_type_utils.cc
@@ -97,6 +97,8 @@ DataType DataTypeUtils::ToType(const TypeProto& type_proto) {
   if (GetTypeStrToProtoMap().find(typeStr) == GetTypeStrToProtoMap().end()) {
     TypeProto type;
     FromString(typeStr, type);
+	// <type_proto> is not used in case it carries non-type related information,
+	// for example, shape information, annotation, etc.
     GetTypeStrToProtoMap()[typeStr] = type;
   }
   return &(GetTypeStrToProtoMap().find(typeStr)->first);

--- a/onnx/defs/data_type_utils.cc
+++ b/onnx/defs/data_type_utils.cc
@@ -97,8 +97,8 @@ DataType DataTypeUtils::ToType(const TypeProto& type_proto) {
   if (GetTypeStrToProtoMap().find(typeStr) == GetTypeStrToProtoMap().end()) {
     TypeProto type;
     FromString(typeStr, type);
-	// <type_proto> is not used in case it carries non-type related information,
-	// for example, shape information, annotation, etc.
+    // <type_proto> is not used in case it carries non-type related information,
+    // for example, shape information, annotation, etc.
     GetTypeStrToProtoMap()[typeStr] = type;
   }
   return &(GetTypeStrToProtoMap().find(typeStr)->first);

--- a/onnx/defs/data_type_utils.cc
+++ b/onnx/defs/data_type_utils.cc
@@ -92,22 +92,20 @@ std::mutex& DataTypeUtils::GetTypeStrLock() {
 }
 
 DataType DataTypeUtils::ToType(const TypeProto& type_proto) {
-  auto type_str = ToString(type_proto);
-  return ToType(type_str);
+  auto typeStr = ToString(type_proto);
+  std::lock_guard<std::mutex> lock(GetTypeStrLock());
+  if (GetTypeStrToProtoMap().find(typeStr) == GetTypeStrToProtoMap().end()) {
+    TypeProto type;
+    FromString(typeStr, type);
+    GetTypeStrToProtoMap()[typeStr] = type;
+  }
+  return &(GetTypeStrToProtoMap().find(typeStr)->first);
 }
 
 DataType DataTypeUtils::ToType(const std::string& type_str) {
-  std::lock_guard<std::mutex> lock(GetTypeStrLock());
-  auto& map = GetTypeStrToProtoMap();
-  auto iter = map.find(type_str);
-  if (iter == GetTypeStrToProtoMap().end()) {
-    TypeProto type;
-    FromString(type_str, type);
-    auto result = map.insert({type_str, type});
-    return &(result.first->first);
-  } else {
-    return &(iter->first);
-  }
+  TypeProto type;
+  FromString(type_str, type);
+  return ToType(type);
 }
 
 const TypeProto& DataTypeUtils::ToTypeProto(const DataType& data_type) {
@@ -143,15 +141,18 @@ std::string DataTypeUtils::ToString(
     case TypeProto::ValueCase::kOpaqueType: {
       static const std::string empty;
       std::string result;
+      std::string param_str;
       const auto& op_type = type_proto.opaque_type();
+      const auto param_size = op_type.parameters_size();
+      for (int p = 0; p < param_size; ++p) {
+        const auto& param_proto = op_type.parameters(p);
+        param_str.append(ToString(param_proto, (p == 0) ? empty : ",", empty));
+      }
       result.append(left).append("opaque(");
-      if (op_type.has_domain() && !op_type.domain().empty()) {
-        result.append(op_type.domain()).append(",");
-      }
-      if (op_type.has_name() && !op_type.name().empty()) {
-        result.append(op_type.name());
-      }
-      result.append(")").append(right);
+      result.append(op_type.has_domain() ? op_type.domain() : empty)
+          .append(",");
+      result.append(op_type.has_name() ? op_type.name() : empty).append(",");
+      result.append("p(").append(param_str).append("))").append(right);
       return result;
     }
 #endif
@@ -194,19 +195,36 @@ void DataTypeUtils::FromString(
     return FromString(
         std::string(v.Data(), v.Size()),
         *type_proto.mutable_map_type()->mutable_value_type());
-  } else if (s.LStrip("opaque")) {
+  } else if (s.LStrip("opaque(")) {
+    // Possible to have an Opaque type w/o parameters
+    // so we make sure it exists
     auto* opaque_type = type_proto.mutable_opaque_type();
     s.ParensWhitespaceStrip();
-    if (!s.Empty()) {
-      size_t cm = s.Find(',');
-      if (cm != std::string::npos) {
-        if (cm > 0) {
-          opaque_type->mutable_domain()->assign(s.Data(), cm);
-        }
-        s.LStrip(cm + 1); // skip comma
+    // Check if we have domain which is positionally first
+    size_t cm = s.Find(',');
+    if (cm > 0) {
+      opaque_type->mutable_domain()->assign(s.Data(), cm);
+    }
+    s.LStrip(cm + 1);
+    cm = s.Find(',');
+    if (cm > 0) {
+      opaque_type->mutable_name()->assign(s.Data(), cm);
+    }
+    s.LStrip(cm + 1);
+    if (s.LStrip("p(")) {
+      s.ParensWhitespaceStrip();
+      auto param_size = s.Find(',');
+      while (param_size != std::string::npos) {
+        // Means there are multiple params
+        std::string param(s.Data(), param_size);
+        FromString(param, *opaque_type->add_parameters());
+        s.LStrip(param_size);
+        s.LStrip(",");
+        param_size = s.Find(',');
       }
       if (!s.Empty()) {
-        opaque_type->mutable_name()->assign(s.Data(), s.Size());
+        std::string param(s.Data(), s.Size());
+        FromString(param, *opaque_type->add_parameters());
       }
     }
   } else
@@ -225,7 +243,7 @@ void DataTypeUtils::FromString(
     // Call mutable_shape() to initialize a shape with no dimension.
     t->mutable_shape();
   }
-} // namespace Utils
+}
 
 bool DataTypeUtils::IsValidDataTypeString(const std::string& type_str) {
   TypesWrapper& t = TypesWrapper::GetTypesWrapper();

--- a/onnx/defs/data_type_utils.cc
+++ b/onnx/defs/data_type_utils.cc
@@ -98,13 +98,16 @@ DataType DataTypeUtils::ToType(const TypeProto& type_proto) {
 
 DataType DataTypeUtils::ToType(const std::string& type_str) {
   std::lock_guard<std::mutex> lock(GetTypeStrLock());
-  auto iter = GetTypeStrToProtoMap().find(type_str);
+  auto& map = GetTypeStrToProtoMap();
+  auto iter = map.find(type_str);
   if (iter == GetTypeStrToProtoMap().end()) {
     TypeProto type;
     FromString(type_str, type);
-    GetTypeStrToProtoMap()[type_str] = type;
+    auto result = map.insert({type_str, type});
+    return &(result.first->first);
+  } else {
+    return &(iter->first);
   }
-  return &(iter->first);
 }
 
 const TypeProto& DataTypeUtils::ToTypeProto(const DataType& data_type) {

--- a/onnx/defs/data_type_utils.cc
+++ b/onnx/defs/data_type_utils.cc
@@ -95,7 +95,9 @@ DataType DataTypeUtils::ToType(const TypeProto& type_proto) {
   auto typeStr = ToString(type_proto);
   std::lock_guard<std::mutex> lock(GetTypeStrLock());
   if (GetTypeStrToProtoMap().find(typeStr) == GetTypeStrToProtoMap().end()) {
-    GetTypeStrToProtoMap()[typeStr] = type_proto;
+	// the <type_proto> is not used here because it may carry more than type information,
+	// say, shape, annotation which are not taken as part of type system.
+    GetTypeStrToProtoMap()[typeStr] = ToTypeProto(ToType(typeStr));
   }
   return &(GetTypeStrToProtoMap().find(typeStr)->first);
 }


### PR DESCRIPTION
when adding <typestr, type proto> element into the global type map, the type proto sent in may carry more info other than type info, say, shape information, annotation, etc. We should not use it but create a clean type proto which only carries type information.