### PR TITLE
Support rtol and atol at the model granularity

### DIFF
--- a/onnx/backend/test/case/model/__init__.py
+++ b/onnx/backend/test/case/model/__init__.py
@@ -30,6 +30,8 @@ def expect(model,  # type: ModelProto
             model=model,
             data_sets=[(inputs, outputs)],
             kind='simple',
+            rtol=1e-3,
+            atol=1e-7,
         ))
 
 
@@ -44,18 +46,18 @@ def collect_testcases():  # type: () -> List[TestCase]
     real_model_testcases = []
 
     model_tests = [
-        ('test_bvlc_alexnet', 'bvlc_alexnet'),
-        ('test_densenet121', 'densenet121'),
-        ('test_inception_v1', 'inception_v1'),
-        ('test_inception_v2', 'inception_v2'),
-        ('test_resnet50', 'resnet50'),
-        ('test_shufflenet', 'shufflenet'),
-        ('test_squeezenet', 'squeezenet'),
-        ('test_vgg19', 'vgg19'),
-        ('test_zfnet512', 'zfnet512'),
+        ('test_bvlc_alexnet', 'bvlc_alexnet', 1e-3, 1e-7),
+        ('test_densenet121', 'densenet121', 1e-3, 1e-7),
+        ('test_inception_v1', 'inception_v1', 1e-3, 1e-7),
+        ('test_inception_v2', 'inception_v2', 1e-3, 1e-7),
+        ('test_resnet50', 'resnet50', 1e-3, 1e-7),
+        ('test_shufflenet', 'shufflenet', 1e-3, 1e-7),
+        ('test_squeezenet', 'squeezenet', 1e-3, 1e-7),
+        ('test_vgg19', 'vgg19', 1e-3, 1e-7),
+        ('test_zfnet512', 'zfnet512', 1e-3, 1e-7),
     ]
 
-    for test_name, model_name in model_tests:
+    for test_name, model_name, rtol, atol in model_tests:
         url = '{}/{}.tar.gz'.format(BASE_URL, model_name)
         real_model_testcases.append(TestCase(
             name=test_name,
@@ -65,6 +67,8 @@ def collect_testcases():  # type: () -> List[TestCase]
             model=None,
             data_sets=None,
             kind='real',
+            rtol=rtol,
+            atol=atol,
         ))
 
     import_recursive(sys.modules[__name__])

--- a/onnx/backend/test/case/node/__init__.py
+++ b/onnx/backend/test/case/node/__init__.py
@@ -50,6 +50,8 @@ def expect(node,  # type: onnx.NodeProto
         model=model,
         data_sets=[(inputs, outputs)],
         kind='node',
+        rtol=1e-3,
+        atol=1e-7,
     ))
 
 

--- a/onnx/backend/test/case/test_case.py
+++ b/onnx/backend/test/case/test_case.py
@@ -6,9 +6,13 @@ from __future__ import unicode_literals
 from collections import namedtuple
 
 TestCase = namedtuple('TestCase', [
-    'name', 'model_name',
+    'name',
+    'model_name',
     'url',
     'model_dir',
-    'model', 'data_sets',
+    'model',
+    'data_sets',
     'kind',
+    'rtol',
+    'atol',
 ])

--- a/onnx/backend/test/cmd_tools.py
+++ b/onnx/backend/test/cmd_tools.py
@@ -35,6 +35,8 @@ def generate_data(args):  # type: (argparse.Namespace) -> None
                 json.dump({
                     'url': case.url,
                     'model_name': case.model_name,
+                    'rtol': case.rtol,
+                    'atol': case.atol,
                 }, fi, sort_keys=True)
         else:
             with open(os.path.join(output_dir, 'model.onnx'), 'wb') as f:

--- a/onnx/backend/test/data/real/test_bvlc_alexnet/data.json
+++ b/onnx/backend/test/data/real/test_bvlc_alexnet/data.json
@@ -1,1 +1,1 @@
-{"model_name": "bvlc_alexnet", "url": "https://s3.amazonaws.com/download.onnx/models/opset_9/bvlc_alexnet.tar.gz"}
+{"atol": 1e-07, "model_name": "bvlc_alexnet", "rtol": 0.001, "url": "https://s3.amazonaws.com/download.onnx/models/opset_9/bvlc_alexnet.tar.gz"}

--- a/onnx/backend/test/data/real/test_densenet121/data.json
+++ b/onnx/backend/test/data/real/test_densenet121/data.json
@@ -1,1 +1,1 @@
-{"model_name": "densenet121", "url": "https://s3.amazonaws.com/download.onnx/models/opset_9/densenet121.tar.gz"}
+{"atol": 1e-07, "model_name": "densenet121", "rtol": 0.002, "url": "https://s3.amazonaws.com/download.onnx/models/opset_9/densenet121.tar.gz"}

--- a/onnx/backend/test/data/real/test_inception_v1/data.json
+++ b/onnx/backend/test/data/real/test_inception_v1/data.json
@@ -1,1 +1,1 @@
-{"model_name": "inception_v1", "url": "https://s3.amazonaws.com/download.onnx/models/opset_9/inception_v1.tar.gz"}
+{"atol": 1e-07, "model_name": "inception_v1", "rtol": 0.001, "url": "https://s3.amazonaws.com/download.onnx/models/opset_9/inception_v1.tar.gz"}

--- a/onnx/backend/test/data/real/test_inception_v2/data.json
+++ b/onnx/backend/test/data/real/test_inception_v2/data.json
@@ -1,1 +1,1 @@
-{"model_name": "inception_v2", "url": "https://s3.amazonaws.com/download.onnx/models/opset_9/inception_v2.tar.gz"}
+{"atol": 1e-07, "model_name": "inception_v2", "rtol": 0.001, "url": "https://s3.amazonaws.com/download.onnx/models/opset_9/inception_v2.tar.gz"}

--- a/onnx/backend/test/data/real/test_resnet50/data.json
+++ b/onnx/backend/test/data/real/test_resnet50/data.json
@@ -1,1 +1,1 @@
-{"model_name": "resnet50", "url": "https://s3.amazonaws.com/download.onnx/models/opset_9/resnet50.tar.gz"}
+{"atol": 1e-07, "model_name": "resnet50", "rtol": 0.001, "url": "https://s3.amazonaws.com/download.onnx/models/opset_9/resnet50.tar.gz"}

--- a/onnx/backend/test/data/real/test_shufflenet/data.json
+++ b/onnx/backend/test/data/real/test_shufflenet/data.json
@@ -1,1 +1,1 @@
-{"model_name": "shufflenet", "url": "https://s3.amazonaws.com/download.onnx/models/opset_9/shufflenet.tar.gz"}
+{"atol": 1e-07, "model_name": "shufflenet", "rtol": 0.001, "url": "https://s3.amazonaws.com/download.onnx/models/opset_9/shufflenet.tar.gz"}

--- a/onnx/backend/test/data/real/test_squeezenet/data.json
+++ b/onnx/backend/test/data/real/test_squeezenet/data.json
@@ -1,1 +1,1 @@
-{"model_name": "squeezenet", "url": "https://s3.amazonaws.com/download.onnx/models/opset_9/squeezenet.tar.gz"}
+{"atol": 1e-07, "model_name": "squeezenet", "rtol": 0.001, "url": "https://s3.amazonaws.com/download.onnx/models/opset_9/squeezenet.tar.gz"}

--- a/onnx/backend/test/data/real/test_vgg19/data.json
+++ b/onnx/backend/test/data/real/test_vgg19/data.json
@@ -1,1 +1,1 @@
-{"model_name": "vgg19", "url": "https://s3.amazonaws.com/download.onnx/models/opset_9/vgg19.tar.gz"}
+{"atol": 1e-07, "model_name": "vgg19", "rtol": 0.001, "url": "https://s3.amazonaws.com/download.onnx/models/opset_9/vgg19.tar.gz"}

