### PR TITLE
Remove typing packages from test requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -301,8 +301,6 @@ setup_requires.append('pytest-runner')
 tests_require.append('pytest')
 tests_require.append('nbval')
 tests_require.append('tabulate')
-tests_require.append('typing')
-tests_require.append('typing-extensions')
 
 if sys.version_info[0] == 3:
     # Mypy doesn't work with Python 2


### PR DESCRIPTION
The requirement is already part of the install_requires so this is redundant. (It should only be required for python_version < 3.5 in any case.)

This was causing me some trouble packaging Onnx for [Nixpkgs](https://github.com/NixOS/nixpkgs).