### PR TITLE
fix testcase names of maxpool_2d_ceil and averagepool_2d_ceil

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -1127,7 +1127,7 @@ y = np.array([[[
     [6, 7.5],
     [12, 13.5]]]]).astype(np.float32)
 
-expect(node, inputs=[x], outputs=[y], name='export_averagepool_2d_ceil')
+expect(node, inputs=[x], outputs=[y], name='test_averagepool_2d_ceil')
 ```
 
 </details>
@@ -6293,7 +6293,7 @@ y = np.array([[[
     [11, 12],
     [15, 16]]]]).astype(np.float32)
 
-expect(node, inputs=[x], outputs=[y], name='export_maxpool_2d_ceil')
+expect(node, inputs=[x], outputs=[y], name='test_maxpool_2d_ceil')
 ```
 
 </details>

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -518,7 +518,7 @@ y = np.array([[[
     [6, 7.5],
     [12, 13.5]]]]).astype(np.float32)
 
-expect(node, inputs=[x], outputs=[y], name='export_averagepool_2d_ceil')
+expect(node, inputs=[x], outputs=[y], name='test_averagepool_2d_ceil')
 ```
 
 </details>
@@ -3195,7 +3195,7 @@ y = np.array([[[
     [11, 12],
     [15, 16]]]]).astype(np.float32)
 
-expect(node, inputs=[x], outputs=[y], name='export_maxpool_2d_ceil')
+expect(node, inputs=[x], outputs=[y], name='test_maxpool_2d_ceil')
 ```
 
 </details>

--- a/onnx/backend/test/case/node/averagepool.py
+++ b/onnx/backend/test/case/node/averagepool.py
@@ -360,4 +360,4 @@ class AveragePool(Base):
             [6, 7.5],
             [12, 13.5]]]]).astype(np.float32)
 
-        expect(node, inputs=[x], outputs=[y], name='export_averagepool_2d_ceil')
+        expect(node, inputs=[x], outputs=[y], name='test_averagepool_2d_ceil')

--- a/onnx/backend/test/case/node/maxpool.py
+++ b/onnx/backend/test/case/node/maxpool.py
@@ -361,7 +361,7 @@ class MaxPool(Base):
             [11, 12],
             [15, 16]]]]).astype(np.float32)
 
-        expect(node, inputs=[x], outputs=[y], name='export_maxpool_2d_ceil')
+        expect(node, inputs=[x], outputs=[y], name='test_maxpool_2d_ceil')
 
     @staticmethod
     def export_maxpool_2d_dilations():  # type: () -> None

--- a/onnx/backend/test/data/node/test_averagepool_2d_ceil/model.onnx
+++ b/onnx/backend/test/data/node/test_averagepool_2d_ceil/model.onnx
@@ -1,9 +1,9 @@
-backend-test:¦
+backend-test:¤
 N
 xy"AveragePool*
 	ceil_mode *
 kernel_shape@@ *
-strides@@ export_averagepool_2d_ceilZ
+strides@@ test_averagepool_2d_ceilZ
 x
 
 

--- a/onnx/backend/test/data/node/test_maxpool_2d_ceil/model.onnx
+++ b/onnx/backend/test/data/node/test_maxpool_2d_ceil/model.onnx
@@ -1,9 +1,9 @@
-backend-test:ž
+backend-test:œ
 J
 xy"MaxPool*
 	ceil_mode *
 kernel_shape@@ *
-strides@@ export_maxpool_2d_ceilZ
+strides@@ test_maxpool_2d_ceilZ
 x
 
 


### PR DESCRIPTION
It fixes Pytest errors that happen after running 'tools/update_doc.sh'

The error message appears like this:
```
_____________ ERROR collecting onnx/test/test_backend_test.py _____________
test_backend_test.py:93: in <module>
    backend_test = onnx.backend.test.BackendTest(DummyBackend, __name__)
../backend/test/runner/__init__.py:67: in __init__
    self._add_model_test(rt, 'Node')
../backend/test/runner/__init__.py:315: in _add_model_test
    self._add_test(kind + 'Model', model_test.name, run, model_marker)
../backend/test/runner/__init__.py:233: in _add_test
    'Test name must start with test_: {}'.format(test_name))
E   ValueError: Test name must start with test_: export_averagepool_2d_ceil
===========================================================================
```