### PR TITLE
Fix output type bug in MaxUnpool definition.

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -8827,7 +8827,7 @@ This version of the operator has been available since version 9 of the default O
 #### Outputs
 
 <dl>
-<dt><tt>output</tt> : T2</dt>
+<dt><tt>output</tt> : T1</dt>
 <dd>Output data tensor that contains the result of the unpooling.</dd>
 </dl>
 

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -6285,7 +6285,7 @@ This version of the operator has been available since version 9 of the default O
 #### Outputs
 
 <dl>
-<dt><tt>output</tt> : T2</dt>
+<dt><tt>output</tt> : T1</dt>
 <dd>Output data tensor that contains the result of the unpooling.</dd>
 </dl>
 

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -452,7 +452,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             0,
             "output",
             "Output data tensor that contains the result of the unpooling.",
-            "T2")
+            "T1")
         .TypeConstraint(
             "T1",
             {"tensor(float16)",


### PR DESCRIPTION
The type of output tensor should be type of the first input tensor (the pooled input image). This change fixes it to be so.