### PR TITLE
Fix inconsistency in describing graph's initializer. 

### DIFF
--- a/docs/IR.md
+++ b/docs/IR.md
@@ -156,7 +156,7 @@ Graphs have the following properties:
 |---|---|---|
 name|string|The name of the model graph.
 node|Node[]|A list of nodes, forming a partially ordered computation graph based on input/output data dependencies.
-initializer|Tensor[]|A list of named tensor values, used to specify default values for some of the inputs of the graph. Each initializer value is associated with an input by name matching.
+initializer|Tensor[]|A list of named tensor values. When an initializer has the same name as a graph input, it specifies a default value for that input. When an initializer has a name different from all graph inputs, it specifies a constant value.
 doc_string|string|A human-readable documentation for this model. Markdown is allowed.
 input|ValueInfo[]|The input “parameters” of the graph, possibly initialized by a default value found in ‘initializer.’
 output|ValueInfo[]|The output parameters of the graph. Once all output parameters have been written to by a graph execution, the execution is complete.


### PR DESCRIPTION
This PR is to ensure the consistency on relations between graph's input and initializer.
Essentially, a graph's initializer is not required to be subset of the graph's input, and
any initializer not part of graph's input are considered constant definition in the graph.
