### PR TITLE
Fix bug that kernel_shape rather than effective_kernel_shape is used in dilated conv

### DIFF
--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -549,6 +549,22 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (30, 50, 6, 6, 6))])
 
+    def test_conv_auto_pad(self):  # type: () -> None
+        graph = self._make_graph(
+            [('x', TensorProto.FLOAT, (30, 4, 7, 6, 4)),
+             ('y', TensorProto.FLOAT, (50, 4, 4, 3, 2))],
+            [make_node('Conv', ['x', 'y'], 'z', auto_pad='SAME_UPPER')],
+            [])
+        self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (30, 50, 7, 6, 4))])
+
+    def test_conv_auto_pad_dilation(self):  # type: () -> None
+        graph = self._make_graph(
+            [('x', TensorProto.FLOAT, (30, 4, 65, 64, 63)),
+             ('y', TensorProto.FLOAT, (50, 4, 4, 3, 2))],
+            [make_node('Conv', ['x', 'y'], 'z', auto_pad='SAME_UPPER', dilations=[2, 3, 4])],
+            [])
+        self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (30, 50, 65, 64, 63))])
+
     def test_conv_group(self):  # type: () -> None
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (30, 4, 8, 8, 8)),
@@ -1037,6 +1053,13 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 2, 2))])
 
+    def test_maxpool_with_same_upper_padding_and_stride_and_dilation(self):  # type: () -> None
+        graph = self._make_graph(
+            [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
+            [make_node("MaxPool", ["X"], ["Y"], auto_pad="SAME_UPPER", kernel_shape=[2, 2], strides=[2, 2], dilations=[2, 3])],
+            [])
+        self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 2, 2))])
+
     def test_maxpool_with_same_upper_padding_and_stride_one(self):  # type: () -> None
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
@@ -1048,6 +1071,13 @@ class TestShapeInference(unittest.TestCase):
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 9, 9))],
             [make_node("MaxPool", ["X"], ["Y"], auto_pad="SAME_LOWER", kernel_shape=[2, 2], strides=[2, 2])],
+            [])
+        self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 5, 5))])
+
+    def test_maxpool_with_same_lower_padding_and_stride_and_dilation(self):  # type: () -> None
+        graph = self._make_graph(
+            [("X", TensorProto.FLOAT, (5, 3, 9, 9))],
+            [make_node("MaxPool", ["X"], ["Y"], auto_pad="SAME_LOWER", kernel_shape=[2, 2], strides=[2, 2], dilations=[2, 3])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 5, 5))])
 


### PR DESCRIPTION
The shape inference is wrong when auto_pad is set to SAME_UPPER or SAME_LOWER and the dilation is not one, because kernel_shape rather than effective_kernel_shape is used.

The simplest model for reproducing it:

```python
import onnx
from onnx import helper, shape_inference
from onnx import AttributeProto, TensorProto, GraphProto

# Create one input (ValueInfoProto)
X = helper.make_tensor_value_info('X', TensorProto.FLOAT, [1, 16, 16, 16])

# Create one input (ValueInfoProto)
W = helper.make_tensor_value_info('W', TensorProto.FLOAT, [16, 16, 3, 3])

# Create one output (ValueInfoProto)
Z = helper.make_tensor_value_info('Z', TensorProto.FLOAT, [1, 16, 16, 16])

# Create a node (NodeProto)
conv_node_def = helper.make_node(
    'Conv', # node name
    ['X', 'W'], # inputs
    ['Y'], # outputs
    auto_pad='SAME_UPPER', # attributes
    dilations=[2, 2],
    )

id_node_def = helper.make_node(
    'Identity', # node name
    ['Y'], # inputs
    ['Z'] # outputs
    )

# Create the graph (GraphProto)
graph_def = helper.make_graph(
    [conv_node_def, id_node_def],
    'test-model',
    [X, W],
    [Z],
    )

# Create the model (ModelProto)
model_def = helper.make_model(graph_def)

onnx.checker.check_model(model_def)
print('The model is checked!')

model_def = shape_inference.infer_shapes(model_def)

onnx.checker.check_model(model_def)
print('The model is checked!')

```