### PR TITLE
Catch unexpected MemoryError for large model test on Windows-CI

### DIFF
--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -53,7 +53,7 @@ jobs:
       set CMAKE_ARGS=-DONNX_USE_PROTOBUF_SHARED_LIBS=ON -DProtobuf_USE_STATIC_LIBS=OFF -DONNX_USE_LITE_PROTO=ON
 
       python setup.py --quiet install
-      pytest
+      pytest -s
       IF NOT %ERRORLEVEL% EQU 0 (
         @echo "pytest failed"
         EXIT 1

--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -53,7 +53,7 @@ jobs:
       set CMAKE_ARGS=-DONNX_USE_PROTOBUF_SHARED_LIBS=ON -DProtobuf_USE_STATIC_LIBS=OFF -DONNX_USE_LITE_PROTO=ON
 
       python setup.py --quiet install
-      pytest -s
+      pytest
       IF NOT %ERRORLEVEL% EQU 0 (
         @echo "pytest failed"
         EXIT 1

--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -56,6 +56,7 @@ jobs:
       pytest
       IF NOT %ERRORLEVEL% EQU 0 (
         @echo "pytest failed"
+        EXIT 1
       )
 
       python onnx/defs/gen_doc.py

--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -54,6 +54,10 @@ jobs:
 
       python setup.py --quiet install
       pytest
+      IF NOT %ERRORLEVEL% EQU 0 (
+        @echo "pytest failed"
+      )
+
       python onnx/defs/gen_doc.py
       python onnx/gen_proto.py -l
       python onnx/gen_proto.py -l --ml

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -285,9 +285,12 @@ class TestLarge2GBExternalData(TestLoadExternalDataBase):
     # 2GB models would fail onnx.checker with ModelProto but pass with model path
     def test_check_model_by_model(self):  # type: () -> None
         model = onnx.load_model(self.model_filename, load_external_data=False)
-        with pytest.raises((ValueError, MemoryError)):
+        try:
             load_external_data_for_model(model, self.temp_dir)  # Exceeds maximum protobuf
-            checker.check_model(model)  # checker catches 2GB models as well
+        except MemoryError:
+            print("Warning: Because of the hardware limitation (memory), this test was not executed.")
+            return
+        self.assertRaises(ValueError, checker.check_model, model) # checker catches 2GB models and throw error
 
 
 if __name__ == '__main__':

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -18,7 +18,6 @@ from onnx.external_data_helper import load_external_data_for_model
 from onnx.numpy_helper import to_array, from_array
 from typing import Any, Tuple, Text, List
 import pytest  # type: ignore
-import sys
 
 
 class TestLoadExternalDataBase(unittest.TestCase):

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -290,8 +290,8 @@ class TestLarge2GBExternalData(TestLoadExternalDataBase):
             self.assertRaises(ValueError, checker.check_model, model)  # checker catches 2GB models and throw error
         except MemoryError:
             print("Warning: Because of the hardware limitation (memory), this test was not executed.")
-            self.assertRaises(ValueError, checker.check_model, model)  # checker catch
             return
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -286,8 +286,8 @@ class TestLarge2GBExternalData(TestLoadExternalDataBase):
     # 2GB models would fail onnx.checker with ModelProto but pass with model path
     # Currently Windows-CI with Azure Pipelines has memory limitation
     # load_external_data_for_model will throw MemoryError for >2GB models. So simply skip this test if Windows.
-    @pytest.mark.skipif(sys.platform.startswith("win"),
-        reason="Because of the hardware limitation (memory) in Windows-CI, this test was not executed.")  # type: ignore
+    @pytest.mark.skipif(sys.platform.startswith("win"),  # type: ignore
+        reason="Because of the hardware limitation (memory) in Windows-CI, this test was not executed.")
     def test_check_model_by_model(self):  # type: () -> None
         model = onnx.load_model(self.model_filename, load_external_data=False)
         load_external_data_for_model(model, self.temp_dir)  # Exceeds maximum protobuf

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -290,7 +290,7 @@ class TestLarge2GBExternalData(TestLoadExternalDataBase):
         except MemoryError:
             print("Warning: Because of the hardware limitation (memory), this test was not executed.")
             return
-        self.assertRaises(ValueError, checker.check_model, model) # checker catches 2GB models and throw error
+        self.assertRaises(ValueError, checker.check_model, model)  # checker catches 2GB models and throw error
 
 
 if __name__ == '__main__':

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -18,6 +18,7 @@ from onnx.external_data_helper import load_external_data_for_model
 from onnx.numpy_helper import to_array, from_array
 from typing import Any, Tuple, Text, List
 import pytest  # type: ignore
+import sys
 
 
 class TestLoadExternalDataBase(unittest.TestCase):
@@ -289,7 +290,7 @@ class TestLarge2GBExternalData(TestLoadExternalDataBase):
             load_external_data_for_model(model, self.temp_dir)  # Exceeds maximum protobuf
             self.assertRaises(ValueError, checker.check_model, model)  # checker catches 2GB models and throw error
         except MemoryError:
-            print("Warning: Because of the hardware limitation (memory), this test was not executed.")
+            sys.stderr.write("Warning: Because of the hardware limitation (memory), this test was not executed.")
             return
 
 

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -18,6 +18,7 @@ from onnx.external_data_helper import load_external_data_for_model
 from onnx.numpy_helper import to_array, from_array
 from typing import Any, Tuple, Text, List
 import pytest  # type: ignore
+import sys
 
 
 class TestLoadExternalDataBase(unittest.TestCase):
@@ -285,7 +286,8 @@ class TestLarge2GBExternalData(TestLoadExternalDataBase):
     # 2GB models would fail onnx.checker with ModelProto but pass with model path
     # Currently Windows-CI with Azure Pipelines has memory limitation
     # load_external_data_for_model will throw MemoryError for >2GB models. So simply skip this test if Windows.
-    @pytest.mark.skipif(os.name == 'nt', reason="Because of the hardware limitation (memory) in Windows-CI, this test was not executed.")
+    @pytest.mark.skipif(sys.platform.startswith("win"),
+        reason="Because of the hardware limitation (memory) in Windows-CI, this test was not executed.")  # type: ignore
     def test_check_model_by_model(self):  # type: () -> None
         model = onnx.load_model(self.model_filename, load_external_data=False)
         load_external_data_for_model(model, self.temp_dir)  # Exceeds maximum protobuf

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -285,7 +285,7 @@ class TestLarge2GBExternalData(TestLoadExternalDataBase):
     # 2GB models would fail onnx.checker with ModelProto but pass with model path
     def test_check_model_by_model(self):  # type: () -> None
         model = onnx.load_model(self.model_filename, load_external_data=False)
-        with pytest.raises(ValueError):
+        with pytest.raises((ValueError, MemoryError)):
             load_external_data_for_model(model, self.temp_dir)  # Exceeds maximum protobuf
             checker.check_model(model)  # checker catches 2GB models as well
 

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -287,11 +287,11 @@ class TestLarge2GBExternalData(TestLoadExternalDataBase):
         model = onnx.load_model(self.model_filename, load_external_data=False)
         try:
             load_external_data_for_model(model, self.temp_dir)  # Exceeds maximum protobuf
+            self.assertRaises(ValueError, checker.check_model, model)  # checker catches 2GB models and throw error
         except MemoryError:
             print("Warning: Because of the hardware limitation (memory), this test was not executed.")
+            self.assertRaises(ValueError, checker.check_model, model)  # checker catch
             return
-        self.assertRaises(ValueError, checker.check_model, model)  # checker catches 2GB models and throw error
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -284,14 +284,13 @@ class TestLarge2GBExternalData(TestLoadExternalDataBase):
         return model_filename, model
 
     # 2GB models would fail onnx.checker with ModelProto but pass with model path
+    # Currently Windows-CI with Azure Pipelines has memory limitation
+    # load_external_data_for_model will throw MemoryError for >2GB models. So simply skip this test if Windows.
+    @pytest.mark.skipif(os.name == 'nt', reason="Because of the hardware limitation (memory) in Windows-CI, this test was not executed.")
     def test_check_model_by_model(self):  # type: () -> None
         model = onnx.load_model(self.model_filename, load_external_data=False)
-        try:
-            load_external_data_for_model(model, self.temp_dir)  # Exceeds maximum protobuf
-            self.assertRaises(ValueError, checker.check_model, model)  # checker catches 2GB models and throw error
-        except MemoryError:
-            sys.stderr.write("Warning: Because of the hardware limitation (memory), this test was not executed.")
-            return
+        load_external_data_for_model(model, self.temp_dir)  # Exceeds maximum protobuf
+        self.assertRaises(ValueError, checker.check_model, model)  # checker catches 2GB models and throw error
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description**
I checked the Azure Pipeline doc it seems that Microsoft-hosted agents cannot increase the memory. If we cannot enhance our CI Windows machine, the workaround might be to catch `MemoryError` as well. In that case, the test is useless on Windows, but it has been covered on Linux and Mac. (This test worked normally on them) 

**Motivation and Context**
https://github.com/onnx/onnx/pull/2929
`TestLarge2GBExternalData` tests 2 GB models with `onnx.checker`. However, some machines will encounter `MemoryError` because of the hardware limitation. (e.g., Azure Pipeline Windows Machine) 