### PR TITLE
specifying python 3.6 since python 3.7 does not work well with typing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
     - os: osx
       osx_image: xcode9.3
       env: PYTHON_VERSION=python3 ONNX_ML=0
+      python: "3.6"
     - os: linux
       sudo: required
       env: PYTHON_VERSION=python2
@@ -34,6 +35,7 @@ matrix:
     - os: osx
       osx_image: xcode9.3
       env: PYTHON_VERSION=python3
+      python: "3.6"
     - os: linux
       sudo: required
       env: PYTHON_VERSION=python2 LITE=1


### PR DESCRIPTION
CI for some spec update PR is failing with error 

" .....
   File "/Users/travis/virtualenv/lib/python3.7/site-packages/typing.py", line 1005, in __new__
      self._abc_registry = extra._abc_registry
  AttributeError: type object 'Callable' has no attribute '_abc_registry'"
  ......
"

this should be a very specific issue in python 3.7.
