### PR TITLE
Clean command in setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,9 +53,6 @@ onnx/*_pb.pyi
 # PyCharm files
 .idea
 
-# Visual Studio Code files
-.vscode
-
 # OSX dir files
 .DS_Store
 
@@ -88,12 +85,19 @@ onnx/examples/.coverage.nbval
 .pytest_cache
 test_report
 
-# autocomplete
-.ycm_extra_conf.py
-
 # test coverage data files
 *.gcov
 
 .mypy_cache
 virtualenv
 venv
+
+# START KEEP_WHEN_CLEAN
+# Below files won't be removed from "python setup.py clean"
+
+# Visual Studio (Code) files
+.vscode
+.vs
+
+# autocomplete
+.ycm_extra_conf.py

--- a/README.md
+++ b/README.md
@@ -197,6 +197,14 @@ After installing pytest, use the following command to run tests.
 pytest
 ```
 
+# Clean
+
+The following command can help you clean all build files:
+
+```
+python setup.py clean
+```
+
 # Development
 
 Check out the [contributor guide](https://github.com/onnx/onnx/blob/master/docs/CONTRIBUTING.md) for instructions.

--- a/setup.py
+++ b/setup.py
@@ -270,7 +270,6 @@ class mypy_type_check(ONNXCommand):
 
 class clean(distutils.command.clean.clean):
     def run(self):
-        import glob
         import re
         import shutil
         with open('.gitignore', 'r') as f:

--- a/setup.py
+++ b/setup.py
@@ -275,7 +275,7 @@ class clean(distutils.command.clean.clean):
         import shutil
         with open('.gitignore', 'r') as f:
             ignores = f.read()
-            pat = re.compile(r'^#( START KEEP_WHEN_CLEAN )?')
+            pat = re.compile(r'^#( START KEEP_WHEN_CLEAN)?')
             for wildcard in filter(None, ignores.split('\n')):
                 match = pat.match(wildcard)
                 # if matching target line; stop reading

--- a/setup.py
+++ b/setup.py
@@ -289,6 +289,7 @@ class clean(distutils.command.clean.clean):
 
         distutils.command.clean.clean.run(self)
 
+
 cmdclass = {
     'create_version': create_version,
     'cmake_build': cmake_build,


### PR DESCRIPTION
**Description**: 
Add a clean command in setup.py.
Remove files in .gitignore (which means those files are probably produced by build)
Set a list for exception (keep them when cleaning) in .gitignore 

**Motivation and Context**

- A user is looking for this solution: https://github.com/onnx/onnx/issues/2495.
- Actually I have the same requirement for using clean command to clean all build files from setup.py. 
`python setup.py clean` is useful if developers want to tune some environment settings and rebuild the onnx package.
