### PR TITLE
Use // instead of #

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -14297,7 +14297,7 @@ This version of the operator has been available since version 12 of the default 
   If "reduction" attribute is set to "none", the operator's output will be the above loss with shape (N, d1, d2, ..., dk).
   If "reduction" attribute is set to "mean" (the default attribute value), the output loss is (weight) averaged:
   
-      mean(loss), if "weight" is not provided, 
+      mean(loss), if "weight" is not provided,
   
   or if weight is provided,
   
@@ -14308,11 +14308,11 @@ This version of the operator has been available since version 12 of the default 
   
   See also https://pytorch.org/docs/stable/nn.html#torch.nn.NLLLoss.
   
-  Example 1: 
+  Example 1:
   
-      # negative log likelihood loss, "none" reduction
+      // negative log likelihood loss, "none" reduction
       N, C, d1 = 2, 3, 2
-      input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]], 
+      input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]],
                [[0.0, 1.0], [2.0, 2.0], [1.0, 2]]]
       target = [[2, 1], [0, 2]]
   
@@ -14322,15 +14322,15 @@ This version of the operator has been available since version 12 of the default 
               c = target[n][d_1]
               loss[n][d_1] = -input[n][c][d_1]
   
-      # print(loss)
-      # [[-3. -2.]
-      #  [-0. -2.]]
+      // print(loss)
+      // [[-3. -2.]
+      //  [-0. -2.]]
   
   Example 2:
   
-      # weighted negative log likelihood loss, sum reduction
+      // weighted negative log likelihood loss, sum reduction
       N, C, d1 = 2, 3, 2
-      input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]], 
+      input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]],
               [[0.0, 1.0], [2.0, 2.0], [1.0, 2]]]
       target = [[2, 1], [0, 2]]
       weight = [0.2, 0.3, 0.1]
@@ -14341,14 +14341,14 @@ This version of the operator has been available since version 12 of the default 
               loss[n][d_1] = -input[n][c][d_1] * weight[c]
   
       loss = np.sum(loss)
-      # print(loss)
-      # -1.1
+      // print(loss)
+      // -1.1
   
   Example 3:
   
-      # weighted negative log likelihood loss, mean reduction
+      // weighted negative log likelihood loss, mean reduction
       N, C, d1 = 2, 3, 2
-      input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]], 
+      input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]],
               [[0.0, 1.0], [2.0, 2.0], [1.0, 2]]]
       target = [[2, 1], [0, 2]]
       weight = [0.2, 0.3, 0.1]
@@ -14361,8 +14361,8 @@ This version of the operator has been available since version 12 of the default 
               weight_total = weight_total + weight[c]
   
       loss = np.sum(loss) / weight_total
-      # print(loss)
-      # -1.57
+      // print(loss)
+      // -1.57
 
 #### Version
 

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -9974,7 +9974,7 @@ expect(node, inputs=[x], outputs=[y],
   If "reduction" attribute is set to "none", the operator's output will be the above loss with shape (N, d1, d2, ..., dk).
   If "reduction" attribute is set to "mean" (the default attribute value), the output loss is (weight) averaged:
   
-      mean(loss), if "weight" is not provided, 
+      mean(loss), if "weight" is not provided,
   
   or if weight is provided,
   
@@ -9985,11 +9985,11 @@ expect(node, inputs=[x], outputs=[y],
   
   See also https://pytorch.org/docs/stable/nn.html#torch.nn.NLLLoss.
   
-  Example 1: 
+  Example 1:
   
-      # negative log likelihood loss, "none" reduction
+      // negative log likelihood loss, "none" reduction
       N, C, d1 = 2, 3, 2
-      input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]], 
+      input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]],
                [[0.0, 1.0], [2.0, 2.0], [1.0, 2]]]
       target = [[2, 1], [0, 2]]
   
