### PR TITLE
Add a virtual destructor to GraphInferencer

### DIFF
--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -13,6 +13,7 @@ class GraphInferencer {
   virtual std::vector<const TypeProto*> doInferencing(
       const std::vector<const TypeProto*>& inputTypes,
       const std::vector<const TensorProto*>& inputData) = 0;
+  virtual ~GraphInferencer() = default;
 };
 
 // Exception class used for handling errors in type and shape inference


### PR DESCRIPTION
In ./onnx/shape_inference/implementation.h:
We have
```
      std::unique_ptr<GraphInferencer> new_inferencer{new GraphInferencerImpl(...)}
```
Therefore, the destructor of GraphInferencer must be virtual. 
