### PR TITLE
Skip install typing package for python >=3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -286,7 +286,7 @@ install_requires.extend([
     'protobuf',
     'numpy',
     'six',
-    'typing>=3.6.4',
+    'typing>=3.6.4; python_version < "3.5"',
     'typing-extensions>=3.6.2.1',
 ])
 


### PR DESCRIPTION
No need to backport
https://github.com/python/typing/issues/573#issuecomment-405986724