### PR TITLE
Fix wrong condition and add "--user" in update_doc.sh

### DIFF
--- a/tools/update_doc.sh
+++ b/tools/update_doc.sh
@@ -8,14 +8,15 @@ if [ -z $python_exist ]; then
   exit 1
 fi
 
-if [ -f "onnx/defs/gen_doc.py" ]; then
+if [ ! -f "onnx/defs/gen_doc.py" ]; then
   echo "Please run this script in the ONNX root folder."
+  exit 1
 fi
 
 set -e
 
 echo -e "===> recompile onnx"
-python setup.py develop
+python setup.py develop --user
 
 echo -e "\n===> regenerate test data from node test"
 python onnx/backend/test/cmd_tools.py generate-data


### PR DESCRIPTION
Related issue: #2049 

1. The script echoes "Please run this script in the ONNX root folder" when "onnx/defs/gen_doc.py" _exists_.

1. The script runs `python setup.py develop` without `--user`. So the script can only be run as a root user. It's not the best practice. What's more, the script will create or edit many files, and they will be all owned by root. As a result, the regular user cannot delete, edit or git add them anymore without running chown manually.