### PR TITLE
Allow Constant operator to promote scalar and list to tensors.

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -12168,7 +12168,7 @@ This version of the operator has been available since version 11 of the default 
 
 ### <a name="Range-11"></a>**Range-11**</a>
 
-  Generate a tensor containing a sequence of numbers that begin at `start` and extends by increments of `delta` 
+  Generate a tensor containing a sequence of numbers that begin at `start` and extends by increments of `delta`
   up to `limit` (exclusive).
   
   The number of elements in the output of range is computed as below-
@@ -12180,10 +12180,10 @@ This version of the operator has been available since version 11 of the default 
   `for(int i=0; i<number_of_elements; ++i)`
   
   `{`
-     
-  `    output[i] =  start + (i * delta);  ` 
   
-  `}`	
+  `    output[i] =  start + (i * delta);  `
+  
+  `}`
   
   `Example 1`
   Inputs: start = 3, limit = 9, delta = 3
@@ -14051,6 +14051,53 @@ This version of the operator has been available since version 12 of the default 
 <dd>Constrain input and output types to float tensors.</dd>
 <dt><tt>T1</tt> : tensor(bool)</dt>
 <dd>Constrain input 'training_mode' types to boolean tensors.</dd>
+</dl>
+
+### <a name="Constant-12"></a>**Constant-12**</a>
+
+  This operator produces a constant tensor. Exactly one of the provided attributes, either value, sparse_value,
+  or value_* must be specified.
+
+#### Version
+
+This version of the operator has been available since version 12 of the default ONNX operator set.
+
+#### Attributes
+
+<dl>
+<dt><tt>sparse_value</tt> : sparse_tensor</dt>
+<dd>The value for the elements of the output tensor in sparse format.</dd>
+<dt><tt>value</tt> : tensor</dt>
+<dd>The value for the elements of the output tensor.</dd>
+<dt><tt>value_float</tt> : float</dt>
+<dd>The value for the sole element for the scalar, float32, output tensor.</dd>
+<dt><tt>value_floats</tt> : list of floats</dt>
+<dd>The values for the elements for the 1D, float32, output tensor.</dd>
+<dt><tt>value_int</tt> : int</dt>
+<dd>The value for the sole element for the scalar, int64, output tensor.</dd>
+<dt><tt>value_ints</tt> : list of ints</dt>
+<dd>The values for the elements for the 1D, int64, output tensor.</dd>
+<dt><tt>value_string</tt> : string</dt>
+<dd>The value for the sole element for the scalar, UTF-8 string, output tensor.</dd>
+<dt><tt>value_strings</tt> : list of strings</dt>
+<dd>The values for the elements for the 1D, UTF-8 string, output tensor.</dd>
+</dl>
+
+#### Inputs
+
+
+#### Outputs
+
+<dl>
+<dt><tt>output</tt> : T</dt>
+<dd>Output tensor containing the same value of the provided tensor.</dd>
+</dl>
+
+#### Type Constraints
+
+<dl>
+<dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128)</dt>
+<dd>Constrain input and output types to all tensor types.</dd>
 </dl>
 
 ### <a name="Dropout-12"></a>**Dropout-12**</a>

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -2791,14 +2791,14 @@ This version of the operator has been available since version 11 of the default 
 
 ### <a name="Constant"></a><a name="constant">**Constant**</a>
 
-  A constant tensor. Exactly one of the two attributes, either value or sparse_value,
-  must be specified.
+  This operator produces a constant tensor. Exactly one of the provided attributes, either value, sparse_value,
+  or value_* must be specified.
 
 #### Version
 
-This version of the operator has been available since version 11 of the default ONNX operator set.
+This version of the operator has been available since version 12 of the default ONNX operator set.
 
-Other versions of this operator: <a href="Changelog.md#Constant-1">Constant-1</a>, <a href="Changelog.md#Constant-9">Constant-9</a>
+Other versions of this operator: <a href="Changelog.md#Constant-1">Constant-1</a>, <a href="Changelog.md#Constant-9">Constant-9</a>, <a href="Changelog.md#Constant-11">Constant-11</a>
 
 #### Attributes
 
@@ -2807,6 +2807,18 @@ Other versions of this operator: <a href="Changelog.md#Constant-1">Constant-1</a
 <dd>The value for the elements of the output tensor in sparse format.</dd>
 <dt><tt>value</tt> : tensor</dt>
 <dd>The value for the elements of the output tensor.</dd>
