### PR TITLE
Add a warning message for optimizer

### DIFF
--- a/docs/Optimizer.md
+++ b/docs/Optimizer.md
@@ -1,5 +1,11 @@
 # ONNX Optimizer
 
+**WARNING: ONNX Optimizer has been moved to https://github.com/onnx/optimizer.**
+
+**All further enhancements and fixes to optimizers will be done in this new repo.**
+
+**The optimizer code in onnx/onnx repo will be removed in 1.9 release.**
+
 ONNX provides a C++ library for performing arbitrary optimizations on
 ONNX models, as well as a growing list of prepackaged optimization
 passes. The library also provides a convenient in-memory

--- a/onnx/optimizer/optimize.cc
+++ b/onnx/optimizer/optimize.cc
@@ -12,8 +12,9 @@ Optimizer::Optimizer(
     const std::vector<std::string>& names,
     const bool fixed_point) {
   std::cout
-      << "WARNING: ONNX Optimizer has been moved to https://github.com/onnx/optimizer. "
-      << "The optimizer code in onnx/onnx repo will be removed in 1.9 release."
+      << "WARNING: ONNX Optimizer has been moved to https://github.com/onnx/optimizer.\n"
+      << "All further enhancements and fixes to optimizers will be done in this new repo.\n"
+      << "The optimizer code in onnx/onnx repo will be removed in 1.9 release.\n"
       << std::endl;
   if (fixed_point) {
     this->pass_manager =

--- a/onnx/optimizer/optimize.cc
+++ b/onnx/optimizer/optimize.cc
@@ -11,6 +11,10 @@ GlobalPassRegistry Optimizer::passes;
 Optimizer::Optimizer(
     const std::vector<std::string>& names,
     const bool fixed_point) {
+  std::cout
+      << "WARNING: ONNX Optimizer has been moved to https://github.com/onnx/optimizer. "
+      << "The optimizer code in onnx/onnx repo will be removed in 1.9 release."
+      << std::endl;
   if (fixed_point) {
     this->pass_manager =
         std::shared_ptr<FixedPointPassManager>(new FixedPointPassManager());


### PR DESCRIPTION
ONNX Optimizer is moving to https://github.com/onnx/optimizer (https://github.com/onnx/optimizer/issues/1). A warning message should be added to suggest users use the new repo.