### PR TITLE
Add operator MurmurHash3

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -9003,6 +9003,45 @@ This version of the operator has been available since version 9 of the default O
 <dd>Constrain index tensor to int64</dd>
 </dl>
 
+### <a name="MurmurHash3-9"></a>**MurmurHash3-9**</a>
+
+  DOC(The underlying implementation is MurmurHash3_x86_32 generating low latency 32bits hash
+  suitable for implementing lookup tables, Bloom filters, count min sketch or feature hashing.
+
+#### Version
+
+This version of the operator has been available since version 9 of the default ONNX operator set.
+
+#### Attributes
+
+<dl>
+<dt><tt>seed</tt> : int (default is 0)</dt>
+<dd>Seed for the hashing algorithm, unsigned 32-bit integer, default to 0.</dd>
+</dl>
+
+#### Inputs
+
+<dl>
+<dt><tt>X</tt> : T1</dt>
+<dd>An input tensor to hash.</dd>
+</dl>
+
+#### Outputs
+
+<dl>
+<dt><tt>Y</tt> : T2</dt>
+<dd>32-bit hash value.</dd>
+</dl>
+
+#### Type Constraints
+
+<dl>
+<dt><tt>T1</tt> : tensor(uint32), tensor(int32), tensor(string)</dt>
+<dd>Constrain input type to unsigned or signed 32-bit integer tensor, or string tensor. It should be utf-8 encoded if using unicode.</dd>
+<dt><tt>T2</tt> : tensor(uint32), tensor(int32)</dt>
+<dd>Constrain output type to unsigned or signed 32-bit integer tensor.</dd>
+</dl>
+
 ### <a name="OneHot-9"></a>**OneHot-9**</a>
 
   Produces a one-hot tensor based on inputs.

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -70,6 +70,7 @@
   * <a href="#Min">Min</a>
   * <a href="#Mul">Mul</a>
   * <a href="#Multinomial">Multinomial</a>
+  * <a href="#MurmurHash3">MurmurHash3</a>
   * <a href="#Neg">Neg</a>
   * <a href="#Not">Not</a>
   * <a href="#OneHot">OneHot</a>
@@ -6962,6 +6963,187 @@ This version of the operator has been available since version 7 of the default O
 <dt><tt>T2</tt> : tensor(int32), tensor(int64)</dt>
 <dd>Constrain output types to integral tensors.</dd>
 </dl>
+
+
+### <a name="MurmurHash3"></a><a name="murmurhash3">**MurmurHash3**</a>
+
+  DOC(The underlying implementation is MurmurHash3_x86_32 generating low latency 32bits hash
+  suitable for implementing lookup tables, Bloom filters, count min sketch or feature hashing.
+
+#### Version
+
+This version of the operator has been available since version 9 of the default ONNX operator set.
+
+#### Attributes
+
+<dl>
+<dt><tt>seed</tt> : int (default is 0)</dt>
+<dd>Seed for the hashing algorithm, unsigned 32-bit integer, default to 0.</dd>
+</dl>
+
+#### Inputs
+
+<dl>
+<dt><tt>X</tt> : T1</dt>
+<dd>An input tensor to hash.</dd>
+</dl>
+
+#### Outputs
+
+<dl>
+<dt><tt>Y</tt> : T2</dt>
+<dd>32-bit hash value.</dd>
+</dl>
+
+#### Type Constraints
+
+<dl>
+<dt><tt>T1</tt> : tensor(uint32), tensor(int32), tensor(string)</dt>
+<dd>Constrain input type to unsigned or signed 32-bit integer tensor, or string tensor. It should be utf-8 encoded if using unicode.</dd>
+<dt><tt>T2</tt> : tensor(uint32), tensor(int32)</dt>
+<dd>Constrain output type to unsigned or signed 32-bit integer tensor.</dd>
+</dl>
+
+
+#### Examples
+
+<details>
+<summary>murmurhash3_array_data</summary>
+
+```python
+node = onnx.helper.make_node(
+    'MurmurHash3',
+    inputs=['X'],
+    outputs=['Y'],
+    seed=0
+
+)
+X = np.array([3, 4]).astype(np.int32)
+Y = np.array([847579505, 1889779975]).astype(np.uint32)
+
+expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_array_data')
+```
+
+</details>
+
+
+<details>
+<summary>murmurhash3_default_seed</summary>
+
+```python
+node = onnx.helper.make_node(
+    'MurmurHash3',
+    inputs=['X'],
+    outputs=['Y']
+
+)
+X = np.array([3]).astype(np.int32)
+Y = np.array([847579505]).astype(np.int32)
+
+expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_default_seed')
+```
+
+</details>
+
+
+<details>
+<summary>murmurhash3_non_zero_seed</summary>
+
+```python
+node = onnx.helper.make_node(
+    'MurmurHash3',
+    inputs=['X'],
+    outputs=['Y'],
+    seed=42
+
+)
+X = np.array([3]).astype(np.int32)
+Y = np.array([-1823081949]).astype(np.int32)
+
+expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_non_zero_seed')
+```
+
+</details>
+
+
+<details>
+<summary>murmurhash3_non_zero_seed_unint_result</summary>
+
+```python
+node = onnx.helper.make_node(
+    'MurmurHash3',
+    inputs=['X'],
+    outputs=['Y'],
+    seed=42
+
+)
+X = np.array([3]).astype(np.int32)
+Y = np.array([2471885347]).astype(np.uint32)
+
+expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_non_zero_seed_unint_result')
+```
+
+</details>
+
+
+<details>
+<summary>murmurhash3_zero_seed</summary>
+
+```python
+node = onnx.helper.make_node(
+    'MurmurHash3',
+    inputs=['X'],
+    outputs=['Y'],
+    seed=0
+
+)
+X = np.array([3]).astype(np.int32)
+Y = np.array([847579505]).astype(np.int32)
+
+expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_zero_seed')
+```
+
+</details>
+
+
+<details>
+<summary>murmurhash3_zero_seed_uint_result</summary>
+
+```python
+node = onnx.helper.make_node(
+    'MurmurHash3',
+    inputs=['X'],
+    outputs=['Y'],
+    seed=0
+
+)
+X = np.array([3]).astype(np.int32)
+Y = np.array([847579505]).astype(np.uint32)
+
+expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_zero_seed_uint_result')
+```
+
+</details>
+
+
+<details>
+<summary>murmurhash3_zero_seed_uint_result2</summary>
+
+```python
+node = onnx.helper.make_node(
+    'MurmurHash3',
+    inputs=['X'],
+    outputs=['Y'],
+    seed=0
+
+)
+X = np.array([4]).astype(np.int32)
+Y = np.array([1889779975]).astype(np.uint32)
+
+expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_zero_seed_uint_result2')
+```
+
+</details>
 
 
 ### <a name="Neg"></a><a name="neg">**Neg**</a>

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -5,7 +5,7 @@
 * [Overall Test Coverage](#overall-test-coverage)
 # Node Test Coverage
 ## Summary
-Node tests have covered 106/113 (93.81%, 5 generators excluded) common operators.
+Node tests have covered 107/114 (93.86%, 5 generators excluded) common operators.
 
 Node tests have covered 2/12 (16.67%, 0 generators excluded) experimental operators.
 
@@ -3632,6 +3632,135 @@ y = np.random.randn(5).astype(np.float32)
 z = x * y
 expect(node, inputs=[x, y], outputs=[z],
        name='test_mul_bcast')
+```
+
+</details>
+
+
+### MurmurHash3
+There are 7 test cases, listed as following:
+<details>
+<summary>murmurhash3_array_data</summary>
+
+```python
+node = onnx.helper.make_node(
+    'MurmurHash3',
+    inputs=['X'],
+    outputs=['Y'],
+    seed=0
+
+)
+X = np.array([3, 4]).astype(np.int32)
+Y = np.array([847579505, 1889779975]).astype(np.uint32)
+
+expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_array_data')
+```
+
+</details>
+<details>
+<summary>murmurhash3_default_seed</summary>
+
+```python
+node = onnx.helper.make_node(
+    'MurmurHash3',
+    inputs=['X'],
+    outputs=['Y']
+
+)
+X = np.array([3]).astype(np.int32)
+Y = np.array([847579505]).astype(np.int32)
+
+expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_default_seed')
+```
+
+</details>
+<details>
+<summary>murmurhash3_non_zero_seed</summary>
+
+```python
+node = onnx.helper.make_node(
+    'MurmurHash3',
+    inputs=['X'],
+    outputs=['Y'],
+    seed=42
+
+)
+X = np.array([3]).astype(np.int32)
+Y = np.array([-1823081949]).astype(np.int32)
+
+expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_non_zero_seed')
+```
+
+</details>
+<details>
+<summary>murmurhash3_non_zero_seed_unint_result</summary>
+
+```python
+node = onnx.helper.make_node(
+    'MurmurHash3',
+    inputs=['X'],
+    outputs=['Y'],
+    seed=42
+
+)
+X = np.array([3]).astype(np.int32)
+Y = np.array([2471885347]).astype(np.uint32)
+
+expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_non_zero_seed_unint_result')
+```
+
+</details>
+<details>
+<summary>murmurhash3_zero_seed</summary>
+
+```python
+node = onnx.helper.make_node(
+    'MurmurHash3',
+    inputs=['X'],
+    outputs=['Y'],
+    seed=0
+
+)
+X = np.array([3]).astype(np.int32)
+Y = np.array([847579505]).astype(np.int32)
+
+expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_zero_seed')
+```
+
+</details>
+<details>
+<summary>murmurhash3_zero_seed_uint_result</summary>
+
+```python
+node = onnx.helper.make_node(
+    'MurmurHash3',
+    inputs=['X'],
+    outputs=['Y'],
+    seed=0
+
+)
+X = np.array([3]).astype(np.int32)
+Y = np.array([847579505]).astype(np.uint32)
+
+expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_zero_seed_uint_result')
+```
+
+</details>
+<details>
+<summary>murmurhash3_zero_seed_uint_result2</summary>
+
+```python
+node = onnx.helper.make_node(
+    'MurmurHash3',
+    inputs=['X'],
+    outputs=['Y'],
+    seed=0
+
+)
+X = np.array([4]).astype(np.int32)
+Y = np.array([1889779975]).astype(np.uint32)
+
+expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_zero_seed_uint_result2')
 ```
 
 </details>

--- a/onnx/backend/test/case/node/murmurhash3.py
+++ b/onnx/backend/test/case/node/murmurhash3.py
@@ -24,7 +24,7 @@ class MurmurHash3(Base):
         Y = np.array([847579505]).astype(np.int32)
 
         expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_default_seed')
-        
+
     @staticmethod
     def export_murmurhash3_zero_seed():  # type: () -> None
         node = onnx.helper.make_node(
@@ -38,7 +38,7 @@ class MurmurHash3(Base):
         Y = np.array([847579505]).astype(np.int32)
 
         expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_zero_seed')
-        
+
     @staticmethod
     def export_murmurhash3_zero_seed_uint_result():  # type: () -> None
         node = onnx.helper.make_node(
@@ -52,7 +52,7 @@ class MurmurHash3(Base):
         Y = np.array([847579505]).astype(np.uint32)
 
         expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_zero_seed_uint_result')
-        
+
     @staticmethod
     def export_murmurhash3_zero_seed_uint_result2():  # type: () -> None
         node = onnx.helper.make_node(
@@ -66,7 +66,7 @@ class MurmurHash3(Base):
         Y = np.array([1889779975]).astype(np.uint32)
 
         expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_zero_seed_uint_result2')
-        
+
     @staticmethod
     def export_murmurhash3_array_data():  # type: () -> None
         node = onnx.helper.make_node(
@@ -80,7 +80,7 @@ class MurmurHash3(Base):
         Y = np.array([847579505, 1889779975]).astype(np.uint32)
 
         expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_array_data')
-        
+
     @staticmethod
     def export_murmurhash3_non_zero_seed():  # type: () -> None
         node = onnx.helper.make_node(
@@ -94,7 +94,7 @@ class MurmurHash3(Base):
         Y = np.array([-1823081949]).astype(np.int32)
 
         expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_non_zero_seed')
-        
+
     @staticmethod
     def export_murmurhash3_non_zero_seed_unint_result():  # type: () -> None
         node = onnx.helper.make_node(

--- a/onnx/backend/test/case/node/murmurhash3.py
+++ b/onnx/backend/test/case/node/murmurhash3.py
@@ -1,0 +1,110 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np  # type: ignore
+
+import onnx
+from ..base import Base
+from . import expect
+
+
+class MurmurHash3(Base):
+
+    @staticmethod
+    def export_murmurhash3_default_seed():  # type: () -> None
+        node = onnx.helper.make_node(
+            'MurmurHash3',
+            inputs=['X'],
+            outputs=['Y']
+
+        )
+        X = np.array([3]).astype(np.int32)
+        Y = np.array([847579505]).astype(np.int32)
+
+        expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_default_seed')
+        
+    @staticmethod
+    def export_murmurhash3_zero_seed():  # type: () -> None
+        node = onnx.helper.make_node(
+            'MurmurHash3',
+            inputs=['X'],
+            outputs=['Y'],
+            seed=0
+
+        )
+        X = np.array([3]).astype(np.int32)
+        Y = np.array([847579505]).astype(np.int32)
+
+        expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_zero_seed')
+        
+    @staticmethod
+    def export_murmurhash3_zero_seed_uint_result():  # type: () -> None
+        node = onnx.helper.make_node(
+            'MurmurHash3',
+            inputs=['X'],
+            outputs=['Y'],
+            seed=0
+
+        )
+        X = np.array([3]).astype(np.int32)
+        Y = np.array([847579505]).astype(np.uint32)
+
+        expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_zero_seed_uint_result')
+        
+    @staticmethod
+    def export_murmurhash3_zero_seed_uint_result2():  # type: () -> None
+        node = onnx.helper.make_node(
+            'MurmurHash3',
+            inputs=['X'],
+            outputs=['Y'],
+            seed=0
+
+        )
+        X = np.array([4]).astype(np.int32)
+        Y = np.array([1889779975]).astype(np.uint32)
+
+        expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_zero_seed_uint_result2')
+        
+    @staticmethod
+    def export_murmurhash3_array_data():  # type: () -> None
+        node = onnx.helper.make_node(
+            'MurmurHash3',
+            inputs=['X'],
+            outputs=['Y'],
+            seed=0
+
+        )
+        X = np.array([3, 4]).astype(np.int32)
+        Y = np.array([847579505, 1889779975]).astype(np.uint32)
+
+        expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_array_data')
+        
+    @staticmethod
+    def export_murmurhash3_non_zero_seed():  # type: () -> None
+        node = onnx.helper.make_node(
+            'MurmurHash3',
+            inputs=['X'],
+            outputs=['Y'],
+            seed=42
+
+        )
+        X = np.array([3]).astype(np.int32)
+        Y = np.array([-1823081949]).astype(np.int32)
+
+        expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_non_zero_seed')
+        
+    @staticmethod
+    def export_murmurhash3_non_zero_seed_unint_result():  # type: () -> None
+        node = onnx.helper.make_node(
+            'MurmurHash3',
+            inputs=['X'],
+            outputs=['Y'],
+            seed=42
+
+        )
+        X = np.array([3]).astype(np.int32)
+        Y = np.array([2471885347]).astype(np.uint32)
+
+        expect(node, inputs=[X], outputs=[Y], name='test_murmurhash3_non_zero_seed_unint_result')

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -1176,19 +1176,19 @@ If input > 0, output 1. if input < 0, output -1. if input == 0, output 0.
 )DOC";
 
 ONNX_OPERATOR_SET_SCHEMA(
-	Sign,
-	9,
-	OpSchema()
-		.SetDoc(Sign_ver9_doc)
-		.Input(0, "input", "Input tensor", "T")
-		.Output(
-			0,
-			"output",
-			"The sign of the input tensor "
-			"computed element-wise. It has the same shape and type of the input.",
-			"T")
-		.TypeConstraint(
-			"T",
+    Sign,
+    9,
+    OpSchema()
+        .SetDoc(Sign_ver9_doc)
+        .Input(0, "input", "Input tensor", "T")
+        .Output(
+            0,
+            "output",
+            "The sign of the input tensor "
+            "computed element-wise. It has the same shape and type of the input.",
+            "T")
+        .TypeConstraint(
+            "T",
             OpSchema::all_numeric_types(),
             "Constrain input and output types to all numeric tensors.")
         .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
@@ -1198,20 +1198,54 @@ Computes the error function of the given input tensor element-wise.
 )DOC";
 
 ONNX_OPERATOR_SET_SCHEMA(
-	Erf,
-	9,
-	OpSchema()
-		.SetDoc(Erf_ver9_doc)
-		.Input(0, "input", "Input tensor", "T")
-		.Output(
-			0,
-			"output",
-			"The error function of the input tensor "
-			"computed element-wise. It has the same shape and type of the input.",
-			"T")
-		.TypeConstraint(
-			"T",
+    Erf,
+    9,
+    OpSchema()
+        .SetDoc(Erf_ver9_doc)
+        .Input(0, "input", "Input tensor", "T")
+        .Output(
+            0,
+            "output",
+            "The error function of the input tensor "
+            "computed element-wise. It has the same shape and type of the input.",
+            "T")
+        .TypeConstraint(
+            "T",
             OpSchema::all_numeric_types(),
             "Constrain input and output types to all numeric tensors.")
         .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+
+static const char* MurmurHash3_ver9_doc = R"DOC(
+DOC(The underlying implementation is MurmurHash3_x86_32 generating low latency 32bits hash
+suitable for implementing lookup tables, Bloom filters, count min sketch or feature hashing.
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(
+    MurmurHash3,
+    9,
+    OpSchema()
+        .SetDoc(MurmurHash3_ver9_doc)
+        .Attr(
+            "seed",
+            "Seed for the hashing algorithm, unsigned 32-bit integer, default to 0.",
+            AttributeProto::INT,
+            static_cast<int64_t>(0LL))
+        .Input(0, "X", "An input tensor to hash.", "T1")
+        .Output(0, "Y", "32-bit hash value.", "T2")
+        .TypeConstraint(
+            "T1",
+            {"tensor(uint32)", "tensor(int32)", "tensor(string)"},
+            "Constrain input type to unsigned or signed 32-bit integer tensor, or string tensor. It should be utf-8 encoded if using unicode.")
+        .TypeConstraint(
+            "T2",
+            {"tensor(uint32)", "tensor(int32)"},
+            "Constrain output type to unsigned or signed 32-bit integer tensor.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+            // Shape inference
+            if (!hasInputShape(ctx, 0))
+              return;
+            
+            auto& input_shape = getInputShape(ctx, 0);
+            updateOutputShape(ctx, 0, input_shape);
+        }));
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/operator_sets.h
+++ b/onnx/defs/operator_sets.h
@@ -478,6 +478,7 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, Less);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, Upsample);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, MaxUnpool);
 class ONNX_FUNCTION_BUILDER_CLASS_NAME(Onnx, 9, MeanVarianceNormalization);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, MurmurHash3);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, Constant);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, MatMul);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, OneHot);
@@ -507,6 +508,7 @@ class OpSet_Onnx_ver9 {
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, Less)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, Upsample)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, MaxUnpool)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, MurmurHash3)>());
     // Add more types' support to Constant/MatMul/PRelu/Gemm/Flatten op.
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, Constant)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 9, MatMul)>());


### PR DESCRIPTION
MurmurHash is a non-cryptographic hash function suitable for general hash-based lookup. (Wiki: https://en.wikipedia.org/wiki/MurmurHash)
MurmurHash3_x86_32 is used to generating low latency 32bits hash suitable for implementing lookup tables, Bloom filters, count min sketch or feature hashing.
It is used in scikit-learn: https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/utils/src/MurmurHash3.cpp