### PR TITLE
Update release doc

### DIFF
--- a/docs/OnnxReleases.md
+++ b/docs/OnnxReleases.md
@@ -1,16 +1,14 @@
-The ONNX project, going forward, will plan to release roughly on a two month cadence. We follow the [Semver](https://semver.org/) versioning approach and will make decisions as a community on a release by release basis on whether to do a major or minor release.
+The ONNX project, going forward, will plan to release roughly on a four month cadence. We follow the [Semver](https://semver.org/) versioning approach and will make decisions as a community on a release by release basis on whether to do a major or minor release.
 
-Next expected release: May 15th 
+Next expected release: Sept 15th 2020
 
-Release Checklist: 
+The following is the release process for v1.7.0, including a few manual steps that could be automated for next release:
 
 * Install Twine, a utility tool to interact with pypi. Do  - ``pip install twine``
-* Get hold of the username and password for the ‘onnx’ pypi account.
-* Pick a release tag for the new release through mutual consent – Gitter Room for Releases (https://gitter.im/onnx/Releases)
-* Prepare a change log for the release – 
-    * ``git log --pretty=format:"%h - %s" <tag of the previous release>...<new tag>``
-    * And draft a new release statement - https://github.com/onnx/onnx/releases listing out the new features and bug fixes, and potential changes being introduced in the release.
-* Checkout the release tag in a clean branch on your local repo. Make sure all tests pass on that branch.
+* Get hold of the username and password for the ‘onnx’ pypi account. The credentials are provided to the release manager by Steering Committee.
+* Make sure onnx/wheel_builder is working, following the wheel builder instructions (https://github.com/onnx/wheel-builder)
+* Pick a version number and release tag for the new release through mutual consent – Gitter Room for Releases (https://gitter.im/onnx/Releases)
+* Create a PR, https://github.com/onnx/onnx/pull/2639, to update VERSION_NUMBER (https://github.com/onnx/onnx/blob/master/VERSION_NUMBER) and versioning doc (https://github.com/onnx/onnx/blob/master/docs/Versioning.md).
 * Make sure that the Release version number information is up-to-date in the following places:
 [VERSION_NUMBER file](https://github.com/onnx/onnx/blob/master/VERSION_NUMBER) and
 [version.h](../onnx/common/version.h)
@@ -18,42 +16,36 @@ Release Checklist:
 [ONNX proto files](../onnx/onnx.in.proto),
 [Versioning.md](Versioning.md) and
 [helper.py](../onnx/helper.py).
-* Make sure all operators version are even number, if opset version is odd number then increment it and update all corresponding OPs.
-* Make sure all the git submodules are updated
+* Create a release branch, for ex rel-1.7.0
+* Create a PR against release branch to update VERSION_NUMBER for release verification in TestPypi. Make sure CI is clean.
+* After PR merged, download Windows wheels from git repo Actions, https://github.com/onnx/onnx/actions, and use the commit ID to update .travis in wheel-builder
+* Create a branch pypi-test in onnx/wheel-builder repo and a PR to trigger CI to upload release candidate wheels for Linux and OSX to TestPypi
+* Upload Windows wheels to TestPypi ``python -m twine upload --verbose *.whl --repository-url https://test.pypi.org/legacy/ -u onnx -p pwd``
+* Build ONNX source distribution
     * ``git submodule update –init``
-* Make sure the git checkout is clean –
     * Do ``git clean -nxd`` and make sure that none of the auto-generated header files *like* the following are not present.
         * onnx/onnx-operators.pb.cc
         * onnx/onnx-operator.pb.h
         * onnx/onnx.pb.cc
         * onnx/onnx.pb.h
     * If they are present run ``git clean -ixd`` and remove those files from your local branch
-* Do ``python setup.py sdist`` to generate the source distribution.
-* Put the following content into ``~/.pypirc`` file:
-```
-[distutils]
-index-servers =
-  pypi
-  pypitest
- 
-[pypi]
-username=<username>
-password=<password>
- 
-[pypitest]
-repository=https://test.pypi.org/legacy/
-username=<username>
-password=<password>
-```
-* Do ``twine upload dist/* -r pypitest`` to upload it to the test instance of pypi.
-* After uploading to pypitest, you can test the source distribution by doing ``pip install –index-url https://test.pypi.org/simple/ onnx`` in a new environment. Test this installation with different environments and versions of protobuf binaries.
-* *NOTE - Once a distribution is uploaded to pypi, you cannot overwrite it on the same pypi instance.*
-* Once completely verified do, ``twine upload dist/*``  to upload to the official pypi.
-* *Conda - *
+    * ``python setup.py sdist``
+* Upload source distribution to TestPypi ``python -m twine upload --verbose dist/* -r --repository-url https://test.pypi.org/legacy/ -u onnx -p pwd``
+* After uploading to TestPypi, you can install the test package by doing ``pip install -–index-url https://test.pypi.org/simple/ onnx`` in a new environment. Test this installation with different environments and versions of protobuf binaries.
+* Verify the release candidate in TestPypi by release test team. The communication is via gitter and an github issue.
+* Prepare a change log for the release
+    * Draft a new release statement - https://github.com/onnx/onnx/releases listing out the new features and bug fixes, and potential changes being introduced in the release.
+* Once the release candidate is completely verified
+  * Create a release in onnx/wheel-builder repo to trigger CI to upload release packages for Linux and OSX to Pypi
+  * Upload Windows wheels to Pypi ``python -m twine upload --verbose *.whl --repository-url https://pypi.org/legacy/ -u onnx -p pwd``
+  * Upload source distribution to Pypi ``python -m twine upload --verbose dist/* -r --repository-url https://pypi.org/legacy/ -u onnx -p pwd``
+* Create a release in onnx/onnx repo
+  * using the tag determinied earlier
+  * on the release branch
+  * providing the release notes
+* Release to Conda
     * Conda builds of ONNX are done via conda-forge, which runs infrastructure for building packages and uploading them to conda-forge. You need to submit a PR to https://github.com/conda-forge/onnx-feedstock (see https://github.com/conda-forge/onnx-feedstock/pull/1/files for an example PR.) You will need to have uploaded to PyPi already, and update the version number and tarball hash of the PyPi uploaded tarball.
-* The release branch needs to be marked as a protected branch to preserve it. The branch corresponding to each release must be preserved. (You may need to ask an admin to do this)
-
-
- 
-
-
+    * The Windows packages for conda are broken after v1.1.1. An open issue, https://github.com/onnx/onnx/issues/2612, is to be worked on.
+* Create a PR in https://github.com/onnx/onnx.github.io to update onnx.ai news
+* *NOTE - Once a distribution is uploaded to pypi, you cannot overwrite it on the same pypi instance.*
+* *The release branch needs to be marked as a protected branch to preserve it. The branch corresponding to each release must be preserved. (You may need to ask an admin to do this)*


### PR DESCRIPTION
This PR updates the release document based on the recent release 1.7 experience. The release doc will be updated again once release 1.8 is out because some manual steps should be automated.  ONNX 1.8 is currently proposed for around mid Sept. 2020.