### PR TITLE
Fix: setup.py is using wrong cmake build type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,6 +148,7 @@ class cmake_build(setuptools.Command):
             os.makedirs(CMAKE_BUILD_DIR)
 
         with cd(CMAKE_BUILD_DIR):
+            build_type = 'Release'
             # configure
             cmake_args = [
                 CMAKE,
@@ -163,7 +164,8 @@ class cmake_build(setuptools.Command):
             if COVERAGE or DEBUG:
                 # in order to get accurate coverage information, the
                 # build needs to turn off optimizations
-                cmake_args.append('-DCMAKE_BUILD_TYPE=Debug')
+                build_type = 'Debug'
+            cmake_args.append('-DCMAKE_BUILD_TYPE=%s' % build_type)
             if WINDOWS:
                 cmake_args.extend([
                     # we need to link with libpython on windows, so
@@ -191,6 +193,7 @@ class cmake_build(setuptools.Command):
 
             build_args = [CMAKE, '--build', os.curdir]
             if WINDOWS:
+                build_args.extend(['--config', build_type])
                 build_args.extend(['--', '/maxcpucount:{}'.format(self.jobs)])
             else:
                 build_args.extend(['--', '-j', str(self.jobs)])


### PR DESCRIPTION
This PR is taken for #1563 except the line:
```
cmake_args.append('-DCMAKE_BUILD_TYPE=%s' % build_type)
```

Before this fix,  if you run 
```
pip install -e .
```
on Windows, you will find, the CMAKE_BUILD_TYPE used for generating the project is 'Release'
But the real build type used with msbuild is 'Debug'
They should be the same.

You can verify it by open CMakeCache.txt and search CMAKE_BUILD_TYPE. Its value should be 'Release'

And, in .setuptools-cmake-build, if there is a sub folder name 'Debug', then it's wrong.

