### PR TITLE
Make NodeProto and TypeProto.Tensor extensible

### DIFF
--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -3,5 +3,10 @@
 set -ex
 
 source /tmp/venv/bin/activate
+
+# install torchvision from master
+# the one on pypi requires cuda
+pip install -q git+https://github.com/pytorch/vision.git
+
 cd /tmp/pytorch
 CI=1 exec "scripts/onnx/test.sh"


### PR DESCRIPTION
To allow downstream frameworks to export additional annotations