### PR TITLE
Fix shape inference for ConstantOfShape op

### DIFF
--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -89,8 +89,6 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
 
           // Shape inference based on input shape
-          auto final_output_shape =
-            ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
           const TensorProto* targetShapeInitializer = ctx.getInputData(0);
           if (!targetShapeInitializer) {
             // This is the case when exact shape input is not available.
@@ -106,6 +104,8 @@ ONNX_OPERATOR_SET_SCHEMA(
                 if (input_shape.dim(0).has_dim_value()) {
                     const auto& input_shape_dim_value = input_shape.dim(0).dim_value();
                     if (input_shape_dim_value > 0) {
+                      auto final_output_shape = 
+                          ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
                         for (int i = 0; i < input_shape_dim_value; ++i) {
                             auto newdim = final_output_shape->add_dim();
                             (void)(newdim); // To eliminate "unused variable" compiler warning.
@@ -132,6 +132,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             targetShape.insert(targetShape.end(), data.begin(), data.end());
           }
           // Next, set output shape to the target shape.
+          auto final_output_shape =
+              ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
           for (const int64_t& targetShapeElem : targetShape) {
             if(targetShapeElem > 0) {
               auto* new_dim = final_output_shape->add_dim();

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -313,15 +313,6 @@ ONNX_OPERATOR_SET_SCHEMA(
 
           auto rank = ctx.getInputType(0)->tensor_type().shape().dim_size();
 
-          // rank == 0 may mean that shape inference can't be done yet.
-          // today shape inference is not complete for all the operators.
-          // when such an op preceeds concat rank can be 0.
-          // TODO : Fix shape inferencing for all ops to fall back to rank
-          // inference when shape inferening cant be done.
-          if (rank == 0) {
-            return;
-          }
-
           auto axisAttr = ctx.getAttribute("axis");
           if (!axisAttr) {
             fail_shape_inference("Required attribute axis is missing");


### PR DESCRIPTION
Bug fix for ConstantOfShape shape inference. mutable_shape for output should be called only when we can do the shape inference.