### PR TITLE
[WIP] Improve version converters documentation

### DIFF
--- a/docs/VersionConverter.md
+++ b/docs/VersionConverter.md
@@ -33,17 +33,17 @@ which accepts an input `ModelProto`, the initial opset version of the model,
 and the target opset verison, and which returns a new `ModelProto` which
 is the result of apply all relevant adapters between initial_version and
 target_version. For a list of available passes, see
-[convert.h](onnx/version_converter/convert.h).
+[convert.h](../onnx/version_converter/convert.h).
 
 ## Implementing Adapters
 
 You can implement a new adapter by subclassing `Adapter`, and registering
 your new adapter with `VersionConverter::registerAdapter()`. Adapters operate
-on an in-memory graph representation defined in [ir.h](onnx/common/ir.h).
-There are a number of examples in the [adapters](onnx/version_converter/adapters)
+on an in-memory graph representation defined in [ir.h](../onnx/common/ir.h).
+There are a number of examples in the [adapters](../onnx/version_converter/adapters)
 directory.  Please ensure that all adapters convert from opset version i to i + 1 
 or i - 1, i.e. from Version 6 to Version 5 or vice versa, even if the 2 versions
 being converted between are Version 1 and Version 6.
 
 If your adapter applies in the default domain, please consider adding it
-to the core ONNX repository
+to the core ONNX repository.


### PR DESCRIPTION
I'm about to start working on a version converter for #2284 and I've noticed a few mistakes in the docs for version converters, as well as some opportunities for improvements, so I'm opening this PR to work on them.

Here is the todo list:

1. *[Done]* fix the broken links in `VersionConverters.md`.
2. Add a small guide to developing a version converter. Including a link to a PR which is a good example.
3. Increase the visibility of the version converters documentation, for example by mentioning it in the [Operator versioning section of the Versions.md](https://github.com/onnx/onnx/blob/master/docs/Versioning.md#operator-versioning) doc.