### PR TITLE
Implement CELU node as a Function

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -14041,6 +14041,48 @@ This version of the operator has been available since version 12 of the default 
 <dd>Constrain input 'training_mode' types to boolean tensors.</dd>
 </dl>
 
+### <a name="Celu-12"></a>**Celu-12**</a>
+
+  Continuously Differentiable Exponential Linear Units:
+         Perform the linear unit element-wise on the input tensor X
+         using formula: <br/> ``` max(0,x) + min(0,alpha*(exp(x/alpha)−1)) ```
+
+#### Version
+
+This version of the operator has been available since version 12 of the default ONNX operator set.
+
+#### Attributes
+
+<dl>
+<dt><tt>alpha</tt> : float (default is 1.0)</dt>
+<dd>The Alpha value in Celu formula which control the shape of the unit. The default value is 1.0.</dd>
+</dl>
+
+#### Inputs
+
+<dl>
+<dt><tt>X</tt> : T</dt>
+<dd>Input tensor</dd>
+</dl>
+
+#### Outputs
+
+<dl>
+<dt><tt>Y</tt> : T</dt>
+<dd>Output tensor</dd>
+</dl>
+
+#### Type Constraints
+
+<dl>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
+<dd>Constrain input and output types to floating-point tensors.</dd>
+</dl>
+
+#### Function
+
+The Function can be represented as a function.
+
 ### <a name="Constant-12"></a>**Constant-12**</a>
 
   This operator produces a constant tensor. Exactly one of the provided attributes, either value, sparse_value,

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -14079,10 +14079,6 @@ This version of the operator has been available since version 12 of the default 
 <dd>Constrain input and output types to floating-point tensors.</dd>
 </dl>
 
-#### Function
-
-The Function can be represented as a function.
-
 ### <a name="Constant-12"></a>**Constant-12**</a>
 
   This operator produces a constant tensor. Exactly one of the provided attributes, either value, sparse_value,

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -159,12 +159,8 @@
   * <a href="#Where">Where</a>
   * <a href="#Xor">Xor</a>
 
-<<<<<<< HEAD
   **Functions**
-=======
-  **Operators with function registered:**
   * <a href="#Celu">Celu</a>
->>>>>>> Udapte docs
   * <a href="#DynamicQuantizeLinear">DynamicQuantizeLinear</a>
   * <a href="#MeanVarianceNormalization">MeanVarianceNormalization</a>
   * <a href="#NegativeLogLikelihoodLoss">NegativeLogLikelihoodLoss</a>
@@ -2428,10 +2424,6 @@ This version of the operator has been available since version 12 of the default 
 <dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
 <dd>Constrain input and output types to floating-point tensors.</dd>
 </dl>
-
-#### Function
-
-The Function can be represented as a function.
 
 
 #### Examples

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -159,7 +159,12 @@
   * <a href="#Where">Where</a>
   * <a href="#Xor">Xor</a>
 
+<<<<<<< HEAD
   **Functions**
+=======
+  **Operators with function registered:**
+  * <a href="#Celu">Celu</a>
+>>>>>>> Udapte docs
   * <a href="#DynamicQuantizeLinear">DynamicQuantizeLinear</a>
   * <a href="#MeanVarianceNormalization">MeanVarianceNormalization</a>
   * <a href="#NegativeLogLikelihoodLoss">NegativeLogLikelihoodLoss</a>
@@ -2381,6 +2386,85 @@ x = np.random.randn(3, 4, 5).astype(np.float32)
 y = np.ceil(x)
 expect(node, inputs=[x], outputs=[y],
        name='test_ceil')
