### PR TITLE
Fix testdata model for CumSum. Add exclusive attribute.

### DIFF
--- a/onnx/backend/test/data/node/test_cumsum_1d_reverse_exclusive/model.onnx
+++ b/onnx/backend/test/data/node/test_cumsum_1d_reverse_exclusive/model.onnx
@@ -1,7 +1,8 @@
-backend-test:~
-$
+backend-test:
+6
 x
-axisy"CumSum*
+axisy"CumSum*
+	exclusive *
 reverse  test_cumsum_1d_reverse_exclusiveZ
 x
 


### PR DESCRIPTION
The test data model in **test_cumsum_1d_reverse_exclusive** was missing the exclusive attribute value. Set this value to 1 in updated model.



