### PR TITLE
Fix errors in RoiAlign shape inference code

### DIFF
--- a/onnx/defs/object_detection/defs.cc
+++ b/onnx/defs/object_detection/defs.cc
@@ -24,109 +24,107 @@ ONNX_OPERATOR_SET_SCHEMA(
     RoiAlign,
     10,
     OpSchema()
-      .SetDoc(RoiAlign_ver1_doc)
-      .Attr(
-          "spatial_scale",
-          "Multiplicative spatial scale factor to translate ROI coordinates "
-          "from their input spatial scale to the scale used when pooling, "
-          "i.e., spatial scale of the input feature map X relative to the "
-          "input image. E.g.; default is 1.0f. ",
-          AttributeProto::FLOAT,
-          1.f)
-      .Attr(
-          "output_height",
-          "default 1; Pooled output Y's height.",
-          AttributeProto::INT,
-          static_cast<int64_t>(1))
-      .Attr(
-          "output_width",
-          "default 1; Pooled output Y's width.",
-          AttributeProto::INT,
-          static_cast<int64_t>(1))
-      .Attr(
-          "sampling_ratio",
-          "Number of sampling points in the interpolation grid used to compute "
-          "the output value of each pooled output bin. If > 0, then exactly "
-          "sampling_ratio x sampling_ratio grid points are used. If == 0, then "
-          "an adaptive number of grid points are used (computed as "
-          "ceil(roi_width / output_width), and likewise for height). Default is 0.",
-          AttributeProto::INT,
-          static_cast<int64_t>(0))
-      .Attr(
-          "mode",
-          "The pooling method. Two modes are supported: 'avg' and 'max'. "
-          "Default is 'avg'.",
-          AttributeProto::STRING,
-          std::string("avg"))
-      .Input(
-          0,
-          "X",
-          "Input data tensor from the previous operator; "
-          "4-D feature map of shape (N, C, H, W), "
-          "where N is the batch size, C is the number of channels, "
-          "and H and W are the height and the width of the data.",
-          "T1")
-      .Input(
-          1,
-          "rois",
-          "RoIs (Regions of Interest) to pool over; rois is "
-          "2-D input of shape (num_rois, 4) given as "
-          "[[x1, y1, x2, y2], ...]. "
-          "The RoIs' coordinates are in the coordinate system of the input image. "
-          "Each coordinate set has a 1:1 correspondence with the 'batch_indices' input.",
-          "T1")
-      .Input(
-          2,
-          "batch_indices",
-          "1-D tensor of shape (num_rois,) with each element denoting "
-          "the index of the corresponding image in the batch.",
-          "T2")
-      .Output(
-          0,
-          "Y",
-          "RoI pooled output, 4-D tensor of shape "
-          "(num_rois, C, output_height, output_width). The r-th batch element Y[r-1] "
-          "is a pooled feature map corresponding to the r-th RoI X[r-1].",
-          "T1")
-      .TypeConstraint(
-          "T1",
-          {"tensor(float16)", "tensor(float)", "tensor(double)"},
-          "Constrain types to float tensors.")
-      .TypeConstraint(
-          "T2",
-          {"tensor(int64)"},
-          "Constrain types to int tensors.")
-      .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-        if (!hasNInputShapes(ctx, 3)) {
-          return;
-        }
-        propagateElemTypeFromInputToOutput(ctx, 0, 0);
+        .SetDoc(RoiAlign_ver1_doc)
+        .Attr(
+            "spatial_scale",
+            "Multiplicative spatial scale factor to translate ROI coordinates "
+            "from their input spatial scale to the scale used when pooling, "
+            "i.e., spatial scale of the input feature map X relative to the "
+            "input image. E.g.; default is 1.0f. ",
+            AttributeProto::FLOAT,
+            1.f)
+        .Attr(
+            "output_height",
+            "default 1; Pooled output Y's height.",
+            AttributeProto::INT,
+            static_cast<int64_t>(1))
+        .Attr(
+            "output_width",
+            "default 1; Pooled output Y's width.",
+            AttributeProto::INT,
+            static_cast<int64_t>(1))
+        .Attr(
+            "sampling_ratio",
+            "Number of sampling points in the interpolation grid used to compute "
+            "the output value of each pooled output bin. If > 0, then exactly "
+            "sampling_ratio x sampling_ratio grid points are used. If == 0, then "
+            "an adaptive number of grid points are used (computed as "
+            "ceil(roi_width / output_width), and likewise for height). Default is 0.",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Attr(
+            "mode",
+            "The pooling method. Two modes are supported: 'avg' and 'max'. "
+            "Default is 'avg'.",
+            AttributeProto::STRING,
+            std::string("avg"))
+        .Input(
+            0,
+            "X",
+            "Input data tensor from the previous operator; "
+            "4-D feature map of shape (N, C, H, W), "
+            "where N is the batch size, C is the number of channels, "
+            "and H and W are the height and the width of the data.",
+            "T1")
+        .Input(
+            1,
+            "rois",
+            "RoIs (Regions of Interest) to pool over; rois is "
+            "2-D input of shape (num_rois, 4) given as "
+            "[[x1, y1, x2, y2], ...]. "
+            "The RoIs' coordinates are in the coordinate system of the input image. "
+            "Each coordinate set has a 1:1 correspondence with the 'batch_indices' input.",
+            "T1")
+        .Input(
+            2,
+            "batch_indices",
+            "1-D tensor of shape (num_rois,) with each element denoting "
+            "the index of the corresponding image in the batch.",
+            "T2")
+        .Output(
+            0,
+            "Y",
+            "RoI pooled output, 4-D tensor of shape "
+            "(num_rois, C, output_height, output_width). The r-th batch element Y[r-1] "
+            "is a pooled feature map corresponding to the r-th RoI X[r-1].",
+            "T1")
+        .TypeConstraint(
+            "T1",
+            {"tensor(float16)", "tensor(float)", "tensor(double)"},
+            "Constrain types to float tensors.")
+        .TypeConstraint(
+            "T2",
+            {"tensor(int64)"},
+            "Constrain types to int tensors.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
 
-        auto& input_shape = getInputShape(ctx, 0);
-        auto& rois_shape = getInputShape(ctx, 1);
-        auto& batch_index_shape = getInputShape(ctx, 2);
-        auto* output_shape = getOutputShape(ctx, 0);
+          size_t input_param = 0, rois_param = 1, batch_index_param = 2;
 
-        if (input_shape.dim_size() != 4) {
-          fail_shape_inference("first input tensor has wrong dimension");
-        }
-        if (rois_shape.dim_size() != 2) {
-          fail_shape_inference("rois input tensor has wrong dimension");
-        }
-        if (batch_index_shape.dim_size() != 1) {
-          fail_shape_inference("batch_indices shape input tensor has wrong dimension");
-        }
+          checkInputRank(ctx, input_param, 4);
+          checkInputRank(ctx, rois_param, 2);
+          checkInputRank(ctx, batch_index_param, 1);
 
-        output_shape->clear_dim();
-        output_shape->add_dim()->set_dim_value(static_cast<int64_t>(
-          rois_shape.dim(0).dim_value()));
-        output_shape->add_dim()->set_dim_value(static_cast<int64_t>(
-          input_shape.dim(1).dim_value()));
-        output_shape->add_dim()->set_dim_value(
-          ctx.getAttribute("output_height")->i());
-        output_shape->add_dim()->set_dim_value(
-          ctx.getAttribute("output_width")->i());
-      }));
+          // Output dimensions, initialized to an unknown-dimension-value
+          Dim num_rois, C, ht, width;
+
+          // Get value of C from dim 1 of input_param, if available
+          unifyDim(ctx, input_param, 1, C);
+
+          // Get value of num_rois from dim 0 of rois_param, if available
+          unifyDim(ctx, rois_param, 0, num_rois);
+          // ... or from dim 0 of batch_index_param, if available
+          unifyDim(ctx, batch_index_param, 0, num_rois);
+
+          // Get height from attribute, using default-value of 1
+          unifyDim(ht, getAttribute(ctx, "output_height", 1));
+
+          // Get width from attribute, using default-value of 1
+          unifyDim(width, getAttribute(ctx, "output_width", 1));
+
+          // set output shape:
+          updateOutputShape(ctx, 0, {num_rois, C, ht, width});
+        }));
 
 static const char* NonMaxSuppression_doc = R"DOC(
 Filter out boxes that have high intersection-over-union (IOU) overlap with previously selected boxes.