+```
+
+</details>
+
+
+### <a name="Celu"></a><a name="celu">**Celu**</a>
+
+  Continuously Differentiable Exponential Linear Units:
+         Perform the linear unit element-wise on the input tensor X
+         using formula: <br/> ``` max(0,x) + min(0,alpha*(exp(x/alpha)−1)) ```
+
+#### Version
+
+This version of the operator has been available since version 12 of the default ONNX operator set.
+
+#### Attributes
+
+<dl>
+<dt><tt>alpha</tt> : float (default is 1.0)</dt>
+<dd>The Alpha value in Celu formula which control the shape of the unit. The default value is 1.0.</dd>
+</dl>
+
+#### Inputs
+
+<dl>
+<dt><tt>X</tt> : T</dt>
+<dd>Input tensor</dd>
+</dl>
+
+#### Outputs
+
+<dl>
+<dt><tt>Y</tt> : T</dt>
+<dd>Output tensor</dd>
+</dl>
+
+#### Type Constraints
+
+<dl>
+<dt><tt>T</tt> : tensor(float16), tensor(float), tensor(double)</dt>
+<dd>Constrain input and output types to floating-point tensors.</dd>
+</dl>
+
+#### Function
+
+The Function can be represented as a function.
+
+
+#### Examples
+
+<details>
+<summary>celu</summary>
+
+```python
+node = onnx.helper.make_node(
+    'Celu',
+    inputs=['X'],
+    outputs=['Y']
+)
+
+input_data = np.array([[[[0.8439683], [0.5665144], [0.05836735]],
+    [[0.02916367], [0.12964272], [0.5060197]],
+    [[0.79538304], [0.9411346], [0.9546573]]],
+    [[[0.17730942], [0.46192095], [0.26480448]],
+    [[0.6746842], [0.01665257], [0.62473077]],
+    [[0.9240844], [0.9722341], [0.11965699]]],
+    [[[0.41356155], [0.9129373], [0.59330076]],
+    [[0.81929934], [0.7862604], [0.11799799]],
+    [[0.69248444], [0.54119414], [0.07513223]]]], dtype=np.float32)
+
+alpha = 2
+
+# Calculate expected output data
+positive_input = np.maximum(0, input_data)
+negative_input = np.minimum(0, alpha * (np.exp(input_data / alpha) - 1))
+expected_output = positive_input + negative_input
+
+expect(node, inputs=[input_data], outputs=[expected_output],
+       name='test_celu')
 ```
 
 </details>

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -5,7 +5,7 @@
 * [Overall Test Coverage](#overall-test-coverage)
 # Node Test Coverage
 ## Summary
-Node tests have covered 138/153 (90.20%, 5 generators excluded) common operators.
+Node tests have covered 139/154 (90.26%, 5 generators excluded) common operators.
 
 Node tests have covered 0/0 (N/A) experimental operators.
 
@@ -1438,6 +1438,42 @@ x = np.random.randn(3, 4, 5).astype(np.float32)
 y = np.ceil(x)
 expect(node, inputs=[x], outputs=[y],
        name='test_ceil')
+```
+
+</details>
+
+
+### Celu
+There are 1 test cases, listed as following:
+<details>
+<summary>celu</summary>
+
+```python
+node = onnx.helper.make_node(
+    'Celu',
+    inputs=['X'],
+    outputs=['Y']
+)
+
+input_data = np.array([[[[0.8439683], [0.5665144], [0.05836735]],
+    [[0.02916367], [0.12964272], [0.5060197]],
+    [[0.79538304], [0.9411346], [0.9546573]]],
+    [[[0.17730942], [0.46192095], [0.26480448]],
+    [[0.6746842], [0.01665257], [0.62473077]],
+    [[0.9240844], [0.9722341], [0.11965699]]],
+    [[[0.41356155], [0.9129373], [0.59330076]],
+    [[0.81929934], [0.7862604], [0.11799799]],
+    [[0.69248444], [0.54119414], [0.07513223]]]], dtype=np.float32)
+
+alpha = 2
+
+# Calculate expected output data
+positive_input = np.maximum(0, input_data)
+negative_input = np.minimum(0, alpha * (np.exp(input_data / alpha) - 1))
+expected_output = positive_input + negative_input
+
+expect(node, inputs=[input_data], outputs=[expected_output],
+       name='test_celu')
 ```
 
 </details>

