### PR TITLE
Fix an error under -Werror by removing redundant const

### DIFF
--- a/onnx/shape_inference/implementation.cc
+++ b/onnx/shape_inference/implementation.cc
@@ -239,7 +239,7 @@ void InferShapeForFunctionNode(
   }
   // Get a temporary initial value map
   std::unordered_map<std::string, const TensorProto*> temp_initializersByName;
-  for (int i = 0; i < (const int)(ctx.getNumInputs()); ++i) {
+  for (int i = 0; i < static_cast<int>(ctx.getNumInputs()); ++i) {
     if (ctx.getInputData(i) != nullptr && i < func.input_size()) {
       temp_initializersByName[func.input().Get(i)] = ctx.getInputData(i);
     }


### PR DESCRIPTION
I got an error

```
/home/daquexian/repos/onnx/onnx/shape_inference/implementation.cc: In function ‘void onnx::shape_inference::InferShapeForFunctionNode(const onnx::Function
Proto&, const onnx::ISchemaRegistry*, onnx::InferenceContext&)’:                                                                                         
/home/daquexian/repos/onnx/onnx/shape_inference/implementation.cc:242:53: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
   for (int i = 0; i < (const int)(ctx.getNumInputs()); ++i) {                                                                                           
                                                     ^         
```

when using gcc 8.2.1.

It is no need to cast a rvalue to const, so I removed it. :)