### PR TITLE
[WIP] Add a installation flag to exclude test data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ ONNX_ML = not bool(os.getenv('ONNX_ML') == '0')
 ONNX_VERIFY_PROTO3 = bool(os.getenv('ONNX_VERIFY_PROTO3') == '1')
 ONNX_NAMESPACE = os.getenv('ONNX_NAMESPACE', 'onnx')
 ONNX_BUILD_TESTS = bool(os.getenv('ONNX_BUILD_TESTS') == '1')
+ONNX_EXCLUDE_TESTS = bool(os.getenv('ONNX_EXCLUDE_TESTS') == '1')
 
 DEBUG = bool(os.getenv('DEBUG'))
 COVERAGE = bool(os.getenv('COVERAGE'))
@@ -290,8 +291,12 @@ ext_modules = [
 # Packages
 ################################################################################
 
+# Exclude test data while building ONNX
+if ONNX_EXCLUDE_TESTS:
+    packages = setuptools.find_packages(exclude='onnx.backend.test*')    
 # no need to do fancy stuff so far
-packages = setuptools.find_packages()
+else:
+    packages = setuptools.find_packages()
 
 install_requires.extend([
     'protobuf',

--- a/setup.py
+++ b/setup.py
@@ -293,7 +293,7 @@ ext_modules = [
 
 # Exclude test data while building ONNX
 if ONNX_EXCLUDE_TESTS:
-    packages = setuptools.find_packages(exclude='onnx.backend.test*')    
+    packages = setuptools.find_packages(exclude='onnx.backend.test*')
 # no need to do fancy stuff so far
 else:
     packages = setuptools.find_packages()


### PR DESCRIPTION
**Description**
To compromise, the setup.py should provide an option (ONNX_EXCLUDE_TESTS) for some users to exclude those test data while installing onnx if they don't need them. The default value is False so it won't influence current usage.
Related PR: https://github.com/onnx/onnx/pull/2857, move the original idea to this WIP PR.

**Motivation and Context**
According to #2821, the user encountered an error while installing onnx. It seems unnecessary to include those testing files for building onnx. Especially some filenames are too long, which is easy to trigger the _**filename too long**_ issue on Windows.
However, there are some users depend on those test data in onnx:
e.g., https://github.com/NervanaSystems/ngraph-onnx/blob/master/tests/test_backend.py#L54

The solution (adding a flag for installation or moving those test/data to another package on PyPI) is still debatable at this moment.