### PR TITLE
Relax shape inference failure when strides > kernel shape in conv shape inference

### DIFF
--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -111,9 +111,7 @@ void convPoolShapeInference(
             residual -= strides[i];
           }
         }
-        int64_t total_pad = residual == 0 ? kernel_shape[i] - strides[i]
-                                          : kernel_shape[i] + residual;
-
+        int64_t total_pad = residual == 0 ? kernel_shape[i] - strides[i] : kernel_shape[i] + residual;
         int64_t half_pad_small = total_pad / 2;
         int64_t half_pad_big = total_pad - half_pad_small;
         if (auto_pad_attr->s() == "SAME_UPPER") {

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -101,13 +101,20 @@ void convPoolShapeInference(
     if ((nullptr != auto_pad_attr) && (auto_pad_attr->s() != "VALID")) {
       int input_dims_size = static_cast<int>(n_input_dims);
       for (int i = 0; i < input_dims_size; ++i) {
-        if (!input_shape.dim(2 + i).has_dim_value()) {
-          continue;
+        int64_t residual = 0;
+        if (strides[i] > 1) {
+          if (!input_shape.dim(2 + i).has_dim_value()) {
+            continue;
+          }
+          residual = input_shape.dim(2 + i).dim_value();
+          while (residual > 0) {
+            residual -= strides[i];
+          }
         }
-        int64_t dim_value = input_shape.dim(2 + i).dim_value();
-        int64_t legacy_target_size = (dim_value + strides[i] - 1) / strides[i];
-        int64_t total_pad = (legacy_target_size - 1) * strides[i] + kernel_shape[i] - dim_value;
-        int64_t half_pad_small = total_pad >> 1;
+        int64_t total_pad = residual == 0 ? kernel_shape[i] - strides[i]
+                                          : kernel_shape[i] + residual;
+
+        int64_t half_pad_small = total_pad / 2;
         int64_t half_pad_big = total_pad - half_pad_small;
         if (auto_pad_attr->s() == "SAME_UPPER") {
           pads[i] = half_pad_small;

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -1051,6 +1051,13 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 5, 5))])
 
+    def test_maxpool_with_same_lower_with_stride_greater_than_kernel(self):  # type: () -> None
+        graph = self._make_graph(
+            [("X", TensorProto.FLOAT, (5, 3, 21, 21))],
+            [make_node("MaxPool", ["X"], ["Y"], auto_pad="SAME_LOWER", kernel_shape=[3, 3], strides=[4, 4])],
+            [])
+        self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 6, 6))])
+
     def test_averagepool(self):  # type: () -> None
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -1051,13 +1051,6 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 5, 5))])
 
-    def test_maxpool_with_same_lower_with_stride_greater_than_kernel(self):  # type: () -> None
-        graph = self._make_graph(
-            [("X", TensorProto.FLOAT, (5, 3, 21, 21))],
-            [make_node("MaxPool", ["X"], ["Y"], auto_pad="SAME_LOWER", kernel_shape=[3, 3], strides=[4, 4])],
-            [])
-        self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 6, 6))])
-
     def test_averagepool(self):  # type: () -> None
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],


### PR DESCRIPTION
When pad values are computed to be negative, it doesn't affect the output dim value in any way. In reality, it only means that a few values are ignored in the conv computation. Relaxing this condition because ResNet 50 from the ONNX model zoo has case(s) where strides > kernel shape and this causes shape inference failure