### PR TITLE
Fix Windows py3.5 CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,6 +52,12 @@ before_build:
   (
   set "PATH=%PATH%;%CONDA_PREFIX%\Library\bin"
   )
+
+  IF "%_prefix%"=="C:\Miniconda35"
+  (
+  pip install --quiet "ipython<7.10"
+  )
+
 - cmd: pip install --quiet pytest nbval numpy
 
 build_script:


### PR DESCRIPTION
https://ci.appveyor.com/project/onnx/onnx/builds/29586926/job/0cx9q6ffptkye0cm

>ImportError: 
IPython 7.10+ supports Python 3.6 and above.
When using Python 2.7, please install IPython 5.x LTS Long Term Support version.
Python 3.3 and 3.4 were supported up to IPython 6.x.
Python 3.5 was supported with IPython 7.0 to 7.9.
See IPython `README.rst` file for more information:
