### PR TITLE
Fix MaxUnpool shape inference when output_shape is provided as input

### DIFF
--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -169,7 +169,7 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
           std::string bytes;
           if (!iter->second->SerializeToString(&bytes)) {
             throw std::runtime_error(
-                "Failed to serilize registered function for '" + iter->first +
+                "Failed to serialize registered function for '" + iter->first +
                 "'!");
           }
           temp_map[iter->first].emplace_back(py::bytes(bytes));

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -295,13 +295,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Constrain index tensor to int64"));
 
 void maxUnpoolShapeInference(InferenceContext& ctx) {
-  propagateElemTypeFromInputToOutput(ctx, 0, 0);
-
   // we need at least two inputs to have a shape for this inference.
-  if (!hasNInputShapes(ctx, 2)) {
-    fail_shape_inference("MaxUnpool op must have atleast 2 inputs.");
+  if (ctx.getNumInputs() != 2 && ctx.getNumInputs() != 3) {
+    fail_type_inference(
+            "MaxUnpool op must have either two or three inputs.");
   }
-
+  propagateElemTypeFromInputToOutput(ctx, 0, 0);
+  if (!hasInputShape(ctx, 0)) {
+    return; // If first input does not have shape, we cannot infer much.
+  }
   auto input_shape = ctx.getInputType(0)->tensor_type().shape();
   if (input_shape.dim_size() < 2) {
     fail_shape_inference("Input tensor X must have atleast 2 dimensions.");
@@ -313,7 +315,7 @@ void maxUnpoolShapeInference(InferenceContext& ctx) {
   std::vector<int64_t> pads;
   if (getRepeatedAttribute(ctx, "pads", pads)) {
     if (pads.size() != n_input_dims * 2) {
-      fail_shape_inference("Attribute pads has incorrect size");
+      fail_shape_inference("Attribute pads has incorrect size.");
     }
   } else {
     pads.assign(n_input_dims * 2, 0);
@@ -322,7 +324,7 @@ void maxUnpoolShapeInference(InferenceContext& ctx) {
   std::vector<int64_t> strides;
   if (getRepeatedAttribute(ctx, "strides", strides)) {
     if (strides.size() != n_input_dims) {
-      fail_shape_inference("Attribute strides has incorrect size");
+      fail_shape_inference("Attribute strides has incorrect size.");
     }
   } else {
     strides.assign(n_input_dims, 1);
@@ -331,31 +333,28 @@ void maxUnpoolShapeInference(InferenceContext& ctx) {
   std::vector<int64_t> kernel_shape;
   if (getRepeatedAttribute(ctx, "kernel_shape", kernel_shape)) {
     if (kernel_shape.size() != n_input_dims) {
-      fail_shape_inference("Attribute kernel_shape has incorrect size");
+      fail_shape_inference("Attribute kernel_shape has incorrect size.");
     }
   } else {
-    fail_shape_inference("Attribute kernel_shape must be specified");
+    fail_shape_inference("Attribute kernel_shape must be specified.");
   }
 
-  if (hasNInputShapes(ctx, 3)) {
-    // If the third input, output_size, is specified then use that instead 
+  if (ctx.getNumInputs() == 3) {
+    // If the third input, output_size, is specified, then use that instead 
     // of inferring shape from inputs.
-    auto& output_shape = getInputShape(ctx, 2);
-    if (output_shape.dim_size() != 1) {
-      fail_type_inference(
-            "'output_shape' must be rank 1 tensor.");
-    }
-    if (!output_shape.dim((int)0).has_dim_value()) {
-      fail_type_inference(
-            "'output_shape' must not be empty.");
-    }
-    else {
-      if (static_cast<int>(output_shape.dim((int)0).dim_value()) != input_shape.dim_size()) {
-        fail_shape_inference(
-                "'output_shape' must have same number of elements as the shape of input tensor X.");
+    if (hasInputShape(ctx, 2)) {
+      auto& output_shape = getInputShape(ctx, 2);
+      if (output_shape.dim_size() != 1) {
+        fail_type_inference(
+              "'output_shape' must be rank 1 tensor.");
+      }
+      if (output_shape.dim((int)0).has_dim_value() && 
+          static_cast<int>(output_shape.dim((int)0).dim_value()) != input_shape.dim_size()) {
+          fail_shape_inference(
+                  "'output_shape' must have same number of elements as the shape of input tensor X.");
       }
     }
-    return; // output_shape is specified as input. Actual shape will be detrermined at runtime.
+    return; // 'output_shape' is specified as input. Actual shape will be determined at runtime.
   }
 
   auto final_output_shape =

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -340,12 +340,22 @@ void maxUnpoolShapeInference(InferenceContext& ctx) {
   if (hasNInputShapes(ctx, 3)) {
     // If the third input, output_size, is specified then use that instead 
     // of inferring shape from inputs.
-    auto output_shape = ctx.getInputType(2)->tensor_type().shape();
-    if (output_shape.dim_size() != input_shape.dim_size()) {
-        fail_shape_inference("output_shape must be the same size as the shape of input tensor X.");
+    auto& output_shape = getInputShape(ctx, 2);
+    if (output_shape.dim_size() != 1) {
+      fail_type_inference(
+            "'output_shape' must be rank 1 tensor.");
     }
-    else
-      return; // output_shape is specified as input. Actual shape will be detrermined at runtime.
+    if (!output_shape.dim((int)0).has_dim_value()) {
+      fail_type_inference(
+            "'output_shape' must not be empty.");
+    }
+    else {
+      if (static_cast<int>(output_shape.dim((int)0).dim_value()) != input_shape.dim_size()) {
+        fail_shape_inference(
+                "'output_shape' must have same number of elements as the shape of input tensor X.");
+      }
+    }
+    return; // output_shape is specified as input. Actual shape will be detrermined at runtime.
   }
 
   auto final_output_shape =

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -1018,6 +1018,23 @@ class TestShapeInference(unittest.TestCase):
 
         self._assert_inferred(graph, [make_tensor_value_info('if_output', TensorProto.FLOAT, (1,))])
 
+    def test_maxunpool_shape_without_output_shape(self):  # type: () -> None
+        graph = self._make_graph(
+            [('xT', TensorProto.FLOAT, (1, 1, 2, 2)),
+             ('xI', TensorProto.FLOAT, (1, 1, 2, 2))],
+            [make_node('MaxUnpool', ['xT', 'xI'], 'Y', kernel_shape=[2, 2], strides=[2, 2])],
+            [])
+        self._assert_inferred(graph, [make_tensor_value_info('Y', TensorProto.FLOAT, (1, 1, 4, 4))])
+
+    def test_maxunpool_shape_with_output_shape(self):  # type: () -> None
+        graph = self._make_graph(
+            [('xT', TensorProto.FLOAT, (1, 1, 2, 2)),
+             ('xI', TensorProto.FLOAT, (1, 1, 2, 2)),
+             ('output_shape', TensorProto.FLOAT, (4, ))],
+            [make_node('MaxUnpool', ['xT', 'xI', 'output_shape'], 'Y', kernel_shape=[2, 2], strides=[2, 2])],
+            [make_tensor_value_info("Y", TensorProto.FLOAT, None)])
+        self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, None)])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Currently there is a bug in shape inference for `MaxUnpool` op. Specifically, the problem happens when `output_shape` input is provided. In this case, the current code checks (wrongly) the `dim_size` for `output_shape` with the `dim_size` for first input tensor. The right thing to do is to match the number of elements in `output_shape` (which must be rank 1) to the `dim_size` of first input tensor. 

This PR fixes that. I have also included two test points in `shape_inference_test.py` for this scenario.