### PR TITLE
Enforce non-negative lambd attribute values of the Shrink operator

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -12598,7 +12598,7 @@ This version of the operator has been available since version 9 of the default O
 <dt><tt>bias</tt> : float (default is 0.0)</dt>
 <dd>The bias value added to output. Default is 0.</dd>
 <dt><tt>lambd</tt> : float (default is 0.5)</dt>
-<dd>The lambd value for the Shrink formulation. Default is 0.5.</dd>
+<dd>The non-negative lambd value for the Shrink formulation. Default is 0.5.</dd>
 </dl>
 
 #### Inputs


### PR DESCRIPTION
I'd like to propose a slight change of accepted values for the `lambd` attribute of the Shrink operator.

While implementing this op I started creating test cases and came up with a set of attributes for which I could not produce non-ambiguous values of Shrink.

```
 L = lambd
 B = bias
 input = [0;5]

       {x < -L} => x + B 
      /
shrink - 0
      \ 
       {x > L}  => x - B

 L B | 0  1 2 3 4 5
 ------------------
 2 2 | 0  0 0 1 2 3
 0 2 | 0 -1 0 1 2 3
-1 2 | ?  ? 0 1 2 3
```

For positive lambd values, the range against which input values should be checked is `[-lambd;lambd]` for example `1 => [-1;1]`. For negative values, this range becomes inverted `[1;-1]` and some input values fall into multiple branches of the `if`.