### PR TITLE
Add size check to make_tensor

### DIFF
--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -225,16 +225,23 @@ def make_tensor(
     if data_type == TensorProto.STRING:
         assert not raw, "Can not use raw_data to store string type"
 
+    # Check number of vals specified equals tensor size
+    size = 1 if (not raw) else (mapping.TENSOR_TYPE_TO_NP_TYPE[data_type].itemsize)
+    for d in dims:
+        size = size * d
+    if (len(vals) != size):
+        raise ValueError("Number of values does not match tensor's size.")
+
     if (data_type == TensorProto.COMPLEX64
             or data_type == TensorProto.COMPLEX128):
         vals = split_complex_to_pairs(vals)
+
     if raw:
         tensor.raw_data = vals
     else:
         field = mapping.STORAGE_TENSOR_TYPE_TO_FIELD[
             mapping.TENSOR_TYPE_TO_STORAGE_TENSOR_TYPE[data_type]]
         getattr(tensor, field).extend(vals)
-
     tensor.dims.extend(dims)
     return tensor
 

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -1934,11 +1934,11 @@ class TestShapeInference(unittest.TestCase):
     def test_constantofshape_with_shape_zero(self):  # type: () -> None
         graph = self._make_graph([],
             [make_node("Constant", [], ['shape'],
-                       value=make_tensor('shape', TensorProto.INT64, (3,), (0,))),
+                       value=make_tensor('shape', TensorProto.INT64, (1,), (0,))),
              make_node("ConstantOfShape", ['shape'], ['y'], value=make_tensor('value', TensorProto.INT32, (1, ), (2, )))],
             [])
         self._assert_inferred(graph,
-            [make_tensor_value_info('shape', TensorProto.INT64, (3,)),
+            [make_tensor_value_info('shape', TensorProto.INT64, (1,)),
              make_tensor_value_info('y', TensorProto.INT32, (0,))])  # type: ignore
 
     def test_convinteger(self):  # type: () -> None
@@ -3236,8 +3236,12 @@ class TestShapeInference(unittest.TestCase):
         if initializer_shape is None:
             initializer = []  # type: ignore
         else:
-            initializer = [make_tensor("x", TensorProto.FLOAT, initializer_shape, ()),  # type: ignore
-                make_tensor("y", TensorProto.FLOAT, initializer_shape, ())]
+            size = 1
+            for d in initializer_shape:
+                size = size * d
+            vals = [0.0 for i in range(size)]
+            initializer = [make_tensor("x", TensorProto.FLOAT, initializer_shape, vals),  # type: ignore
+                make_tensor("y", TensorProto.FLOAT, initializer_shape, vals)]
         if input_shape is None:
             inputs = []  # type: ignore
         else:


### PR DESCRIPTION
Add a check in make_tensor to ensure that the specified dims and the number of elements in the tensor are consistent. Fix a couple of bugs in shape-inference-tests that were violating this condition.