### PR TITLE
Use the master of pytorch/vision in CircleCI

### DIFF
--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -10,10 +10,7 @@ sudo apt install ./libturbojpeg0_2.0.5-1_amd64.deb -y
 
 # install torchvision from master
 # the one on pypi requires cuda
-# Currently the master branch of pytorch/vision is not stable
-# Should set it back to the master if the issue from master branch has been resovled
-
-pip install -vvv git+https://github.com/pytorch/vision.git
+pip install -q git+https://github.com/pytorch/vision.git
 
 cd /tmp/pytorch
 CI=1 exec "scripts/onnx/test.sh"

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -4,12 +4,16 @@ set -ex
 
 source /tmp/venv/bin/activate
 
+# install new libturbojpeg for pytorch/vision
+wget http://ftp.br.debian.org/debian/pool/main/libj/libjpeg-turbo/libturbojpeg0_2.0.5-1_amd64.deb
+sudo apt install ./libturbojpeg0_2.0.5-1_amd64.deb -y
+
 # install torchvision from master
 # the one on pypi requires cuda
 # Currently the master branch of pytorch/vision is not stable
 # Should set it back to the master if the issue from master branch has been resovled
-# Therefore use certain commit on 07/06/2020 for now
-pip install -q git+https://github.com/pytorch/vision.git@86b6c3e22e9d7d8b0fa25d08704e6a31a364973b
+
+pip install -vvv git+https://github.com/pytorch/vision.git
 
 cd /tmp/pytorch
 CI=1 exec "scripts/onnx/test.sh"


### PR DESCRIPTION
**Description**
https://github.com/pytorch/vision/issues/2480
The master branch of pytorch/vision needs additionally `apt install libturbojpeg`.

**Motivation and Context**
Old fix: https://github.com/onnx/onnx/pull/2890
However, using an old commit is a temporary solution. onnx should use the latest pytorch/vision.