+<dt><tt>value_float</tt> : float</dt>
+<dd>The value for the sole element for the scalar, float32, output tensor.</dd>
+<dt><tt>value_floats</tt> : list of floats</dt>
+<dd>The values for the elements for the 1D, float32, output tensor.</dd>
+<dt><tt>value_int</tt> : int</dt>
+<dd>The value for the sole element for the scalar, int64, output tensor.</dd>
+<dt><tt>value_ints</tt> : list of ints</dt>
+<dd>The values for the elements for the 1D, int64, output tensor.</dd>
+<dt><tt>value_string</tt> : string</dt>
+<dd>The value for the sole element for the scalar, UTF-8 string, output tensor.</dd>
+<dt><tt>value_strings</tt> : list of strings</dt>
+<dd>The values for the elements for the 1D, UTF-8 string, output tensor.</dd>
 </dl>
 
 #### Inputs
@@ -12072,7 +12084,7 @@ This version of the operator has been available since version 1 of the default O
 
 ### <a name="Range"></a><a name="range">**Range**</a>
 
-  Generate a tensor containing a sequence of numbers that begin at `start` and extends by increments of `delta` 
+  Generate a tensor containing a sequence of numbers that begin at `start` and extends by increments of `delta`
   up to `limit` (exclusive).
   
   The number of elements in the output of range is computed as below-
@@ -12084,10 +12096,10 @@ This version of the operator has been available since version 1 of the default O
   `for(int i=0; i<number_of_elements; ++i)`
   
   `{`
-     
-  `    output[i] =  start + (i * delta);  ` 
   
-  `}`	
+  `    output[i] =  start + (i * delta);  `
+  
+  `}`
   
   `Example 1`
   Inputs: start = 3, limit = 9, delta = 3

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -76,7 +76,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           auto* value_string = ctx.getAttribute("value_string");
           auto* value_strings = ctx.getAttribute("value_strings");
 
-          std::vector<int> non_null_attr = {
+          std::vector<bool> non_null_attr = {
             (nullptr != value),
             (nullptr != sparse_value),
             (nullptr != value_int),

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -29,32 +29,32 @@ ONNX_OPERATOR_SET_SCHEMA(
             false)
         .Attr(
             "value_int",
-            "The value for the elements of the output tensor.",
+            "The value for the sole element for the scalar, int64, output tensor.",
             AttributeProto::INT,
             false)
         .Attr(
             "value_ints",
-            "The value for the elements of the output tensor.",
+            "The values for the elements for the 1D, int64, output tensor.",
             AttributeProto::INTS,
             false)
         .Attr(
             "value_float",
-            "The value for the elements of the output tensor.",
+            "The value for the sole element for the scalar, float32, output tensor.",
             AttributeProto::FLOAT,
             false)
         .Attr(
             "value_floats",
-            "The value for the elements of the output tensor.",
+            "The values for the elements for the 1D, float32, output tensor.",
             AttributeProto::FLOATS,
             false)
         .Attr(
             "value_string",
-            "The value for the elements of the output tensor.",
+            "The value for the sole element for the scalar, UTF-8 string, output tensor.",
             AttributeProto::STRING,
             false)
         .Attr(
             "value_strings",
-            "The value for the elements of the output tensor.",
+            "The values for the elements for the 1D, UTF-8 string, output tensor.",
             AttributeProto::STRINGS,
             false)
         .Output(
@@ -103,7 +103,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             if (!value_int->has_i())
               fail_shape_inference("Attribute 'value_int' expect an integer.")
             updateOutputElemType(ctx, 0, TensorProto::INT64);
-            appendDim(getOutputShape(ctx, 0), 1);
+            updateOutputShape(ctx, 0, TensorShapeProto());
             return;
           }
 
@@ -121,7 +121,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             if (!value_float->has_f())
               fail_shape_inference("Attribute 'value_float' expect a float.")
             updateOutputElemType(ctx, 0, TensorProto::FLOAT);
-            appendDim(getOutputShape(ctx, 0), 1);
+            updateOutputShape(ctx, 0, TensorShapeProto());
             return;
           }
 
@@ -139,7 +139,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             if (!value_string->has_s())
               fail_shape_inference("Attribute 'value_string' expect a string.")
             updateOutputElemType(ctx, 0, TensorProto::STRING);
-            appendDim(getOutputShape(ctx, 0), 1);
+            updateOutputShape(ctx, 0, TensorShapeProto());
             return;
           }
 
@@ -164,8 +164,10 @@ ONNX_OPERATOR_SET_SCHEMA(
               appendDim(output_shape, sparse.dims(i));
             return;
           }
