### PR TITLE
Relicensing MIT to Apache-2.0

### DIFF
--- a/docs/Relicensing.md
+++ b/docs/Relicensing.md
@@ -1,0 +1,3 @@
+# Relicensing MIT to Apache-2.0
+
+The following copyright holders agree that all of their contributions originally submitted to this project under the MIT license are hereby relicensed to Apache-2.0, and are submitted pursuant to the Developer Certificate of Origin, version 1.1:


### PR DESCRIPTION
Add a document to collect approvals for relicensing ONNX repo
files from MIT to Apache-2.0

Invite organizations to add the name of their organization, the
name of the authorized approver, e.g legal, and the date the
email was received indicating the approval for relicensing.