--- a/onnx/backend/test/data/real/test_zfnet512/data.json
+++ b/onnx/backend/test/data/real/test_zfnet512/data.json
@@ -1,1 +1,1 @@
-{"model_name": "zfnet512", "url": "https://s3.amazonaws.com/download.onnx/models/opset_9/zfnet512.tar.gz"}
+{"atol": 1e-07, "model_name": "zfnet512", "rtol": 0.001, "url": "https://s3.amazonaws.com/download.onnx/models/opset_9/zfnet512.tar.gz"}

--- a/onnx/backend/test/loader/__init__.py
+++ b/onnx/backend/test/loader/__init__.py
@@ -31,6 +31,8 @@ def load_model_tests(
     for test_name in os.listdir(kind_dir):
         case_dir = os.path.join(kind_dir, test_name)
         # skip the non-dir files, such as generated __init__.py.
+        rtol = 1e-3
+        atol = 1e-7
         if not os.path.isdir(case_dir):
             continue
         if os.path.exists(os.path.join(case_dir, 'model.onnx')):
@@ -42,6 +44,8 @@ def load_model_tests(
                 data = json.load(f)
                 url = data['url']
                 model_name = data['model_name']
+                rtol = data.get('rtol', 1e-3)
+                atol = data.get('atol', 1e-7)
                 model_dir = None
         testcases.append(
             TestCase(
@@ -52,6 +56,8 @@ def load_model_tests(
                 model=None,
                 data_sets=None,
                 kind=kind,
+                rtol=rtol,
+                atol=atol,
             ))
 
     return testcases

--- a/onnx/backend/test/runner/__init__.py
+++ b/onnx/backend/test/runner/__init__.py
@@ -164,15 +164,15 @@ class Runner(object):
         return tests
 
     @staticmethod
-    def _assert_similar_outputs(ref_outputs, outputs):  # type: (Sequence[Any], Sequence[Any]) -> None
+    def _assert_similar_outputs(ref_outputs, outputs, rtol, atol):  # type: (Sequence[Any], Sequence[Any], float, float) -> None
         np.testing.assert_equal(len(ref_outputs), len(outputs))
         for i in range(len(outputs)):
             np.testing.assert_equal(ref_outputs[i].dtype, outputs[i].dtype)
             np.testing.assert_allclose(
                 ref_outputs[i],
                 outputs[i],
-                rtol=1e-3,
-                atol=1e-7)
+                rtol=rtol,
+                atol=atol)
 
     @staticmethod
     @retry_excute(3)
@@ -282,7 +282,9 @@ class Runner(object):
                 inputs = list(test_data['inputs'])
                 outputs = list(prepared_model.run(inputs))
                 ref_outputs = test_data['outputs']
-                self._assert_similar_outputs(ref_outputs, outputs)
+                self._assert_similar_outputs(ref_outputs, outputs,
+                                             rtol=model_test.rtol,
+                                             atol=model_test.atol)
 
             for test_data_dir in glob.glob(
                     os.path.join(model_dir, "test_data_set*")):
@@ -303,6 +305,8 @@ class Runner(object):
                         tensor.ParseFromString(f.read())
                     ref_outputs.append(numpy_helper.to_array(tensor))
                 outputs = list(prepared_model.run(inputs))
-                self._assert_similar_outputs(ref_outputs, outputs)
+                self._assert_similar_outputs(ref_outputs, outputs,
+                                             rtol=model_test.rtol,
+                                             atol=model_test.atol)
 
         self._add_test(kind + 'Model', model_test.name, run, model_marker)


### PR DESCRIPTION
Some models, rtol=1e-3 and atol=1e-7 may be too tight. Let's enable that different models may have different rtol and atol.