### PR TITLE
[CircleCI] Use stable libturbojpeg for torch/vision

### DIFF
--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -6,7 +6,7 @@ source /tmp/venv/bin/activate
 
 # install new libturbojpeg for pytorch/vision
 wget http://ftp.br.debian.org/debian/pool/main/libj/libjpeg-turbo/libturbojpeg0_1.5.2-2+b1_amd64.deb
-sudo apt install ./libturbojpeg0_2.0.5-1_amd64.deb -y
+sudo apt install ./libturbojpeg0_1.5.2-2+b1_amd64.deb -y
 
 # install torchvision from master
 # the one on pypi requires cuda

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -5,7 +5,7 @@ set -ex
 source /tmp/venv/bin/activate
 
 # install new libturbojpeg for pytorch/vision
-wget http://ftp.br.debian.org/debian/pool/main/libj/libjpeg-turbo/libturbojpeg0_2.0.5-1_amd64.deb
+wget http://ftp.br.debian.org/debian/pool/main/libj/libjpeg-turbo/libturbojpeg0_1.5.2-2+b1_amd64.deb
 sudo apt install ./libturbojpeg0_2.0.5-1_amd64.deb -y
 
 # install torchvision from master


### PR DESCRIPTION
**Description**
To prevent the link (download dependency for torch/vision) from being invalid again, it should use a stable version.

**Motivation and Context**
Related to https://github.com/onnx/onnx/pull/2909, the latest version of libturbojpeg becomes invalid just now.