### PR TITLE
Fix circleci build and drop unsupported Windows builds

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -26,7 +26,7 @@ if [[ "${CIRCLE_JOB}" =~ py((2|3)\.?[0-9]?\.?[0-9]?) ]]; then
 fi
 $PYTHON -m virtualenv "$VENV_DIR"
 source "$VENV_DIR/bin/activate"
-pip install -U pip=19 setuptools
+pip install -U pip==19 setuptools
 
 # setup onnx as the submodule of pytorch
 PYTORCH_DIR=/tmp/pytorch

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -26,7 +26,7 @@ if [[ "${CIRCLE_JOB}" =~ py((2|3)\.?[0-9]?\.?[0-9]?) ]]; then
 fi
 $PYTHON -m virtualenv "$VENV_DIR"
 source "$VENV_DIR/bin/activate"
-pip install -U pip setuptools
+pip install -U pip=19 setuptools
 
 # setup onnx as the submodule of pytorch
 PYTORCH_DIR=/tmp/pytorch

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,15 +17,10 @@ environment:
     ONNX_NAMESPACE: ONNX_NAMESPACE_FOO_BAR_FOR_CI
 
   matrix:
-  - CONDA_PREFIX: C:\Miniconda35-x64
-    ONNX_VERIFY_PROTO3: 1
-
   - CONDA_PREFIX: C:\Miniconda36-x64
     ONNX_VERIFY_PROTO3: 1
 
   - CONDA_PREFIX: C:\Miniconda36
-
-  - CONDA_PREFIX: C:\Miniconda35
 
   - CONDA_PREFIX: C:\Miniconda37-x64
 
@@ -38,24 +33,12 @@ before_build:
 - cmd: SET PATH=%CONDA_PREFIX%;%CONDA_PREFIX%\Scripts;%PATH%
 - cmd: SET _prefix=%CONDA_PREFIX:~0,14%
 - cmd: SET _arch=%CONDA_PREFIX:~15,18%
+- cmd: conda install -y -c conda-forge libprotobuf=3.9.2 numpy
 - >
-  IF "%_arch%"=="x64"
-  (
-  conda install -y -c conda-forge libprotobuf=3.5.2=he51fdeb_1 numpy
-  )
-  ELSE
-  (
-  conda install -y -c conda-forge libprotobuf=3.5.2=vc14_0 numpy
-  )
 
   IF "%_prefix%"=="C:\Miniconda37"
   (
   set "PATH=%PATH%;%CONDA_PREFIX%\Library\bin"
-  )
-
-  IF "%_prefix%"=="C:\Miniconda35"
-  (
-  pip install --quiet "ipython<7.10"
   )
 
 - cmd: pip install --quiet pytest nbval numpy

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,6 +47,7 @@ build_script:
 # Build and test onnx.
 - cmd: cd c:\projects\onnx
 - cmd: set ONNX_BUILD_TESTS=1
+- cmd: set CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=ON"
 - cmd: python setup.py --quiet bdist_wheel --universal --dist-dir .
 - cmd: dir /s /b /a-d "onnx_gtests.exe" >UT.txt & set /p _UT= < UT.txt & %_UT%
 - cmd: dir /b /a-d "*.whl" >WheelFile.txt & set /p _wheel= < WheelFile.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ before_build:
 - cmd: SET PATH=%CONDA_PREFIX%;%CONDA_PREFIX%\Scripts;%PATH%
 - cmd: SET _prefix=%CONDA_PREFIX:~0,14%
 - cmd: SET _arch=%CONDA_PREFIX:~15,18%
-- cmd: conda install -y -c conda-forge libprotobuf=3.9.2 numpy
+- cmd: conda install -y -c conda-forge libprotobuf=3.9.2
 - >
 
   IF "%_prefix%"=="C:\Miniconda37"


### PR DESCRIPTION
For circleci, `nijna` cannot be installed with `pip>=20`, so we switch to `pip=19`. Anaconda doesn't have packages for `protobuf=3.9.2`  when `python=3.5`, so we drop python 3.5 Windows builds. I don't know if this is a long-term solution, but at least I can unblock myself with them.