### PR TITLE
Update description for initializer in IR and Loop in operator

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -11702,6 +11702,8 @@ This version of the operator has been available since version 11 of the default 
   time being the inner looping dimension), with each successive layer consuming
   the scan_outputs from the previous layer, possibly going through several
   point-wise operators (e.g. dropout, residual connections, linear layer).
+  
+  The input/output of subgrpah (produced by loop node) matching is based on order instead of name. The implementation will figure out the names based on this order.
 
 #### Version
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -11703,7 +11703,7 @@ This version of the operator has been available since version 11 of the default 
   the scan_outputs from the previous layer, possibly going through several
   point-wise operators (e.g. dropout, residual connections, linear layer).
   
-  The input/output of subgrpah (produced by loop node) matching is based on order instead of name. The implementation will figure out the names based on this order.
+  The input/output of subgraph (produced by loop node) matching is based on order instead of name. The implementation will figure out the names based on this order.
 
 #### Version
 

--- a/docs/IR.md
+++ b/docs/IR.md
@@ -179,7 +179,7 @@ Graphs have the following properties:
 |---|---|---|
 name|string|The name of the model graph.
 node|Node[]|A list of nodes, forming a partially ordered computation graph based on input/output data dependencies. It is in topological order.
-initializer|Tensor[]|A list of named tensor values. When an initializer has the same name as a graph input, it specifies a default value for that input. When an initializer has a name different from all graph inputs, it specifies a constant value. It may not be not in topological order. 
+initializer|Tensor[]|A list of named tensor values. When an initializer has the same name as a graph input, it specifies a default value for that input. When an initializer has a name different from all graph inputs, it specifies a constant value. It may not be in topological order. 
 doc_string|string|A human-readable documentation for this model. Markdown is allowed.
 input|ValueInfo[]|The input “parameters” of the graph, possibly initialized by a default value found in ‘initializer.’
 output|ValueInfo[]|The output parameters of the graph. Once all output parameters have been written to by a graph execution, the execution is complete.

--- a/docs/IR.md
+++ b/docs/IR.md
@@ -179,7 +179,7 @@ Graphs have the following properties:
 |---|---|---|
 name|string|The name of the model graph.
 node|Node[]|A list of nodes, forming a partially ordered computation graph based on input/output data dependencies. It is in topological order.
-initializer|Tensor[]|A list of named tensor values. When an initializer has the same name as a graph input, it specifies a default value for that input. When an initializer has a name different from all graph inputs, it specifies a constant value. It is not in topological order. 
+initializer|Tensor[]|A list of named tensor values. When an initializer has the same name as a graph input, it specifies a default value for that input. When an initializer has a name different from all graph inputs, it specifies a constant value. It may not be not in topological order. 
 doc_string|string|A human-readable documentation for this model. Markdown is allowed.
 input|ValueInfo[]|The input “parameters” of the graph, possibly initialized by a default value found in ‘initializer.’
 output|ValueInfo[]|The output parameters of the graph. Once all output parameters have been written to by a graph execution, the execution is complete.

--- a/docs/IR.md
+++ b/docs/IR.md
@@ -178,8 +178,8 @@ Graphs have the following properties:
 |Name|Type|Description|
 |---|---|---|
 name|string|The name of the model graph.
-node|Node[]|A list of nodes, forming a partially ordered computation graph based on input/output data dependencies.
-initializer|Tensor[]|A list of named tensor values. When an initializer has the same name as a graph input, it specifies a default value for that input. When an initializer has a name different from all graph inputs, it specifies a constant value.
+node|Node[]|A list of nodes, forming a partially ordered computation graph based on input/output data dependencies. It is in topological order.
+initializer|Tensor[]|A list of named tensor values. When an initializer has the same name as a graph input, it specifies a default value for that input. When an initializer has a name different from all graph inputs, it specifies a constant value. It is not in topological order. 
 doc_string|string|A human-readable documentation for this model. Markdown is allowed.
 input|ValueInfo[]|The input “parameters” of the graph, possibly initialized by a default value found in ‘initializer.’
 output|ValueInfo[]|The output parameters of the graph. Once all output parameters have been written to by a graph execution, the execution is complete.

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -8676,7 +8676,7 @@ expect(node, inputs=[x], outputs=[y],
   time being the inner looping dimension), with each successive layer consuming
   the scan_outputs from the previous layer, possibly going through several
   point-wise operators (e.g. dropout, residual connections, linear layer).
