### PR TITLE
Clarify namescopes in the presence of nested subgraphs

### DIFF
--- a/docs/IR.md
+++ b/docs/IR.md
@@ -180,7 +180,7 @@ Graphs SHOULD be populated with documentation strings, which MAY be interpreted 
 
 All names MUST adhere to C identifier syntax rules.
 
-Names of nodes, inputs, outputs, initializers, and attributes are organized into several namespaces. Within a namespace, each name MUST be unique for each given graph. 
+Names of nodes, inputs, outputs, initializers, and attributes are organized into several namespaces. Within a namespace, each name MUST be unique for each given graph. When a graph contains nested subgraphs (as attribute values), each name in a namespace MUST be unique across these graphs.
 
 The namespaces are:
 
@@ -214,9 +214,9 @@ doc_string|string|A human-readable documentation for this value. Markdown is all
 
 Edges in the computation graph are established by outputs of one node being referenced by name in the inputs of a subsequent node.
 
-The outputs of a given node introduce new names into the graph. The values of node outputs are computed by the node's operator. Node inputs MAY refer to node outputs, graph inputs, and graph initializers. When the name of a node output coincides with the name of a graph output, the graph output's value is the corresponding output value computed by that node.
+The outputs of a given node introduce new names into the graph. The values of node outputs are computed by the node's operator. Node inputs MAY refer to node outputs, graph inputs, and graph initializers. When the name of a node output coincides with the name of a graph output, the graph output's value is the corresponding output value computed by that node. A node input in a nested subgraph MAY refer to names introduced in outer graphs (as node outputs, graph inputs, or graph initializers).
 
-The graph MUST use single static assignment for all node outputs, which means that all node output names MUST be unique within a graph.
+The graph MUST use single static assignment for all node outputs, which means that all node output names MUST be unique within a graph. This restriction applies across a graph and nested subgraphs contained within it.
 
 Node dependencies MUST NOT create cycles in the computation graph.
 


### PR DESCRIPTION
We need to clarify the treatment of names occurring in nested subgraphs, now that we have control-flow ops that use nested subgraphs.

The agreed part is that a nested subgraph can contain references to a name X defined in an outer scope (graph).

The following are less obvious (pros/cons with the different choices):

(1) Should reuse of same name X for different outputs in different graphs be permitted in (a) some cases, (b) all cases, or (c) no cases?

(2) What about node names? Are they required to be unique across a graph and a nested subgraph?

Here is my understanding of what the checker currently does:

X = ADD(…) //
{ // nested subgraph 1
    X = MULTIPLY(…) // forbidden by checker
    Y = ADD(…) // permitted by checker
    Z = ADD(…) // permitted by checker
}
Y = MULTIPLY(…) // permitted by checker
{ // nested subgraph 2
   Z = MULTIPLY(…) // permitted by checker
}

Note that forbidding reuse in all above cases is easier to explain/document!

Please indicate if there is any specific requirement or usecase for a particular choice above.