### PR TITLE
Clarify SplitToSequence default value for Input split

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -13584,7 +13584,7 @@ This version of the operator has been available since version 11 of the default 
 <dt><tt>input</tt> : T</dt>
 <dd>The tensor to split</dd>
 <dt><tt>split</tt> (optional) : I</dt>
-<dd>Length of each output. It can be either a scalar(tensor of empty shape), or a 1-D tensor. All values must be positive. </dd>
+<dd>Length of each output. It can be either a scalar(tensor of empty shape), or a 1-D tensor. All values must be positive. It is optional and default to a scalar of value 1. </dd>
 </dl>
 
 #### Outputs

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -16922,7 +16922,7 @@ This version of the operator has been available since version 11 of the default 
 <dt><tt>input</tt> : T</dt>
 <dd>The tensor to split</dd>
 <dt><tt>split</tt> (optional) : I</dt>
-<dd>Length of each output. It can be either a scalar(tensor of empty shape), or a 1-D tensor. All values must be positive. </dd>
+<dd>Length of each output. It can be either a scalar(tensor of empty shape), or a 1-D tensor. All values must be positive. It is optional and default to a scalar of value 1. </dd>
 </dl>
 
 #### Outputs

--- a/onnx/defs/sequence/defs.cc
+++ b/onnx/defs/sequence/defs.cc
@@ -347,7 +347,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "split",
             "Length of each output. "
             "It can be either a scalar(tensor of empty shape), or a 1-D tensor. "
-            "All values must be positive. ",
+            "All values must be positive. "
+            "It is optional and default to a scalar of value 1. ",
             "I",
             OpSchema::Optional)
         .Output(


### PR DESCRIPTION
Fixing #2396. This logic was missing in the spec, and was only present in shape inferencing/test cases. 