### PR TITLE
Enhance shape inference for tile.

### DIFF
--- a/onnx/test/cpp/shape_inference_test.cc
+++ b/onnx/test/cpp/shape_inference_test.cc
@@ -376,7 +376,7 @@ static void doInferencingTest(bool use_scan_opset8) {
   valueTypesByName["loop_state_start"] = &loop_state_in_tensor;
   valueTypesByName["scan_op_in"] = &scan_in_tensor;
 
-  InferenceContextImpl ctx(scan, valueTypesByName, {}, &graphInfCtx);
+  InferenceContextImpl ctx(scan, valueTypesByName, {{}}, &graphInfCtx);
   if (use_scan_opset8)
     ScanInferenceFunctionOpset8(ctx);
   else

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -234,6 +234,16 @@ class TestShapeInference(unittest.TestCase):
             make_tensor_value_info('shape', TensorProto.INT64, (2,)),
             make_tensor_value_info('y', TensorProto.UINT8, (3, 8))])
 
+    def test_tile(self):  # type: () -> None
+        graph = self._make_graph(
+            [('in', TensorProto.FLOAT, (2, 300, 10, 10)),
+             ('repeats', TensorProto.INT64, (4,))],
+            [make_node('Tile', ['in', 'repeats'], ['z'])],
+            [],
+            initializer=[make_tensor('repeats', TensorProto.INT64, (4,), (2, 3, 4, 5))])
+        self._assert_inferred(graph,
+            [make_tensor_value_info('z', TensorProto.FLOAT, (4, 900, 40, 50))])
+
     def test_upsample(self):  # type: () -> None
         graph = self._make_graph(
             [('x', TensorProto.INT32, (2, 4, 3, 5)),


### PR DESCRIPTION
Currently tile's shape inference only gets the elem_type. This commit
enhances it to get the rank same as the input.
If the repeats input is specified in the model. We can also get the
exact size of each dim.

Also includes an extremely minor change to replace {} to {{}}
in shape_inference_test.cc to make it compile with c++11.

Changes to be committed:

    modified:   onnx/defs/tensor/defs.cc
    modified:   onnx/test/cpp/shape_inference_test.cc
    modified:   onnx/test/shape_inference_test.py