### PR TITLE
Fix the example and equivalent C code in the Loop's documentation.

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -6307,13 +6307,13 @@ expect(node, inputs=[x], outputs=[y],
   
       graph body-net (
         %i[INT32, scalar]
-        %keepgoing[BOOL, scalar]
-        %b[INT32, scalar]
+        %keepgoing_in[BOOL, scalar]
+        %b_in[INT32, scalar]
       ) {
-        %my_local = Add(%a, %b)
-        %b_out = Sub(%a, %b)
+        %my_local = Add(%a, %b_in)
+        %b_out = Sub(%a, %b_in)
         %keepgoing_out = Greater(%my_local, %b_out)
-        %user_defined_vals = Add(%b, %b)
+        %user_defined_vals = Add(%b_in, %b_in)
         return %keepgoing_out, %b_out, %user_defined_vals
       }
   
@@ -6329,12 +6329,14 @@ expect(node, inputs=[x], outputs=[y],
         const int max_trip_count = 10; // Analogous to input M
         int user_defined_vals[]; // Imagine this is resizable
         /* End implicitly-defined code */
+        int b_out = b;
         for (int i=0; i < max_trip_count && keepgoing; ++i) {
           /* User-defined code (loop body) */
           int my_local = a + b; // Reading values in the enclosing scope is fine
-          b = a - b; // writes fine if we specify b as a loop-carried dependency
-          keepgoing = my_local > b; // keepgoing is a loop-carried dependency
+          b_out = a - b; // writes fine if we specify b as a loop-carried dependency
+          keepgoing = my_local > b_out; // keepgoing is a loop-carried dependency
           user_defined_vals[i] = b + b;
+          b = b_out;
           /* End user-defined code */
         }
         // my_local = 123; // Can't do this. my_local was defined in the the body


### PR DESCRIPTION
- Change the formal parameter names to be different from the actual to avoid confusion.
- Fix the equivalent C code so that the C code is semantically equal to the ONNX code.

