### PR TITLE
Allow int32 input tensor in ConstantOfShape, Expand, Reshape, Pad operator.

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -8201,7 +8201,7 @@ This version of the operator has been available since version 9 of the default O
 #### Type Constraints
 
 <dl>
-<dt><tt>T1</tt> : tensor(int64)</dt>
+<dt><tt>T1</tt> : tensor(int64), tensor(int32)</dt>
 <dd>Constrain input types.</dd>
 <dt><tt>T2</tt> : tensor(float16), tensor(float), tensor(double), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(bool)</dt>
 <dd>Constrain output types to be numerics.</dd>
@@ -16675,7 +16675,7 @@ This version of the operator has been available since version 13 of the default 
 <dl>
 <dt><tt>data</tt> : T</dt>
 <dd>Input tensor.</dd>
-<dt><tt>pads</tt> : tensor(int64)</dt>
+<dt><tt>pads</tt> : T1</dt>
 <dd>Tensor of integers indicating the number of padding elements to add or remove (if negative) at the beginning and end of each axis. For 2D input tensor, it is the number of pixels. `pads` should be a 1D tensor of shape [2 * input_rank]. `pads` format should be: [x1_begin, x2_begin,...,x1_end, x2_end,...], where xi_begin is the number of pad values added at the beginning of axis `i` and xi_end, the number of pad values added at the end of axis `i`.</dd>
 <dt><tt>constant_value</tt> (optional) : T</dt>
 <dd>(Optional) A scalar value to be used if the mode chosen is `constant` (by default it is 0).</dd>
@@ -16693,6 +16693,8 @@ This version of the operator has been available since version 13 of the default 
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128)</dt>
 <dd>Constrains input and output to only numeric types.</dd>
+<dt><tt>T1</tt> : tensor(int64), tensor(int32)</dt>
+<dd>Constrain pad input to int64/int32 type.</dd>
 </dl>
 
 ### <a name="Pow-13"></a>**Pow-13**</a>
@@ -17241,7 +17243,7 @@ This version of the operator has been available since version 13 of the default 
 <dl>
 <dt><tt>data</tt> (differentiable) : T</dt>
 <dd>An input tensor.</dd>
-<dt><tt>shape</tt> (non-differentiable) : tensor(int64)</dt>
+<dt><tt>shape</tt> (non-differentiable) : T1</dt>
 <dd>Specified shape for output.</dd>
 </dl>
 
@@ -17257,6 +17259,8 @@ This version of the operator has been available since version 13 of the default 
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128)</dt>
 <dd>Constrain input and output types to all tensor types.</dd>
+<dt><tt>T1</tt> : tensor(int64), tensor(int32)</dt>
+<dd>Constrain pad input to int64/int32 type</dd>
 </dl>
 
 ### <a name="Resize-13"></a>**Resize-13**</a>

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -3004,7 +3004,7 @@ This version of the operator has been available since version 9 of the default O
 #### Type Constraints
 
 <dl>
-<dt><tt>T1</tt> : tensor(int64)</dt>
+<dt><tt>T1</tt> : tensor(int64), tensor(int32)</dt>
 <dd>Constrain input types.</dd>
 <dt><tt>T2</tt> : tensor(float16), tensor(float), tensor(double), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(bool)</dt>
 <dd>Constrain output types to be numerics.</dd>
@@ -12065,7 +12065,7 @@ Other versions of this operator: <a href="Changelog.md#Pad-1">Pad-1</a>, <a href
 <dl>
 <dt><tt>data</tt> : T</dt>
 <dd>Input tensor.</dd>
-<dt><tt>pads</tt> : tensor(int64)</dt>
+<dt><tt>pads</tt> : T1</dt>
 <dd>Tensor of integers indicating the number of padding elements to add or remove (if negative) at the beginning and end of each axis. For 2D input tensor, it is the number of pixels. `pads` should be a 1D tensor of shape [2 * input_rank]. `pads` format should be: [x1_begin, x2_begin,...,x1_end, x2_end,...], where xi_begin is the number of pad values added at the beginning of axis `i` and xi_end, the number of pad values added at the end of axis `i`.</dd>
 <dt><tt>constant_value</tt> (optional) : T</dt>
 <dd>(Optional) A scalar value to be used if the mode chosen is `constant` (by default it is 0).</dd>
@@ -12083,6 +12083,8 @@ Other versions of this operator: <a href="Changelog.md#Pad-1">Pad-1</a>, <a href
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128)</dt>
 <dd>Constrains input and output to only numeric types.</dd>
+<dt><tt>T1</tt> : tensor(int64), tensor(int32)</dt>
+<dd>Constrain pad input to int64/int32 type.</dd>
 </dl>
 
 
@@ -15080,7 +15082,7 @@ Other versions of this operator: <a href="Changelog.md#Reshape-1">Reshape-1</a>,
 <dl>
 <dt><tt>data</tt> (differentiable) : T</dt>
 <dd>An input tensor.</dd>
-<dt><tt>shape</tt> (non-differentiable) : tensor(int64)</dt>
+<dt><tt>shape</tt> (non-differentiable) : T1</dt>
 <dd>Specified shape for output.</dd>
 </dl>
 
