### PR TITLE
Replace np.long by np.int64

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -11983,9 +11983,9 @@ node = onnx.helper.make_node(
 
 x = np.random.randn(20, 10, 5).astype(np.float32)
 y = x[0:3, 0:10]
-starts = np.array([0, 0], dtype=np.long)
-ends = np.array([3, 10], dtype=np.long)
-axes = np.array([0, 1], dtype=np.long)
+starts = np.array([0, 0], dtype=np.int64)
+ends = np.array([3, 10], dtype=np.int64)
+axes = np.array([0, 1], dtype=np.int64)
 
 expect(node, inputs=[x, starts, ends, axes], outputs=[y],
        name='test_dynamic_slice')
@@ -12005,8 +12005,8 @@ node = onnx.helper.make_node(
 )
 
 x = np.random.randn(20, 10, 5).astype(np.float32)
-starts = np.array([0, 0, 3], dtype=np.long)
-ends = np.array([20, 10, 4], dtype=np.long)
+starts = np.array([0, 0, 3], dtype=np.int64)
+ends = np.array([20, 10, 4], dtype=np.int64)
 y = x[:, :, 3:4]
 
 expect(node, inputs=[x, starts, ends], outputs=[y],
@@ -12027,9 +12027,9 @@ node = onnx.helper.make_node(
 )
 
 x = np.random.randn(20, 10, 5).astype(np.float32)
-starts = np.array([1], dtype=np.long)
-ends = np.array([1000], dtype=np.long)
-axes = np.array([1], dtype=np.long)
+starts = np.array([1], dtype=np.int64)
+ends = np.array([1000], dtype=np.int64)
+axes = np.array([1], dtype=np.int64)
 y = x[:, 1:1000]
 
 expect(node, inputs=[x, starts, ends, axes], outputs=[y],
@@ -12050,9 +12050,9 @@ node = onnx.helper.make_node(
 )
 
 x = np.random.randn(20, 10, 5).astype(np.float32)
-starts = np.array([0], dtype=np.long)
-ends = np.array([-1], dtype=np.long)
-axes = np.array([1], dtype=np.long)
+starts = np.array([0], dtype=np.int64)
+ends = np.array([-1], dtype=np.int64)
+axes = np.array([1], dtype=np.int64)
 y = x[:, 0:-1]
 
 expect(node, inputs=[x, starts, ends, axes], outputs=[y],
@@ -12073,9 +12073,9 @@ node = onnx.helper.make_node(
 )
 
 x = np.random.randn(20, 10, 5).astype(np.float32)
-starts = np.array([1000], dtype=np.long)
-ends = np.array([1000], dtype=np.long)
-axes = np.array([1], dtype=np.long)
+starts = np.array([1000], dtype=np.int64)
+ends = np.array([1000], dtype=np.int64)
+axes = np.array([1], dtype=np.int64)
 y = x[:, 1000:1000]
 
 expect(node, inputs=[x, starts, ends, axes], outputs=[y],

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -6191,9 +6191,9 @@ node = onnx.helper.make_node(
 
 x = np.random.randn(20, 10, 5).astype(np.float32)
 y = x[0:3, 0:10]
-starts = np.array([0, 0], dtype=np.long)
-ends = np.array([3, 10], dtype=np.long)
-axes = np.array([0, 1], dtype=np.long)
+starts = np.array([0, 0], dtype=np.int64)
+ends = np.array([3, 10], dtype=np.int64)
+axes = np.array([0, 1], dtype=np.int64)
 
 expect(node, inputs=[x, starts, ends, axes], outputs=[y],
        name='test_dynamic_slice')
@@ -6211,8 +6211,8 @@ node = onnx.helper.make_node(
 )
 
 x = np.random.randn(20, 10, 5).astype(np.float32)
-starts = np.array([0, 0, 3], dtype=np.long)
-ends = np.array([20, 10, 4], dtype=np.long)
+starts = np.array([0, 0, 3], dtype=np.int64)
+ends = np.array([20, 10, 4], dtype=np.int64)
 y = x[:, :, 3:4]
 
 expect(node, inputs=[x, starts, ends], outputs=[y],
@@ -6231,9 +6231,9 @@ node = onnx.helper.make_node(
 )
 
 x = np.random.randn(20, 10, 5).astype(np.float32)
-starts = np.array([1], dtype=np.long)
-ends = np.array([1000], dtype=np.long)
-axes = np.array([1], dtype=np.long)
+starts = np.array([1], dtype=np.int64)
+ends = np.array([1000], dtype=np.int64)
+axes = np.array([1], dtype=np.int64)
 y = x[:, 1:1000]
 
 expect(node, inputs=[x, starts, ends, axes], outputs=[y],
@@ -6252,9 +6252,9 @@ node = onnx.helper.make_node(
 )
 
 x = np.random.randn(20, 10, 5).astype(np.float32)
-starts = np.array([0], dtype=np.long)
-ends = np.array([-1], dtype=np.long)
-axes = np.array([1], dtype=np.long)
+starts = np.array([0], dtype=np.int64)
+ends = np.array([-1], dtype=np.int64)
+axes = np.array([1], dtype=np.int64)
 y = x[:, 0:-1]
 
 expect(node, inputs=[x, starts, ends, axes], outputs=[y],
@@ -6273,9 +6273,9 @@ node = onnx.helper.make_node(
 )
 
 x = np.random.randn(20, 10, 5).astype(np.float32)
-starts = np.array([1000], dtype=np.long)
-ends = np.array([1000], dtype=np.long)
-axes = np.array([1], dtype=np.long)
+starts = np.array([1000], dtype=np.int64)
+ends = np.array([1000], dtype=np.int64)
+axes = np.array([1], dtype=np.int64)
 y = x[:, 1000:1000]
 
 expect(node, inputs=[x, starts, ends, axes], outputs=[y],

--- a/onnx/backend/test/case/node/dynamicslice.py
+++ b/onnx/backend/test/case/node/dynamicslice.py
@@ -22,9 +22,9 @@ class DynamicSlice(Base):
 
         x = np.random.randn(20, 10, 5).astype(np.float32)
         y = x[0:3, 0:10]
-        starts = np.array([0, 0], dtype=np.long)
-        ends = np.array([3, 10], dtype=np.long)
-        axes = np.array([0, 1], dtype=np.long)
+        starts = np.array([0, 0], dtype=np.int64)
+        ends = np.array([3, 10], dtype=np.int64)
+        axes = np.array([0, 1], dtype=np.int64)
 
         expect(node, inputs=[x, starts, ends, axes], outputs=[y],
                name='test_dynamic_slice')
@@ -38,9 +38,9 @@ class DynamicSlice(Base):
         )
 
         x = np.random.randn(20, 10, 5).astype(np.float32)
-        starts = np.array([0], dtype=np.long)
-        ends = np.array([-1], dtype=np.long)
-        axes = np.array([1], dtype=np.long)
+        starts = np.array([0], dtype=np.int64)
+        ends = np.array([-1], dtype=np.int64)
+        axes = np.array([1], dtype=np.int64)
         y = x[:, 0:-1]
 
         expect(node, inputs=[x, starts, ends, axes], outputs=[y],
@@ -55,9 +55,9 @@ class DynamicSlice(Base):
         )
 
         x = np.random.randn(20, 10, 5).astype(np.float32)
-        starts = np.array([1000], dtype=np.long)
-        ends = np.array([1000], dtype=np.long)
-        axes = np.array([1], dtype=np.long)
+        starts = np.array([1000], dtype=np.int64)
+        ends = np.array([1000], dtype=np.int64)
+        axes = np.array([1], dtype=np.int64)
         y = x[:, 1000:1000]
 
         expect(node, inputs=[x, starts, ends, axes], outputs=[y],
@@ -72,9 +72,9 @@ class DynamicSlice(Base):
         )
 
         x = np.random.randn(20, 10, 5).astype(np.float32)
-        starts = np.array([1], dtype=np.long)
-        ends = np.array([1000], dtype=np.long)
-        axes = np.array([1], dtype=np.long)
+        starts = np.array([1], dtype=np.int64)
+        ends = np.array([1000], dtype=np.int64)
+        axes = np.array([1], dtype=np.int64)
         y = x[:, 1:1000]
 
         expect(node, inputs=[x, starts, ends, axes], outputs=[y],
@@ -89,8 +89,8 @@ class DynamicSlice(Base):
         )
 
         x = np.random.randn(20, 10, 5).astype(np.float32)
-        starts = np.array([0, 0, 3], dtype=np.long)
-        ends = np.array([20, 10, 4], dtype=np.long)
+        starts = np.array([0, 0, 3], dtype=np.int64)
+        ends = np.array([20, 10, 4], dtype=np.int64)
         y = x[:, :, 3:4]
 
         expect(node, inputs=[x, starts, ends], outputs=[y],


### PR DESCRIPTION
np.long is a platform dependent type. Replace use of np.long with np.int64.