### PR TITLE
Fix shape inference for matmul

### DIFF
--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -751,7 +751,7 @@ void matmulShapeInference(
     ONNX_NAMESPACE::InferenceContext& ctx,
     int input1Idx,
     int input2Idx) {
-  if (!hasInputShape(ctx, input1Idx) && !hasInputShape(ctx, input2Idx)) {
+  if (!hasInputShape(ctx, input1Idx) || !hasInputShape(ctx, input2Idx)) {
     return;
   }
 

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -156,6 +156,8 @@ class TestShapeInference(unittest.TestCase):
         self._make_matmul_test_allow_unknown((4, None), (None, "a"), (4, "a"))
         self._make_matmul_test_allow_unknown((1, 4, 2), ("a", 2, 5), ("a", 4, 5))
         self._make_matmul_test_allow_unknown((1, 3, 4, 2), ("a", 2, 5), (1, 3, 4, 5))
+        self._make_matmul_test_allow_unknown((3,), None, None)
+        self._make_matmul_test_allow_unknown(None, None, None)
 
     def test_cast(self):  # type: () -> None
         graph = self._make_graph(

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -1630,6 +1630,8 @@ class TestShapeInference(unittest.TestCase):
         self._make_qlinearmatmul_test_allow_unknown((4, None), (None, "a"), (4, "a"))
         self._make_qlinearmatmul_test_allow_unknown((1, 4, 2), ("a", 2, 5), ("a", 4, 5))
         self._make_qlinearmatmul_test_allow_unknown((1, 3, 4, 2), ("a", 2, 5), (1, 3, 4, 5))
+        self._make_qlinearmatmul_test_allow_unknown(None, ("a", 2, 5), None)
+        self._make_qlinearmatmul_test_allow_unknown(None, None, None)
 
     def _make_matmulinteger_test(self, shape1, shape2):  # type: (Sequence[int], Sequence[int]) -> None
         expected_out_shape = np.matmul(np.arange(np.product(shape1)).reshape(shape1),


### PR DESCRIPTION
Recent commit changes the logic
https://github.com/onnx/onnx/blob/6de42d7d7f8ad6e601a8388147400b344b2728ea/onnx/defs/math/defs.cc#L774
to
https://github.com/onnx/onnx/blob/3717dc617fa06e4eea326e85dc0ccfdcdf4f4ab5/onnx/defs/math/defs.cc#L754
to accommodate qlinearmatmul when there are more than 2 inputs.
However it seems the logic should be
```
if (!hasInputShape(ctx, input1Idx) || !hasInputShape(ctx, input2Idx)) {
```

This is causing a bug when only one of the input does not have shape. Also these cases are not captured in the previous unit tests.