@@ -9999,15 +9999,15 @@ expect(node, inputs=[x], outputs=[y],
               c = target[n][d_1]
               loss[n][d_1] = -input[n][c][d_1]
   
-      # print(loss)
-      # [[-3. -2.]
-      #  [-0. -2.]]
+      // print(loss)
+      // [[-3. -2.]
+      //  [-0. -2.]]
   
   Example 2:
   
-      # weighted negative log likelihood loss, sum reduction
+      // weighted negative log likelihood loss, sum reduction
       N, C, d1 = 2, 3, 2
-      input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]], 
+      input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]],
               [[0.0, 1.0], [2.0, 2.0], [1.0, 2]]]
       target = [[2, 1], [0, 2]]
       weight = [0.2, 0.3, 0.1]
@@ -10018,14 +10018,14 @@ expect(node, inputs=[x], outputs=[y],
               loss[n][d_1] = -input[n][c][d_1] * weight[c]
   
       loss = np.sum(loss)
-      # print(loss)
-      # -1.1
+      // print(loss)
+      // -1.1
   
   Example 3:
   
-      # weighted negative log likelihood loss, mean reduction
+      // weighted negative log likelihood loss, mean reduction
       N, C, d1 = 2, 3, 2
-      input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]], 
+      input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]],
               [[0.0, 1.0], [2.0, 2.0], [1.0, 2]]]
       target = [[2, 1], [0, 2]]
       weight = [0.2, 0.3, 0.1]
@@ -10038,8 +10038,8 @@ expect(node, inputs=[x], outputs=[y],
               weight_total = weight_total + weight[c]
   
       loss = np.sum(loss) / weight_total
-      # print(loss)
-      # -1.57
+      // print(loss)
+      // -1.57
 
 #### Version
 

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -1696,7 +1696,7 @@ See also https://pytorch.org/docs/stable/nn.html#torch.nn.NLLLoss.
 
 Example 1:
 
-    &sharp; negative log likelihood loss, "none" reduction
+    // negative log likelihood loss, "none" reduction
     N, C, d1 = 2, 3, 2
     input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]],
              [[0.0, 1.0], [2.0, 2.0], [1.0, 2]]]
@@ -1708,13 +1708,13 @@ Example 1:
             c = target[n][d_1]
             loss[n][d_1] = -input[n][c][d_1]
 
-    &sharp; print(loss)
-    &sharp; [[-3. -2.]
-    &sharp;  [-0. -2.]]
+    // print(loss)
+    // [[-3. -2.]
+    //  [-0. -2.]]
 
 Example 2:
 
-    &sharp; weighted negative log likelihood loss, sum reduction
+    // weighted negative log likelihood loss, sum reduction
     N, C, d1 = 2, 3, 2
     input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]],
             [[0.0, 1.0], [2.0, 2.0], [1.0, 2]]]
@@ -1727,12 +1727,12 @@ Example 2:
             loss[n][d_1] = -input[n][c][d_1] * weight[c]
 
     loss = np.sum(loss)
-    &sharp; print(loss)
-    &sharp; -1.1
+    // print(loss)
+    // -1.1
 
 Example 3:
 
-    &sharp; weighted negative log likelihood loss, mean reduction
+    // weighted negative log likelihood loss, mean reduction
     N, C, d1 = 2, 3, 2
     input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]],
             [[0.0, 1.0], [2.0, 2.0], [1.0, 2]]]
@@ -1747,8 +1747,8 @@ Example 3:
             weight_total = weight_total + weight[c]
 
     loss = np.sum(loss) / weight_total
-    &sharp; print(loss)
-    &sharp; -1.57
+    // print(loss)
+    // -1.57
 )DOC";
 
 TensorProto ToDimensionOneTensor(int32_t value) {

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -1683,7 +1683,7 @@ When an optional "weight" is provided, the sample loss is calculated as:
 If "reduction" attribute is set to "none", the operator's output will be the above loss with shape (N, d1, d2, ..., dk).
 If "reduction" attribute is set to "mean" (the default attribute value), the output loss is (weight) averaged:
 
-    mean(loss), if "weight" is not provided, 
+    mean(loss), if "weight" is not provided,
 
 or if weight is provided,
 
@@ -1694,11 +1694,11 @@ If "reduction" attribute is set to "sum", the output is a scalar:
 
 See also https://pytorch.org/docs/stable/nn.html#torch.nn.NLLLoss.
 
-Example 1: 
+Example 1:
 
-    # negative log likelihood loss, "none" reduction
+    &sharp; negative log likelihood loss, "none" reduction
     N, C, d1 = 2, 3, 2
-    input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]], 
+    input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]],
              [[0.0, 1.0], [2.0, 2.0], [1.0, 2]]]
     target = [[2, 1], [0, 2]]
 
