### PR TITLE
Add check to disallow squeezing input axes which are not 1

### DIFF
--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -957,7 +957,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
           const auto& input_shape = ctx.getInputType(0)->tensor_type().shape();
 
-          for (int i = 0, j = 0; input_shape.dim_size(); ++i) {
+          for (int i = 0, j = 0; i < input_shape.dim_size(); ++i) {
             if (static_cast<size_t>(j) < axes.size() && axes[j] == i) {
                 if(input_shape.dim(i).has_dim_value() && input_shape.dim(i).dim_value() != 1) {
                     fail_shape_inference(

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -955,18 +955,24 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
 
           ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
+          const auto& input_shape = ctx.getInputType(0)->tensor_type().shape();
 
-          for (int i = 0, j = 0;
-               i < ctx.getInputType(0)->tensor_type().shape().dim_size();
-               ++i) {
+          for (int i = 0, j = 0; input_shape.dim_size(); ++i) {
             if (static_cast<size_t>(j) < axes.size() && axes[j] == i) {
+                if(input_shape.dim(i).has_dim_value() && input_shape.dim(i).dim_value() != 1) {
+                    fail_shape_inference(
+                        "Dimension of input ", 
+                        i, 
+                        " must be 1 instead of ", 
+                        input_shape.dim(i).dim_value());
+                }
               ++j;
             } else {
               *ctx.getOutputType(0)
                    ->mutable_tensor_type()
                    ->mutable_shape()
                    ->add_dim() =
-                  ctx.getInputType(0)->tensor_type().shape().dim(i);
+                  input_shape.dim(i);
             }
           }
         }));


### PR DESCRIPTION
Per the Squeeze op spec : "If an axis is selected with shape entry not equal to one, an error is raised." This check is not done in squeeze shape inference. Adding this PR to address this gap.

This issue is reported here: https://github.com/onnx/onnx/issues/1993