--- a/onnx/backend/test/case/node/celu.py
+++ b/onnx/backend/test/case/node/celu.py
@@ -34,7 +34,7 @@ class Celu(Base):
 
         # Calculate expected output data
         positive_input = np.max(0, input_data)
-        negative_input = np.min(0, alpha * np.exp(input_data / alpha) - 1)
+        negative_input = np.min(0, alpha * (np.exp(input_data / alpha) - 1))
         expected_output = positive_input + negative_input
 
         expect(node, inputs=[input_data], outputs=[expected_output],

--- a/onnx/backend/test/case/node/celu.py
+++ b/onnx/backend/test/case/node/celu.py
@@ -33,8 +33,8 @@ class Celu(Base):
         alpha = 2
 
         # Calculate expected output data
-        positive_input = np.max(0, input_data)
-        negative_input = np.min(0, alpha * (np.exp(input_data / alpha) - 1))
+        positive_input = np.maximum(0, input_data)
+        negative_input = np.minimum(0, alpha * (np.exp(input_data / alpha) - 1))
         expected_output = positive_input + negative_input
 
         expect(node, inputs=[input_data], outputs=[expected_output],

--- a/onnx/backend/test/case/node/celu.py
+++ b/onnx/backend/test/case/node/celu.py
@@ -1,0 +1,41 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import numpy as np  # type: ignore
+
+import onnx
+from ..base import Base
+from . import expect
+
+
+class Celu(Base):
+
+    @staticmethod
+    def export():  # type: () -> None
+        node = onnx.helper.make_node(
+            'Celu',
+            inputs=['X'],
+            outputs=['Y']
+        )
+
+        input_data = np.array([[[[0.8439683], [0.5665144], [0.05836735]],
+            [[0.02916367], [0.12964272], [0.5060197]],
+            [[0.79538304], [0.9411346], [0.9546573]]],
+            [[[0.17730942], [0.46192095], [0.26480448]],
+            [[0.6746842], [0.01665257], [0.62473077]],
+            [[0.9240844], [0.9722341], [0.11965699]]],
+            [[[0.41356155], [0.9129373], [0.59330076]],
+            [[0.81929934], [0.7862604], [0.11799799]],
+            [[0.69248444], [0.54119414], [0.07513223]]]], dtype=np.float32)
+
+        alpha = 2
+
+        # Calculate expected output data
+        positive_input = np.max(0, input_data)
+        negative_input = np.min(0, alpha * np.exp(input_data / alpha) - 1)
+        expected_output = positive_input + negative_input
+
+        expect(node, inputs=[input_data], outputs=[expected_output],
+               name='test_celu')

--- a/onnx/defs/attr_proto_util.h
+++ b/onnx/defs/attr_proto_util.h
@@ -38,7 +38,7 @@ AttributeProto MakeAttribute(
 
 // Make a "reference" attribute for a node in a function body.
 // <attr_name> specifies the attribute name of both the function node and its
-// function body node. They're using same attribute name.
+// function body node. They're using the same attribute name.
 // <type> specifies the attribute type.
 AttributeProto MakeRefAttribute(
     const std::string& attr_name,
@@ -47,7 +47,8 @@ AttributeProto MakeRefAttribute(
 // Make a "reference" attribute for a node in a function body.
 // <attr_name> specifies the attribute name of the function body node.
 // <referred_attr_name> specifies the referred attribute name of the function
-// node. <type> specifies the attribute type.
+// node.
+// <type> specifies the attribute type.
 AttributeProto MakeRefAttribute(
     const std::string& attr_name,
     const std::string& referred_attr_name,

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -403,6 +403,38 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Constrain input and output types to float tensors.")
         .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
+static const char* celu_ver12_doc = R"DOC(
+       Continuously Differentiable Exponential Linear Units:
+       Perform the linear unit element-wise on the input tensor X
+       using formula: <br/> ``` max(0,x) + min(0,alpha*(exp(x/alpha)−1)) ```
+)DOC";
+
+static float celu_default_alpha = 1.0;
+
+ONNX_OPERATOR_SET_SCHEMA(
+    Celu,
+    12,
+    OpSchema()
+       .SetDoc(celu_ver12_doc)
+       .Input(0, "X", "Input tensor", "T")
+       .Output(0, "Y", "Output tensor", "T")
+       .Attr(
+           "alpha",
+           "The Alpha value in Celu formula which control the shape of "
+           "the unit. The default value is 1.0.",
+           AttributeProto::FLOAT,
+           celu_default_alpha)
+       .TypeConstraint(
+           "T",
+           {"tensor(float16)", "tensor(float)", "tensor(double)"},
+           "Constrain input and output types to floating-point tensors.")
+       .FunctionBody(FunctionBodyHelper::BuildNodes(
+           {// nodes: {outputs, op, inputs, attributes}
+            FunctionBodyHelper::NodeDef{{"alpha"}, "Constant", {}, {MakeRefAttribute("value_float", "alpha", AttributeProto::FLOAT)}},
+            {{"X_alpha"}, "Div", {"X", "alpha"}},
+            {{"Elu_Result"}, "Elu", {"X_alpha"}, {{"alpha", 1.f}}},
+            {{"Y"}, "Mul", {"alpha", "Elu_Result"}}})));
+
 static const char* Exp_ver6_doc = R"DOC(
 Calculates the exponential of the given input tensor, element-wise.
 )DOC";

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -2216,11 +2216,14 @@ ONNX_OPERATOR_SET_SCHEMA(
            "Constrain input and output types to floating-point tensors.")
        .FunctionBody(FunctionBodyHelper::BuildNodes(
            {// nodes: {outputs, op, inputs, attributes}
+            //FunctionBodyHelper::NodeDef{{"alpha"}, "Constant", {}, {{"value", 1.f}}},
+	    //FunctionBodyHelper::Const<float>("alpha", 1.0f),
+            //FunctionBodyHelper::Const<float>("Y", 1.0f),
+	    FunctionBodyHelper::NodeDef{{"Y"}, "Constant", {}, {MakeRefAttribute("value", AttributeProto::FLOAT, "alpha")}},
             {{"X_alpha"},
              "Div",
-             {"X"},
-             {MakeRefAttribute("alpha", AttributeProto::FLOAT)}
-	    },
-            {{"Y"}, "Elu", {"X_alpha"}}})));
+             {"X", "alpha"}
+            },
+            {{"U"}, "Elu", {"X_alpha"}}})));
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -2218,7 +2218,7 @@ ONNX_OPERATOR_SET_SCHEMA(
            {// nodes: {outputs, op, inputs, attributes}
             {{"X_alpha"},
              "Div",
-             {"X", "alpha"},
+             {"X", "alpha"}
 	    },
             {{"Y"}, "Elu", {"X_alpha"}}})));
 

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -2216,19 +2216,9 @@ ONNX_OPERATOR_SET_SCHEMA(
            "Constrain input and output types to floating-point tensors.")
        .FunctionBody(FunctionBodyHelper::BuildNodes(
            {// nodes: {outputs, op, inputs, attributes}
-	    // How can we create a constant node `alpha` containing the value of
-            // the attribute `alpha` as a Tensor and not a scalar?
-            // The following (commented) line do not work:
-	    // FunctionBodyHelper::NodeDef{{"alpha"}, "Constant", {}, {MakeRefAttribute("value", AttributeProto::FLOAT, "alpha")}},
-	    FunctionBodyHelper::Const<float>("alpha", 2.f),
-	    FunctionBodyHelper::Const<float>("zero", 0),
-            FunctionBodyHelper::Const<float>("one", 1.f),
-	    {{"Positive"}, "Max", {"zero", "X"}},
-	    {{"X_alpha"}, "Div", {"X", "alpha"}},
-	    {{"Exponential"}, "Exp", {"X_alpha"}},
-	    {{"A"}, "Sub", {"Exponential", "one"}},
-	    {{"B"}, "Mul", {"A", "alpha"}},
-	    {{"Negative"}, "Max", {"zero", "B"}},
-	    {{"Y"}, "Add", {"Negative", "Positive"}}})));
+            FunctionBodyHelper::NodeDef{{"alpha"}, "Constant", {}, {MakeRefAttribute("value_float", "alpha", AttributeProto::FLOAT)}},
+            {{"X_alpha"}, "Div", {"X", "alpha"}},
+            {{"Elu_Result"}, "Elu", {"X_alpha"}, {{"alpha", 1.f}}},
+            {{"Y"}, "Mul", {"alpha", "Elu_Result"}}})));
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -2189,4 +2189,37 @@ ONNX_OPERATOR_SET_SCHEMA(
              {{"Processed_STD"}, "Add", {"STD", "Epsilon"}},
              {{"Y"}, "Div", {"X_variance", "Processed_STD"}}})));
 
