### PR TITLE
Add attributes to scan op

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -8874,6 +8874,182 @@ This version of the operator has been available since version 9 of the default O
 <dd>Constrain input and output types to float/int tensors.</dd>
 </dl>
 
+### <a name="Scan-9"></a>**Scan-9**</a>
+
+  Scan can be used to iterate over one or more scan_input tensors,
+  constructing zero or more scan_output tensors. It combines ideas from general recurrences,
+  functional programming constructs such as scan, fold, map, and zip and is intended to enable
+  generalizations of RNN-like constructs for sequence-to-sequence processing.
+  Other tensors (referred to as state_variables here) can be used to carry a state
+  when iterating from one element to another (similar to hidden-state in RNNs, also referred
+  to as loop-carried dependences in the context of loops). All these tensors are required to
+  have the same shape in each iteration of the loop (a restriction imposed to enable efficient
+  memory allocation). Many common usages involve a single scan_input tensor (where functionality
+  similar to scan, fold and map can be obtained). When more than one scan_input is used,
+  a behavior similar to zip is obtained.
+  
+  The attribute body must be a graph, specifying the computation to be performed in
+  every iteration. It takes as input the current values of the state_variables and
+  the current iterated element of the scan_inputs. It must return the (updated) values
+  of the state_variables and zero or more scan_output_element tensors. The values of the
+  scan_output_element tensors are concatenated over all the iterations to produce the
+  scan_output values of the scan construct (similar to the concatenated intermediate
+  hidden-state values of RNN-like constructs).
+  
+  The scan operation returns the final values of the state_variables as well as the
+  scan_outputs.
+  
+  The operation supports batching, and the batch-axis is required to be 0.
+  When multiple scan_input tensors are used, they must all have the same batch-size,
+  and they must all have the same maximum-sequence-length (the dimensionality of the
+  sequence axis or scan axis). The sequence axis or scan axis is required to be 1.
+  
+  The operation has an optional sequence_lens input (of shape [BATCH_SIZE]) to
+  allow variable length sequences of length <= the maximum-sequence-length. If this
+  input is not specified, all sequences are assumed to be of length equal to
+  maximum-sequence-length. For variable length input sequences, the scan_outputs
+  will consist of a sequence of same length as the input, padded to the
+  maximum-sequence-length.
+  
+  The optional attribute directions can be used to scan a sequence in the reverse direction.
+  If this attribute is omitted, all sequences are scanned in the forward direction.
+  A bidirectional scan be performed by specifying the same tensor input twice in the
+  scan_inputs, once with a forward direction, and once with a backward direction.
+  
+  The scan_output of the operation is produced by concatenating the scan_output_element
+  values produced by the body in each iteration. By default, the scan_output_element is
+  appended to the scan_output in each iteration. The optional attribute scan_output_directions
+  can be used to change the order in which scan_output is constructed (by prepending the
+  scan_output_element to scan_output in each iteration.)
+  
+  Note that because of the ONNX restriction that only the last parameter of an operator can
+  be variadic, the initial-states and scan-inputs are listed together as one input parameter.
+  Similarly, the final-states and scan-outputs are listed together as one output parameter.
+  The attribute num_scan_inputs indicates the number M of scan-inputs.
+  
+  The behavior of
+  
+      Scan <
+          num_scan_inputs = m,
+          body = loop-body
+      > (sequence_lengths, init_1, ..., init_n, scan_1, ..., scan_m)
+  
+  is equivalent to the following pseudo-code:
+  
+      // T.shape[0] denotes the batch-size of T
+      // The batch-size of scan_1, ..., scan_m are all required to be equal
+      batch_size = scan_1.shape[0];
+  
+      // scan_i.shape[1] denotes the (max) sequence-length of scan_i
+      // scan_i.shape[1] is required to be equal to scan_j.shape[1] for all i,j.
+      max_sequence_length = scan_1.shape[1];
+  
+      for (int batch = 0; batch < batch_size; ++batch) {
+          // initialize state-variables
+          st_1 = init_1; ... st_n = init_n;
+          // initialize scan-output variables: [] denotes an empty tensor
+          scan_out_1 = []; ...; scan_out_k = [];
+          // identify number of iterations:
+          N = (sequence_lengths specified) ? sequence_lengths[batch] : max_sequence_length;
+  
+          // execute loop
+          for (int t = 0; t < N; ++t) {
+              // generate the scan-input elements: the notation T<axis=k>[t] indicates the sub-tensor
+              // of rank one less than T obtained by indexing T at position t along axis k.
+              si_1 = (scan_1<axis=0>[batch])<axis=1>[t];
+              ... ;
+              si_m = (scan_m<axis=0>[batch])<axis=1>[t];
+              // execute loop-body
+              st_1, ..., st_n, so_1, ..., so_k = loop-body(st_1, ..., st_n, si_1, ..., si_m)
+              // accumulate the scan-output elements
+              scan_out_1 = Concat<axis=0>(scan_out_1, so_1); ... ; scan_out_k = Concat<axis=0>(scan_out_k, so_k);
+          }
+          // accumulate the outputs for this batch:
+          bst_1[batch] = st_1; ..., bst_n[batch] = st_n;
+          // Note scan-outputs will have size max_sequence_length, but only first N values will be meaningful.
+          // The remaining values have an undefined value.
+          b_scan_out_1[batch] = scan_out_1; ...; b_scan_out_k[batch] = scan_out_k;
+      }
+      return bst_1, ..., bst_n, b_scan_out_1, ..., b_scan_out_k;
+  
+  
+  
+  *Sample usage: Encoding RNN using a Scan*
+  
+  The following example shows how a simple RNN over an input tensor %X, with weight tensor %Wi,
+  recurrence weight tensor %Ri, bias tensors %Wbi and %Rbi, and initial hidden-state %H_0 can
+  be encoded as a ScanLoop. Note that the loop-body is a nested graph, and it directly computes
+  %Wi, %Ri, %Wbi, and %Rbi (typically constants or initializers in the body graph). If these
+  values are computed in the outer graph, they need to be passed in as extra state_variables.
+  
+      graph rnn-encoding {
+        %H_0 = ... 
+        %X = ...
+        %Y_h, %Y = Scan[body = <graph rnn-cell-1>, num_scan_inputs=1]("", %H_0, %X)
+        return %Y, %Y_h
+      }
+  
+      graph rnn-cell-1 (
+        %H_tminus1[FLOAT, tensor]
+        %X_t[FLOAT, tensor]
+      ) {
+        %Wi = ...
+        %Ri = ...
+        %Wbi = ...
+        %Rbi = ...
+        %t1 = X_t * (Wi^T)
+        %t2 = H_tminus1*(Ri^T)
+        %t3 = Add(%t1, %t2)
+        %t4 = Add(%t3, %Wbi)
+        %t5 = Add(%t4, %Rbi)
+        %Ht = Tanh(%t5)
+        %Accumulate = Identity(%Ht)
+        return %Ht, %Accumulate
+      }
+  
+
+#### Version
+
+This version of the operator has been available since version 9 of the default ONNX operator set.
+
+#### Attributes
+
+<dl>
+<dt><tt>body</tt> : graph (required)</dt>
+<dd>The graph run each iteration. It has N+M inputs: (loop state variables..., scan_input_elts...). It has N+K outputs: (loop state variables..., scan_output_elts...). Each scan_output is created by concatenating the value of the specified scan_output_elt value at the end of each iteration of the loop. It is an error if the dimensions of these values change across loop iterations.</dd>
+<dt><tt>directions</tt> : list of ints</dt>
+<dd>An optional list of M flags. The i-th element of the list specifies the direction to be scanned for the i-th scan_input tensor: 0 indicates forward direction and 1 indicates reverse direction. If omitted, all scan_input tensors will be scanned in the forward direction.</dd>
+<dt><tt>num_scan_inputs</tt> : int (required)</dt>
+<dd>An attribute specifying the number of scan_inputs M. </dd>
+<dt><tt>scan_output_directions</tt> : list of ints</dt>
+<dd>An optional list of K flags, one for each scan_output. The i-th element of the list specifies whether the i-th scan_output should be constructed by appending or prepending a new value in each iteration: 0 indicates appending and 1 indicates prepending. If omitted, all scan_output tensors will be produced by appending a value in each iteration.</dd>
+</dl>
+
+#### Inputs (2 - &#8734;)
+
+<dl>
+<dt><tt>sequence_lens</tt> (optional) : I</dt>
+<dd>Optional tensor specifying lengths of the sequences in a batch. If this input is not specified, all sequences are assumed to be of the maximum sequence length (the dimension of the sequence axis of the scan_input tensors).</dd>
+<dt><tt>initial_state_and_scan_inputs</tt> (variadic) : V</dt>
+<dd>Initial values of the loop's N state variables followed by M scan_inputs</dd>
+</dl>
+
+#### Outputs (1 - &#8734;)
+
+<dl>
+<dt><tt>final_state_and_scan_outputs</tt> (variadic) : V</dt>
+<dd>Final values of the loop's N state variables followed by K scan_outputs</dd>
+</dl>
+
+#### Type Constraints
+
+<dl>
+<dt><tt>I</tt> : tensor(int64)</dt>
+<dd>Int64 tensor</dd>
+<dt><tt>V</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128)</dt>
+<dd>All Tensor types</dd>
+</dl>
+
 ### <a name="Upsample-9"></a>**Upsample-9**</a>
 
   Upsample the input tensor.

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -8899,10 +8899,13 @@ This version of the operator has been available since version 9 of the default O
   The scan operation returns the final values of the state_variables as well as the
   scan_outputs.
   
