### PR TITLE
Skip the schema check on ops in non-standard domain

### DIFF
--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -355,11 +355,6 @@ void check_node(
       // python, so we can load and register operators in other domains
       //
       // before we complete the above todo, let's skip the schema check for now
-      std::cerr
-          << "Warning: Op " << node.op_type() << " in domain " << node.domain()
-          << " version " << ONNX_NAMESPACE::to_string(domain_version)
-          << " has no corresponding schema. Very likely the schema is not registered with"
-          << " ONNX checker. Skip the schema check on this op now.";
     }
   } else if (schema->Deprecated()) {
     fail_check(

--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -343,10 +343,24 @@ void check_node(
   const auto* schema = ctx.get_schema_registry()->GetSchema(
       node.op_type(), domain_version, node.domain());
   if (!schema) {
+    if (node.domain() == ONNX_DOMAIN || node.domain() == AI_ONNX_ML_DOMAIN ||
+        node.domain() == "ai.onnx") {
+      // fail the checker if op in built-in domains has no schema
       fail_check(
           "No Op registered for " + node.op_type() +
           " with domain_version of " +
           ONNX_NAMESPACE::to_string(domain_version));
+    } else {
+      // TODO: expose the registration of the op schemas appropriately in
+      // python, so we can load and register operators in other domains
+      //
+      // before we complete the above todo, let's skip the schema check for now
+      std::cerr
+          << "Warning: Op " << node.op_type() << " in domain " << node.domain()
+          << " version " << ONNX_NAMESPACE::to_string(domain_version)
+          << " has no corresponding schema. Very likely the schema is not registered with"
+          << " ONNX checker. Skip the schema check on this op now.";
+    }
   } else if (schema->Deprecated()) {
     fail_check(
         "Op registered for " + node.op_type() + " is depracted in domain_version of " +

--- a/onnx/test/checker_test.py
+++ b/onnx/test/checker_test.py
@@ -236,6 +236,19 @@ class TestChecker(unittest.TestCase):
             "ConstantFill", [], ["Y"], name="test", shape=[1, 2])
         checker.check_node(node)
 
+    def test_skip_schema_check_on_non_standard_domain(self):  # type: () -> None
+        node = helper.make_node(
+            "NonExistOp", ["X"], ["Y"], name="test", domain="test.domain")
+        graph = helper.make_graph(
+            [node],
+            "test",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 2])],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 2])])
+        onnx_id = helper.make_opsetid("test.domain", 1)
+        model = helper.make_model(graph, producer_name='test',
+                                  opset_imports=[onnx_id])
+        checker.check_model(model)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
We don't have a good way to expose and integrate non-standard domain operators yet. Let's skip the schema check on the non-standard domain ops.