### PR TITLE
Bump NMS version for avoiding regression in existing models

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -11876,6 +11876,52 @@ This version of the operator has been available since version 11 of the default 
 <dd>Constrain index tensor to int64</dd>
 </dl>
 
+### <a name="NonMaxSuppression-11"></a>**NonMaxSuppression-11**</a>
+
+  Filter out boxes that have high intersection-over-union (IOU) overlap with previously selected boxes.
+  Bounding boxes with score less than score_threshold are removed. Bounding box format is indicated by attribute center_point_box.
+  Note that this algorithm is agnostic to where the origin is in the coordinate system and more generally is invariant to
+  orthogonal transformations and translations of the coordinate system; thus translating or reflections of the coordinate system
+  result in the same boxes being selected by the algorithm.
+  The selected_indices output is a set of integers indexing into the input collection of bounding boxes representing the selected boxes.
+  The bounding box coordinates corresponding to the selected indices can then be obtained using the Gather or GatherND operation.
+
+#### Version
+
+This version of the operator has been available since version 11 of the default ONNX operator set.
+
+#### Attributes
+
+<dl>
+<dt><tt>center_point_box</tt> : int (default is 0)</dt>
+<dd>Integer indicate the format of the box data. The default is 0. 0 - the box data is supplied as [y1, x1, y2, x2] where (y1, x1) and (y2, x2) are the coordinates of any diagonal pair of box corners and the coordinates can be provided as normalized (i.e., lying in the interval [0, 1]) or absolute. Mostly used for TF models. 1 - the box data is supplied as [x_center, y_center, width, height]. Mostly used for Pytorch models.</dd>
+</dl>
+
+#### Inputs (2 - 5)
+
+<dl>
+<dt><tt>boxes</tt> : tensor(float)</dt>
+<dd>An input tensor with shape [num_batches, spatial_dimension, 4]. The single box data format is indicated by center_point_box.</dd>
+<dt><tt>scores</tt> : tensor(float)</dt>
+<dd>An input tensor with shape [num_batches, num_classes, spatial_dimension]</dd>
+<dt><tt>max_output_boxes_per_class</tt> (optional) : tensor(int64)</dt>
+<dd>Integer representing the maximum number of boxes to be selected per batch per class. It is a scalar. Default to 0, which means no output.</dd>
+<dt><tt>iou_threshold</tt> (optional) : tensor(float)</dt>
+<dd>Float representing the threshold for deciding whether boxes overlap too much with respect to IOU. It is scalar. Value range [0, 1]. Default to 0.</dd>
+<dt><tt>score_threshold</tt> (optional) : tensor(float)</dt>
+<dd>Float representing the threshold for deciding when to remove boxes based on score. It is a scalar.</dd>
+</dl>
+
+#### Outputs
+
+<dl>
+<dt><tt>selected_indices</tt> : tensor(int64)</dt>
+<dd>selected indices from the boxes tensor. [num_selected_indices, 3], the selected index format is [batch_index, class_index, box_index].</dd>
+</dl>
+
+#### Type Constraints
+
+
 ### <a name="OneHot-11"></a>**OneHot-11**</a>
 
   Produces a one-hot tensor based on inputs.

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -9376,7 +9376,9 @@ expect(node, inputs=[x], outputs=[y],
 
 #### Version
 
-This version of the operator has been available since version 10 of the default ONNX operator set.
+This version of the operator has been available since version 11 of the default ONNX operator set.
+
+Other versions of this operator: <a href="Changelog.md#NonMaxSuppression-10">NonMaxSuppression-10</a>
 
 #### Attributes
 

--- a/onnx/defs/object_detection/defs.cc
+++ b/onnx/defs/object_detection/defs.cc
@@ -138,7 +138,7 @@ The bounding box coordinates corresponding to the selected indices can then be o
 
 ONNX_OPERATOR_SET_SCHEMA(
     NonMaxSuppression,
-    10,
+    11,
     OpSchema()
         .Input(
             0,

--- a/onnx/defs/object_detection/old.cc
+++ b/onnx/defs/object_detection/old.cc
@@ -61,6 +61,13 @@ ONNX_OPERATOR_SET_SCHEMA(
             "1 - the box data is supplied as [x_center, y_center, width, height]. Mostly used for Pytorch models.",
             AttributeProto::INT,
             static_cast<int64_t>(0))
-        .SetDoc(NonMaxSuppression_doc));
+        .SetDoc(NonMaxSuppression_doc)
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          auto selected_indices_type =
+              ctx.getOutputType(0)->mutable_tensor_type();
+          selected_indices_type->set_elem_type(
+              ::ONNX_NAMESPACE::TensorProto_DataType::
+                  TensorProto_DataType_INT64);
+        }));
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/object_detection/old.cc
+++ b/onnx/defs/object_detection/old.cc
@@ -1,0 +1,66 @@
+// Copyright (c) Facebook Inc. and Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "onnx/defs/schema.h"
+using namespace ONNX_NAMESPACE;
+
+namespace ONNX_NAMESPACE {
+
+static const char* NonMaxSuppression_doc = R"DOC(
+Filter out boxes that have high intersection-over-union (IOU) overlap with previously selected boxes.
+Bounding boxes with score less than score_threshold are removed. Bounding box format is indicated by attribute center_point_box.
+Note that this algorithm is agnostic to where the origin is in the coordinate system and more generally is invariant to
+orthogonal transformations and translations of the coordinate system; thus translating or reflections of the coordinate system
+result in the same boxes being selected by the algorithm.
+The selected_indices output is a set of integers indexing into the input collection of bounding boxes representing the selected boxes.
+The bounding box coordinates corresponding to the selected indices can then be obtained using the Gather or GatherND operation.
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(
+    NonMaxSuppression,
+    10,
+    OpSchema()
+        .Input(
+            0,
+            "boxes",
+            "An input tensor with shape [num_batches, spatial_dimension, 4]. The single box data format is indicated by center_point_box.",
+            "tensor(float)")
+        .Input(
+            1,
+            "scores",
+            "An input tensor with shape [num_batches, num_classes, spatial_dimension]",
+            "tensor(float)")
+        .Input(
+            2,
+            "max_output_boxes_per_class",
+            "Integer representing the maximum number of boxes to be selected per batch per class. It is a scalar. Default to 0, which means no output.",
+            "tensor(int64)",
+            OpSchema::Optional)
+        .Input(
+            3,
+            "iou_threshold",
+            "Float representing the threshold for deciding whether boxes overlap too much with respect to IOU. It is scalar. Value range [0, 1]. Default to 0.",
+            "tensor(float)",
+            OpSchema::Optional)
+        .Input(
+            4,
+            "score_threshold",
+            "Float representing the threshold for deciding when to remove boxes based on score. It is a scalar.",
+            "tensor(float)",
+            OpSchema::Optional)
+        .Output(
+            0,
+            "selected_indices",
+            "selected indices from the boxes tensor. [num_selected_indices, 3], the selected index format is [batch_index, class_index, box_index].",
+            "tensor(int64)")
+        .Attr(
+            "center_point_box",
+            "Integer indicate the format of the box data. The default is 0. "
+            "0 - the box data is supplied as [y1, x1, y2, x2] where (y1, x1) and (y2, x2) are the coordinates of any diagonal pair of box corners "
+            "and the coordinates can be provided as normalized (i.e., lying in the interval [0, 1]) or absolute. Mostly used for TF models. "
+            "1 - the box data is supplied as [x_center, y_center, width, height]. Mostly used for Pytorch models.",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .SetDoc(NonMaxSuppression_doc));
+
+} // namespace ONNX_NAMESPACE

--- a/onnx/defs/operator_sets.h
+++ b/onnx/defs/operator_sets.h
@@ -633,6 +633,7 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, SplitToSequence);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, ConcatFromSequence);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, Pad);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, Gemm);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, NonMaxSuppression);
 
 // Iterate over schema from ai.onnx version 11
 class OpSet_Onnx_ver11 {
@@ -702,6 +703,7 @@ class OpSet_Onnx_ver11 {
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, ConcatFromSequence)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, Pad)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, Gemm)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, NonMaxSuppression)>());
   }
 };
 


### PR DESCRIPTION
In opset 10, NMS doesn't produce shape. With the newly added shape inference function, some existing models can be broken due to the interaction between NSM and IF nodes (IF's then branch and else branch produce different shapes). Thus, I feel it'd be better to bump the version of NMS so that old code can still work with old models.

Because shape inference produces side information for a model, if we consider side information a part of the spec, we also need to bump operator's version each time we add a shape inference function.