### PR TITLE
pin pytest version

### DIFF
--- a/.azure-pipelines/Linux-CI.yml
+++ b/.azure-pipelines/Linux-CI.yml
@@ -83,7 +83,14 @@ jobs:
       ! grep -R --include='*.cc' --include='*.h' 'onnx::' .
 
       # onnx python api tests
-      pip install --quiet pytest nbval
+      if [ "$(python.version)" == "2.7" ]; then
+        pip install --quiet pytest nbval
+      else
+        # pytest 6.0 made deprecation warnings fail by default, pinning pytest to 5.4.3.
+        # TODO replace deprecated function with the suggested one. https://docs.pytest.org/en/stable/deprecations.html#id5
+        pip install --quiet pytest==5.4.3 nbval
+      fi
+
       pytest
       if [ $? -ne 0 ]; then
         echo "pytest failed"

--- a/.azure-pipelines/MacOS-CI.yml
+++ b/.azure-pipelines/MacOS-CI.yml
@@ -63,7 +63,14 @@ jobs:
       ! grep -R --include='*.cc' --include='*.h' 'onnx::' .
 
       # onnx python api tests
-      pip install --quiet pytest nbval
+      if [ "$(python.version)" == "2.7" ]; then
+        pip install --quiet pytest nbval
+      else
+        # pytest 6.0 made deprecation warnings fail by default, pinning pytest to 5.4.3.
+        # TODO replace deprecated function with the suggested one. https://docs.pytest.org/en/stable/deprecations.html#id5
+        pip install --quiet pytest==5.4.3 nbval
+      fi
+
       pytest
       if [ $? -ne 0 ]; then
         echo "pytest failed"

--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -41,7 +41,9 @@ jobs:
   - script: |
       call activate py$(python.version)
       python -m pip install --upgrade pip
-      python -m pip install --quiet pytest nbval numpy
+      # pytest 6.0 made deprecation warnings fail by default, pinning pytest to 5.4.3.
+      # TODO replace deprecated function with the suggested one. https://docs.pytest.org/en/stable/deprecations.html#id5
+      python -m pip install --quiet pytest==5.4.3 nbval numpy
 
       git submodule update --init --recursive
       set ONNX_BUILD_TESTS=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,14 @@ jobs:
     - name: Install python dependencies
       run: |
         python -m pip install --upgrade pip
-        IF '${{ matrix.python-version }}' == '2.7' (
+        if ('${{ matrix.python-version }}' -eq '2.7') {
           pip install pytest nbval numpy wheel
-        )
-        ELSE (
+        }
+        else {
           # pytest 6.0 made deprecation warnings fail by default, pinning pytest to 5.4.3.
           # TODO replace deprecated function with the suggested one. https://docs.pytest.org/en/stable/deprecations.html#id5
           pip install pytest==5.4.3 nbval numpy wheel
-        )
+        }
     - name: Build wheel
       run: |
         $Env:USE_MSVC_STATIC_RUNTIME=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,14 @@ jobs:
     - name: Install python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest nbval numpy wheel
+        IF '${{ matrix.python-version }}' == '2.7' (
+          pip install pytest nbval numpy wheel
+        )
+        ELSE (
+          # pytest 6.0 made deprecation warnings fail by default, pinning pytest to 5.4.3.
+          # TODO replace deprecated function with the suggested one. https://docs.pytest.org/en/stable/deprecations.html#id5
+          pip install pytest==5.4.3 nbval numpy wheel
+        )
     - name: Build wheel
       run: |
         $Env:USE_MSVC_STATIC_RUNTIME=1

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -10,7 +10,14 @@ export LD_LIBRARY_PATH="${top_dir}/.setuptools-cmake-build/:$LD_LIBRARY_PATH"
 ./.setuptools-cmake-build/onnxifi_test_driver_gtests onnx/backend/test/data/node
 
 # onnx python API tests
-pip install --quiet pytest nbval
+if [ "${PYTHON_VERSION}" == "python2" ]; then
+  pip install --quiet pytest nbval
+else
+  # pytest 6.0 made deprecation warnings fail by default, pinning pytest to 5.4.3.
+  # TODO replace deprecated function with the suggested one. https://docs.pytest.org/en/stable/deprecations.html#id5
+  pip install --quiet pytest==5.4.3 nbval
+fi
+
 pytest
 
 # lint python code


### PR DESCRIPTION
pytest 6.0.0 made deprecation warnings fail by default. Pinning pytest to 5.4.3 to fix all CI failures
https://docs.pytest.org/en/stable/deprecations.html#id5