### PR TITLE
Cleanup cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -470,8 +470,6 @@ if(MSVC)
                                  /wd4146 # unary minus operator applied to
                                          # unsigned type, result still unsigned
                                  ${EXTRA_FLAGS})
-  add_msvc_runtime_flag(onnx_proto)
-  add_msvc_runtime_flag(onnx)
   set(onnx_static_library_flags
       -IGNORE:4221 # LNK4221: This object file does not define any previously
                    # undefined public symbols, so it will not be used by any
@@ -512,9 +510,6 @@ set_target_properties(onnxifi_loader
                                  C_EXTENSIONS
                                  NO)
 target_link_libraries(onnxifi_loader PUBLIC onnxifi ${CMAKE_DL_LIBS})
-if(MSVC)
-  add_msvc_runtime_flag(onnxifi_loader)
-endif()
 
 if (NOT ANDROID AND NOT IOS)
   # ---[ ONNXIFI wrapper
@@ -556,9 +551,6 @@ target_include_directories(onnxifi_dummy PRIVATE
   $<INSTALL_INTERFACE:include>)
 target_link_libraries(onnxifi_dummy PUBLIC onnxifi ${CMAKE_DL_LIBS})
 target_compile_definitions(onnxifi_dummy PRIVATE ONNXIFI_BUILD_LIBRARY=TRUE)
-if(MSVC)
-  add_msvc_runtime_flag(onnxifi_dummy)
-endif()
 
 install(DIRECTORY ${ONNX_ROOT}/onnx
         DESTINATION include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,9 +274,9 @@ list(APPEND ONNX_PROTO_HDRS ${__tmp_hdrs})
 
 file(GLOB_RECURSE __tmp_srcs "${ONNX_ROOT}/onnx/*.h" "${ONNX_ROOT}/onnx/*.cc")
 file(GLOB_RECURSE onnx_gtests_src "${ONNX_ROOT}/onnx/test/cpp/*.h"
-	"${ONNX_ROOT}/onnx/test/cpp/*.cc"
-	"${ONNX_ROOT}/onnx/backend/test/cpp/*.cc"
-	"${ONNX_ROOT}/onnx/backend/test/cpp/*.h")
+    "${ONNX_ROOT}/onnx/test/cpp/*.cc"
+    "${ONNX_ROOT}/onnx/backend/test/cpp/*.cc"
+    "${ONNX_ROOT}/onnx/backend/test/cpp/*.h")
 list(REMOVE_ITEM __tmp_srcs "${ONNX_ROOT}/onnx/cpp2py_export.cc")
 list(REMOVE_ITEM __tmp_srcs ${onnx_gtests_src})
 list(APPEND ONNX_SRCS ${__tmp_srcs})
@@ -411,8 +411,9 @@ if(BUILD_ONNX_PYTHON)
                                            # unsigned type, result still
                                            # unsigned from include\google\protob
                                            # uf\wire_format_lite.h
+                                   /wd4244 # conversion from 'uint64' to 'uint32',
+                                           # possible loss of data
                                    ${EXTRA_FLAGS})
-    target_compile_options(onnx_cpp2py_export PRIVATE /MT)
     add_onnx_global_defines(onnx_cpp2py_export)
   endif()
 endif()
@@ -458,6 +459,8 @@ if(MSVC)
                                          # unsigned type, result still unsigned:
                                          # include\google\protobuf\wire_format_l
                                          # ite.h
+                                 /wd4244 # conversion from 'uint64' to 'uint32',
+                                         # possible loss of data
                                  ${EXTRA_FLAGS})
   target_compile_options(onnx
                          PRIVATE /MP
@@ -469,6 +472,8 @@ if(MSVC)
                                          # exceeded, name was truncated
                                  /wd4146 # unary minus operator applied to
                                          # unsigned type, result still unsigned
+                                 /wd4244 # conversion from 'uint64' to 'uint32',
+                                         # possible loss of data
                                  ${EXTRA_FLAGS})
   set(onnx_static_library_flags
       -IGNORE:4221 # LNK4221: This object file does not define any previously

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ way to get these dependencies is via
 
 ```
 # Use conda-forge protobuf, as default doesn't come with protoc
-conda install -c conda-forge protobuf numpy
+conda install -c conda-forge protobuf>=3.7.1 numpy
 ```
 
 You can then install ONNX from PyPi (Note: Set environment variable `ONNX_ML=1` for onnx-ml):

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,12 +38,12 @@ before_build:
 - >
   IF "%_prefix%"=="C:\Miniconda37"
   (
-  conda install -y -c conda-forge libprotobuf=3.5.2 numpy &&
+  conda install -y -c conda-forge libprotobuf=3.7.1 numpy &&
   set "PATH=%PATH%;%CONDA_PREFIX%\Library\bin"
   )
   ELSE
   (
-  conda install -y -c conda-forge libprotobuf=3.5.2 numpy
+  conda install -y -c conda-forge libprotobuf=3.7.1 numpy
   )
 - cmd: pip install --quiet pytest nbval numpy
 

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -1,15 +1,3 @@
-#
-# Add MSVC RunTime Flag, this part is necessary for tests in CI
-function(add_msvc_runtime_flag lib)
-  if(${ONNX_USE_MSVC_STATIC_RUNTIME})
-    if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
-      target_compile_options(${lib} PRIVATE /MTd)
-    else()
-      target_compile_options(${lib} PRIVATE /MT)
-    endif()
-  endif()
-endfunction()
-
 function(add_onnx_global_defines target)
   target_compile_definitions(${target} PUBLIC "ONNX_NAMESPACE=${ONNX_NAMESPACE}")
 
@@ -19,20 +7,5 @@ function(add_onnx_global_defines target)
 
   if(ONNX_USE_LITE_PROTO)
     target_compile_definitions(${target} PUBLIC "ONNX_USE_LITE_PROTO=1")
-  endif()
-endfunction()
-
-function(add_whole_archive_flag lib output_var)
-  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-    set(${output_var} -Wl,-force_load,$<TARGET_FILE:${lib}> PARENT_SCOPE)
-  elseif(MSVC)
-    # In MSVC, we will add whole archive in default.
-    set(${output_var} -WHOLEARCHIVE:$<SHELL_PATH:$<TARGET_FILE:${lib}>>
-        PARENT_SCOPE)
-  else()
-    # Assume everything else is like gcc
-    set(${output_var}
-        "-Wl,--whole-archive $<TARGET_FILE:${lib}> -Wl,--no-whole-archive"
-        PARENT_SCOPE)
   endif()
 endfunction()


### PR DESCRIPTION
There are many ways of setting compiler flags globally.

See: https://gitlab.kitware.com/cmake/cmake/issues/18390

It doesn't need any special code in the project itself.
Let's keep it simple.


