### PR TITLE
fix macro ONNX_DISALLOW_COPY_AND_ASSIGN bug

### DIFF
--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -25,7 +25,7 @@
 
 #define ONNX_DISALLOW_COPY_AND_ASSIGN(TypeName) \
   TypeName(const TypeName&) = delete; \
-  void operator=(const TypeName&) = delete
+  TypeName& operator=(const TypeName&) = delete
 
 
 namespace ONNX_NAMESPACE {


### PR DESCRIPTION
"TypeName& operator=(const TypeName&) = delete"  may be better than "void operator=(const TypeName&) = delete"