### PR TITLE
Fix CI build break

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,13 +46,9 @@ if(NOT DEFINED ONNX_VERIFY_PROTO3)
 endif()
 
  if (ONNX_USE_PROTOBUF_SHARED_LIBS)
-  if(MSVC AND ONNX_USE_MSVC_STATIC_RUNTIME)
-    add_definitions(-DPROTOBUF_USE_DLLS)
-  else()
-    message(
-      FATAL_ERROR 
-        "Building ONNX with Protobuf as shared lib is only available for MSVC compilers and that too when USE_MSVC_STATIC_RUNTIME environment variable is set to 1. Please read the build instructions for more details."
-    )
+  if(MSVC)
+    #TODO: if ONNX_USE_MSVC_STATIC_RUNTIME is ON, it may not work  
+    add_definitions(-DPROTOBUF_USE_DLLS)  
   endif()
 endif()
 
@@ -308,9 +304,9 @@ list(APPEND ONNX_PROTO_HDRS ${__tmp_hdrs})
 
 file(GLOB_RECURSE __tmp_srcs "${ONNX_ROOT}/onnx/*.h" "${ONNX_ROOT}/onnx/*.cc")
 file(GLOB_RECURSE onnx_gtests_src "${ONNX_ROOT}/onnx/test/cpp/*.h"
-	"${ONNX_ROOT}/onnx/test/cpp/*.cc"
-	"${ONNX_ROOT}/onnx/backend/test/cpp/*.cc"
-	"${ONNX_ROOT}/onnx/backend/test/cpp/*.h")
+    "${ONNX_ROOT}/onnx/test/cpp/*.cc"
+    "${ONNX_ROOT}/onnx/backend/test/cpp/*.cc"
+    "${ONNX_ROOT}/onnx/backend/test/cpp/*.h")
 list(REMOVE_ITEM __tmp_srcs "${ONNX_ROOT}/onnx/cpp2py_export.cc")
 list(REMOVE_ITEM __tmp_srcs ${onnx_gtests_src})
 list(APPEND ONNX_SRCS ${__tmp_srcs})
@@ -456,6 +452,12 @@ if(BUILD_ONNX_PYTHON)
                                            # unsigned type, result still
                                            # unsigned from include\google\protob
                                            # uf\wire_format_lite.h
