### PR TITLE
Improve sparse tensor support when used as sparse initializers

### DIFF
--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -689,7 +689,9 @@ void check_graph(
   }
 
   for (const auto& sparse_init : graph.sparse_initializer()) {
-    const auto& name = sparse_init.values().name();
+    const auto& values = sparse_init.values();
+    enforce_has_field(values, name);
+    const auto& name = values.name();
     if (name.empty()) {
       fail_check("Sparse tensor initializers must have a non-empty name");
     }

--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -424,6 +424,13 @@ void check_sparse_tensor(
 
   const TensorProto& values = sparse_tensor_proto.values();
   check_tensor(values, ctx);
+  // SparseTensors names are stored as values names
+  // and this is important for use as inputs or sparse initializers
+  enforce_has_field(values, name);
+  if (values.name().empty()) {
+    fail_check(
+        "Sparse tensor values must have a non-empty name");
+  }
 
   // values must be a tensor of shape [NNZ]
   // Currently we restrict the value associated with a particular index-tuple

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -133,9 +133,12 @@ def make_graph(
     initializer=None,  # type: Optional[Sequence[TensorProto]]
     doc_string=None,  # type: Optional[Text]
     value_info=[],  # type: Sequence[ValueInfoProto]
+    sparse_initializer=None, # type: Optional[Sequence[SparseTensorProto]]
 ):  # type: (...) -> GraphProto
     if initializer is None:
         initializer = []
+    if sparse_initializer is None:
+        sparse_initializer = []
     if value_info is None:
         value_info = []
     graph = GraphProto()
@@ -144,6 +147,7 @@ def make_graph(
     graph.input.extend(inputs)
     graph.output.extend(outputs)
     graph.initializer.extend(initializer)
+    graph.sparse_initializer.extend(sparse_initializer)
     graph.value_info.extend(value_info)
     if doc_string:
         graph.doc_string = doc_string

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -133,7 +133,7 @@ def make_graph(
     initializer=None,  # type: Optional[Sequence[TensorProto]]
     doc_string=None,  # type: Optional[Text]
     value_info=[],  # type: Sequence[ValueInfoProto]
-    sparse_initializer=None, # type: Optional[Sequence[SparseTensorProto]]
+    sparse_initializer=None,  # type: Optional[Sequence[SparseTensorProto]]
 ):  # type: (...) -> GraphProto
     if initializer is None:
         initializer = []

--- a/onnx/onnx-ml.proto
+++ b/onnx/onnx-ml.proto
@@ -423,8 +423,8 @@ message GraphProto {
   optional string name = 2;   // namespace Graph
 
   // A list of named tensor values, used to specify constant inputs of the graph.
-  // Each TensorProto entry must have a distinct name (within the list) that
-  // MAY also appear in the input list.
+  // Each TensorProto entry must have a distinct name (between initializer and sparse_initializer)
+  // that MAY also appear in the input list.
   repeated TensorProto initializer = 5;
 
   // Initializers (see above) stored in sparse format.
@@ -603,6 +603,8 @@ message TensorProto {
 message SparseTensorProto {
   // The sequence of non-default values are encoded as a tensor of shape [NNZ].
   // The default-value is zero for numeric tensors, and empty-string for string tensors.
+  // values must have a non-empty name present which serves as a name for SparseTensorProto
+  // when used in sparse_initializer list.
   optional TensorProto values = 1;
 
   // The indices of the non-default values, which may be stored in one of two formats.

--- a/onnx/onnx-ml.proto3
+++ b/onnx/onnx-ml.proto3
@@ -423,8 +423,8 @@ message GraphProto {
   string name = 2;   // namespace Graph
 
   // A list of named tensor values, used to specify constant inputs of the graph.
-  // Each TensorProto entry must have a distinct name (within the list) that
-  // MAY also appear in the input list.
+  // Each TensorProto entry must have a distinct name (between initializer and sparse_initializer)
+  // that MAY also appear in the input list.
   repeated TensorProto initializer = 5;
 
   // Initializers (see above) stored in sparse format.
@@ -603,6 +603,8 @@ message TensorProto {
 message SparseTensorProto {
   // The sequence of non-default values are encoded as a tensor of shape [NNZ].
   // The default-value is zero for numeric tensors, and empty-string for string tensors.
+  // values must have a non-empty name present which serves as a name for SparseTensorProto
+  // when used in sparse_initializer list.
   TensorProto values = 1;
 
   // The indices of the non-default values, which may be stored in one of two formats.

--- a/onnx/onnx.in.proto
+++ b/onnx/onnx.in.proto
@@ -601,6 +601,7 @@ message SparseTensorProto {
   // The sequence of non-default values are encoded as a tensor of shape [NNZ].
   // The default-value is zero for numeric tensors, and empty-string for string tensors.
   // values must have a non-empty name present which serves as a name for SparseTensorProto
+  // when used in sparse_initializer list.
   optional TensorProto values = 1;
 
   // The indices of the non-default values, which may be stored in one of two formats.

--- a/onnx/onnx.in.proto
+++ b/onnx/onnx.in.proto
@@ -420,8 +420,8 @@ message GraphProto {
   optional string name = 2;   // namespace Graph
 
   // A list of named tensor values, used to specify constant inputs of the graph.
-  // Each TensorProto entry must have a distinct name (within the list) that
-  // MAY also appear in the input list.
+  // Each TensorProto entry must have a distinct name (between initializer and sparse_initializer)
+  // that MAY also appear in the input list.
   repeated TensorProto initializer = 5;
 
   // Initializers (see above) stored in sparse format.
@@ -600,6 +600,7 @@ message TensorProto {
 message SparseTensorProto {
   // The sequence of non-default values are encoded as a tensor of shape [NNZ].
   // The default-value is zero for numeric tensors, and empty-string for string tensors.
+  // values must have a non-empty name present which serves as a name for SparseTensorProto
   optional TensorProto values = 1;
 
   // The indices of the non-default values, which may be stored in one of two formats.

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -421,8 +421,8 @@ message GraphProto {
   optional string name = 2;   // namespace Graph
 
   // A list of named tensor values, used to specify constant inputs of the graph.
-  // Each TensorProto entry must have a distinct name (within the list) that
-  // MAY also appear in the input list.
+  // Each TensorProto entry must have a distinct name (between initializer and sparse_initializer)
+  // that MAY also appear in the input list.
   repeated TensorProto initializer = 5;
 
   // Initializers (see above) stored in sparse format.
@@ -601,6 +601,7 @@ message TensorProto {
 message SparseTensorProto {
   // The sequence of non-default values are encoded as a tensor of shape [NNZ].
   // The default-value is zero for numeric tensors, and empty-string for string tensors.
+  // values must have a non-empty name present which serves as a name for SparseTensorProto
   optional TensorProto values = 1;
 
   // The indices of the non-default values, which may be stored in one of two formats.

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -602,6 +602,7 @@ message SparseTensorProto {
   // The sequence of non-default values are encoded as a tensor of shape [NNZ].
   // The default-value is zero for numeric tensors, and empty-string for string tensors.
   // values must have a non-empty name present which serves as a name for SparseTensorProto
+  // when used in sparse_initializer list.
   optional TensorProto values = 1;
 
   // The indices of the non-default values, which may be stored in one of two formats.

--- a/onnx/onnx.proto3
+++ b/onnx/onnx.proto3
@@ -602,6 +602,7 @@ message SparseTensorProto {
   // The sequence of non-default values are encoded as a tensor of shape [NNZ].
   // The default-value is zero for numeric tensors, and empty-string for string tensors.
   // values must have a non-empty name present which serves as a name for SparseTensorProto
+  // when used in sparse_initializer list.
   TensorProto values = 1;
 
   // The indices of the non-default values, which may be stored in one of two formats.

--- a/onnx/onnx.proto3
+++ b/onnx/onnx.proto3
@@ -421,8 +421,8 @@ message GraphProto {
   string name = 2;   // namespace Graph
 
   // A list of named tensor values, used to specify constant inputs of the graph.
-  // Each TensorProto entry must have a distinct name (within the list) that
-  // MAY also appear in the input list.
+  // Each TensorProto entry must have a distinct name (between initializer and sparse_initializer)
+  // that MAY also appear in the input list.
   repeated TensorProto initializer = 5;
 
   // Initializers (see above) stored in sparse format.
@@ -601,6 +601,7 @@ message TensorProto {
 message SparseTensorProto {
   // The sequence of non-default values are encoded as a tensor of shape [NNZ].
   // The default-value is zero for numeric tensors, and empty-string for string tensors.
+  // values must have a non-empty name present which serves as a name for SparseTensorProto
   TensorProto values = 1;
 
   // The indices of the non-default values, which may be stored in one of two formats.

--- a/onnx/test/checker_test.py
+++ b/onnx/test/checker_test.py
@@ -328,6 +328,16 @@ class TestChecker(unittest.TestCase):
         sparse = self.make_sparse([10, 10], [13, 17, 19], [3, 1], [0, 1, 2])
         self.assertRaises(checker.ValidationError, checker.check_sparse_tensor, sparse)
 
+    def test_check_sparse_tensor_no_name(self):  # type: () -> None
+        # values tensor name is empty
+        values = [13, 17, 19]
+        sparse = SparseTensorProto()
+        sparse.dims.extend([100])
+        nnz = len(values)
+        sparse.values.CopyFrom(helper.make_tensor('', TensorProto.INT64, (nnz,), values))
+        sparse.indices.CopyFrom(helper.make_tensor('spind', TensorProto.INT64, [3], [9, 27, 81]))
+        self.assertRaises(checker.ValidationError, checker.check_sparse_tensor, sparse)
+
     def test_check_sparse_matmul(self):  # type: () -> None
         M = 5
         N = 10

--- a/onnx/test/checker_test.py
+++ b/onnx/test/checker_test.py
@@ -350,11 +350,6 @@ class TestChecker(unittest.TestCase):
         sparse = self.make_sparse([10, 10], [13, 17, 19], [3, 1], [0, 1, 2])
         self.assertRaises(checker.ValidationError, checker.check_sparse_tensor, sparse)
 
-    def test_check_sparse_tensor_no_name(self):  # type: () -> None
-        # Sparse Tensor name is empty
-        sparse = self.make_sparse([100], [13, 17, 19], [3], [9, 27, 81], '')
-        self.assertRaises(checker.ValidationError, checker.check_sparse_tensor, sparse)
-
     def test_check_sparse_matmul(self):  # type: () -> None
         M = 5
         N = 10


### PR DESCRIPTION
Clearly specify in proto files that values name is considered a SparseTensor name.
Enforce values name is present and not empty in checker.
Enforce that the sparse tensor initializers name is unique across initializers and sparse initializers.
Add python tests.