### PR TITLE
Turn rtol to 0.002 on densenet121

### DIFF
--- a/onnx/backend/test/case/model/__init__.py
+++ b/onnx/backend/test/case/model/__init__.py
@@ -47,7 +47,7 @@ def collect_testcases():  # type: () -> List[TestCase]
 
     model_tests = [
         ('test_bvlc_alexnet', 'bvlc_alexnet', 1e-3, 1e-7),
-        ('test_densenet121', 'densenet121', 1e-3, 1e-7),
+        ('test_densenet121', 'densenet121', 2e-3, 1e-7),
         ('test_inception_v1', 'inception_v1', 1e-3, 1e-7),
         ('test_inception_v2', 'inception_v2', 1e-3, 1e-7),
         ('test_resnet50', 'resnet50', 1e-3, 1e-7),


### PR DESCRIPTION
 since AMD and NVidia GPU's difference on the precision. Let's relax the precision on the densenet121 a little bit.