+static const char* celu_ver11_doc = R"DOC(
+       Continuously Differentiable Exponential Linear Units:
+       Perform the linear unit element-wise on the input tensor X
+       using formula: <br/> ``` max(0,x) + min(0,α*(exp(x/α)−1)) ```
+)DOC";
+
+static float celu_default_alpha = 1.0;
+
+ONNX_OPERATOR_SET_SCHEMA(
+    Celu,
+    11,
+    OpSchema()
+       .SetDoc(celu_ver11_doc)
+       .Input(0, "X", "Input tensor", "T")
+       .Output(0, "Y", "Output tensor", "T")
+       .Attr(
+           "alpha",
+           "The Alpha value in Celu formula which control the shape of "
+           "the unit. The default value is 1.0.",
+           AttributeProto::FLOAT,
+           celu_default_alpha)
+       .TypeConstraint(
+           "T",
+           {"tensor(float16)", "tensor(float)", "tensor(double)"},
+           "Constrain input and output types to all numeric tensors.")
+       .FunctionBody(FunctionBodyHelper::BuildNodes(
+           {// nodes: {outputs, op, inputs, attributes}
+            {{"X_alpha"},
+             "Div",
+             {"X", "alpha"},
+	    },
+            {{"Y"}, "Elu", {"X_alpha"}}})));
+
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -2189,36 +2189,4 @@ ONNX_OPERATOR_SET_SCHEMA(
              {{"Processed_STD"}, "Add", {"STD", "Epsilon"}},
              {{"Y"}, "Div", {"X_variance", "Processed_STD"}}})));
 
