### PR TITLE
Use an empty initializer to create map

### DIFF
--- a/onnx/shape_inference/implementation.cc
+++ b/onnx/shape_inference/implementation.cc
@@ -193,11 +193,9 @@ void InferShapes(
     const std::unordered_map<std::string, int>& opset_imports,
     const ISchemaRegistry* schema_registry,
     const IFunctionBuilderRegistry* func_registry) {
-  const std::unordered_map<std::string, TypeProto*>
-      outer_scope_value_types_by_name;
   InferShapesImpl(
       g,
-      outer_scope_value_types_by_name,
+      {},
       opset_imports,
       schema_registry,
       func_registry);
@@ -213,12 +211,9 @@ void InferShapes(
         static_cast<int>(opset_import.version());
   }
   auto* g = m.mutable_graph();
-  const std::unordered_map<std::string, TypeProto*>
-      outer_scope_value_types_by_name;
-
   InferShapesImpl(
       g,
-      outer_scope_value_types_by_name,
+      {},
       opset_imports,
       schema_registry,
       func_registry);


### PR DESCRIPTION
Clang 3.8 has a detect, which cannot accept variable with compiler-generated default constructor.

This diff will fix the problem.

Reference: https://circleci.com/gh/pytorch/pytorch/291144?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link