@@ -186,8 +184,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             static_cast<int64_t>(0))
         .SetDoc(NonMaxSuppression_doc)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-            auto selected_indices_type = ctx.getOutputType(0)->mutable_tensor_type();
-            selected_indices_type->set_elem_type(::ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT64);
+          auto selected_indices_type =
+              ctx.getOutputType(0)->mutable_tensor_type();
+          selected_indices_type->set_elem_type(
+              ::ONNX_NAMESPACE::TensorProto_DataType::
+                  TensorProto_DataType_INT64);
         }));
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/object_detection/defs.cc
+++ b/onnx/defs/object_detection/defs.cc
@@ -109,12 +109,12 @@ ONNX_OPERATOR_SET_SCHEMA(
           Dim num_rois, C, ht, width;
 
           // Get value of C from dim 1 of input_param, if available
-          unifyDim(ctx, input_param, 1, C);
+          unifyInputDim(ctx, input_param, 1, C);
 
           // Get value of num_rois from dim 0 of rois_param, if available
-          unifyDim(ctx, rois_param, 0, num_rois);
+          unifyInputDim(ctx, rois_param, 0, num_rois);
           // ... or from dim 0 of batch_index_param, if available
-          unifyDim(ctx, batch_index_param, 0, num_rois);
+          unifyInputDim(ctx, batch_index_param, 0, num_rois);
 
           // Get height from attribute, using default-value of 1
           unifyDim(ht, getAttribute(ctx, "output_height", 1));

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -272,12 +272,6 @@ inline bool hasNInputShapes(InferenceContext& ctx, size_t n) {
   return true;
 }
 
-inline const TypeProto_Tensor& getInputTensorType(
-    InferenceContext& ctx,
-    size_t n) {
-  auto* type_proto = ctx.getInputType(n);
-}
-
 inline const TensorShapeProto& getInputShape(InferenceContext& ctx, size_t n) {
   return ctx.getInputType(n)->tensor_type().shape();
 }

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -645,10 +645,8 @@ static constexpr T narrow_cast(U&& u) noexcept {
   return static_cast<T>(std::forward<U>(u));
 }
 
-inline void checkInputRank(
-    InferenceContext& ctx,
-    size_t input_index,
-    size_t expected_rank) {
+inline void
+checkInputRank(InferenceContext& ctx, size_t input_index, int expected_rank) {
   // We check the rank only if a rank is known for the input:
   if (hasInputShape(ctx, input_index)) {
     auto rank = getInputShape(ctx, input_index).dim_size();

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -661,8 +661,52 @@ checkInputRank(InferenceContext& ctx, size_t input_index, int expected_rank) {
   }
 }
 
-inline void
-unifyDim(InferenceContext& ctx, size_t input_index, int dim_index, Dim& dim) {
+// Unification (between dimensions and/or shapes) is at the heart of
+// shape-inference. The current inference algorithm can check input
+// shapes/dimensions of a node and update the output shapes/dimensions. It
+// cannot currently update input shapes and dimensions (even though in some
+// contexts this inference is possible). Hence, we have the variants below to
+// support "const" and "mutable" dimensions/shapes in unification.
+
+inline void checkDimEquality(int64_t value1, int64_t value2) {
+  if (value1 != value2)
+    fail_shape_inference(
+        "Dimension mismatch in unification between ", value1, " and ", value2);
+}
+
+inline void unifyDim(const Dim& dim1, const Dim& dim2) {
+  if (dim1.has_dim_value() && dim2.has_dim_value())
+    checkDimEquality(dim1.dim_value(), dim2.dim_value());
+}
+
+// TODO: The functionality of unifyDim is similar to that of
+// mergeInDimensionInfo. However, the error messages are different. Leaving this
+// duplication in-place to preserve error message content.
+inline void unifyDim(const Dim& source_dim, Dim& target_dim) {
+  if (source_dim.has_dim_value()) {
+    auto source_value = source_dim.dim_value();
+    if (target_dim.has_dim_value()) {
+      auto target_value = target_dim.dim_value();
+      checkDimEquality(source_value, target_value);
+    } else {
+      target_dim.set_dim_value(source_value);
+    }
+  } else if (target_dim.has_dim_value()) {
+    // if target has a value we preserve it.
+    // we cannot set source dim value.
+  } else if (target_dim.has_dim_param()) {
+    // prefer target param over source
+    // we cannot currently unify the dim_params
+  } else if (source_dim.has_dim_param()) {
+    target_dim.set_dim_param(source_dim.dim_param());
+  }
+}
+
+inline void unifyInputDim(
+    InferenceContext& ctx,
+    size_t input_index,
+    int dim_index,
+    Dim& dim) {
   // We unify the dimensions only if it is available for specified input:
   if (hasInputShape(ctx, input_index)) {
     auto& input_shape = getInputShape(ctx, input_index);
@@ -677,7 +721,7 @@ unifyDim(InferenceContext& ctx, size_t input_index, int dim_index, Dim& dim) {
           input_shape.dim_size());
     const Dim& input_dim = input_shape.dim(dim_index);
     // Now, unify dim and input_dim:
-    mergeInDimensionInfo(input_dim, dim, dim_index);
+    unifyDim(input_dim, dim);
   }
 }
 
@@ -685,12 +729,7 @@ unifyDim(InferenceContext& ctx, size_t input_index, int dim_index, Dim& dim) {
 // already has a value, we check for equality of new value with old value.
 inline void unifyDim(Dim& dim, int64_t value) {
   if (dim.has_dim_value()) {
-    if (dim.dim_value() != value)
-      fail_shape_inference(
-          "Dimension mismatch in unification between ",
-          value,
-          " and ",
-          dim.dim_value());
+    checkDimEquality(dim.dim_value(), value);
   } else
     dim.set_dim_value(value);
 }

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -1980,5 +1980,14 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, ('num_rois', 'C', 1, 1))])  # type: ignore
 
+    def test_roialign_num_rois(self):   # type: () -> None
+        graph = self._make_graph(
+            [('x', TensorProto.FLOAT, ('N', 'C', 'H', 'W')),
+             ('rois', TensorProto.FLOAT, ('num_rois', 4)),
+             ('batch_indices', TensorProto.INT64, (15,))],
+            [make_node('RoiAlign', ['x', 'rois', 'batch_indices'], ['y'])],
+            [])
+        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (15, 'C', 1, 1))])  # type: ignore
+
 if __name__ == '__main__':
     unittest.main()

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -1962,12 +1962,12 @@ class TestShapeInference(unittest.TestCase):
                                           make_tensor_value_info('z', TensorProto.FLOAT, (4, 3))],
                                           opset_imports=[make_opsetid('ai.onnx.ml', 1), make_opsetid('', 11)])
 
