### PR TITLE
Best way to implement add_msvc_runtime_flag for choose msvc runtime p…

### DIFF
--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -2,11 +2,9 @@
 # Add MSVC RunTime Flag, this part is necessary for tests in CI
 function(add_msvc_runtime_flag lib)
   if(${ONNX_USE_MSVC_STATIC_RUNTIME})
-    if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
-      target_compile_options(${lib} PRIVATE /MTd)
-    else()
-      target_compile_options(${lib} PRIVATE /MT)
-    endif()
+    target_compile_options(${lib} PRIVATE $<$<NOT:$<CONFIG:Debug>>:/MT> $<$<CONFIG:Debug>:/MTd>)
+  else()
+    target_compile_options(${lib} PRIVATE $<$<NOT:$<CONFIG:Debug>>:/MD> $<$<CONFIG:Debug>:/MDd>)
   endif()
 endfunction()
 


### PR DESCRIPTION
Best way to implement add_msvc_runtime_flag for choose msvc runtime properly.
Refer to https://stackoverflow.com/questions/24460486/cmake-build-type-not-being-used-in-cmakelists-txt
Implement the else branch of ONNX_USE_MSVC_STATIC_RUNTIME
