### PR TITLE
Update ManagingExperimentalOps.md to include deprecated operators table

### DIFF
--- a/docs/ManagingExperimentalOps.md
+++ b/docs/ManagingExperimentalOps.md
@@ -1,4 +1,22 @@
-## [Deprecated - as of v1.5 experimental ops are no longer supported]
+## Deprecated Experimental Operators
+
+The following experimental operators were deprecated and removed from ONNX. They should be removed from models, either substituted with newer superseding operators or decomposed into functionally equivalent operators:
+
+Old operator        |New Operator
+--------------------|--------------------------
+`ATen`              |NA
+`Affine`            |`Add(Mul(X, alpha), beta)`
+`ConstantFill`      |`ConstantOfShape`
+`Crop`              |`Slice-1`
+`DynamicSlice`      |`Slice-10`
+`GRUUnit`           |NA
+`GivenTensorFill`   |`Const` or `ConstantOfShape`
+`ImageScaler`       |`Add(Mul(X, scale), Unsqueeze(bias, axes=[0, 2, 3]))`
+`ParametricSoftplus`|`Mul(alpha, Softplus(Mul(beta, X)))`
+`Scale`             |`Mul(X, scale)`
+`ScaledTanh`        |`Mul(Tanh(Mul(X, beta)), alpha)`
+
+## Adding Experimental Operators [Deprecated - as of v1.5 experimental ops are no longer supported]
 
 The experimental flag in ONNX operator definitions indicates that a customer of ONNX may not be able to take a long term dependency on that op. Ops in the ONNX namespace (ai.onnx) in the _master_ branch, whether experimental or not, go through the regular review process. 
 


### PR DESCRIPTION
The 1.6 release missed adding a row for opset 11 to the table.

Many experimental operators were removed from ONNX, including dozens used in client models for published applications, which now cause warnings to be written to the console in check_node. e.g. "Warning: Affine was a removed experimental op. In the future, we may directly reject this operator...". These warnings provide no guidance on what to do though, and they're confusing to the user given frameworks like ONNX Runtime continue to support these operators anyway for backwards compatibility. Since this is related to versioning, I'm proposing to document the guidance here (note we can't it in Operators.md because these operators don't exist anymore, and we can't include it in ChangeLog.md either because all records of these operators were removed).

Part of issue #2239.