### PR TITLE
Add sample implementation support

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -196,6 +196,8 @@ expect(node, inputs=[x], outputs=[y],
 #### Sample Implementation
 
 <details>
+<summary>Abs</summary>
+
 ```python
 from __future__ import absolute_import
 from __future__ import division

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -184,10 +184,30 @@ node = onnx.helper.make_node(
     outputs=['y'],
 )
 x = np.random.randn(3, 4, 5).astype(np.float32)
-y = np.abs(x)
+y = abs(x)
 
 expect(node, inputs=[x], outputs=[y],
        name='test_abs')
+```
+
+</details>
+
+
+#### Sample Implementation
+
+<details>
+```python
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np  # type: ignore
+
+
+def abs(input):  # type: (np.ndarray) -> np.ndarray
+    return np.abs(input)
+
 ```
 
 </details>

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -27,7 +27,7 @@ node = onnx.helper.make_node(
     outputs=['y'],
 )
 x = np.random.randn(3, 4, 5).astype(np.float32)
-y = np.abs(x)
+y = abs(x)
 
 expect(node, inputs=[x], outputs=[y],
        name='test_abs')

--- a/onnx/backend/sample/ops/__init__.py
+++ b/onnx/backend/sample/ops/__init__.py
@@ -7,18 +7,20 @@ import importlib
 import inspect
 import sys
 import pkgutil
+from typing import Dict, Text
+from types import ModuleType
 
 
 def collect_sample_implementations():  # type: () -> Dict[Text, Text]
-    dict = {}
+    dict = {}  # type: Dict[Text, Text]
     _recursive_scan(sys.modules[__name__], dict)
     return dict
 
 
-def _recursive_scan(package, dict):  # type: (ModuleType) -> None
+def _recursive_scan(package, dict):  # type: (ModuleType, Dict[Text, Text]) -> None
     pkg_dir = package.__path__  # type: ignore
     module_location = package.__name__
-    for (_module_loader, name, ispkg) in pkgutil.iter_modules(pkg_dir):
+    for _module_loader, name, ispkg in pkgutil.iter_modules(pkg_dir):  # type: ignore
         module_name = "{}.{}".format(module_location, name)  # Module/package
         module = importlib.import_module(module_name)
         dict[name] = inspect.getsource(module)

--- a/onnx/backend/sample/ops/__init__.py
+++ b/onnx/backend/sample/ops/__init__.py
@@ -1,0 +1,26 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import importlib
+import inspect
+import sys
+import pkgutil
+
+
+def collect_sample_implementations():  # type: () -> Dict[Text, Text]
+    dict = {}
+    _recursive_scan(sys.modules[__name__], dict)
+    return dict
+
+
+def _recursive_scan(package, dict):  # type: (ModuleType) -> None
+    pkg_dir = package.__path__  # type: ignore
+    module_location = package.__name__
+    for (_module_loader, name, ispkg) in pkgutil.iter_modules(pkg_dir):
+        module_name = "{}.{}".format(module_location, name)  # Module/package
+        module = importlib.import_module(module_name)
+        dict[name] = inspect.getsource(module)
+        if ispkg:
+            _recursive_scan(module, dict)

--- a/onnx/backend/sample/ops/abs.py
+++ b/onnx/backend/sample/ops/abs.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np  # type: ignore
+
+
+def abs(input):  # type: (np.ndarray) -> np.ndarray
+    return np.abs(input)

--- a/onnx/backend/test/case/node/abs.py
+++ b/onnx/backend/test/case/node/abs.py
@@ -9,6 +9,7 @@ import onnx
 from ..base import Base
 from . import expect
 
+from onnx.backend.sample.ops.abs import abs
 
 class Abs(Base):
 
@@ -20,7 +21,7 @@ class Abs(Base):
             outputs=['y'],
         )
         x = np.random.randn(3, 4, 5).astype(np.float32)
-        y = np.abs(x)
+        y = abs(x)
 
         expect(node, inputs=[x], outputs=[y],
                name='test_abs')

--- a/onnx/backend/test/case/node/abs.py
+++ b/onnx/backend/test/case/node/abs.py
@@ -11,6 +11,7 @@ from . import expect
 
 from onnx.backend.sample.ops.abs import abs
 
+
 class Abs(Base):
 
     @staticmethod

--- a/onnx/defs/gen_doc.py
+++ b/onnx/defs/gen_doc.py
@@ -417,6 +417,7 @@ def main(args):  # type: (Type[Args]) -> None
                     if op_type.lower() in SAMPLE_IMPLEMENTATIONS:
                         s += '#### Sample Implementation\n\n'
                         s += '<details>\n'
+                        s += '<summary>{}</summary>\n\n'.format(op_type)
                         s += '```python\n{}\n```\n\n'.format(SAMPLE_IMPLEMENTATIONS[op_type.lower()])
                         s += '</details>\n'
                         s += '\n\n'

--- a/onnx/defs/gen_doc.py
+++ b/onnx/defs/gen_doc.py
@@ -14,10 +14,12 @@ import numpy as np  # type: ignore
 from onnx import defs, FunctionProto, helper, OperatorStatus
 from onnx.defs import OpSchema, ONNX_DOMAIN, ONNX_ML_DOMAIN
 from onnx.backend.test.case import collect_snippets
+from onnx.backend.sample.ops import collect_sample_implementations
 from typing import Any, Text, Sequence, Dict, List, Type, Set, Tuple
 
 
 SNIPPETS = collect_snippets()
+SAMPLE_IMPLEMENTATIONS = collect_sample_implementations()
 ONNX_ML = bool(os.getenv('ONNX_ML') == '1')
 
 
@@ -412,6 +414,13 @@ def main(args):  # type: (Type[Args]) -> None
                             s += '```python\n{}\n```\n\n'.format(code)
                             s += '</details>\n'
                             s += '\n\n'
+                    if op_type.lower() in SAMPLE_IMPLEMENTATIONS:
+                        s += '#### Sample Implementation\n\n'
+                        s += '<details>\n'
+                        s += '```python\n{}\n```\n\n'.format(SAMPLE_IMPLEMENTATIONS[op_type.lower()])
+                        s += '</details>\n'
+                        s += '\n\n'
+
                     fout.write(s)
 
     with io.open(args.function_output, 'w', newline='') as fout:


### PR DESCRIPTION
Add sample implementation for Abs operator serving as example.

Sample example will serve for two purposes:
- generating more test data
- documentation