-static const char* celu_ver12_doc = R"DOC(
-       Continuously Differentiable Exponential Linear Units:
-       Perform the linear unit element-wise on the input tensor X
-       using formula: <br/> ``` max(0,x) + min(0,alpha*(exp(x/alpha)−1)) ```
-)DOC";
-
-static float celu_default_alpha = 1.0;
-
-ONNX_OPERATOR_SET_SCHEMA(
-    Celu,
-    12,
-    OpSchema()
-       .SetDoc(celu_ver12_doc)
-       .Input(0, "X", "Input tensor", "T")
-       .Output(0, "Y", "Output tensor", "T")
-       .Attr(
-           "alpha",
-           "The Alpha value in Celu formula which control the shape of "
-           "the unit. The default value is 1.0.",
-           AttributeProto::FLOAT,
-           celu_default_alpha)
-       .TypeConstraint(
-           "T",
-           {"tensor(float16)", "tensor(float)", "tensor(double)"},
-           "Constrain input and output types to floating-point tensors.")
-       .FunctionBody(FunctionBodyHelper::BuildNodes(
-           {// nodes: {outputs, op, inputs, attributes}
-            FunctionBodyHelper::NodeDef{{"alpha"}, "Constant", {}, {MakeRefAttribute("value_float", "alpha", AttributeProto::FLOAT)}},
-            {{"X_alpha"}, "Div", {"X", "alpha"}},
-            {{"Elu_Result"}, "Elu", {"X_alpha"}, {{"alpha", 1.f}}},
-            {{"Y"}, "Mul", {"alpha", "Elu_Result"}}})));
-
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -2189,7 +2189,7 @@ ONNX_OPERATOR_SET_SCHEMA(
              {{"Processed_STD"}, "Add", {"STD", "Epsilon"}},
              {{"Y"}, "Div", {"X_variance", "Processed_STD"}}})));
 
