### PR TITLE
repaire convtranspose shape inference

### DIFF
--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -791,7 +791,7 @@ void convTransposeShapeInference(InferenceContext& ctx) {
     auto second_input_shape = ctx.getInputType(1)->tensor_type().shape();
     for (int i = 2; i < second_input_shape.dim_size(); ++i) {
       if (!second_input_shape.dim(i).has_dim_value()) {
-          return;
+        return;
       }
       kernel_shape.push_back(second_input_shape.dim(i).dim_value());
     }
@@ -822,7 +822,7 @@ void convTransposeShapeInference(InferenceContext& ctx) {
   *final_output_shape->add_dim() = input_shape.dim(0);
   *final_output_shape->add_dim() =
       ctx.getInputType(1)->tensor_type().shape().dim(
-        1) * group; // channels should be the second dim of second input multiply group.
+          1) * group; // channels should be the second dim of second input multiply group.
 
   int size_of_output;
   if (output_shape_presented) {
@@ -830,13 +830,13 @@ void convTransposeShapeInference(InferenceContext& ctx) {
     for (int i = 0; i < size_of_output; ++i) {
       if (output_shape[i] < input_shape.dim(i + 2).dim_value()) {
         // TODO: throw exception?
-        return; // output shape value cannot be smaller than the input
-                // shape value
+        return; // output shape value cannot be smaller than the input shape
+                // value
       }
 
       final_output_shape->add_dim()->set_dim_value(output_shape[i]);
     }
-    return; // assume no need to proceed further when the output shape is given.
+    return;
   }
   else
   {
@@ -851,8 +851,7 @@ void convTransposeShapeInference(InferenceContext& ctx) {
 
       final_output_shape->add_dim()->set_dim_value(output_shape_dim);
     }
-    return; // assume no need to proceed further when the output shape is
-            // given.
+    return;
   }
 }
 

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -730,26 +730,26 @@ ONNX_OPERATOR_SET_SCHEMA(
 
 void convTransposeShapeInference(InferenceContext& ctx) {
   propagateElemTypeFromInputToOutput(ctx, 0, 0);
-  
+
   // we need at least two inputs to have a shape for this inference.
   if (!hasNInputShapes(ctx, 2)) {
-      return;
+    return;
   }
 
   // don't bother with legacy auto_pad for now
   if (ctx.getAttribute("auto_pad")) {
-      return;
+    return;
   }
 
   int group = 1;
   if (ctx.getAttribute("group") != nullptr)
   {
-      group = ctx.getAttribute("group")->i();
+    group = ctx.getAttribute("group")->i();
   }
 
   auto input_shape = ctx.getInputType(0)->tensor_type().shape();
   if (input_shape.dim_size() < 2) {
-      return; // Input tensor should have at least two dimensions.
+    return; // Input tensor should have at least two dimensions.
   }
 
   // first dim is the batch axis and the next is the number of channels.
@@ -757,17 +757,17 @@ void convTransposeShapeInference(InferenceContext& ctx) {
 
   std::vector<int64_t> dilations;
   if (getRepeatedAttribute(ctx, "dilations", dilations)) {
-      for (auto i : dilations)
-      {
-          if (i != 1)
-              return; // we don't handle dialations not 1.
-      }
+    for (auto i : dilations)
+    {
+      if (i != 1)
+        return; // we don't handle dialations not 1.
+    }
   }
 
   std::vector<int64_t> pads;
   if (getRepeatedAttribute(ctx, "pads", pads)) {
     if (pads.size() != n_input_dims * 2) {
-        return;
+      return;
     }
   } else {
     pads.assign(n_input_dims * 2, 0);
@@ -817,12 +817,12 @@ void convTransposeShapeInference(InferenceContext& ctx) {
   }
 
   auto final_output_shape =
-    ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
+      ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
 
   *final_output_shape->add_dim() = input_shape.dim(0);
   *final_output_shape->add_dim() =
-    ctx.getInputType(1)->tensor_type().shape().dim(
-      1) * group; // channels should be the second dim of second input multiply group.
+      ctx.getInputType(1)->tensor_type().shape().dim(
+        1) * group; // channels should be the second dim of second input multiply group.
 
   int size_of_output;
   if (output_shape_presented) {
@@ -836,8 +836,7 @@ void convTransposeShapeInference(InferenceContext& ctx) {
 
       final_output_shape->add_dim()->set_dim_value(output_shape[i]);
     }
-    return; // assume no need to proceed further when the output shape is
-            // given.
+    return; // assume no need to proceed further when the output shape is given.
   }
   else
   {

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -730,131 +730,131 @@ ONNX_OPERATOR_SET_SCHEMA(
 
 void convTransposeShapeInference(InferenceContext& ctx) {
   propagateElemTypeFromInputToOutput(ctx, 0, 0);
+  
+  // we need at least two inputs to have a shape for this inference.
+  if (!hasNInputShapes(ctx, 2)) {
+      return;
+  }
 
-    // we need at least two inputs to have a shape for this inference.
-    if (!hasNInputShapes(ctx, 2)) {
+  // don't bother with legacy auto_pad for now
+  if (ctx.getAttribute("auto_pad")) {
+      return;
+  }
+
+  int group = 1;
+  if (ctx.getAttribute("group") != nullptr)
+  {
+      group = ctx.getAttribute("group")->i();
+  }
+
+  auto input_shape = ctx.getInputType(0)->tensor_type().shape();
+  if (input_shape.dim_size() < 2) {
+      return; // Input tensor should have at least two dimensions.
+  }
+
+  // first dim is the batch axis and the next is the number of channels.
+  size_t n_input_dims = static_cast<size_t>(input_shape.dim_size() - 2);
+
+  std::vector<int64_t> dilations;
+  if (getRepeatedAttribute(ctx, "dilations", dilations)) {
+      for (auto i : dilations)
+      {
+          if (i != 1)
+              return; // we don't handle dialations not 1.
+      }
+  }
+
+  std::vector<int64_t> pads;
+  if (getRepeatedAttribute(ctx, "pads", pads)) {
+    if (pads.size() != n_input_dims * 2) {
         return;
     }
+  } else {
+    pads.assign(n_input_dims * 2, 0);
+  }
 
-    // don't bother with legacy auto_pad for now
-    if (ctx.getAttribute("auto_pad")) {
-        return;
+  std::vector<int64_t> strides;
+  if (getRepeatedAttribute(ctx, "strides", strides)) {
+    if (strides.size() != n_input_dims) {
+      return;
     }
+  } else {
+    strides.assign(n_input_dims, 1);
+  }
 
-	int group = 1;
-    if (ctx.getAttribute("group") != nullptr)
+  std::vector<int64_t> kernel_shape;
+  if (getRepeatedAttribute(ctx, "kernel_shape", kernel_shape)) {
+    if (kernel_shape.size() != n_input_dims) {
+      return;
+    }
+  } else {
+    auto second_input_shape = ctx.getInputType(1)->tensor_type().shape();
+    for (int i = 2; i < second_input_shape.dim_size(); ++i) {
+      if (!second_input_shape.dim(i).has_dim_value()) {
+          return;
+      }
+      kernel_shape.push_back(second_input_shape.dim(i).dim_value());
+    }
+  }
+
+  std::vector<int64_t> output_shape;
+  bool output_shape_presented = true;
+  if (getRepeatedAttribute(ctx, "output_shape", output_shape)) {
+    if (output_shape.size() != n_input_dims) {
+      return;
+    }
+  } else {
+    output_shape_presented = false;
+  }
+
+  std::vector<int64_t> output_padding;
+  if (getRepeatedAttribute(ctx, "output_padding", output_padding)) {
+    if (output_padding.size() != n_input_dims) { // Added only to one side.
+      return;
+    }
+  } else {
+    output_padding.assign(n_input_dims, 0);
+  }
+
+  auto final_output_shape =
+    ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
+
+  *final_output_shape->add_dim() = input_shape.dim(0);
+  *final_output_shape->add_dim() =
+    ctx.getInputType(1)->tensor_type().shape().dim(
+      1) * group; // channels should be the second dim of second input multiply group.
+
+  int size_of_output;
+  if (output_shape_presented) {
+    size_of_output = static_cast<int>(output_shape.size());
+    for (int i = 0; i < size_of_output; ++i) {
+      if (output_shape[i] < input_shape.dim(i + 2).dim_value()) {
+        // TODO: throw exception?
+        return; // output shape value cannot be smaller than the input
+                // shape value
+      }
+
+      final_output_shape->add_dim()->set_dim_value(output_shape[i]);
+    }
+    return; // assume no need to proceed further when the output shape is
+            // given.
+  }
+  else
+  {
+    size_of_output = input_shape.dim_size() - 2;
+    for (int i = 0; i < size_of_output; ++i)
     {
-        group = ctx.getAttribute("group")->i();
+      int output_shape_dim =
+          strides[i] * (input_shape.dim(i + 2).dim_value() - 1) +
+          output_padding[i] + kernel_shape[i] - pads[i] -
+          pads[i + n_input_dims];
+      
+
+      final_output_shape->add_dim()->set_dim_value(output_shape_dim);
     }
-
-    auto input_shape = ctx.getInputType(0)->tensor_type().shape();
-    if (input_shape.dim_size() < 2) {
-        return; // Input tensor should have at least two dimensions.
-    }
-
-    // first dim is the batch axis and the next is the number of channels.
-    size_t n_input_dims = static_cast<size_t>(input_shape.dim_size() - 2);
-
-    std::vector<int64_t> dilations;
-    if (getRepeatedAttribute(ctx, "dilations", dilations)) {
-		for (auto i : dilations)
-		{
-            if (i != 1)
-                return; // we don't handle dialations not 1.
-		}
-    }
-
-    std::vector<int64_t> pads;
-    if (getRepeatedAttribute(ctx, "pads", pads)) {
-        if (pads.size() != n_input_dims * 2) {
-            return;
-        }
-    } else {
-        pads.assign(n_input_dims * 2, 0);
-    }
-
-    std::vector<int64_t> strides;
-    if (getRepeatedAttribute(ctx, "strides", strides)) {
-        if (strides.size() != n_input_dims) {
-            return;
-        }
-    } else {
-        strides.assign(n_input_dims, 1);
-    }
-
-    std::vector<int64_t> kernel_shape;
-    if (getRepeatedAttribute(ctx, "kernel_shape", kernel_shape)) {
-        if (kernel_shape.size() != n_input_dims) {
-            return;
-        }
-    } else {
-        auto second_input_shape = ctx.getInputType(1)->tensor_type().shape();
-        for (int i = 2; i < second_input_shape.dim_size(); ++i) {
-            if (!second_input_shape.dim(i).has_dim_value()) {
-                return;
-            }
-            kernel_shape.push_back(second_input_shape.dim(i).dim_value());
-        }
-    }
-
-    std::vector<int64_t> output_shape;
-    bool output_shape_presented = true;
-    if (getRepeatedAttribute(ctx, "output_shape", output_shape)) {
-        if (output_shape.size() != n_input_dims) {
-            return;
-        }
-    } else {
-        output_shape_presented = false;
-	}
-
-    std::vector<int64_t> output_padding;
-    if (getRepeatedAttribute(ctx, "output_padding", output_padding)) {
-        if (output_padding.size() != n_input_dims) { // Added only to one side.
-            return;
-        }
-    } else {
-        output_padding.assign(n_input_dims, 0);
-    }
-
-    auto final_output_shape =
-        ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
-
-    *final_output_shape->add_dim() = input_shape.dim(0);
-    *final_output_shape->add_dim() =
-        ctx.getInputType(1)->tensor_type().shape().dim(
-            1) * group; // channels should be the second dim of second input multiply group.
-
-    int size_of_output;
-	if (output_shape_presented) {
-        size_of_output = static_cast<int>(output_shape.size());
-        for (int i = 0; i < size_of_output; ++i) {
-            if (output_shape[i] < input_shape.dim(i + 2).dim_value()) {
-                // TODO: throw exception?
-                return; // output shape value cannot be smaller than the input
-                        // shape value
-            }
-
-            final_output_shape->add_dim()->set_dim_value(output_shape[i]);
-        }
-        return; // assume no need to proceed further when the output shape is
-                // given.
-	}
-    else
-    {
-        size_of_output = input_shape.dim_size() - 2;
-        for (int i = 0; i < size_of_output; ++i)
-        {
-            int output_shape_dim =
-                strides[i] * (input_shape.dim(i + 2).dim_value() - 1) +
-                output_padding[i] + kernel_shape[i] - pads[i] -
-                pads[i + n_input_dims];
-            
-
-            final_output_shape->add_dim()->set_dim_value(output_shape_dim);
-        }
-        return; // assume no need to proceed further when the output shape is
-                // given.
-	}
+    return; // assume no need to proceed further when the output shape is
+            // given.
+  }
 }
 
 namespace ONNX_NAMESPACE {

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -731,116 +731,130 @@ ONNX_OPERATOR_SET_SCHEMA(
 void convTransposeShapeInference(InferenceContext& ctx) {
   propagateElemTypeFromInputToOutput(ctx, 0, 0);
 
-  // we need at least two inputs to have a shape for this inference.
-  if (!hasNInputShapes(ctx, 2)) {
-    return;
-  }
-
-  // don't bother with legacy auto_pad for now
-  if (ctx.getAttribute("auto_pad")) {
-    return;
-  }
-
-  auto input_shape = ctx.getInputType(0)->tensor_type().shape();
-  if (input_shape.dim_size() < 2) {
-    return; // Input tensor should have at least two dimensions.
-  }
-
-  // first dim is the batch axis and the next is the number of channels.
-  size_t n_input_dims = static_cast<size_t>(input_shape.dim_size() - 2);
-
-  std::vector<int64_t> dilations;
-  if (getRepeatedAttribute(ctx, "dilations", dilations)) {
-    return; // we don't handle the dialations.
-  }
-
-  std::vector<int64_t> pads;
-  if (getRepeatedAttribute(ctx, "pads", pads)) {
-    if (pads.size() != n_input_dims * 2) {
-      return;
-    }
-  } else {
-    pads.assign(n_input_dims * 2, 0);
-  }
-
-  std::vector<int64_t> strides;
-  if (getRepeatedAttribute(ctx, "strides", strides)) {
-    if (strides.size() != n_input_dims) {
-      return;
-    }
-  } else {
-    strides.assign(n_input_dims, 1);
-  }
-
-  std::vector<int64_t> kernel_shape;
-  if (getRepeatedAttribute(ctx, "kernel_shape", kernel_shape)) {
-    if (kernel_shape.size() != n_input_dims) {
-      return;
-    }
-  } else {
-    auto second_input_shape = ctx.getInputType(1)->tensor_type().shape();
-    for (int i = 2; i < second_input_shape.dim_size(); ++i) {
-      if (!second_input_shape.dim(i).has_dim_value()) {
+    // we need at least two inputs to have a shape for this inference.
+    if (!hasNInputShapes(ctx, 2)) {
         return;
-      }
-      kernel_shape.push_back(second_input_shape.dim(i).dim_value());
-    }
-  }
-
-  std::vector<int64_t> output_shape;
-  if (getRepeatedAttribute(ctx, "output_shape", output_shape)) {
-    if (output_shape.size() != n_input_dims) {
-      return;
-    }
-  }
-
-  std::vector<int64_t> output_padding;
-  if (getRepeatedAttribute(ctx, "output_padding", output_padding)) {
-    if (output_padding.size() != n_input_dims) { // Added only to one side.
-      return;
-    }
-  } else {
-    output_padding.assign(n_input_dims, 0);
-  }
-
-  auto final_output_shape =
-      ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
-
-  *final_output_shape->add_dim() = input_shape.dim(0);
-  *final_output_shape->add_dim() =
-      ctx.getInputType(1)->tensor_type().shape().dim(
-          1); // channels should be the second dim of second input.
-
-  int size_of_output = static_cast<int>(output_shape.size());
-  if (size_of_output > 0) {
-    for (int i = 0; i < size_of_output; ++i) {
-      if (output_shape[i] < input_shape.dim(i + 2).dim_value()) {
-        // TODO: throw exception?
-        return; // output shape value cannot be smaller than the input shape
-                // value
-      }
-
-      final_output_shape->add_dim()->set_dim_value(output_shape[i]);
-    }
-    return; // assume no need to proceed further when the output shape is given.
-  }
-
-  int kernel_shape_size = static_cast<int>(kernel_shape.size());
-  for (int i = 0; i < kernel_shape_size; ++i) {
-    auto newdim = final_output_shape->add_dim();
-    if (!input_shape.dim(2 + i).has_dim_value()) {
-      continue;
     }
 
-    int64_t newdim_value =
-        strides[i] * (input_shape.dim(2 + i).dim_value() - 1);
-    newdim_value += (output_padding[i] + kernel_shape[i]);
-    newdim_value -= pads[i];
-    newdim_value -= pads[i + kernel_shape_size];
+    // don't bother with legacy auto_pad for now
+    if (ctx.getAttribute("auto_pad")) {
+        return;
+    }
 
-    // add in the initial position
-    newdim->set_dim_value(newdim_value);
-  }
+	int group = 1;
+    if (ctx.getAttribute("group") != nullptr)
+    {
+        group = ctx.getAttribute("group")->i();
+    }
+
+    auto input_shape = ctx.getInputType(0)->tensor_type().shape();
+    if (input_shape.dim_size() < 2) {
+        return; // Input tensor should have at least two dimensions.
+    }
+
+    // first dim is the batch axis and the next is the number of channels.
+    size_t n_input_dims = static_cast<size_t>(input_shape.dim_size() - 2);
+
+    std::vector<int64_t> dilations;
+    if (getRepeatedAttribute(ctx, "dilations", dilations)) {
+		for (auto i : dilations)
+		{
+            if (i != 1)
+                return; // we don't handle dialations not 1.
+		}
+    }
+
+    std::vector<int64_t> pads;
+    if (getRepeatedAttribute(ctx, "pads", pads)) {
+        if (pads.size() != n_input_dims * 2) {
+            return;
+        }
+    } else {
+        pads.assign(n_input_dims * 2, 0);
+    }
+
+    std::vector<int64_t> strides;
+    if (getRepeatedAttribute(ctx, "strides", strides)) {
+        if (strides.size() != n_input_dims) {
+            return;
+        }
+    } else {
+        strides.assign(n_input_dims, 1);
+    }
+
+    std::vector<int64_t> kernel_shape;
+    if (getRepeatedAttribute(ctx, "kernel_shape", kernel_shape)) {
+        if (kernel_shape.size() != n_input_dims) {
+            return;
+        }
+    } else {
+        auto second_input_shape = ctx.getInputType(1)->tensor_type().shape();
+        for (int i = 2; i < second_input_shape.dim_size(); ++i) {
+            if (!second_input_shape.dim(i).has_dim_value()) {
+                return;
+            }
+            kernel_shape.push_back(second_input_shape.dim(i).dim_value());
+        }
+    }
+
+    std::vector<int64_t> output_shape;
+    bool output_shape_presented = true;
+    if (getRepeatedAttribute(ctx, "output_shape", output_shape)) {
+        if (output_shape.size() != n_input_dims) {
+            return;
+        }
+    } else {
+        output_shape_presented = false;
+	}
+
+    std::vector<int64_t> output_padding;
+    if (getRepeatedAttribute(ctx, "output_padding", output_padding)) {
+        if (output_padding.size() != n_input_dims) { // Added only to one side.
+            return;
+        }
+    } else {
+        output_padding.assign(n_input_dims, 0);
+    }
+
+    auto final_output_shape =
+        ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
+
+    *final_output_shape->add_dim() = input_shape.dim(0);
+    *final_output_shape->add_dim() =
+        ctx.getInputType(1)->tensor_type().shape().dim(
+            1) * group; // channels should be the second dim of second input multiply group.
+
+    int size_of_output;
+	if (output_shape_presented) {
+        size_of_output = static_cast<int>(output_shape.size());
+        for (int i = 0; i < size_of_output; ++i) {
+            if (output_shape[i] < input_shape.dim(i + 2).dim_value()) {
+                // TODO: throw exception?
+                return; // output shape value cannot be smaller than the input
+                        // shape value
+            }
+
+            final_output_shape->add_dim()->set_dim_value(output_shape[i]);
+        }
+        return; // assume no need to proceed further when the output shape is
+                // given.
+	}
+    else
+    {
+        size_of_output = input_shape.dim_size() - 2;
+        for (int i = 0; i < size_of_output; ++i)
+        {
+            int output_shape_dim =
+                strides[i] * (input_shape.dim(i + 2).dim_value() - 1) +
+                output_padding[i] + kernel_shape[i] - pads[i] -
+                pads[i + n_input_dims];
+            
+
+            final_output_shape->add_dim()->set_dim_value(output_shape_dim);
+        }
+        return; // assume no need to proceed further when the output shape is
+                // given.
+	}
 }
 
 namespace ONNX_NAMESPACE {


### PR DESCRIPTION
convtranspose shape inference does not work, since convtranspose has two ways of determine the output shape, but the old code only supports one, I added code to support two ways of shape inference. 