### PR TITLE
Fix shape propagation for Dropout to mask (2nd output)

### DIFF
--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -83,10 +83,10 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Constrain output types to be numerics.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           if (ctx.getAttribute("value") != nullptr) {
-            propagateElemTypeFromDtypeToOutput(
+            propagateElemTypeFromAttributeTensorToOutput(
                 ctx, ctx.getAttribute("value"), 0);
           } else {
-            propagateElemTypeFromDtypeToOutput(ctx, TensorProto::FLOAT, 0);
+            validateAndSetElemType(TensorProto::FLOAT, ctx.getOutputType(0));
           }
 
           // Shape inference based on input shape
@@ -95,7 +95,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           const TensorProto* targetShapeInitializer = ctx.getInputData(0);
           if (!targetShapeInitializer) {
             // This is the case when exact shape input is not available.
-            // In this case, if the number of dimensions can be infered 
+            // In this case, if the number of dimensions can be infered
             // from the input 'shape' tensor, then we add the same number
             // of dimensions (without any dim_value information) to the output.
             if (ctx.getInputType(0)->tensor_type().has_shape()) {

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -1306,7 +1306,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
             "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInputToAllOutputs));
 
 static const char* Shrink_ver9_doc = R"DOC(
 Shrink takes one input data (Tensor<numeric>) and produces one Tensor output,

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -158,7 +158,7 @@ inline void validateAndSetElemType(
     TypeProto* output_type) {
   if (output_type->value_case() == TypeProto::VALUE_NOT_SET) {
     output_type->mutable_tensor_type()->set_elem_type(data_type);
-  } else if (output_type->value_case() == TypeProto::kTensorType) {
+  } else if (output_type->has_tensor_type()) {
     if (output_type->tensor_type().has_elem_type()) {
       if (data_type != output_type->tensor_type().elem_type()) {
         fail_type_inference(
@@ -201,7 +201,7 @@ inline void propagateElemTypeWithValidation(
     fail_type_inference("Input type was null");
   }
 
-  if (input_type->value_case() != TypeProto::kTensorType) {
+  if (!input_type->has_tensor_type()) {
     fail_type_inference(
         "Input was expected to have tensor type. Got ",
         input_type->value_case());
@@ -276,11 +276,11 @@ inline void appendSingleDimCopiedFromInputTypeToOutputType(
     size_t fromDimIndex) {
   auto output_type = ctx.getOutputType(outputIndex);
   auto input_type = ctx.getInputType(inputIndex);
-  if (TypeProto::kTensorType != output_type->value_case()) {
+  if (!output_type->has_tensor_type()) {
     fail_type_inference(
         "Output ", outputIndex, " expected to have tensor type");
   }
-  if (TypeProto::kTensorType != input_type->value_case()) {
+  if (!input_type->has_tensor_type()) {
     fail_type_inference("Input ", inputIndex, " expected to have tensor type");
   }
   auto* dim = ctx.getOutputType(outputIndex)
@@ -296,8 +296,8 @@ inline void propagateShapeFromInputToOutput(
     size_t outputIndex) {
   auto output_type = ctx.getOutputType(outputIndex);
   auto input_type = ctx.getInputType(inputIndex);
-  if (TypeProto::kTensorType != input_type->value_case() ||
-      TypeProto::kTensorType != output_type->value_case()) {
+  if (!input_type->has_tensor_type() ||
+      !output_type->has_tensor_type()) {
     throw std::runtime_error(ONNX_NAMESPACE::to_string(
         ctx.getInputType(inputIndex)->tensor_type().shape().dim_size()));
   }
@@ -361,7 +361,7 @@ inline void propagateElemTypeFromAttributeToOutput(
 inline TensorShapeProto* getOutputShape(InferenceContext& ctx, size_t n) {
   auto output_type = ctx.getOutputType(n);
   if ((output_type != nullptr) &&
-      (output_type->value_case() == TypeProto::kTensorType ||
+      (output_type->has_tensor_type() ||
        output_type->value_case() == TypeProto::VALUE_NOT_SET)) {
     return output_type->mutable_tensor_type()->mutable_shape();
   } else

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -240,6 +240,15 @@ inline void propagateElemTypeFromAttributeTensorToOutput(
   validateAndSetElemType(attribute_tensor_datatype, ctx.getOutputType(outputIndex));
 }
 
+inline bool hasInputType(InferenceContext& ctx, size_t idx) {
+  if (idx >= ctx.getNumInputs()) {
+    return false;
+  }
+  auto inputType = ctx.getInputType(idx);
+  return inputType->has_tensor_type() &&
+      inputType->tensor_type().elem_type() != TensorProto::UNDEFINED;
+}
+
 inline bool hasInputShape(InferenceContext& ctx, size_t n) {
   return ctx.getNumInputs() > n && ctx.getInputType(n) &&
       ctx.getInputType(n)->has_tensor_type() &&
@@ -298,7 +307,9 @@ inline void propagateShapeFromInputToOutput(
 }
 
 inline void propagateShapeAndTypeFromInputToOutput(InferenceContext& ctx, size_t inputIndex, size_t outputIndex) {
-  propagateElemTypeFromInputToOutput(ctx, inputIndex, outputIndex);
+  if (hasInputType(ctx, inputIndex)) {
+    propagateElemTypeFromInputToOutput(ctx, inputIndex, outputIndex);
+  }
   if (hasInputShape(ctx, inputIndex)) {
     propagateShapeFromInputToOutput(ctx, inputIndex, outputIndex);
   }

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -315,10 +315,9 @@ inline void propagateShapeFromInputToOutput(
 
 inline void propagateShapeAndTypeFromInputToOutput(InferenceContext& ctx, size_t inputIndex, size_t outputIndex) {
   propagateElemTypeFromInputToOutput(ctx, inputIndex, outputIndex);
-  if (!hasNInputShapes(ctx, inputIndex + 1)) {
-    return;
+  if (hasInputShape(ctx, inputIndex)) {
+    propagateShapeFromInputToOutput(ctx, inputIndex, outputIndex);
   }
-  propagateShapeFromInputToOutput(ctx, inputIndex, outputIndex);
 }
 
 inline void propagateShapeAndTypeFromFirstInput(InferenceContext& ctx) {

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -771,7 +771,21 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, (24, 1, 11))])
 
     def test_dropout(self):  # type: () -> None
+        # No mask
         self._identity_prop('Dropout')
+        # With mask
+        graph = self._make_graph(
+            [('x', TensorProto.FLOAT, (30, 4, 5))],
+            [make_node('Dropout', 'x', ['y', 'mask'])],
+            [])
+        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (30, 4, 5)),
+                                      make_tensor_value_info('mask', TensorProto.FLOAT, (30, 4, 5))])
+        # Without mask but using empty string notation for optional output
+        graph = self._make_graph(
+            [('x', TensorProto.FLOAT, (30, 4, 5))],
+            [make_node('Dropout', 'x', ['y', ''])],
+            [])
+        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (30, 4, 5))])
 
     def test_LRN(self):  # type: () -> None
         self._identity_prop('LRN', alpha=0.5, beta=0.5, size=1)


### PR DESCRIPTION
Fixes #1728

Extends test case for Dropout to test all 3 variants:
  - 1 output, optional missing
  - 1 output, optional empty
  - 2 outputs