### PR TITLE
fix check_graph

### DIFF
--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -4,7 +4,7 @@
 #include "onnx/string_utils.h"
 
 #include <unordered_set>
-
+#include <algorithm>
 namespace ONNX_NAMESPACE {
 namespace checker {
 


### PR DESCRIPTION
in checker::check_graph(), 
1. An initializer can be the input to a node in the sub-graph. In this case, the initializer does not have to be one of the sub-graph's input.
2. If an input to a node of the sub-graph has an initializer, the input does not need to be connected to any output from previous nodes.