### PR TITLE
Enable -Wall -Wextra -Werror for CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -470,7 +470,7 @@ if(MSVC)
 elseif(APPLE)
 
 else()
-  target_compile_options(onnx PRIVATE -Wall)
+  target_compile_options(onnx PRIVATE -Wall -Wextra)
   if(${ONNX_WERROR})
     target_compile_options(onnx PRIVATE -Werror=sign-compare -Werror=conversion)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,7 +472,7 @@ elseif(APPLE)
 else()
   target_compile_options(onnx PRIVATE -Wall -Wextra)
   if(${ONNX_WERROR})
-    target_compile_options(onnx PRIVATE -Werror=sign-compare -Werror=conversion)
+    target_compile_options(onnx PRIVATE -Werror)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -470,6 +470,7 @@ if(MSVC)
 elseif(APPLE)
 
 else()
+  target_compile_options(onnx PRIVATE -Wall)
   if(${ONNX_WERROR})
     target_compile_options(onnx PRIVATE -Werror=sign-compare -Werror=conversion)
   endif()

--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -394,7 +394,7 @@ void check_graph(
 void check_function(
     const FunctionProto& function,
     const CheckerContext& ctx,
-    const LexicalScopeContext& parent_lex) {
+    const LexicalScopeContext& /*parent_lex*/) {
   enforce_non_empty_field(function, name);
   enforce_has_field(function, since_version);
 

--- a/onnx/defs/function.cc
+++ b/onnx/defs/function.cc
@@ -93,8 +93,11 @@ Common::Status FunctionBuilderRegistry::GetFunctions(
   }
 
 #ifndef __ONNX_DISABLE_STATIC_REGISTRATION
-  static bool functionBuilder_registerer =
-      (RegisterOnnxFunctionBuilder(), false);
+  static bool registred = false;
+  if (!registred) {
+    RegisterOnnxFunctionBuilder();
+    registred = true;
+  }
 #endif
 
   auto function_name_map_iter = domain_functions_map.find(domain);
@@ -166,7 +169,6 @@ void FunctionExpandHelper(
   }
   std::string node_name =
       node.has_name() ? node.name() : func.name() + uniq_prefix;
-  int version = (int)func.since_version();
   std::unordered_map<std::string, std::string> input_names_map;
   std::unordered_map<std::string, std::string> output_names_map;
   std::unordered_map<std::string, AttributeProto> attr_map;

--- a/onnx/defs/function.cc
+++ b/onnx/defs/function.cc
@@ -93,11 +93,8 @@ Common::Status FunctionBuilderRegistry::GetFunctions(
   }
 
 #ifndef __ONNX_DISABLE_STATIC_REGISTRATION
-  static bool registred = false;
-  if (!registred) {
-    RegisterOnnxFunctionBuilder();
-    registred = true;
-  }
+  static bool ONNX_UNUSED functionBuilder_registerer =
+      (RegisterOnnxFunctionBuilder(), false);
 #endif
 
   auto function_name_map_iter = domain_functions_map.find(domain);

--- a/onnx/optimizer/pass.h
+++ b/onnx/optimizer/pass.h
@@ -101,10 +101,10 @@ class Pass {
   virtual PassAnalysisType getPassAnalysisType() const = 0;
   virtual std::string getPassName() const = 0;
 
-  virtual bool initializePass(Graph& graph) {
+  virtual bool initializePass(Graph&) {
     return false;
   }
-  virtual bool finalizePass(Graph& graph) {
+  virtual bool finalizePass(Graph&) {
     return false;
   }
   virtual std::shared_ptr<PostPassAnalysis> runPass(Graph& graph) = 0;

--- a/onnx/optimizer/passes/eliminate_identity.h
+++ b/onnx/optimizer/passes/eliminate_identity.h
@@ -22,7 +22,7 @@ struct EliminateIdentity final : public PredicateBasedPass {
   bool patternMatchPredicate(Node* node) override {
     return node->kind() == kIdentity;
   }
-  bool runTransform(Node* node, Graph& graph, NodeDestroyType& destroy_current)
+  bool runTransform(Node* node, Graph&, NodeDestroyType& destroy_current)
       override {
     node->output()->replaceAllUsesWith(node->input());
     destroy_current = NodeDestroyType::DestroyOne;

--- a/onnx/optimizer/passes/eliminate_nop_pad.h
+++ b/onnx/optimizer/passes/eliminate_nop_pad.h
@@ -29,7 +29,7 @@ struct EliminateNopPad final : public PredicateBasedPass {
     return (node->kind() == kPad && node->hasAttribute(kpads)) &&
         is_nop_pad(node->is(kpads));
   }
-  bool runTransform(Node* node, Graph& graph, NodeDestroyType& destroy_current)
+  bool runTransform(Node* node, Graph&, NodeDestroyType& destroy_current)
       override {
     node->output()->replaceAllUsesWith(node->input());
     destroy_current = NodeDestroyType::DestroyOne;

--- a/onnx/optimizer/passes/eliminate_nop_transpose.h
+++ b/onnx/optimizer/passes/eliminate_nop_transpose.h
@@ -31,7 +31,7 @@ struct EliminateNopTranspose final : public PredicateBasedPass {
         is_nop_transpose(node->is(kperm));
   }
 
-  bool runTransform(Node* node, Graph& graph, NodeDestroyType& destroy_current)
+  bool runTransform(Node* node, Graph&, NodeDestroyType& destroy_current)
       override {
     node->output()->replaceAllUsesWith(node->input());
     destroy_current = NodeDestroyType::DestroyOne;

--- a/onnx/optimizer/passes/fuse_consecutive_log_softmax.h
+++ b/onnx/optimizer/passes/fuse_consecutive_log_softmax.h
@@ -29,7 +29,6 @@ struct FuseConsecutiveLogSoftmax final : public PredicateBasedPass {
       NodeDestroyType& destroy_current) override {
     Value* log_node_output = log_node->output();
     Node* softmax_node = log_node->inputs()[0]->node();
-    auto orig_input = log_node->input();
     Node* log_softmax_node = graph.create(kLogSoftmax, 1);
 
     // log_softmax_node construction

--- a/onnx/optimizer/passes/fuse_consecutive_squeezes.h
+++ b/onnx/optimizer/passes/fuse_consecutive_squeezes.h
@@ -62,7 +62,7 @@ struct FuseConsecutiveSqueezes final : public PredicateBasedPass {
     return node->kind() == kSqueeze &&
         node->input()->node()->kind() == kSqueeze;
   }
-  bool runTransform(Node* n, Graph& graph, NodeDestroyType& destroy_current)
+  bool runTransform(Node* n, Graph&, NodeDestroyType& destroy_current)
       override {
     auto orig_input = n->input();
     n->is_(

--- a/onnx/optimizer/passes/fuse_consecutive_transposes.h
+++ b/onnx/optimizer/passes/fuse_consecutive_transposes.h
@@ -41,7 +41,7 @@ struct FuseConsecutiveTransposes final : public PredicateBasedPass {
         node->input()->node()->kind() == kTranspose;
   }
 
-  bool runTransform(Node* n, Graph& graph, NodeDestroyType& destroy_current)
+  bool runTransform(Node* n, Graph&, NodeDestroyType& destroy_current)
       override {
     auto origInput = n->input();
     if (!n->hasAttribute(kperm) && !origInput->node()->hasAttribute(kperm)) {

--- a/onnx/optimizer/passes/fuse_transpose_into_gemm.h
+++ b/onnx/optimizer/passes/fuse_transpose_into_gemm.h
@@ -20,7 +20,7 @@ struct FuseTransposeIntoGemm final : public PredicateBasedPass {
   bool patternMatchPredicate(Node* node) override {
     return node->kind() == kGemm;
   }
-  bool runTransform(Node* n, Graph& graph, NodeDestroyType& destroy_current)
+  bool runTransform(Node* n, Graph&, NodeDestroyType& destroy_current)
       override {
     const std::vector<int64_t> simple_trans_perm({1, 0});
     destroy_current = NodeDestroyType::DestroyZero;

--- a/onnx/optimizer/passes/nop.h
+++ b/onnx/optimizer/passes/nop.h
@@ -18,7 +18,7 @@ struct NopEmptyPass final : public FullGraphBasedPass {
   PassAnalysisType getPassAnalysisType() const override {
     return PassAnalysisType::Empty;
   }
-  std::shared_ptr<PostPassAnalysis> runPass(Graph& graph) override {
+  std::shared_ptr<PostPassAnalysis> runPass(Graph&) override {
     return std::make_shared<PostPassAnalysis>();
   }
 };

--- a/onnx/version_converter/adapters/averagepool_7_6.h
+++ b/onnx/version_converter/adapters/averagepool_7_6.h
@@ -10,7 +10,7 @@ class AveragePool_7_6 final : public Adapter {
   public:
     explicit AveragePool_7_6(): Adapter("AveragePool", OpSetID(7), OpSetID(6)) {}
 
-    void adapt_averagepool_7_6(std::shared_ptr<Graph> graph, Node* node) const {
+    void adapt_averagepool_7_6(std::shared_ptr<Graph>, Node* node) const {
       if (node->hasAttribute(kcount_include_pad))
         ONNX_ASSERTM(node->i(kcount_include_pad) == 0, "AveragePool in Opset "
             "Version 6 does not support including pad");

--- a/onnx/version_converter/adapters/batch_normalization_6_5.h
+++ b/onnx/version_converter/adapters/batch_normalization_6_5.h
@@ -12,7 +12,7 @@ class BatchNormalization_6_5 final : public Adapter {
       : Adapter("BatchNormalization", OpSetID(6), OpSetID(5)) {
       }
 
-    void adapt_batch_normalization_6_5(std::shared_ptr<Graph> graph, Node* node) const {
+    void adapt_batch_normalization_6_5(std::shared_ptr<Graph>, Node* node) const {
       node->is_(kconsumed_inputs, {0, 0});
     }
 

--- a/onnx/version_converter/adapters/batch_normalization_6_7.h
+++ b/onnx/version_converter/adapters/batch_normalization_6_7.h
@@ -11,7 +11,7 @@ struct BatchNormalization_6_7 final : public Adapter {
     : Adapter("BatchNormalization", OpSetID(6), OpSetID(7)) {
     }
 
-  void adapt_batch_normalization_6_7(std::shared_ptr<Graph> graph, Node* node) const {
+  void adapt_batch_normalization_6_7(std::shared_ptr<Graph>, Node* node) const {
     if (node->hasAttribute(kis_test)) {
       ONNX_ASSERTM(node->i(kis_test) != 0,
           "ONNX currently only supports inference, not training.");

--- a/onnx/version_converter/adapters/broadcast_backward_compatibility.h
+++ b/onnx/version_converter/adapters/broadcast_backward_compatibility.h
@@ -11,7 +11,7 @@ class BroadcastBackwardCompatibility final : public Adapter {
     explicit BroadcastBackwardCompatibility(const std::string& op_name, const OpSetID&
       initial, const OpSetID& target): Adapter(op_name, initial, target) {}
 
-    void adapt_broadcast_backward_compatibility(std::shared_ptr<Graph> graph, Node* node) const {
+    void adapt_broadcast_backward_compatibility(std::shared_ptr<Graph>, Node* node) const {
       // Verify that broadcasts are allowed in limited spec of opset version 6
       // Multidirectional broadcasting, as defined in Broadcasting.md
       // MathDocGenerator provides differences

--- a/onnx/version_converter/adapters/compatible.h
+++ b/onnx/version_converter/adapters/compatible.h
@@ -11,7 +11,7 @@ struct CompatibleAdapter final : public Adapter {
   explicit CompatibleAdapter(const std::string& op_name, const OpSetID&
     initial, const OpSetID& target): Adapter(op_name, initial, target) {}
 
-  void adapt(std::shared_ptr<Graph> graph, Node* node) const override {}
+  void adapt(std::shared_ptr<Graph>, Node*) const override {}
 };
 
 }} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/concat_3_4.h
+++ b/onnx/version_converter/adapters/concat_3_4.h
@@ -11,7 +11,7 @@ class Concat_3_4 final : public Adapter {
     explicit Concat_3_4()
       : Adapter("Concat", OpSetID(3), OpSetID(4)) {}
 
-    void adapt_concat_3_4(std::shared_ptr<Graph> graph, Node* node) const {
+    void adapt_concat_3_4(std::shared_ptr<Graph>, Node* node) const {
       // If axis is not present, set to 1
       if(!(node->hasAttribute(kaxis))) node->i_(kaxis, 1);
     }

--- a/onnx/version_converter/adapters/dropout_6_7.h
+++ b/onnx/version_converter/adapters/dropout_6_7.h
@@ -10,7 +10,7 @@ class Dropout_6_7 final : public Adapter {
   public:
     explicit Dropout_6_7(): Adapter("Dropout", OpSetID(6), OpSetID(7)) {}
 
-    void adapt_dropout_6_7(std::shared_ptr<Graph> graph, Node* node) const {
+    void adapt_dropout_6_7(std::shared_ptr<Graph>, Node* node) const {
       if (node->hasAttribute(kis_test)) {
         ONNX_ASSERTM(node->i(kis_test) == 1, "Training is not supported with Dropout Op");
         node->removeAttribute(kis_test);

--- a/onnx/version_converter/adapters/gemm_6_7.h
+++ b/onnx/version_converter/adapters/gemm_6_7.h
@@ -10,7 +10,7 @@ class Gemm_6_7 final : public Adapter {
   public:
     explicit Gemm_6_7(): Adapter("Gemm", OpSetID(6), OpSetID(7)) {}
 
-    void adapt_gemm_6_7(std::shared_ptr<Graph> graph, Node* node) const {
+    void adapt_gemm_6_7(std::shared_ptr<Graph>, Node* node) const {
       const ArrayRef<Value*>& inputs = node->inputs();
       assertInputsAvailable(inputs, name().c_str(), 3);
       const auto& A_shape = inputs[0]->sizes();

--- a/onnx/version_converter/adapters/gemm_7_6.h
+++ b/onnx/version_converter/adapters/gemm_7_6.h
@@ -10,7 +10,7 @@ class Gemm_7_6 final : public Adapter {
   public:
     explicit Gemm_7_6(): Adapter("Gemm", OpSetID(7), OpSetID(6)) {}
 
-    void adapt_gemm_7_6(std::shared_ptr<Graph> graph, Node* node) const {
+    void adapt_gemm_7_6(std::shared_ptr<Graph>, Node* node) const {
       const ArrayRef<Value*>& inputs = node->inputs();
       assertInputsAvailable(inputs, name().c_str(), 3);
       const auto& A_shape = inputs[0]->sizes();

--- a/onnx/version_converter/adapters/maxpool_8_7.h
+++ b/onnx/version_converter/adapters/maxpool_8_7.h
@@ -11,7 +11,7 @@ class MaxPool_8_7 final : public Adapter {
     explicit MaxPool_8_7()
       : Adapter("MaxPool", OpSetID(8), OpSetID(7)) {}
 
-    void adapt_maxpool_8_7(std::shared_ptr<Graph> graph, Node* node) const {
+    void adapt_maxpool_8_7(std::shared_ptr<Graph>, Node* node) const {
       const ArrayRef<Value*>& outputs = node->outputs();
       ONNX_ASSERTM(outputs.size() != 2,
           "Opset version 7 of MaxPool cannot include Indices output");

--- a/onnx/version_converter/adapters/remove_consumed_inputs.h
+++ b/onnx/version_converter/adapters/remove_consumed_inputs.h
@@ -11,7 +11,7 @@ class RemoveConsumedInputs : public Adapter {
     explicit RemoveConsumedInputs(const std::string& op_name, const OpSetID&
       initial, const OpSetID& target): Adapter(op_name, initial, target) {}
 
-    void adapt(std::shared_ptr<Graph> graph, Node* node) const override {
+    void adapt(std::shared_ptr<Graph>, Node* node) const override {
       if (node->hasAttribute(kconsumed_inputs)) node->removeAttribute(kconsumed_inputs);
     }
 };

--- a/onnx/version_converter/adapters/set_is_test.h
+++ b/onnx/version_converter/adapters/set_is_test.h
@@ -10,7 +10,7 @@ struct SetIsTest final : public Adapter {
   explicit SetIsTest(const std::string& op_name, const OpSetID&
     initial, const OpSetID& target): Adapter(op_name, initial, target) {}
 
-  void adapt_set_is_test(std::shared_ptr<Graph> graph, Node* node) const {
+  void adapt_set_is_test(std::shared_ptr<Graph>, Node* node) const {
     node->i_(kis_test, 1);
   }
 

--- a/onnx/version_converter/adapters/sum_8_7.h
+++ b/onnx/version_converter/adapters/sum_8_7.h
@@ -10,7 +10,7 @@ class Sum_8_7 final : public Adapter {
   public:
     explicit Sum_8_7(): Adapter("Sum", OpSetID(8), OpSetID(7)) {}
 
-    void adapt_sum_8_7(std::shared_ptr<Graph> graph, Node* node) const {
+    void adapt_sum_8_7(std::shared_ptr<Graph>, Node* node) const {
       // Throw an exception if any broadcasting occurs
       const ArrayRef<Value*>& inputs = node->inputs();
       // Determine if inputs are of different sizes

--- a/onnx/version_converter/adapters/type_restriction.h
+++ b/onnx/version_converter/adapters/type_restriction.h
@@ -13,7 +13,7 @@ class TypeRestriction : public Adapter {
       unallowed_types): Adapter(op_name, initial, target), unallowed_types_(
         unallowed_types) {}
 
-    void adapt_type_restriction(std::shared_ptr<Graph> graph, Node* node) const {
+    void adapt_type_restriction(std::shared_ptr<Graph>, Node* node) const {
       // Since consumed_inputs is optional, no need to add it (as in batchnorm)
       // Iterate over all inputs and outputs
       for (Value* input : node->inputs()) {


### PR DESCRIPTION
As explained in #1538 and shown in #1540 the warnings generated by GCC and Clang can help to spot real bugs. An example is added enum values but forgotten handling in switch cases. Unless this is already caught by tests it will hit you to late.

This enables `-Wall -Wextra` (the most useful ones on linux) and extends `ONNX_WERROR` to acutally add `-Werror` (I assume CI does set `ONNX_WERROR=ON`)

In the last commit all warnings currently produced are fixed. Most of them were unused parameters or variables which might only have a performance impact. But on 1 case of static initialization the variable is not used and might be eliminated by the optimizer. The solution I changed this too is easier to read (no comma operator) and safe.