### PR TITLE
[WIP] Deprecate CircleCI; Consider proper tests under pytorch

### DIFF
--- a/.azure-pipelines/Linux-CI.yml
+++ b/.azure-pipelines/Linux-CI.yml
@@ -126,3 +126,32 @@ jobs:
         ONNX_NAMESPACE=ONNX_NAMESPACE_FOO_BAR_FOR_CI pip install .
       fi
     displayName: 'Run ONNX tests'
+  - script: |
+      export ONNX_ML=0
+      export ONNX_DIR=$PWD
+      # setup onnx as the submodule of pytorch
+      cd ..
+      git clone --recursive --quiet https://github.com/pytorch/pytorch.git
+      TORCH_ONNX_DIR="pytorch/third_party/onnx"
+      rm -rf "$TORCH_ONNX_DIR"
+      cp -r "$ONNX_DIR" "$TORCH_ONNX_DIR"
+      
+      # install ninja to speedup the build
+      pip install ninja
+      # install pytorch
+      cd pytorch
+      ./scripts/onnx/install-develop.sh
+      # install onnxruntime
+      pip install -i https://test.pypi.org/simple/ ort-nightly==1.3.1.dev202006254
+      # install new libturbojpeg for pytorch/vision
+      wget http://ftp.br.debian.org/debian/pool/main/libj/libjpeg-turbo/libturbojpeg0_1.5.2-2+b1_amd64.deb
+      sudo apt install ./libturbojpeg0_1.5.2-2+b1_amd64.deb -y
+      # install torchvision from master
+      # the one on pypi requires cuda
+      pip install -q git+https://github.com/pytorch/vision.git
+      ./scripts/onnx/test.sh
+      if [ $? -ne 0 ]; then
+        echo "pytorch/onnx tests failed"
+        exit 1
+      fi
+    displayName: 'Run pytorch/onnx tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ linux_default: &linux_default
   - run:
       name: Test
       no_output_timeout: "1h"
+      build_environment: "ort1-py3.6"
       command: |
         docker exec -e CIRCLE_JOB=${CIRCLE_JOB} -u jenkins $(cat .docker_pid) .circleci/test.sh
 


### PR DESCRIPTION
**Description**
Deprecate CircleCI and move pytorch/onnx tests to Azure Pipelines for now. 

**Motivation and Context**
Reviewing the tests in CircleCI and considering which tests need to be added/removed under pytorch/onnx

P.S. There were some bugs in the previous PR. Just made a new one to test. 