### PR TITLE
allow attribute type to be float, floats, int, ints, string, strings

### DIFF
--- a/docs/IR.md
+++ b/docs/IR.md
@@ -366,7 +366,7 @@ _Historical Notes_: The following extensions were considered early on, but were 
 
 ### Attribute Types
 
-The type system used for attributes is a superset of that used for of inputs and outputs. In addition to tensors, attribute values may be scalar numerical values, strings, and graphs. Sequences are available for attributes in both ONNX and ONNX-ML. Maps are not available for attributes in either variant. 
+The type system used for attributes is a superset of that used for of inputs and outputs. In addition to dense and sparse tensors, attribute values may be scalar numerical values, strings, and graphs. Scalar numerical values and strings （INT/INTS, FLOAT/FLOATS, STRING/STRINGS) are compatible with dense tensor. Operator which is defined with "TENSOR" attribute can work with these 6 scalar types. Sequences and Maps are not available for attributes in either variant. 
 
 ## Other Specification Documents 
 

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -48,69 +48,72 @@ ONNX_OPERATOR_SET_SCHEMA(
             switch (attr_type) {
               case AttributeProto_AttributeType::
                   AttributeProto_AttributeType_FLOAT:
-                ctx.getOutputType()->mutable_tensor_type()->set_elem_type(
+                ctx.getOutputType(0)->mutable_tensor_type()->set_elem_type(
                     TensorProto::DataType::TensorProto_DataType_FLOAT);
-                ctx.getOutputType()
+                ctx.getOutputType(0)
                     ->mutable_tensor_type()
                     ->mutable_shape()
                     ->clear_dim();
                 break;
               case AttributeProto_AttributeType::
                   AttributeProto_AttributeType_INT:
-                ctx.getOutputType()->mutable_tensor_type()->set_elem_type(
+                ctx.getOutputType(0)->mutable_tensor_type()->set_elem_type(
                     TensorProto::DataType::TensorProto_DataType_INT32);
-                ctx.getOutputType()
+                ctx.getOutputType(0)
                     ->mutable_tensor_type()
                     ->mutable_shape()
                     ->clear_dim();
                 break;
               case AttributeProto_AttributeType::
                   AttributeProto_AttributeType_STRING:
-                ctx.getOutputType()->mutable_tensor_type()->set_elem_type(
+                ctx.getOutputType(0)->mutable_tensor_type()->set_elem_type(
                     TensorProto::DataType::TensorProto_DataType_STRING);
-                ctx.getOutputType()
+                ctx.getOutputType(0)
                     ->mutable_tensor_type()
                     ->mutable_shape()
                     ->clear_dim();
                 break;
               case AttributeProto_AttributeType::
                   AttributeProto_AttributeType_FLOATS:
-                ctx.getOutputType()->mutable_tensor_type()->set_elem_type(
+                ctx.getOutputType(0)->mutable_tensor_type()->set_elem_type(
                     TensorProto::DataType::TensorProto_DataType_FLOAT);
-                ctx.getOutputType()
+                ctx.getOutputType(0)
                     ->mutable_tensor_type()
                     ->mutable_shape()
                     ->clear_dim();
-                ctx.getOutputType()
+                ctx.getOutputType(0)
                     ->mutable_tensor_type()
                     ->mutable_shape()
-                    ->add_dim(value->floats_size());
+                    ->add_dim()
+                    ->set_dim_value(value->floats_size());
                 break;
               case AttributeProto_AttributeType::
                   AttributeProto_AttributeType_INTS:
-                ctx.getOutputType()->mutable_tensor_type()->set_elem_type(
+                ctx.getOutputType(0)->mutable_tensor_type()->set_elem_type(
                     TensorProto::DataType::TensorProto_DataType_INT32);
-                ctx.getOutputType()
+                ctx.getOutputType(0)
                     ->mutable_tensor_type()
                     ->mutable_shape()
                     ->clear_dim();
-                ctx.getOutputType()
+                ctx.getOutputType(0)
                     ->mutable_tensor_type()
                     ->mutable_shape()
-                    ->add_dim(value->ints_size());
+                    ->add_dim()
+                    ->set_dim_value(value->ints_size());
                 break;
               case AttributeProto_AttributeType::
                   AttributeProto_AttributeType_STRINGS:
-                ctx.getOutputType()->mutable_tensor_type()->set_elem_type(
+                ctx.getOutputType(0)->mutable_tensor_type()->set_elem_type(
                     TensorProto::DataType::TensorProto_DataType_STRING);
-                ctx.getOutputType()
+                ctx.getOutputType(0)
                     ->mutable_tensor_type()
                     ->mutable_shape()
                     ->clear_dim();
-                ctx.getOutputType()
+                ctx.getOutputType(0)
                     ->mutable_tensor_type()
                     ->mutable_shape()
-                    ->add_dim(value->strings_size());
+                    ->add_dim()
+                    ->set_dim_value(value->strings_size());
                 break;
               case AttributeProto_AttributeType::
                   AttributeProto_AttributeType_TENSOR: {

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -44,10 +44,86 @@ ONNX_OPERATOR_SET_SCHEMA(
                 "Only one of the attributes 'value' or 'sparse_value' must be specified for a Constant node.");
 
           if (nullptr != value) {
-            // OpSchema::Verify check ensures that the attribute value has_t():
-            const TensorProto& tensor_proto = value->t();
-            updateOutputElemType(ctx, 0, tensor_proto.data_type());
-            updateOutputShape(ctx, 0, tensor_proto);
+            auto attr_type = value->type();
+            switch (attr_type) {
+              case AttributeProto_AttributeType::
+                  AttributeProto_AttributeType_FLOAT:
+                ctx.getOutputType()->mutable_tensor_type()->set_elem_type(
+                    TensorProto::DataType::TensorProto_DataType_FLOAT);
+                ctx.getOutputType()
+                    ->mutable_tensor_type()
+                    ->mutable_shape()
+                    ->clear_dim();
+                break;
+              case AttributeProto_AttributeType::
+                  AttributeProto_AttributeType_INT:
+                ctx.getOutputType()->mutable_tensor_type()->set_elem_type(
+                    TensorProto::DataType::TensorProto_DataType_INT32);
+                ctx.getOutputType()
+                    ->mutable_tensor_type()
+                    ->mutable_shape()
+                    ->clear_dim();
+                break;
+              case AttributeProto_AttributeType::
+                  AttributeProto_AttributeType_STRING:
+                ctx.getOutputType()->mutable_tensor_type()->set_elem_type(
+                    TensorProto::DataType::TensorProto_DataType_STRING);
+                ctx.getOutputType()
+                    ->mutable_tensor_type()
+                    ->mutable_shape()
+                    ->clear_dim();
+                break;
+              case AttributeProto_AttributeType::
+                  AttributeProto_AttributeType_FLOATS:
+                ctx.getOutputType()->mutable_tensor_type()->set_elem_type(
+                    TensorProto::DataType::TensorProto_DataType_FLOAT);
+                ctx.getOutputType()
+                    ->mutable_tensor_type()
+                    ->mutable_shape()
+                    ->clear_dim();
+                ctx.getOutputType()
+                    ->mutable_tensor_type()
+                    ->mutable_shape()
+                    ->add_dim(value->floats_size());
+                break;
+              case AttributeProto_AttributeType::
+                  AttributeProto_AttributeType_INTS:
+                ctx.getOutputType()->mutable_tensor_type()->set_elem_type(
+                    TensorProto::DataType::TensorProto_DataType_INT32);
+                ctx.getOutputType()
+                    ->mutable_tensor_type()
+                    ->mutable_shape()
+                    ->clear_dim();
+                ctx.getOutputType()
+                    ->mutable_tensor_type()
+                    ->mutable_shape()
+                    ->add_dim(value->ints_size());
+                break;
+              case AttributeProto_AttributeType::
+                  AttributeProto_AttributeType_STRINGS:
+                ctx.getOutputType()->mutable_tensor_type()->set_elem_type(
+                    TensorProto::DataType::TensorProto_DataType_STRING);
+                ctx.getOutputType()
+                    ->mutable_tensor_type()
+                    ->mutable_shape()
+                    ->clear_dim();
+                ctx.getOutputType()
+                    ->mutable_tensor_type()
+                    ->mutable_shape()
+                    ->add_dim(value->strings_size());
+                break;
+              case AttributeProto_AttributeType::
+                  AttributeProto_AttributeType_TENSOR: {
+                // OpSchema::Verify check ensures that the attribute value
+                // has_t():
+                const TensorProto& tensor_proto = value->t();
+                updateOutputElemType(ctx, 0, tensor_proto.data_type());
+                updateOutputShape(ctx, 0, tensor_proto);
+                break;
+              }
+              default:
+                break;
+            }
             return;
           }
 

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -97,58 +97,83 @@ OpSchemaRegistry* OpSchemaRegistry::Instance() {
 void OpSchema::CheckInputOutputType(struct InferenceContext& ctx) const {
   std::unordered_map<std::string, std::string> type_constraints;
   // check all input types
-  for (size_t in_idx = 0; in_idx < ctx.getNumInputs() && in_idx < inputs_.size(); ++in_idx) {
-    const auto& param      = inputs_[in_idx];
-    const auto& type_str   = param.GetTypeStr();
+  for (size_t in_idx = 0;
+       in_idx < ctx.getNumInputs() && in_idx < inputs_.size();
+       ++in_idx) {
+    const auto& param = inputs_[in_idx];
+    const auto& type_str = param.GetTypeStr();
     const auto& param_type = ctx.getInputType(in_idx);
-    const auto& all_types  = param.GetTypes();
-    if (nullptr == param_type || param_type->value_case() == TypeProto::VALUE_NOT_SET) {
+    const auto& all_types = param.GetTypes();
+    if (nullptr == param_type ||
+        param_type->value_case() == TypeProto::VALUE_NOT_SET) {
       continue;
-    } else if (!all_types.empty() && all_types.find(Utils::DataTypeUtils::ToType(*param_type)) == all_types.end()) {
-      fail_check(param.GetName(), " typestr: ", type_str, ", has unsupported type: ", *Utils::DataTypeUtils::ToType(*param_type));
+    } else if (
+        !all_types.empty() &&
+        all_types.find(Utils::DataTypeUtils::ToType(*param_type)) ==
+            all_types.end()) {
+      fail_check(
+          param.GetName(),
+          " typestr: ",
+          type_str,
+          ", has unsupported type: ",
+          *Utils::DataTypeUtils::ToType(*param_type));
     }
     if (param.GetIsHomogeneous()) {
       const auto& type_proto = Utils::DataTypeUtils::ToType(*param_type);
       if (type_constraints.find(type_str) == type_constraints.end()) {
         type_constraints[type_str] = *type_proto;
       } else if (type_constraints[type_str] != *type_proto) {
-        fail_check(param.GetName(), " has inconsistent type ", *Utils::DataTypeUtils::ToType(*param_type));
+        fail_check(
+            param.GetName(),
+            " has inconsistent type ",
+            *Utils::DataTypeUtils::ToType(*param_type));
       }
     }
-  }//for inputs
-  //check all output types
-  for (size_t out_idx = 0; out_idx < ctx.getNumOutputs() && out_idx < outputs_.size(); ++out_idx) {
-    const auto& param      = outputs_[out_idx];
-    const auto& type_str   = param.GetTypeStr();
+  } // for inputs
+  // check all output types
+  for (size_t out_idx = 0;
+       out_idx < ctx.getNumOutputs() && out_idx < outputs_.size();
+       ++out_idx) {
+    const auto& param = outputs_[out_idx];
+    const auto& type_str = param.GetTypeStr();
     const auto& param_type = ctx.getOutputType(out_idx);
-    const auto& all_types  = param.GetTypes();
+    const auto& all_types = param.GetTypes();
     bool output_type_found = true;
-    //infer type if necessary
+    // infer type if necessary
     if (param_type->value_case() == TypeProto::VALUE_NOT_SET) {
       if (all_types.size() == 1) {
         *param_type = Utils::DataTypeUtils::ToTypeProto(*all_types.begin());
       } else if (type_constraints.find(type_str) != type_constraints.end()) {
-        auto data_type = Utils::DataTypeUtils::ToType(type_constraints[type_str]);
+        auto data_type =
+            Utils::DataTypeUtils::ToType(type_constraints[type_str]);
         *param_type = Utils::DataTypeUtils::ToTypeProto(data_type);
       } else {
         output_type_found = false;
-      } 
+      }
     }
     if (!output_type_found) {
       continue;
     }
-    if (!all_types.empty() && all_types.find(Utils::DataTypeUtils::ToType(*param_type)) == all_types.end()) {
-      fail_check(param.GetName(), " has unsupported type ", *Utils::DataTypeUtils::ToType(*param_type));
+    if (!all_types.empty() &&
+        all_types.find(Utils::DataTypeUtils::ToType(*param_type)) ==
+            all_types.end()) {
+      fail_check(
+          param.GetName(),
+          " has unsupported type ",
+          *Utils::DataTypeUtils::ToType(*param_type));
     }
     if (param.GetIsHomogeneous()) {
       const auto& type_proto = Utils::DataTypeUtils::ToType(*param_type);
       if (type_constraints.find(type_str) == type_constraints.end()) {
         type_constraints[type_str] = *type_proto;
       } else if (type_constraints[type_str] != *type_proto) {
-        fail_check(param.GetName(), " has inconsistent type ", *Utils::DataTypeUtils::ToType(*param_type));
+        fail_check(
+            param.GetName(),
+            " has inconsistent type ",
+            *Utils::DataTypeUtils::ToType(*param_type));
       }
-    }//else
-  }//for outputs
+    } // else
+  } // for outputs
 }
 
 void OpSchema::Verify(const NodeProto& node) const {
@@ -288,10 +313,27 @@ void OpSchema::Verify(const NodeProto& node) const {
           "Unrecognized attribute: ", name, " for operator ", node.op_type());
     }
 
-   // Type would be UNDEFINED if not set
+    // Type would be UNDEFINED if not set
     if (attr_proto.type() != expected_type) {
-      fail_check(
-          "Mismatched attribute type in '", node.name() + " : " + name, "'");
+      // Expected attribute type is "Tensor", in this case, "FLOAT", "FLOATS",
+      // "INT", "INTS", "STRING", "STRINGS" should be also OK.
+      if (AttributeProto_AttributeType::AttributeProto_AttributeType_TENSOR !=
+              expected_type ||
+          (AttributeProto_AttributeType::AttributeProto_AttributeType_FLOAT !=
+               attr_proto.type() &&
+           AttributeProto_AttributeType::AttributeProto_AttributeType_FLOATS !=
+               attr_proto.type() &&
+           AttributeProto_AttributeType::AttributeProto_AttributeType_INT !=
+               attr_proto.type() &&
+           AttributeProto_AttributeType::AttributeProto_AttributeType_INTS !=
+               attr_proto.type() &&
+           AttributeProto_AttributeType::AttributeProto_AttributeType_STRING !=
+               attr_proto.type() &&
+           AttributeProto_AttributeType::AttributeProto_AttributeType_STRINGS !=
+               attr_proto.type())) {
+        fail_check(
+            "Mismatched attribute type in '", node.name() + " : " + name, "'");
+      }
     }
 
     // ref_attr_name is only valid when non-empty

--- a/onnx/onnx-ml.proto
+++ b/onnx/onnx-ml.proto
@@ -597,3 +597,7 @@ message OperatorSetIdProto {
   // This field MUST be present in this version of the IR.
   optional int64 version = 2;
 }
+
+// For using protobuf-lite
+option optimize_for = LITE_RUNTIME;
+

--- a/onnx/onnx-ml.proto
+++ b/onnx/onnx-ml.proto
@@ -92,7 +92,11 @@ enum Version {
   // - Add support for sparse tensor constants stored in model.
   //   - Add message SparseTensorProto
   //   - Add sparse initializers
-  IR_VERSION = 0x0000000000000006;
+  IR_VERSION_2019_9_19 = 0x0000000000000006;
+  
+  // IR VERSION 7 published on Feb 5, 2020
+  // - Add support for allowing feeding scalar attributes to an operator which asks for "Tensor" attribute.
+  IR_VERSION = 0x0000000000000007;
 }
 
 // Attributes
@@ -593,7 +597,3 @@ message OperatorSetIdProto {
   // This field MUST be present in this version of the IR.
   optional int64 version = 2;
 }
-
-// For using protobuf-lite
-option optimize_for = LITE_RUNTIME;
-

--- a/onnx/onnx-ml.proto3
+++ b/onnx/onnx-ml.proto3
@@ -92,7 +92,11 @@ enum Version {
   // - Add support for sparse tensor constants stored in model.
   //   - Add message SparseTensorProto
   //   - Add sparse initializers
-  IR_VERSION = 0x0000000000000006;
+  IR_VERSION_2019_9_19 = 0x0000000000000006;
+  
+  // IR VERSION 7 published on Feb 5, 2020
+  // - Add support for allowing feeding scalar attributes to an operator which asks for "Tensor" attribute.
+  IR_VERSION = 0x0000000000000007;
 }
 
 // Attributes
@@ -593,7 +597,3 @@ message OperatorSetIdProto {
   // This field MUST be present in this version of the IR.
   int64 version = 2;
 }
-
-// For using protobuf-lite
-option optimize_for = LITE_RUNTIME;
-

--- a/onnx/onnx-ml.proto3
+++ b/onnx/onnx-ml.proto3
@@ -597,3 +597,7 @@ message OperatorSetIdProto {
   // This field MUST be present in this version of the IR.
   int64 version = 2;
 }
+
+// For using protobuf-lite
+option optimize_for = LITE_RUNTIME;
+

--- a/onnx/onnx.in.proto
+++ b/onnx/onnx.in.proto
@@ -89,7 +89,7 @@ enum Version {
   // - Add support for sparse tensor constants stored in model.
   //   - Add message SparseTensorProto
   //   - Add sparse initializers
-  IR_VERSION = 0x0000000000000006;
+  IR_VERSION_2019_9_19 = 0x0000000000000006;
   
   // IR VERSION 7 published on Feb 5, 2020
   // - Add support for allowing feeding scalar attributes to an operator which asks for "Tensor" attribute.

--- a/onnx/onnx.in.proto
+++ b/onnx/onnx.in.proto
@@ -90,6 +90,10 @@ enum Version {
   //   - Add message SparseTensorProto
   //   - Add sparse initializers
   IR_VERSION = 0x0000000000000006;
+  
+  // IR VERSION 7 published on Feb 5, 2020
+  // - Add support for allowing feeding scalar attributes to an operator which asks for "Tensor" attribute.
+  IR_VERSION = 0x0000000000000007;
 }
 
 // Attributes

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -90,7 +90,11 @@ enum Version {
   // - Add support for sparse tensor constants stored in model.
   //   - Add message SparseTensorProto
   //   - Add sparse initializers
-  IR_VERSION = 0x0000000000000006;
+  IR_VERSION_2019_9_19 = 0x0000000000000006;
+  
+  // IR VERSION 7 published on Feb 5, 2020
+  // - Add support for allowing feeding scalar attributes to an operator which asks for "Tensor" attribute.
+  IR_VERSION = 0x0000000000000007;
 }
 
 // Attributes

--- a/onnx/onnx.proto3
+++ b/onnx/onnx.proto3
@@ -90,7 +90,11 @@ enum Version {
   // - Add support for sparse tensor constants stored in model.
   //   - Add message SparseTensorProto
   //   - Add sparse initializers
-  IR_VERSION = 0x0000000000000006;
+  IR_VERSION_2019_9_19 = 0x0000000000000006;
+  
+  // IR VERSION 7 published on Feb 5, 2020
+  // - Add support for allowing feeding scalar attributes to an operator which asks for "Tensor" attribute.
+  IR_VERSION = 0x0000000000000007;
 }
 
 // Attributes


### PR DESCRIPTION
allow attribute type to be float, floats, int, ints, string, strings when expected attribute type is tensor. This will ask a IR version bump, I think.