### PR TITLE
Dropout-12 should check for input `ratio` parameter's size to be 1.

### DIFF
--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -1792,7 +1792,7 @@ ONNX_OPERATOR_SET_SCHEMA(
 
           if (ctx.getNumInputs() > 1 && hasInputShape(ctx, 1)) {
             auto& ratio_input_shape = getInputShape(ctx, 1);
-            if (static_cast<int>(ratio_input_shape.dim_size()) != 0) {
+            if (static_cast<int>(ratio_input_shape.dim_size()) != 1) {
                 fail_shape_inference("Ratio of Dropout must be a scalar.");
             }
           }


### PR DESCRIPTION
Currently Dropout-12 checks for input `ratio` parameter tensor size to be equal to zero but I think this should be 1.