-static const char* celu_ver11_doc = R"DOC(
+static const char* celu_ver12_doc = R"DOC(
        Continuously Differentiable Exponential Linear Units:
        Perform the linear unit element-wise on the input tensor X
        using formula: <br/> ``` max(0,x) + min(0,α*(exp(x/α)−1)) ```
@@ -2199,9 +2199,9 @@ static float celu_default_alpha = 1.0;
 
 ONNX_OPERATOR_SET_SCHEMA(
     Celu,
-    11,
+    12,
     OpSchema()
-       .SetDoc(celu_ver11_doc)
+       .SetDoc(celu_ver12_doc)
        .Input(0, "X", "Input tensor", "T")
        .Output(0, "Y", "Output tensor", "T")
        .Attr(

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -2213,7 +2213,7 @@ ONNX_OPERATOR_SET_SCHEMA(
        .TypeConstraint(
            "T",
            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-           "Constrain input and output types to all numeric tensors.")
+           "Constrain input and output types to floating-point tensors.")
        .FunctionBody(FunctionBodyHelper::BuildNodes(
            {// nodes: {outputs, op, inputs, attributes}
             {{"X_alpha"},

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -2218,7 +2218,8 @@ ONNX_OPERATOR_SET_SCHEMA(
            {// nodes: {outputs, op, inputs, attributes}
             {{"X_alpha"},
              "Div",
-             {"X", "alpha"}
+             {"X"},
+             {MakeRefAttribute("alpha", AttributeProto::FLOAT)}
 	    },
             {{"Y"}, "Elu", {"X_alpha"}}})));
 

--- a/onnx/defs/operator_sets.h
+++ b/onnx/defs/operator_sets.h
@@ -635,6 +635,7 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, Pad);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, Gemm);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, If);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, NonMaxSuppression);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, Celu);
 
 // Iterate over schema from ai.onnx version 11
 class OpSet_Onnx_ver11 {
@@ -706,6 +707,7 @@ class OpSet_Onnx_ver11 {
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, Gemm)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, If)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, NonMaxSuppression)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, Celu)>());
   }
 };
 

--- a/onnx/defs/operator_sets.h
+++ b/onnx/defs/operator_sets.h
@@ -635,7 +635,6 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, Pad);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, Gemm);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, If);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, NonMaxSuppression);
-class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, Celu);
 
 // Iterate over schema from ai.onnx version 11
 class OpSet_Onnx_ver11 {
@@ -707,7 +706,6 @@ class OpSet_Onnx_ver11 {
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, Gemm)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, If)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, NonMaxSuppression)>());
-    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 11, Celu)>());
   }
 };
 
@@ -722,6 +720,7 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 12, NegativeLogLikelihoodLoss);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 12, Dropout);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 12, BatchNormalization);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 12, Constant);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 12, Celu);
 
 // Iterate over schema from ai.onnx version 12
 class OpSet_Onnx_ver12 {
@@ -737,6 +736,7 @@ class OpSet_Onnx_ver12 {
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 12, Dropout)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 12, BatchNormalization)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 12, Constant)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 12, Celu)>());
   }
 };
 