-  The operation supports batching, and the batch-axis is required to be 0.
-  When multiple scan_input tensors are used, they must all have the same batch-size,
-  and they must all have the same maximum-sequence-length (the dimensionality of the
-  sequence axis or scan axis). The sequence axis or scan axis is required to be 1.
+  The operation optionally supports batching. If the attribute handle_batch has a value of
+  1, axis 0 is treated as the batch-axis and handled by the scan op and the ops in the body
+  will not see any batched input. When multiple scan_input tensors are used, they must all
+  have the same batch-size, and they must all have the same maximum-sequence-length (the
+  dimensionality of the sequence axis or scan axis). The sequence axis or scan axis is
+  axis 0 when attribute handle_batch has a value 0, and the sequence axis is axis 1
+  when handle_batch is 1.
   
   The operation has an optional sequence_lens input (of shape [BATCH_SIZE]) to
   allow variable length sequences of length <= the maximum-sequence-length. If this
@@ -8911,10 +8914,10 @@ This version of the operator has been available since version 9 of the default O
   will consist of a sequence of same length as the input, padded to the
   maximum-sequence-length.
   
-  The optional attribute directions can be used to scan a sequence in the reverse direction.
-  If this attribute is omitted, all sequences are scanned in the forward direction.
-  A bidirectional scan be performed by specifying the same tensor input twice in the
-  scan_inputs, once with a forward direction, and once with a backward direction.
+  The optional attribute scan_input_directions can be used to scan a sequence in the
+  reverse direction. If this attribute is omitted, all sequences are scanned in the forward
+  direction. A bidirectional scan may be performed by specifying the same tensor input twice
+  in the scan_inputs, once with a forward direction, and once with a backward direction.
   
   The scan_output of the operation is produced by concatenating the scan_output_element
   values produced by the body in each iteration. By default, the scan_output_element is
