### PR TITLE
[Dup] Changed make_attribute to allow a mix of ints and floats 

### DIFF
--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -371,9 +371,6 @@ def make_attribute(
             # (and converts the ints to floats).
             attr.floats.extend(float(v) for v in value)
             attr.type = AttributeProto.FLOATS
-            # Turn np.int32/64 into Python built-in int.
-            attr.ints.extend(int(v) for v in value)
-            attr.type = AttributeProto.INTS
         elif all(map(lambda bytes_or_false: bytes_or_false is not False, byte_array)):
             attr.strings.extend(cast(List[bytes], byte_array))
             attr.type = AttributeProto.STRINGS

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -362,10 +362,15 @@ def make_attribute(
     # third, iterable cases
     elif is_iterable:
         byte_array = [_to_bytes_or_false(v) for v in value]
-        if all(isinstance(v, float) for v in value):
-            attr.floats.extend(value)
+        if all(isinstance(v, numbers.Integral) for v in value):
+            # Turn np.int32/64 into Python built-in int.
+            attr.ints.extend(int(v) for v in value)
+            attr.type = AttributeProto.INTS
+        elif all(isinstance(v, numbers.Real) for v in value):
+            # Since ints and floats are members of Real, this allows a mix of ints and floats
+            # (and converts the ints to floats).
+            attr.floats.extend(float(v) for v in value)
             attr.type = AttributeProto.FLOATS
-        elif all(isinstance(v, numbers.Integral) for v in value):
             # Turn np.int32/64 into Python built-in int.
             attr.ints.extend(int(v) for v in value)
             attr.type = AttributeProto.INTS

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -92,6 +92,12 @@ class TestHelperAttributeFunctions(unittest.TestCase):
         self.assertEqual(list(attr.ints), [1, 2])
         checker.check_attribute(attr)
 
+    def test_attr_repeated_mixed_floats_and_ints(self):  # type: () -> None
+        attr = helper.make_attribute("mixed", [1, 2, 3.0, 4.5])
+        self.assertEqual(attr.name, "mixed")
+        self.assertEqual(list(attr.floats), [1.0, 2.0, 3.0, 4.5])
+        checker.check_attribute(attr)
+
     def test_attr_repeated_str(self):  # type: () -> None
         attr = helper.make_attribute("strings", ["str1", "str2"])
         self.assertEqual(attr.name, "strings")


### PR DESCRIPTION
**Description**
Duplicate of https://github.com/onnx/onnx/pull/1940 for solving the CLA and DCO issue
@calebmadrigal Thank you so much for your contribution!

**Motivation**
 This fix is required for lightgbm models and needs to be in the upcoming 1.8 release hence pushing this forward