-    def test_roialign_symbolic(self):  # type: () -> None
+    def test_roialign_symbolic(self):   # type: () -> None
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, ('N', 'C', 'H', 'W')),
-             ('rois', TensorProto.INT64, ('num_rois', 4)),
-             ('batch_indices', TensorProto.FLOAT, ('num_rois',))],
-            [make_node('RoiAlign', ['x', 'rois', 'batch_indices'], ['y'])],
+             ('rois', TensorProto.FLOAT, ('num_rois', 4)),
+             ('batch_indices', TensorProto.INT64, ('num_rois',))],
+            [make_node('RoiAlign', ['x', 'rois', 'batch_indices'], ['y'], output_height=1, output_width=1)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, ('num_rois', 'C', 1, 1))])  # type: ignore
 

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -1989,5 +1989,6 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (15, 'C', 1, 1))])  # type: ignore
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -1962,6 +1962,15 @@ class TestShapeInference(unittest.TestCase):
                                           make_tensor_value_info('z', TensorProto.FLOAT, (4, 3))],
                                           opset_imports=[make_opsetid('ai.onnx.ml', 1), make_opsetid('', 11)])
 
+    def test_roialign_symbolic(self):  # type: () -> None
+        graph = self._make_graph(
+            [('x', TensorProto.FLOAT, ('N', 'C', 'H', 'W')),
+             ('rois', TensorProto.INT64, ('num_rois', 4)),
+             ('batch_indices', TensorProto.FLOAT, ('num_rois',))],
+            [make_node('RoiAlign', ['x', 'rois', 'batch_indices'], ['y'])],
+            [])
+        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, ('num_rois', 'C', 1, 1))])  # type: ignore
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -1967,10 +1967,18 @@ class TestShapeInference(unittest.TestCase):
             [('x', TensorProto.FLOAT, ('N', 'C', 'H', 'W')),
              ('rois', TensorProto.FLOAT, ('num_rois', 4)),
              ('batch_indices', TensorProto.INT64, ('num_rois',))],
