### PR TITLE
Fix environment settings for CI

### DIFF
--- a/.azure-pipelines/Linux-CI.yml
+++ b/.azure-pipelines/Linux-CI.yml
@@ -44,11 +44,9 @@ jobs:
       python -m pip install --quiet -U dos2unix
       python -m pip install numpy
       git submodule update --init --recursive
-      set ONNX_ML=${onnx_ml}
-      set DEBUG=${onnx_debug}
-      set ONNX_BUILD_TESTS=1
-      set USE_MSVC_STATIC_RUNTIME=0
-      set CMAKE_ARGS=-DONNX_USE_PROTOBUF_SHARED_LIBS=ON -DProtobuf_USE_STATIC_LIBS=OFF -DONNX_USE_LITE_PROTO=ON
+      export ONNX_ML=${onnx_ml}
+      export DEBUG=${onnx_debug}
+      export ONNX_BUILD_TESTS=1
       python setup.py --quiet install
     displayName: 'Install ONNX and dependencies'
 

--- a/.azure-pipelines/MacOS-CI.yml
+++ b/.azure-pipelines/MacOS-CI.yml
@@ -29,10 +29,8 @@ jobs:
       python -m pip install numpy
       conda install -c conda-forge pybind11 protobuf
       brew install protobuf
-      set ONNX_ML=${onnx_ml}
-      set ONNX_BUILD_TESTS=1
-      set USE_MSVC_STATIC_RUNTIME=0
-      set CMAKE_ARGS=-DONNX_USE_PROTOBUF_SHARED_LIBS=ON -DProtobuf_USE_STATIC_LIBS=OFF -DONNX_USE_LITE_PROTO=ON
+      export ONNX_ML=${onnx_ml}
+      export ONNX_BUILD_TESTS=1
       python setup.py --quiet install
     displayName: 'Install dependencies and ONNX'
 

--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -55,6 +55,8 @@ jobs:
       python onnx/defs/gen_doc.py
       python onnx/gen_proto.py -l
       python onnx/gen_proto.py -l --ml
+      python onnx/backend/test/stat_coverage.py
+      backend-test-tools generate-data
 
       rm -rf .setuptools-cmake-build
       pip install --quiet -e .[mypy]


### PR DESCRIPTION
**Description**: 
Remove unnecessary environment settings for Linux and Mac.
Use `export` instead of `set` on Linux and Mac to validate the setting for `ONNX_ML` and `ONNX_BUILD_TESTS`.
In addition, add backend test on Windows (not sure whether it is necessary)

**Motivation and Context**
Some environment settings might be unnecessary for Linux and Mac.
Should use `export` instead of `set` on Unix-like operating systems. 

