### PR TITLE
Fix shape inference when auto_pad is notset again

### DIFF
--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -52,7 +52,8 @@ void convPoolTypeAndShapeInference(
   }
 
   // don't bother with legacy auto_pad for now
-  if (ctx.getAttribute("auto_pad")) {
+  const auto* auto_pad_attr = ctx.getAttribute("auto_pad");
+  if ((nullptr != auto_pad_attr) && (auto_pad_attr->s() != "NOTSET")) {
     return;
   }
 


### PR DESCRIPTION
Forget to fix another op in the previous pr.
Treat auto_pad notset as no auto_pad,
since our newest Modelzoo onnx models still make auto_pad notset instead of removing it.