--- a/onnx/shape_inference/implementation.cc
+++ b/onnx/shape_inference/implementation.cc
@@ -336,7 +336,9 @@ void InferShapeForFunctionNode(
     for (auto attr : n.attribute()) {
       if (attr.has_ref_attr_name()) {
         if (attr_map.count(attr.ref_attr_name())) {
-          copy_n.add_attribute()->CopyFrom(*attr_map[attr.ref_attr_name()]);
+          auto copy_attr = *attr_map[attr.ref_attr_name()];
+          copy_attr.set_name(attr.name());
+          copy_n.add_attribute()->CopyFrom(std::move(copy_attr));
         }
       } else {
         copy_n.add_attribute()->CopyFrom(attr);

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -2993,6 +2993,14 @@ class TestShapeInference(unittest.TestCase):
             [])
         self.assertRaises(checker.ValidationError, self._inferred, graph)
 
+    def test_celu_function_output_shape(self):  # type: () -> None
+        graph = self._make_graph(
+            [('X', TensorProto.FLOAT, (25, 48, 16, 16))],
+            [make_node('Celu', 'X', 'Y', alpha=2.0)],
+            []
+        )
+        self._assert_inferred(graph, [make_tensor_value_info('Y', TensorProto.FLOAT, (25, 48, 16, 16))])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -2996,7 +2996,7 @@ class TestShapeInference(unittest.TestCase):
     def test_celu_function_output_shape(self):  # type: () -> None
         graph = self._make_graph(
             [('X', TensorProto.FLOAT, (25, 48, 16, 16))],
-            [make_node('Celu', 'X', 'Y', alpha=2.0)],
+            [make_node('Celu', ['X'], ['Y'], alpha=2.0)],
             []
         )
         self._assert_inferred(graph, [make_tensor_value_info('Y', TensorProto.FLOAT, (25, 48, 16, 16))])


### PR DESCRIPTION
I had a look at your guidelines and tutorial for adding missing op according to https://github.com/onnx/onnx/issues/1121#issuecomment-519319483 .

# Description:

The CELU operator has been required at this issue https://github.com/onnx/onnx/issues/1121 and is now part of the new operator request list https://github.com/onnx/onnx/issues/1646 .

First introduced in [Continuously Differentiable Exponential Linear Units](https://arxiv.org/abs/1704.07483) the CELU is similar to the ELU operation.

Given the attribute α, CELU is a pointwise application of the following formula:
```
CELU(x)=max(0,x)+min(0,α*(exp(x/α)−1))
```
and allow `leakage` of the gradient in the negative values, while having a differential remaining continuous for any value of alpha (which is not the case of ELU).

It is [implemented in Pytorch](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/Activation.cpp) based on the Pytorch-ELU operation:
```
Tensor celu(const Tensor & self, Scalar alpha) {
  double inv_alpha = 1. / alpha.to<double>();
  return at::elu(self, alpha, Scalar(1.0), Scalar(inv_alpha));
}
```
A similar approach for ONNX-ELU is `alpha * ELU(x / alpha, alpha=1)`.

An alternative implementation in numpy, not requiring the Pytorch-ELU operator is given in the tests:
```
import numpy as np

input_data = np.random.randn(1, 2, 3)
alpha = 2

positive_input = np.maximum(0, input_data)
negative_input = np.minimum(0, alpha * (np.exp(input_data / alpha) - 1))
output_data = positive_input + negative_input
```

A first implementation was intended in https://github.com/onnx/onnx/pull/1676 but never merged.

# Graph
The CELU function is implemented using the expression `alpha * ELU(x / alpha, alpha=1)`. This make the graph smaller (and easier to read) than using each individual functions (sum, dub, div, exp, mult) present in the expression of the operator. It also leverage good supports of `Elu in most onnx backend implementations.

# Tests
A unit test and a shape inference test are available following the tests of `MeanVarianceNormalization` function.