### PR TITLE
ARGN is not a variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # orflow/contrib/cmake/tf_core_framework.cmake to solve the problem that
 # customized dir can't be specified when calling PROTOBUF_GENERATE_CPP.
 function(RELATIVE_PROTOBUF_GENERATE_CPP NAME SRCS HDRS ROOT_DIR DEPEND)
-  if(NOT ARGN)
+  if(NOT ${ARGN})
     message(
       SEND_ERROR
         "Error: RELATIVE_PROTOBUF_GENERATE_CPP() called without any proto files"


### PR DESCRIPTION
Latest CMake is complaining about this for me.
The current code returns the error:
Error: RELATIVE_PROTOBUF_GENERATE_CPP() called without any proto files

From the docs:
https://cmake.org/cmake/help/v3.14/command/macro.html
Since ARGN, ARGC, ARGV, ARGV0 etc. are not variables, you will NOT be able to use commands like
if (ARGV1)
...
In the first case, you can use if(${ARGV1}).