+
           fail_shape_inference(
-              "One of the attributes 'value' or 'sparse_value' must be specified for a Constant node.")
+              "TypeAndShapeInferenceFunction implementation incomplete: "
+              "this line should never be reached.")
         }));
 
 static const char* ConstantOfShape_ver9_doc = R"DOC(

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 #include <cmath>
-#include <numeric>
 #include <algorithm>
 #include "onnx/defs/function.h"
 #include "onnx/defs/schema.h"

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -14,7 +14,7 @@ or value_* must be specified.
 
 ONNX_OPERATOR_SET_SCHEMA(
     Constant,
-    11,
+    12,
     OpSchema()
         .SetDoc(Constant_ver11_doc)
         .Attr(

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -8,7 +8,7 @@
 
 namespace ONNX_NAMESPACE {
 static const char* Constant_ver11_doc = R"DOC(
-A constant tensor. Exactly one of the provided attributes, either value, sparse_value,
+This operator produces a constant tensor. Exactly one of the provided attributes, either value, sparse_value,
 or value_* must be specified.
 )DOC";
 

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -128,7 +128,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (nullptr != value_floats) {
             // OpSchema::Verify check ensures that the attribute value has ints.
             if (value_floats->floats_size() < 1)
-              fail_shape_inference("Attribute 'value_floats' expect a collection of floats.")
+              fail_shape_inference("Attribute 'value_floats' expect a list of floats.")
             updateOutputElemType(ctx, 0, TensorProto::FLOAT);
             appendDim(getOutputShape(ctx, 0), value_floats->floats_size());
             return;

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -101,10 +101,19 @@ ONNX_OPERATOR_SET_SCHEMA(
 
           if (nullptr != value_int) {
             // OpSchema::Verify check ensures that the attribute value has_i():
-            value->i();
-            updateOutputElemType(ctx, 0, TensorProto::INT32);
-            auto* output_shape = getOutputShape(ctx, 0);
-            appendDim(output_shape, 1);
+            if (!value_int->has_i())
+              fail_shape_inference("Attribute 'value_int' expect an integer.")
+            updateOutputElemType(ctx, 0, TensorProto::INT64);
+            appendDim(getOutputShape(ctx, 0), 1);
+            return;
+          }
+
+          if (nullptr != value_ints) {
+            // OpSchema::Verify check ensures that the attribute value has ints.
+            if (value_ints->ints_size() < 1)
+              fail_shape_inference("Attribute 'value_ints' expect a collection of integers.")
+            updateOutputElemType(ctx, 0, TensorProto::INT64);
+            appendDim(getOutputShape(ctx, 0), value_ints->ints_size());
             return;
           }
 

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -117,6 +117,24 @@ ONNX_OPERATOR_SET_SCHEMA(
             return;
           }
 
+          if (nullptr != value_float) {
+            // OpSchema::Verify check ensures that the attribute value has_i():
+            if (!value_float->has_f())
+              fail_shape_inference("Attribute 'value_float' expect a float.")
+            updateOutputElemType(ctx, 0, TensorProto::FLOAT);
+            appendDim(getOutputShape(ctx, 0), 1);
+            return;
+          }
+
+          if (nullptr != value_floats) {
+            // OpSchema::Verify check ensures that the attribute value has ints.
+            if (value_floats->floats_size() < 1)
+              fail_shape_inference("Attribute 'value_floats' expect a collection of floats.")
+            updateOutputElemType(ctx, 0, TensorProto::FLOAT);
+            appendDim(getOutputShape(ctx, 0), value_floats->floats_size());
+            return;
+          }
+
           if (nullptr != sparse_value) {
             // OpSchema::Verify check ensures that the attribute value
             // has_sparse_tensor():

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -99,6 +99,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             return;
           }
 
+          if (nullptr != value_int) {
+            // OpSchema::Verify check ensures that the attribute value has_i():
+            value->i();
+            updateOutputElemType(ctx, 0, TensorProto::INT32);
+            auto* output_shape = getOutputShape(ctx, 0);
+            appendDim(output_shape, 1);
+            return;
+          }
+
           if (nullptr != sparse_value) {
             // OpSchema::Verify check ensures that the attribute value
             // has_sparse_tensor():

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -110,7 +110,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (nullptr != value_ints) {
             // OpSchema::Verify check ensures that the attribute value has ints.
             if (value_ints->ints_size() < 1)
-              fail_shape_inference("Attribute 'value_ints' expect a collection of integers.")
+              fail_shape_inference("Attribute 'value_ints' expect a list of integers.")
             updateOutputElemType(ctx, 0, TensorProto::INT64);
             appendDim(getOutputShape(ctx, 0), value_ints->ints_size());
             return;

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -146,7 +146,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (nullptr != value_strings) {
             // OpSchema::Verify check ensures that the attribute value has ints.
             if (value_strings->strings_size() < 1)
-              fail_shape_inference("Attribute 'value_strings' expect a collection of strings.")
+              fail_shape_inference("Attribute 'value_strings' expect a list of strings.")
             updateOutputElemType(ctx, 0, TensorProto::STRING);
             appendDim(getOutputShape(ctx, 0), value_strings->strings_size());
             return;

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -135,6 +135,24 @@ ONNX_OPERATOR_SET_SCHEMA(
             return;
           }
 
+          if (nullptr != value_string) {
+            // OpSchema::Verify check ensures that the attribute value has_i():
+            if (!value_string->has_s())
+              fail_shape_inference("Attribute 'value_string' expect a string.")
+            updateOutputElemType(ctx, 0, TensorProto::STRING);
+            appendDim(getOutputShape(ctx, 0), 1);
+            return;
+          }
+
+          if (nullptr != value_strings) {
+            // OpSchema::Verify check ensures that the attribute value has ints.
+            if (value_strings->strings_size() < 1)
+              fail_shape_inference("Attribute 'value_strings' expect a collection of strings.")
+            updateOutputElemType(ctx, 0, TensorProto::STRING);
+            appendDim(getOutputShape(ctx, 0), value_strings->strings_size());
+            return;
+          }
+
           if (nullptr != sparse_value) {
             // OpSchema::Verify check ensures that the attribute value
             // has_sparse_tensor():

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -7,7 +7,7 @@
 #include "onnx/defs/schema.h"
 
 namespace ONNX_NAMESPACE {
-static const char* Constant_ver11_doc = R"DOC(
+static const char* Constant_ver12_doc = R"DOC(
 This operator produces a constant tensor. Exactly one of the provided attributes, either value, sparse_value,
 or value_* must be specified.
 )DOC";
@@ -16,7 +16,7 @@ ONNX_OPERATOR_SET_SCHEMA(
     Constant,
     12,
     OpSchema()
-        .SetDoc(Constant_ver11_doc)
+        .SetDoc(Constant_ver12_doc)
         .Attr(
             "value",
             "The value for the elements of the output tensor.",

--- a/onnx/defs/generator/old.cc
+++ b/onnx/defs/generator/old.cc
@@ -66,4 +66,65 @@ ONNX_OPERATOR_SET_SCHEMA(
           updateOutputShape(ctx, 0, tensor_proto);
         }));
 
+static const char* Constant_ver11_doc = R"DOC(
+A constant tensor. Exactly one of the two attributes, either value or sparse_value,
+must be specified.
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(
+    Constant,
+    11,
+    OpSchema()
+        .SetDoc(Constant_ver11_doc)
+        .Attr(
+            "value",
+            "The value for the elements of the output tensor.",
+            AttributeProto::TENSOR,
+            false)
+        .Attr(
+            "sparse_value",
+            "The value for the elements of the output tensor in sparse format.",
+            AttributeProto::SPARSE_TENSOR,
+            false)
+        .Output(
+            0,
+            "output",
+            "Output tensor containing the same value of the provided tensor.",
+            "T")
+        .TypeConstraint(
+            "T",
+            OpSchema::all_tensor_types(),
+            "Constrain input and output types to all tensor types.")
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          auto* value = ctx.getAttribute("value");
+          auto* sparse_value = ctx.getAttribute("sparse_value");
+
+          if ((nullptr != value) && (nullptr != sparse_value))
+            fail_shape_inference(
+                "Only one of the attributes 'value' or 'sparse_value' must be specified for a Constant node.");
+
+          if (nullptr != value) {
+            // OpSchema::Verify check ensures that the attribute value has_t():
+            const TensorProto& tensor_proto = value->t();
+            updateOutputElemType(ctx, 0, tensor_proto.data_type());
+            updateOutputShape(ctx, 0, tensor_proto);
+            return;
+          }
+
+          if (nullptr != sparse_value) {
+            // OpSchema::Verify check ensures that the attribute value
+            // has_sparse_tensor():
+            const SparseTensorProto& sparse = sparse_value->sparse_tensor();
+            // checker.cc::check_sparse_tensor checks that the sparse-value is
+            // well-formed
+            updateOutputElemType(ctx, 0, sparse.values().data_type());
+            auto* output_shape = getOutputShape(ctx, 0);
+            for (int i = 0; i < sparse.dims_size(); ++i)
+              appendDim(output_shape, sparse.dims(i));
+            return;
+          }
+          fail_shape_inference(
+              "One of the attributes 'value' or 'sparse_value' must be specified for a Constant node.")
+        }));
+
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/operator_sets.h
+++ b/onnx/defs/operator_sets.h
@@ -719,6 +719,7 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 12, ReduceMin);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 12, NegativeLogLikelihoodLoss);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 12, Dropout);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 12, BatchNormalization);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 12, Constant);
 
 // Iterate over schema from ai.onnx version 12
 class OpSet_Onnx_ver12 {
@@ -733,6 +734,7 @@ class OpSet_Onnx_ver12 {
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 12, NegativeLogLikelihoodLoss)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 12, Dropout)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 12, BatchNormalization)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 12, Constant)>());
   }
 };
 

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -2375,6 +2375,21 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, y_shape)])  # type: ignore
 
+    def test_constant_value_int(self):  # type: () -> None
+        graph = self._make_graph(
+            [],
+            [make_node('Constant', [], ['y'], value_int=42)],
+            [])
+        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, [1])])
+
+    def test_constant_value_ints(self):  # type: () -> None
+        value_ints = [1, 2, 3]
+        graph = self._make_graph(
+            [],
+            [make_node('Constant', [], ['y'], value_ints=value_ints)],
+            [])
+        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, [len(value_ints)])])
+
     def test_range(self):  # type: () -> None
         graph = self._make_graph(
             [('start', TensorProto.FLOAT, ()),

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -2390,6 +2390,21 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, [len(value_ints)])])
 
+    def test_constant_value_float(self):  # type: () -> None
+        graph = self._make_graph(
+            [],
+            [make_node('Constant', [], ['y'], value_float=1.42)],
+            [])
+        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, [1])])
+
+    def test_constant_value_floats(self):  # type: () -> None
+        value_floats = [1.0, 1.1, 1.2]
+        graph = self._make_graph(
+            [],
+            [make_node('Constant', [], ['y'], value_floats=value_floats)],
+            [])
+        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, [len(value_floats)])])
+
     def test_range(self):  # type: () -> None
         graph = self._make_graph(
             [('start', TensorProto.FLOAT, ()),

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -2405,6 +2405,21 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, [len(value_floats)])])
 
+    def test_constant_value_string(self):  # type: () -> None
+        graph = self._make_graph(
+            [],
+            [make_node('Constant', [], ['y'], value_string="String value")],
+            [])
+        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.STRING, [1])])
+
+    def test_constant_value_strings(self):  # type: () -> None
+        value_strings = ["o", "n", "n", "x"]
+        graph = self._make_graph(
+            [],
+            [make_node('Constant', [], ['y'], value_strings=value_strings)],
+            [])
+        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.STRING, [len(value_strings)])])
+
     def test_range(self):  # type: () -> None
         graph = self._make_graph(
             [('start', TensorProto.FLOAT, ()),

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -2380,7 +2380,7 @@ class TestShapeInference(unittest.TestCase):
             [],
             [make_node('Constant', [], ['y'], value_int=42)],
             [])
-        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, [1])])
+        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, [])])
 
     def test_constant_value_ints(self):  # type: () -> None
         value_ints = [1, 2, 3]
@@ -2395,7 +2395,7 @@ class TestShapeInference(unittest.TestCase):
             [],
             [make_node('Constant', [], ['y'], value_float=1.42)],
             [])
-        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, [1])])
+        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, [])])
 
     def test_constant_value_floats(self):  # type: () -> None
         value_floats = [1.0, 1.1, 1.2]
@@ -2410,7 +2410,7 @@ class TestShapeInference(unittest.TestCase):
             [],
             [make_node('Constant', [], ['y'], value_string="String value")],
             [])
-        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.STRING, [1])])
+        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.STRING, [])])
 
     def test_constant_value_strings(self):  # type: () -> None
         value_strings = ["o", "n", "n", "x"]


### PR DESCRIPTION
This PR follow comments https://github.com/onnx/onnx/pull/2575#issuecomment-582698230 and https://github.com/onnx/onnx/pull/2575#issuecomment-582581695 in order to allow Function operators like https://github.com/onnx/onnx/pull/2575 to promote scalar values to tensors.

## Content of the PR
This PR define new attributes `value_int`, `value_ints`, `value_float`,  `value_floats`,  `value_string`, `value_strings` that take *scalar types* for the Constant operator.

## Promoting scalar
Right now scalar and tensors have two separated type systems. This do not create any trouble with operator that are implemented in backend as the backend is responsible of mixing scalars and tensors in the way he want.
But for operators defined as functions (i.e. graph) such mixing should happen directly in the defined graph. Unfortunately, we miss an operator that can do this "mixing" of types. One way to solve this issue is simply to allow the `Constant` operator to lift the *scalars* to *tensors*.


---

I am not use to this code base so let me know if something is missing :)