### PR TITLE
Bump docker image version to 230 used in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ linux_default: &linux_default
 jobs:
   py2-gcc7-ubuntu16.04:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-gcc7-ubuntu16.04:213"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-gcc7-ubuntu16.04:230"
     <<: *linux_default
 
 workflows:


### PR DESCRIPTION
213 will be deleted by an automatic job soon