@@ -1708,15 +1708,15 @@ Example 1:
             c = target[n][d_1]
             loss[n][d_1] = -input[n][c][d_1]
 
-    # print(loss)
-    # [[-3. -2.]
-    #  [-0. -2.]]
+    &sharp; print(loss)
+    &sharp; [[-3. -2.]
+    &sharp;  [-0. -2.]]
 
 Example 2:
 
-    # weighted negative log likelihood loss, sum reduction
+    &sharp; weighted negative log likelihood loss, sum reduction
     N, C, d1 = 2, 3, 2
-    input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]], 
+    input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]],
             [[0.0, 1.0], [2.0, 2.0], [1.0, 2]]]
     target = [[2, 1], [0, 2]]
     weight = [0.2, 0.3, 0.1]
@@ -1727,14 +1727,14 @@ Example 2:
             loss[n][d_1] = -input[n][c][d_1] * weight[c]
 
     loss = np.sum(loss)
-    # print(loss)
-    # -1.1
+    &sharp; print(loss)
+    &sharp; -1.1
 
 Example 3:
 
-    # weighted negative log likelihood loss, mean reduction
+    &sharp; weighted negative log likelihood loss, mean reduction
     N, C, d1 = 2, 3, 2
-    input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]], 
+    input = [[[1.0, 2.0], [2.0, 2.0], [3.0, 2.0]],
             [[0.0, 1.0], [2.0, 2.0], [1.0, 2]]]
     target = [[2, 1], [0, 2]]
     weight = [0.2, 0.3, 0.1]
@@ -1747,8 +1747,8 @@ Example 3:
             weight_total = weight_total + weight[c]
 
     loss = np.sum(loss) / weight_total
-    # print(loss)
-    # -1.57
+    &sharp; print(loss)
+    &sharp; -1.57
 )DOC";
 
 TensorProto ToDimensionOneTensor(int32_t value) {


### PR DESCRIPTION
I think this triggers bugs in VC. So let's avoid # .

https://circleci.com/api/v1.1/project/github/pytorch/pytorch/4474680/output/105/0?file=true&allocation-id=5e444da0eb32cc36d80175e8-0-build%2F2AADD64F

```
C:\Users\circleci\project\build\win_tmp\bin\sccache.exe  cl   /TP -DONNX_ML=1 -DONNX_NAMESPACE=onnx_torch -DTH_BLAS_MKL -D_OPENMP_NOFORCE_MANIFEST -I..\cmake\..\third_party\benchmark\include -Icaffe2\contrib\aten -I..\third_party\onnx -Ithird_party\onnx -I..\cmake\..\third_party\googletest\googlemock\include -I..\cmake\..\third_party\googletest\googletest\include -I..\third_party\protobuf\src -Iwin_tmp\mkl\include -I..\cmake\..\third_party\eigen -IC:\Jenkins\Miniconda3\include -IC:\Jenkins\Miniconda3\lib\site-packages\numpy\core\include -I..\cmake\..\third_party\pybind11\include -I\opt\rocm\hip\include -I\include -I..\cmake\..\third_party\cub /DWIN32 /D_WINDOWS /GR  /w /EHa /bigobj -openmp /MD /O2 /Ob2 /DNDEBUG /w /EHa /bigobj   /MP /WX /wd4800 /wd4503 /wd4146 /MD -std:c++14 /showIncludes /Fothird_party\onnx\CMakeFiles\onnx.dir\onnx\defs\math\defs.cc.obj /Fdthird_party\onnx\CMakeFiles\onnx.dir\onnx.pdb /FS -c ..\third_party\onnx\onnx\defs\math\defs.cc
..\third_party\onnx\onnx\defs\math\defs.cc(1472): fatal error C1021: invalid preprocessor command 'negative'
```