### PR TITLE
Both update value_info and output for shape_inference undefined output

### DIFF
--- a/onnx/shape_inference/implementation.cc
+++ b/onnx/shape_inference/implementation.cc
@@ -346,11 +346,11 @@ static void InferShapesImpl(
   deleteCreatedTypes(initializerTypeList);
   // Throw shape inference error if any
   if (!inference_errors.empty()) {
-    std::cerr << "Shape inference error(s): ";
+    std::string full_errors = "Shape inference error(s): ";
     for (const std::string &error: inference_errors) {
-      std::cerr << error << std::endl;
+      full_errors += error + "\n";
     }
-    throw ONNX_NAMESPACE::InferenceError("");
+    throw ONNX_NAMESPACE::InferenceError(full_errors);
   }
 }
 

--- a/onnx/shape_inference/implementation.cc
+++ b/onnx/shape_inference/implementation.cc
@@ -183,13 +183,11 @@ static void InferShapesImpl(
     }
   }
   for (auto& vi : *g->mutable_output()) {
-    // TODO: Remove this condition and undefinedValueTypesByName in the future
     if (vi.has_type()) {
       valueTypesByName[vi.name()] = vi.mutable_type();
     } else {
       // Some output type might be undefined in subgraph. e.g., Loop Op
-      // To assgin inferred type to them,
-      // Also save names of output with undefined types
+      // Saving names of outputs with undefined types to allow assigning inferred types to them
       undefinedValueTypesByName[vi.name()] = vi.mutable_type();
     } 
   }


### PR DESCRIPTION
**Description**
- Both update value_info and output for output with undefined type 
- Throw `ONNX_NAMESPACE::InferenceError` instead of `std::runtime_error`, which is more proper for debugging

**Motivation**
shape_inference used to update “undefined” output to value_info, but after this PR (https://github.com/onnx/onnx/pull/2783), if the type of output is undefined, shape_inference will directly merge inferred type into the output instead of creating a new value_info with the output’s name. It should be fine for valid models, but it will influence the behavior of invalid models (like missing output type initially).

However, part of `torch.onnx.export` replies on `onnx.shape_inference` and it only considers value_info. As a workaround, shape_inference now both updates value_info and output for output without defined type.
Please note that in the future, shape_inference will only update output in this case.