### PR TITLE
Fix scan shape inference for sequence/batch being dim_param

### DIFF
--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -949,7 +949,7 @@ class TestShapeInference(unittest.TestCase):
 
     def test_scan(self):    # type: () -> None
         batch_size = 1
-        seq_len = 1
+        seq_len = 'sequence'
         input_size = 2
         loop_state_size = 3
 


### PR DESCRIPTION
This makes sure Scan shape inference works for dim_param on sequence/batch dimension