-            [make_node('RoiAlign', ['x', 'rois', 'batch_indices'], ['y'], output_height=1, output_width=1)],
+            [make_node('RoiAlign', ['x', 'rois', 'batch_indices'], ['y'], output_height=10, output_width=5)],
+            [])
+        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, ('num_rois', 'C', 10, 5))])  # type: ignore
+
+    def test_roialign_symbolic_defaults(self):   # type: () -> None
+        graph = self._make_graph(
+            [('x', TensorProto.FLOAT, ('N', 'C', 'H', 'W')),
+             ('rois', TensorProto.FLOAT, ('num_rois', 4)),
+             ('batch_indices', TensorProto.INT64, ('num_rois',))],
+            [make_node('RoiAlign', ['x', 'rois', 'batch_indices'], ['y'])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, ('num_rois', 'C', 1, 1))])  # type: ignore
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix errors in RoiAlign shape inference. The existing version has the following issues:
(a) It assumes that the attributes for height and width are present, but they are optional. This will cause a null-dereference.
(b) It assumes that the input-shape dimensions are all known values, but they could be unknown or symbolic dimensions. This will cause output dimensions to be inferred as zero incorrectly.

This PR also adds shape-inference-tests to catch above two issues.

This PR also adds some utility functions to help simplify writing shape-inference.