@@ -15096,6 +15098,8 @@ Other versions of this operator: <a href="Changelog.md#Reshape-1">Reshape-1</a>,
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128)</dt>
 <dd>Constrain input and output types to all tensor types.</dd>
+<dt><tt>T1</tt> : tensor(int64), tensor(int32)</dt>
+<dd>Constrain pad input to int64/int32 type</dd>
 </dl>
 
 

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include "onnx/defs/function.h"
 #include "onnx/defs/schema.h"
+#include "onnx/defs/tensor_proto_util.h"
 
 namespace ONNX_NAMESPACE {
 static const char* Constant_ver13_doc = R"DOC(
@@ -199,7 +200,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "If attribute 'value' is not specified, the value in the output defaults to 0, and the datatype "
             "defaults to float32.",
             "T2")
-        .TypeConstraint("T1", {"tensor(int64)"}, "Constrain input types.")
+        .TypeConstraint("T1", {"tensor(int64)", "tensor(int32)"}, "Constrain input types.")
         .TypeConstraint(
             "T2",
             {"tensor(float16)",
@@ -260,17 +261,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           // In this case, we extract the shape values from input tensor
           // and create output tensor of that shape.
           // First, extract target shape value.
-          std::vector<int64_t> targetShape;
-          if (targetShapeInitializer->has_raw_data()) {
-            const std::string& bytes = targetShapeInitializer->raw_data();
-            targetShape.insert(
-                targetShape.end(),
-                reinterpret_cast<const int64_t*>(bytes.c_str()),
-                reinterpret_cast<const int64_t*>(bytes.c_str() + bytes.size()));
-          } else {
-            const auto& data = targetShapeInitializer->int64_data();
-            targetShape.insert(targetShape.end(), data.begin(), data.end());
-          }
+          std::vector<int64_t> targetShape = GetIntInitializerData(targetShapeInitializer);
           // Next, set output shape to the target shape.
           auto final_output_shape =
               ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -1374,13 +1374,14 @@ ONNX_OPERATOR_SET_SCHEMA(
             const auto& shape_initializer_shape =
                 ctx.getInputType(1)->tensor_type().shape();
             if (shape_initializer_shape.dim_size() != 1 ||
-                shape_initializer->data_type() != TensorProto::INT64)
+                (shape_initializer->data_type() != TensorProto::INT64 &&
+                 shape_initializer->data_type() != TensorProto::INT32))
               fail_shape_inference(
-                  "'shape' input must be 1D tensor of type INT64");
+                  "'shape' input must be 1D tensor of type INT64 or INT32");
 
             const auto& input_shape =
                 ctx.getInputType(0)->tensor_type().shape();
-            const auto& shape_data = ParseData<int64_t>(shape_initializer);
+            const auto& shape_data = GetIntInitializerData(shape_initializer);
 
             TensorShapeProto second_shape;
             for (const auto& e : shape_data) {

--- a/onnx/defs/tensor_proto_util.cc
+++ b/onnx/defs/tensor_proto_util.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 #include "tensor_proto_util.h"
+#include <sstream>
 #include <vector>
 #include "onnx/common/platform_helpers.h"
 
@@ -85,5 +86,22 @@ DEFINE_PARSE_DATA(int32_t, int32_data)
 DEFINE_PARSE_DATA(int64_t, int64_data)
 DEFINE_PARSE_DATA(float, float_data)
 DEFINE_PARSE_DATA(double, double_data)
+
+const std::vector<int64_t> GetIntInitializerData(const TensorProto* tensor) {
+  std::vector<int64_t> vec;
+  if (tensor->data_type() == TensorProto::INT64) {
+    const auto& data = ParseData<int64_t>(tensor);
+    vec.insert(vec.end(), data.begin(), data.end());
+  } else if (tensor->data_type() == TensorProto::INT32) {
+    const auto& data = ParseData<int32_t>(tensor);
+    vec.insert(vec.end(), data.begin(), data.end());
+  } else {
+    // unaccepted data type
+    std::ostringstream oss;
+    oss << "Only supports `int32_t` or `int64_t` inputs " << tensor->name();
+    throw std::invalid_argument(oss.str());
+  }
+  return vec;
+}
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/tensor_proto_util.h
+++ b/onnx/defs/tensor_proto_util.h
@@ -16,4 +16,6 @@ TensorProto ToTensor(const std::vector<T>& values);
 template <typename T>
 const std::vector<T> ParseData(const TensorProto* tensor_proto);
 
+const std::vector<int64_t> GetIntInitializerData(const TensorProto* tensor_proto);
+
 } // namespace ONNX_NAMESPACE


### PR DESCRIPTION
**Description**
```
ConstantOfShape, Expand, Reshape and Pad operator operators allowed only
int64 input previously.  Now we enhance them to support int32 input too.
```
    
**Changes to be committed**
``` 
            modified:   onnx/defs/generator/defs.cc
            modified:   onnx/defs/math/defs.cc
            modified:   onnx/defs/tensor/defs.cc
            modified:   onnx/defs/tensor_proto_util.cc
            modified:   onnx/defs/tensor_proto_util.h
            modified:   docs/Changelog.md
            modified:   docs/Operators.md
```