### PR TITLE
Remove backend/test for building package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,6 @@
 recursive-include onnx *.h *.c *.cc *.proto
 recursive-include third_party *
 include LICENSE
-recursive-include onnx/backend/test/data *
 recursive-include onnx/examples *
 recursive-include cmake *
 recursive-include tools *

--- a/onnx/backend/test/loader/__init__.py
+++ b/onnx/backend/test/loader/__init__.py
@@ -15,12 +15,13 @@ DATA_DIR = os.path.join(
 
 
 def load_model_tests(
-    data_dir=DATA_DIR,  # type: Text
+    data_dir=None,  # type: Text
     kind=None,  # type: Optional[Text]
 ):  # type: (...) -> List[TestCase]
     '''Load model test cases from on-disk data files.
     '''
-
+    if data_dir is None:
+        data_dir = DATA_DIR
     supported_kinds = os.listdir(data_dir)
     if kind not in supported_kinds:
         raise ValueError("kind must be one of {}".format(supported_kinds))

--- a/onnx/backend/test/loader/__init__.py
+++ b/onnx/backend/test/loader/__init__.py
@@ -15,7 +15,7 @@ DATA_DIR = os.path.join(
 
 
 def load_model_tests(
-    data_dir=None,  # type: Text
+    data_dir=None,  # type: Optional[Text]
     kind=None,  # type: Optional[Text]
 ):  # type: (...) -> List[TestCase]
     '''Load model test cases from on-disk data files.

--- a/onnx/backend/test/runner/__init__.py
+++ b/onnx/backend/test/runner/__init__.py
@@ -51,7 +51,7 @@ def retry_excute(times):  # type: (int) -> Callable[[Callable[..., Any]], Callab
 
 class Runner(object):
 
-    def __init__(self, backend, parent_module=None):  # type: (Type[Backend], Optional[str]) -> None
+    def __init__(self, backend, parent_module=None, data_dir=None):  # type: (Type[Backend], Optional[str]) -> None
         self.backend = backend
         self._parent_module = parent_module
         self._include_patterns = set()  # type: Set[Pattern[Text]]
@@ -63,8 +63,13 @@ class Runner(object):
         # {category: {name: func}}
         self._test_items = defaultdict(dict)  # type: Dict[Text, Dict[Text, TestItem]]
 
-        for rt in load_model_tests(kind='node'):
-            self._add_model_test(rt, 'Node')
+        if data_dir is None:
+            for rt in load_model_tests(data_dir=data_dir, kind='node'):
+                self._add_model_test(rt, 'Node')
+        else:
+            for rt in load_model_tests(data_dir=data_dir, kind='node'):
+                self._add_model_test(rt, 'Node')
+            
 
         for rt in load_model_tests(kind='real'):
             self._add_model_test(rt, 'Real')

--- a/onnx/backend/test/runner/__init__.py
+++ b/onnx/backend/test/runner/__init__.py
@@ -51,7 +51,7 @@ def retry_excute(times):  # type: (int) -> Callable[[Callable[..., Any]], Callab
 
 class Runner(object):
 
-    def __init__(self, backend, parent_module=None, data_dir=None):  # type: (Type[Backend], Optional[str], Optional[str]) -> None
+    def __init__(self, backend, parent_module=None, data_dir=None):  # type: (Type[Backend], Optional[str], Optional[Text]) -> None
         self.backend = backend
         self._parent_module = parent_module
         self._include_patterns = set()  # type: Set[Pattern[Text]]

--- a/onnx/backend/test/runner/__init__.py
+++ b/onnx/backend/test/runner/__init__.py
@@ -51,7 +51,7 @@ def retry_excute(times):  # type: (int) -> Callable[[Callable[..., Any]], Callab
 
 class Runner(object):
 
-    def __init__(self, backend, parent_module=None, data_dir=None):  # type: (Type[Backend], Optional[str]) -> None
+    def __init__(self, backend, parent_module=None, data_dir=None):  # type: (Type[Backend], Optional[str], Optional[str]) -> None
         self.backend = backend
         self._parent_module = parent_module
         self._include_patterns = set()  # type: Set[Pattern[Text]]
@@ -63,24 +63,19 @@ class Runner(object):
         # {category: {name: func}}
         self._test_items = defaultdict(dict)  # type: Dict[Text, Dict[Text, TestItem]]
 
-        if data_dir is None:
-            for rt in load_model_tests(data_dir=data_dir, kind='node'):
-                self._add_model_test(rt, 'Node')
-        else:
-            for rt in load_model_tests(data_dir=data_dir, kind='node'):
-                self._add_model_test(rt, 'Node')
-            
+        for rt in load_model_tests(data_dir=data_dir, kind='node'):
+            self._add_model_test(rt, 'Node')
 
-        for rt in load_model_tests(kind='real'):
+        for rt in load_model_tests(data_dir=data_dir, kind='real'):
             self._add_model_test(rt, 'Real')
 
-        for rt in load_model_tests(kind='simple'):
+        for rt in load_model_tests(data_dir=data_dir, kind='simple'):
             self._add_model_test(rt, 'Simple')
 
-        for ct in load_model_tests(kind='pytorch-converted'):
+        for ct in load_model_tests(data_dir=data_dir, kind='pytorch-converted'):
             self._add_model_test(ct, 'PyTorchConverted')
 
-        for ot in load_model_tests(kind='pytorch-operator'):
+        for ot in load_model_tests(data_dir=data_dir, kind='pytorch-operator'):
             self._add_model_test(ot, 'PyTorchOperator')
 
     def _get_test_case(self, name):  # type: (Text) -> Type[unittest.TestCase]

--- a/onnx/backend/test/stat_coverage.py
+++ b/onnx/backend/test/stat_coverage.py
@@ -133,7 +133,8 @@ def gen_model_test_coverage(schemas, f, ml):
     # Need to grab associated nodes
     attrs = dict()  # type: Dict[Text, Dict[Text, List[Any]]]
     model_paths = []  # type: List[Any]
-    for rt in load_model_tests(kind='real'):
+    data_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+    for rt in load_model_tests(data_dir=data_dir, kind='real'):
         model_dir = Runner.prepare_model_data(rt)
         model_paths.append(os.path.join(model_dir, 'model.onnx'))
     model_paths.sort()

--- a/onnx/test/test_backend_test.py
+++ b/onnx/test/test_backend_test.py
@@ -90,8 +90,8 @@ def do_enforce_test_coverage_whitelist(model):  # type: (ModelProto) -> bool
             return False
     return True
 
-
-backend_test = onnx.backend.test.BackendTest(DummyBackend, __name__)
+data_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../backend/test/data')
+backend_test = onnx.backend.test.BackendTest(DummyBackend, __name__, data_dir=data_dir)
 if os.getenv('APPVEYOR'):
     backend_test.exclude(r'(test_vgg19|test_zfnet)')
 if platform.architecture()[0] == '32bit':

--- a/onnx/test/test_backend_test.py
+++ b/onnx/test/test_backend_test.py
@@ -90,6 +90,7 @@ def do_enforce_test_coverage_whitelist(model):  # type: (ModelProto) -> bool
             return False
     return True
 
+
 data_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../backend/test/data')
 backend_test = onnx.backend.test.BackendTest(DummyBackend, __name__, data_dir=data_dir)
 if os.getenv('APPVEYOR'):


### PR DESCRIPTION
According to #2821, the user encountered an error while installing onnx. It seems unnecessary to include those testing files for building onnx. Especially some filenames are too long, which is easy to trigger the _**filename too long**_ issue on Windows.

Therefore, I don't see there is any benefit to put these testing files into the package. If someone has concern about it, please let me know. THANKS!