+                                 /wd4244 # 'argument': conversion from 'google::
+                                         # protobuf::uint64' to 'int', possible 
+                                         # loss of data
+                                 /wd4267 # Conversion from 'size_t' to 'int', 
+                                         # possible loss of data
+                                 /wd4996 # The second parameter is ignored.
                                    ${EXTRA_FLAGS})
     if(ONNX_USE_PROTOBUF_SHARED_LIBS)
       target_compile_options(onnx_cpp2py_export 
@@ -510,6 +512,11 @@ if(MSVC)
                                          # unsigned type, result still unsigned:
                                          # include\google\protobuf\wire_format_l
                                          # ite.h
+                                 /wd4244 #'argument': conversion from 'google::
+                                         #protobuf::uint64' to 'int', possible 
+                                         # loss of data
+                                 /wd4267 # Conversion from 'size_t' to 'int', 
+                                         # possible loss of data
                                  ${EXTRA_FLAGS})
   target_compile_options(onnx
                          PRIVATE /MP
@@ -521,6 +528,12 @@ if(MSVC)
                                          # exceeded, name was truncated
                                  /wd4146 # unary minus operator applied to
                                          # unsigned type, result still unsigned
+                                 /wd4244 # 'argument': conversion from 'google::
+                                         # protobuf::uint64' to 'int', possible 
+                                         # loss of data
+                                 /wd4267 # Conversion from 'size_t' to 'int', 
+                                         # possible loss of data
+                                 /wd4996 # The second parameter is ignored.
                                  ${EXTRA_FLAGS})
   if(ONNX_USE_PROTOBUF_SHARED_LIBS)
       target_compile_options(onnx_proto 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,10 +30,12 @@ install:
 - cmd: git submodule update --init --recursive
 
 before_build:
-- cmd: SET PATH=%CONDA_PREFIX%;%CONDA_PREFIX%\Scripts;%PATH%
+#TODO:We should put libprotobuf.dll within onnx's package.
+#Then we don't need to add %CONDA_PREFIX%\Library\bin at here
+- cmd: SET PATH=%CONDA_PREFIX%;%CONDA_PREFIX%\Scripts;%CONDA_PREFIX%\Library\bin;%PATH%
 - cmd: SET _prefix=%CONDA_PREFIX:~0,14%
 - cmd: SET _arch=%CONDA_PREFIX:~15,18%
-- cmd: conda install -y -c conda-forge libprotobuf=3.9.2
+- cmd: conda install -y libprotobuf=3.11.3 protobuf=3.11.3 numpy
 - >
 
   IF "%_prefix%"=="C:\Miniconda37"
@@ -47,7 +49,14 @@ build_script:
 # Build and test onnx.
 - cmd: cd c:\projects\onnx
 - cmd: set ONNX_BUILD_TESTS=1
-- cmd: set CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=ON"
+#The latest libprotobuf Windows packages in anaconda was built with          
+#        -Dprotobuf_BUILD_SHARED_LIBS=ON 
+#        -Dprotobuf_MSVC_STATIC_RUNTIME=OFF
+#We must align with them. We must set USE_MSVC_STATIC_RUNTIME and 
+#ONNX_USE_PROTOBUF_SHARED_LIBS based on their config
+- cmd: set USE_MSVC_STATIC_RUNTIME=0
+# Don't put quotation marks in the following line
+- cmd: set CMAKE_ARGS=-DONNX_USE_PROTOBUF_SHARED_LIBS=ON -DProtobuf_USE_STATIC_LIBS=OFF -DONNX_USE_LITE_PROTO=ON
 - cmd: python setup.py --quiet bdist_wheel --universal --dist-dir .
 - cmd: dir /s /b /a-d "onnx_gtests.exe" >UT.txt & set /p _UT= < UT.txt & %_UT%
 - cmd: dir /b /a-d "*.whl" >WheelFile.txt & set /p _wheel= < WheelFile.txt

--- a/cmake/external/googletest.cmake
+++ b/cmake/external/googletest.cmake
@@ -14,6 +14,11 @@ else()
       ${CMAKE_CURRENT_BINARY_DIR}/googletest/src/googletest/googletest/libgtest.a)
 endif()
 
+if(ONNX_USE_MSVC_STATIC_RUNTIME)
+  set(ONNX_USE_MSVC_SHARED_RUNTIME OFF)
+else()
+  set(ONNX_USE_MSVC_SHARED_RUNTIME ON)
+endif()
 ExternalProject_Add(googletest
     PREFIX googletest
     GIT_REPOSITORY ${googletest_URL}
@@ -26,6 +31,6 @@ ExternalProject_Add(googletest
         -DCMAKE_BUILD_TYPE:STRING=Release
         -DBUILD_GMOCK:BOOL=OFF
         -DBUILD_GTEST:BOOL=ON
-        -Dgtest_force_shared_crt:BOOL=OFF
+        -Dgtest_force_shared_crt:BOOL=${ONNX_USE_MSVC_SHARED_RUNTIME}
     BUILD_BYPRODUCTS ${googletest_STATIC_LIBRARIES}
 )

--- a/cmake/unittest.cmake
+++ b/cmake/unittest.cmake
@@ -60,6 +60,12 @@ function(AddTest)
                                            # unsigned type, result still
                                            # unsigned from include\google\protob
                                            # uf\wire_format_lite.h
+                                 /wd4244 # 'argument': conversion from 'google::
+                                         # protobuf::uint64' to 'int', possible 
+                                         # loss of data
+                                 /wd4267 # Conversion from 'size_t' to 'int', 
+                                         # possible loss of data
+                                 /wd4996 # The second parameter is ignored.
                            )
 
   endif()


### PR DESCRIPTION
1. Add conda's Library\bin folder to the PATH, because libprotobuf.dll is there.
2. Fix the protobuf version mismatch problem. Currently the C/C++ part is 3.9.2 but the python part is 3.11.3. This PR changes them to the same version: 3.11.3
3. USE_MSVC_STATIC_RUNTIME should be disabled when the libprotobuf is from conda
4. We should set the gtest_force_shared_crt variable according to the value of USE_MSVC_STATIC_RUNTIME 