### PR TITLE
Control build paralllelism via `--parallel` option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -139,10 +139,14 @@ class cmake_build(setuptools.Command):
     built = False
 
     def initialize_options(self):
-        self.jobs = multiprocessing.cpu_count()
+        self.jobs = None
 
     def finalize_options(self):
-        self.jobs = int(self.jobs)
+        if sys.version_info[0] >= 3:
+            self.set_undefined_options('build', ('parallel', 'jobs'))
+        if self.jobs is None and os.getenv("MAX_JOBS") is not None:
+            self.jobs = os.getenv("MAX_JOBS")
+        self.jobs = multiprocessing.cpu_count() if self.jobs is None else int(self.jobs)
 
     def run(self):
         if cmake_build.built:


### PR DESCRIPTION
When building with python3 respect setuptools `--parallel` option, i.e.:
`python3 setup.py build --parallel=4` should not spawn more than 4 compiler jobs at once
Also, if neither of the options is specified, check `MAX_JOBS` environment variable

Test Plan:  `MAX_JOBS=4 pip3 install  git+https://github.com/malfet/onnx@follow-parallel-build-option` and see how many jobs are spawned