-
+  
   The input/output of subgrpah (produced by loop node) matching is based on order instead of name. The implementation will figure out the names based on this order.
 
 #### Version

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -8677,6 +8677,8 @@ expect(node, inputs=[x], outputs=[y],
   the scan_outputs from the previous layer, possibly going through several
   point-wise operators (e.g. dropout, residual connections, linear layer).
 
+  The input/output of subgrpah (produced by loop node) matching is based on order instead of name. The implementation will figure out the names based on this order.
+
 #### Version
 
 This version of the operator has been available since version 11 of the default ONNX operator set.

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -8677,7 +8677,7 @@ expect(node, inputs=[x], outputs=[y],
   the scan_outputs from the previous layer, possibly going through several
   point-wise operators (e.g. dropout, residual connections, linear layer).
   
-  The input/output of subgrpah (produced by loop node) matching is based on order instead of name. The implementation will figure out the names based on this order.
+  The input/output of subgraph (produced by loop node) matching is based on order instead of name. The implementation will figure out the names based on this order.
 
 #### Version
 

--- a/onnx/defs/controlflow/defs.cc
+++ b/onnx/defs/controlflow/defs.cc
@@ -557,7 +557,7 @@ time being the inner looping dimension), with each successive layer consuming
 the scan_outputs from the previous layer, possibly going through several
 point-wise operators (e.g. dropout, residual connections, linear layer).
 
-The input/output of subgrpah (produced by loop node) matching is based on order instead of name. The implementation will figure out the names based on this order.
+The input/output of subgraph (produced by loop node) matching is based on order instead of name. The implementation will figure out the names based on this order.
 )DOC";
 
 ONNX_OPERATOR_SET_SCHEMA(

--- a/onnx/defs/controlflow/defs.cc
+++ b/onnx/defs/controlflow/defs.cc
@@ -556,6 +556,8 @@ Frontends should emit multi-layer RNNs as a series of While operators (with
 time being the inner looping dimension), with each successive layer consuming
 the scan_outputs from the previous layer, possibly going through several
 point-wise operators (e.g. dropout, residual connections, linear layer).
+
+The input/output of subgrpah (produced by loop node) matching is based on order instead of name. The implementation will figure out the names based on this order.
 )DOC";
 
 ONNX_OPERATOR_SET_SCHEMA(

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -4,18 +4,12 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import sys
-import platform
 
 import numpy as np  # type: ignore
 from onnx import TensorProto
 from onnx import mapping
 from six import text_type, binary_type
 from typing import Sequence, Any, Optional, Text, List
-
-if platform.system() != 'AIX' and sys.byteorder != 'little':
-    raise RuntimeError(
-        'Numpy helper for tensor/ndarray is not available on big endian '
-        'systems yet.')
 
 
 def combine_pairs_to_complex(fa):  # type: (Sequence[int]) -> Sequence[np.complex64]
@@ -50,6 +44,9 @@ def to_array(tensor):  # type: (TensorProto) -> np.ndarray[Any]
 
     if tensor.HasField("raw_data"):
         # Raw_bytes support: using frombuffer.
+        if sys.byteorder == 'big':
+            # Convert endian from little to big
+            convert_endian(tensor)
         return np.frombuffer(
             tensor.raw_data,
             dtype=np_dtype).reshape(dims)
@@ -114,5 +111,19 @@ def from_array(arr, name=None):  # type: (np.ndarray[Any], Optional[Text]) -> Te
             "Numpy data type not understood yet: {}".format(str(arr.dtype)))
     tensor.data_type = dtype
     tensor.raw_data = arr.tobytes()  # note: tobytes() is only after 1.9.
+    if sys.byteorder == 'big':
+        # Convert endian from big to little
+        convert_endian(tensor)
 
     return tensor
+
+
+def convert_endian(tensor):  # type: (TensorProto) -> None
+    """
+    call to convert endianess of raw data in tensor.
+    @params
+    TensorProto: TensorProto to be converted.
+    """
+    tensor_dtype = tensor.data_type
+    np_dtype = mapping.TENSOR_TYPE_TO_NP_TYPE[tensor_dtype]
+    tensor.raw_data = np.frombuffer(tensor.raw_data, dtype=np_dtype).byteswap().tobytes()


### PR DESCRIPTION
**Description**
Add more descriptions in documents:
1. Specify that `.initializer` is not in topological order but `.node` is
2. Add a description: Subgraph input/output matching is based on order not name.

**Motivation and Context**
1. Users are confused about why `initializer` does not follow topological order https://github.com/onnx/onnx/issues/2860
2. Users thought the input/output of subgraph (produced by loop node) is matching by the name. https://github.com/onnx/onnx/issues/2498