@@ -9017,10 +9020,12 @@ This version of the operator has been available since version 9 of the default O
 <dl>
 <dt><tt>body</tt> : graph (required)</dt>
 <dd>The graph run each iteration. It has N+M inputs: (loop state variables..., scan_input_elts...). It has N+K outputs: (loop state variables..., scan_output_elts...). Each scan_output is created by concatenating the value of the specified scan_output_elt value at the end of each iteration of the loop. It is an error if the dimensions of these values change across loop iterations.</dd>
-<dt><tt>directions</tt> : list of ints</dt>
-<dd>An optional list of M flags. The i-th element of the list specifies the direction to be scanned for the i-th scan_input tensor: 0 indicates forward direction and 1 indicates reverse direction. If omitted, all scan_input tensors will be scanned in the forward direction.</dd>
+<dt><tt>handle_batch</tt> : int (default is 1)</dt>
+<dd>A flag with a value of 0 or 1. A value of 1 indicates that axis 0 is a batch axis and should be handled by the scan op.</dd>
 <dt><tt>num_scan_inputs</tt> : int (required)</dt>
 <dd>An attribute specifying the number of scan_inputs M. </dd>
+<dt><tt>scan_input_directions</tt> : list of ints</dt>
+<dd>An optional list of M flags. The i-th element of the list specifies the direction to be scanned for the i-th scan_input tensor: 0 indicates forward direction and 1 indicates reverse direction. If omitted, all scan_input tensors will be scanned in the forward direction.</dd>
 <dt><tt>scan_output_directions</tt> : list of ints</dt>
 <dd>An optional list of K flags, one for each scan_output. The i-th element of the list specifies whether the i-th scan_output should be constructed by appending or prepending a new value in each iteration: 0 indicates appending and 1 indicates prepending. If omitted, all scan_output tensors will be produced by appending a value in each iteration.</dd>
 </dl>

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -8949,7 +8949,7 @@ This version of the operator has been available since version 9 of the default O
   
       for (int batch = 0; batch < batch_size; ++batch) {
           // initialize state-variables
-          st_1 = init_1; ... st_n = init_n;
+          st_1 = init_1[batch]; ... st_n = init_n[batch];
           // initialize scan-output variables: [] denotes an empty tensor
           scan_out_1 = []; ...; scan_out_k = [];
           // identify number of iterations:

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -9262,6 +9262,12 @@ for test_name, shape in test_cases.items():
   A bidirectional scan be performed by specifying the same tensor input twice in the
   scan_inputs, once with a forward direction, and once with a backward direction.
   
+  The scan_output of the operation is produced by concatenating the scan_output_element
+  values produced by the body in each iteration. By default, the scan_output_element is
+  appended to the scan_output in each iteration. The optional attribute scan_output_directions
+  can be used to change the order in which scan_output is constructed (by prepending the
+  scan_output_element to scan_output in each iteration.)
+  
   Note that because of the ONNX restriction that only the last parameter of an operator can
   be variadic, the initial-states and scan-inputs are listed together as one input parameter.
   Similarly, the final-states and scan-outputs are listed together as one output parameter.
@@ -9350,7 +9356,9 @@ for test_name, shape in test_cases.items():
 
 #### Version
 
-This version of the operator has been available since version 8 of the default ONNX operator set.
+This version of the operator has been available since version 9 of the default ONNX operator set.
+
+Other versions of this operator: <a href="Changelog.md#Scan-8">Scan-8</a>
 
 #### Attributes
 
@@ -9361,6 +9369,8 @@ This version of the operator has been available since version 8 of the default O
 <dd>An optional list of M flags. The i-th element of the list specifies the direction to be scanned for the i-th scan_input tensor: 0 indicates forward direction and 1 indicates reverse direction. If omitted, all scan_input tensors will be scanned in the forward direction.</dd>
 <dt><tt>num_scan_inputs</tt> : int (required)</dt>
 <dd>An attribute specifying the number of scan_inputs M. </dd>
+<dt><tt>scan_output_directions</tt> : list of ints</dt>
+<dd>An optional list of K flags, one for each scan_output. The i-th element of the list specifies whether the i-th scan_output should be constructed by appending or prepending a new value in each iteration: 0 indicates appending and 1 indicates prepending. If omitted, all scan_output tensors will be produced by appending a value in each iteration.</dd>
 </dl>
 
 #### Inputs (2 - &#8734;)

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -9295,7 +9295,7 @@ for test_name, shape in test_cases.items():
   
       for (int batch = 0; batch < batch_size; ++batch) {
           // initialize state-variables
-          st_1 = init_1; ... st_n = init_n;
+          st_1 = init_1[batch]; ... st_n = init_n[batch];
           // initialize scan-output variables: [] denotes an empty tensor
           scan_out_1 = []; ...; scan_out_k = [];
           // identify number of iterations:

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -9245,10 +9245,13 @@ for test_name, shape in test_cases.items():
   The scan operation returns the final values of the state_variables as well as the
   scan_outputs.
   
-  The operation supports batching, and the batch-axis is required to be 0.
-  When multiple scan_input tensors are used, they must all have the same batch-size,
-  and they must all have the same maximum-sequence-length (the dimensionality of the
-  sequence axis or scan axis). The sequence axis or scan axis is required to be 1.
+  The operation optionally supports batching. If the attribute handle_batch has a value of
+  1, axis 0 is treated as the batch-axis and handled by the scan op and the ops in the body
+  will not see any batched input. When multiple scan_input tensors are used, they must all
+  have the same batch-size, and they must all have the same maximum-sequence-length (the
+  dimensionality of the sequence axis or scan axis). The sequence axis or scan axis is
+  axis 0 when attribute handle_batch has a value 0, and the sequence axis is axis 1
+  when handle_batch is 1.
   
   The operation has an optional sequence_lens input (of shape [BATCH_SIZE]) to
   allow variable length sequences of length <= the maximum-sequence-length. If this
@@ -9257,10 +9260,10 @@ for test_name, shape in test_cases.items():
   will consist of a sequence of same length as the input, padded to the
   maximum-sequence-length.
   
-  The optional attribute directions can be used to scan a sequence in the reverse direction.
-  If this attribute is omitted, all sequences are scanned in the forward direction.
-  A bidirectional scan be performed by specifying the same tensor input twice in the
-  scan_inputs, once with a forward direction, and once with a backward direction.
+  The optional attribute scan_input_directions can be used to scan a sequence in the
+  reverse direction. If this attribute is omitted, all sequences are scanned in the forward
+  direction. A bidirectional scan may be performed by specifying the same tensor input twice
+  in the scan_inputs, once with a forward direction, and once with a backward direction.
   
   The scan_output of the operation is produced by concatenating the scan_output_element
   values produced by the body in each iteration. By default, the scan_output_element is
@@ -9365,10 +9368,12 @@ Other versions of this operator: <a href="Changelog.md#Scan-8">Scan-8</a>
 <dl>
 <dt><tt>body</tt> : graph (required)</dt>
 <dd>The graph run each iteration. It has N+M inputs: (loop state variables..., scan_input_elts...). It has N+K outputs: (loop state variables..., scan_output_elts...). Each scan_output is created by concatenating the value of the specified scan_output_elt value at the end of each iteration of the loop. It is an error if the dimensions of these values change across loop iterations.</dd>
-<dt><tt>directions</tt> : list of ints</dt>
-<dd>An optional list of M flags. The i-th element of the list specifies the direction to be scanned for the i-th scan_input tensor: 0 indicates forward direction and 1 indicates reverse direction. If omitted, all scan_input tensors will be scanned in the forward direction.</dd>
+<dt><tt>handle_batch</tt> : int (default is 1)</dt>
+<dd>A flag with a value of 0 or 1. A value of 1 indicates that axis 0 is a batch axis and should be handled by the scan op.</dd>
 <dt><tt>num_scan_inputs</tt> : int (required)</dt>
 <dd>An attribute specifying the number of scan_inputs M. </dd>
+<dt><tt>scan_input_directions</tt> : list of ints</dt>
+<dd>An optional list of M flags. The i-th element of the list specifies the direction to be scanned for the i-th scan_input tensor: 0 indicates forward direction and 1 indicates reverse direction. If omitted, all scan_input tensors will be scanned in the forward direction.</dd>
 <dt><tt>scan_output_directions</tt> : list of ints</dt>
 <dd>An optional list of K flags, one for each scan_output. The i-th element of the list specifies whether the i-th scan_output should be constructed by appending or prepending a new value in each iteration: 0 indicates appending and 1 indicates prepending. If omitted, all scan_output tensors will be produced by appending a value in each iteration.</dd>
 </dl>

--- a/onnx/defs/controlflow/defs.cc
+++ b/onnx/defs/controlflow/defs.cc
@@ -88,8 +88,8 @@ void ScanInferenceFunction(InferenceContext& ctx) {
       // We can pass through the type and shape to the subgraph inputs but need
       // to remove the batch size and sequence length dimensions from the shape.
       if (has_shape) {
-        // remove (optional) batch size and sequence length dimensions and add to
-        // subgraph_input_types
+        // remove (optional) batch size and sequence length dimensions and add
+        // to subgraph_input_types
         temporary_type_protos.push_back(
             RemoveDimensionsFromShape(*input_type, has_batch ? 2 : 1));
         subgraph_input_types.push_back(&temporary_type_protos.back());
@@ -145,14 +145,15 @@ void ScanInferenceFunction(InferenceContext& ctx) {
             i,
             " was not");
       }
-      
+
       if (is_loop_state_var) {
-        // output and input loop_state must have same/compatible shapes
-        auto& input_type = ctx.getInputType(i+1)->tensor_type();
-        checkShapeCompatibility(subgraph_output_type->tensor_type(), input_type);
+        // type and shape of loop state vars were propagated earlier in the
+        // above code. We check compatibility here, to ensure that the
+        // subgraph's output and input loop_state have same/compatible shapes
+        auto& input_type = ctx.getInputType(i + 1)->tensor_type();
+        checkShapeCompatibility(scan_output_type->tensor_type(), input_type);
       } else {
         // propagate subgraph output type to scan's output.
-        // loop state vars were done in the above code.
         scan_output_type->mutable_tensor_type()->set_elem_type(
             subgraph_output_type->tensor_type().elem_type());
       }

--- a/onnx/defs/controlflow/defs.cc
+++ b/onnx/defs/controlflow/defs.cc
@@ -145,7 +145,6 @@ void ScanInferenceFunction(InferenceContext& ctx) {
             i,
             " was not");
       }
-
       
       if (is_loop_state_var) {
         // output and input loop_state must have same/compatible shapes
@@ -461,7 +460,7 @@ is equivalent to the following pseudo-code:
 
     for (int batch = 0; batch < batch_size; ++batch) {
         // initialize state-variables
-        st_1 = init_1; ... st_n = init_n;
+        st_1 = init_1[batch]; ... st_n = init_n[batch];
         // initialize scan-output variables: [] denotes an empty tensor
         scan_out_1 = []; ...; scan_out_k = [];
         // identify number of iterations:

--- a/onnx/defs/controlflow/defs.cc
+++ b/onnx/defs/controlflow/defs.cc
@@ -146,8 +146,14 @@ void ScanInferenceFunction(InferenceContext& ctx) {
             " was not");
       }
 
-      // propagate output type. loop state vars were done in the above code.
-      if (!is_loop_state_var) {
+      
+      if (is_loop_state_var) {
+        // output and input loop_state must have same/compatible shapes
+        auto& input_type = ctx.getInputType(i+1)->tensor_type();
+        checkShapeCompatibility(subgraph_output_type->tensor_type(), input_type);
+      } else {
+        // propagate subgraph output type to scan's output.
+        // loop state vars were done in the above code.
         scan_output_type->mutable_tensor_type()->set_elem_type(
             subgraph_output_type->tensor_type().elem_type());
       }
@@ -189,9 +195,6 @@ void ScanInferenceFunction(InferenceContext& ctx) {
         mergeInShapeInfo(
             *mutable_inferred_tensor_type, *mutable_scan_output_tensor_type);
       }
-
-      // Note: for loop_state_vars, subgraph's output shape must match input shape.
-      // We can check for their equality here.
     }
   }
 }

--- a/onnx/defs/operator_sets.h
+++ b/onnx/defs/operator_sets.h
@@ -481,6 +481,7 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, MatMul);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, PRelu);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, Gemm);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, Flatten);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, Scan);
 
 // Iterate over schema from ai.onnx version 9
 class OpSet_Onnx_ver9 {

--- a/onnx/defs/operator_sets.h
+++ b/onnx/defs/operator_sets.h
@@ -503,6 +503,7 @@ class OpSet_Onnx_ver9 {
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, PRelu)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, Gemm)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, Flatten)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, Scan)>());
   }
   static void ForEachFunctionBuilder(
       std::function<void(FunctionBuilder&&)> fn) {

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -494,7 +494,6 @@ inline void checkShapeCompatibility(
     const TypeProto_Tensor& type1,
     const TypeProto_Tensor& type2) {
   // Create temporary copy of type1 and use mergeInShapeInfo to do the check.
-  // We do not use the merged shape
   TypeProto_Tensor temp(type2);
   mergeInShapeInfo(type1, temp);
 }

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -490,4 +490,13 @@ inline void mergeInShapeInfo(
   }
 }
 
+inline void checkShapeCompatibility(
+    const TypeProto_Tensor& type1,
+    const TypeProto_Tensor& type2) {
+  // Create temporary copy of type1 and use mergeInShapeInfo to do the check.
+  // We do not use the merged shape
+  TypeProto_Tensor temp(type2);
+  mergeInShapeInfo(type1, temp);
+}
+
 } // namespace ONNX_NAMESPACE


### PR DESCRIPTION
Add two new attributes to the scan op:
(a) One to specify whether scan_outputs should be constructed in forward or reverse direction, and
(b) One to specify whether the scan op should explicitly handle batch (axis 0) or treat it as unbatched.
Update shape inference accordingly.