### PR TITLE
Allow removed experimental ops in the checker for now

### DIFF
--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -319,6 +319,15 @@ void check_node(
         ") has zero input and zero output.");
   }
 
+  // Put the removed experimental ops here
+  if (node.op_type() == "ConstantFill") {
+    std::cerr << "Warning: " << node.op_type() << " was a removed "
+      << " experimental ops. In the future, we may directly "
+      << "reject this operator. Please update your model as soon "
+      << "as possible.";
+    return;
+  }
+
   // Resolve domain for node
   const auto& opset_imports = ctx.get_opset_imports();
   auto dit = opset_imports.find(node.domain());

--- a/onnx/test/checker_test.py
+++ b/onnx/test/checker_test.py
@@ -231,6 +231,11 @@ class TestChecker(unittest.TestCase):
         tensor = self._sample_0_elem_tensor
         checker.check_tensor(tensor)
 
+    def test_check_removed_experimental_op(self):  # type: () -> None
+        node = helper.make_node(
+            "ConstantFill", [], ["Y"], name="test", shape=[1, 2])
+        checker.check_node(node)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Let's print the warning now. So people can smoothly remove the experimental ops in their models.