### PR TITLE
Fix Convtranspose attribute check bug: default value is acceptable

### DIFF
--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -1215,7 +1215,7 @@ void convTransposeShapeInference(InferenceContext& ctx) {
       fail_shape_inference("Attribute pads has incorrect size");
     }
     const auto* auto_pad_attr = ctx.getAttribute("auto_pad");
-    if (nullptr != auto_pad_attr) {
+    if (nullptr != auto_pad_attr && auto_pad_attr->s() != "NOTSET") {
       fail_shape_inference(
           "The pads attribute cannot be used simultaneously with auto_pad attribute");
     }


### PR DESCRIPTION
**Description**
Correct the condition from `nullptr != auto_pad_attr` to `nullptr != auto_pad_attr && auto_pad_attr->s() != "NOTSET"`.

**Motivation**
https://github.com/jcwchen/onnx/blob/master/onnx/defs/nn/defs.cc#L1218
There is a bug in this condition. Even though the pads attribute cannot be used simultaneously with auto_pad attribute, the default value "NOTSET" is acceptable.

Thank @askhade for catching this.