### PR TITLE
Update all docs with Gitter links to Slack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ If you think some operator should be added to ONNX specification, please read
 [this document](docs/AddNewOp.md).
 
 # Discuss
-We encourage you to open [Issues](https://github.com/onnx/onnx/issues), or use Gitter for more real-time discussion:
-[![Join the chat at https://gitter.im/onnx/Lobby](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/onnx/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+We encourage you to open [Issues](https://github.com/onnx/onnx/issues), or use [Slack](https://slack.lfai.foundation/) for more real-time discussion
 
 # Follow Us
 Stay up to date with the latest ONNX news. [[Facebook](https://www.facebook.com/onnxai/)] [[Twitter](https://twitter.com/onnxai)]

--- a/community/readme.md
+++ b/community/readme.md
@@ -21,14 +21,14 @@ The ONNX community adheres to the following principles:
 ## Community Roles
 
 ### Members
-Members are individuals who are interested in or participate in the ONNX community. Members are able to follow and participate in all public modes of communication used by the ONNX community including but not limited to GitHub, Slack, Gitter, Stack Overflow, email announcements and discussion aliases. Members are expected to adhere to the Code of Conduct but do not have any specific responsibilities.
+Members are individuals who are interested in or participate in the ONNX community. Members are able to follow and participate in all public modes of communication used by the ONNX community including but not limited to GitHub, Slack, Stack Overflow, email announcements and discussion aliases. Members are expected to adhere to the Code of Conduct but do not have any specific responsibilities.
 
 ### Contributors
 Contributors are Members who are active contributors in the community. They can have issues and PRs assigned to them. They also have voting privileges. Contributors can be active in many ways including but not limited to:
 
 * Authoring or reviewing PRs on GitHub
 * Filing or commenting on issues on GitHub
-* Contributing to SIG, subproject, or community discussions (e.g. Slack, Gitter, meetings, email discussion forums, Stack Overflow, etc)
+* Contributing to SIG, subproject, or community discussions (e.g. Slack, meetings, email discussion forums, Stack Overflow, etc)
 * Creator of content, promoting and advocating the ONNX specification
 
 A Member can become a Contributor by being sponsored by 2 existing Approvers from different companies. Contributors who are not active in the last 12 months will be removed.
@@ -98,7 +98,7 @@ A Steering Committee member can be removed due to Code of Conduct violations.
 
 The ONNX project is organized primarily into Special Interest Groups, or SIGs. Each SIG is comprised of individuals from multiple companies and organizations, with a common purpose of advancing the project with respect to a specific topic. 
 
-Our goal is to enable a distributed decision structure and code ownership, as well as providing focused forums for getting work done, making decisions, and on-boarding new contributors. Every identifiable part of the project (e.g., repository, subdirectory, API, test, issue, PR, Gitter channel) is intended to be owned by some SIG. At the time of inception of this organizational structure, the following SIGs will be present:
+Our goal is to enable a distributed decision structure and code ownership, as well as providing focused forums for getting work done, making decisions, and on-boarding new contributors. Every identifiable part of the project (e.g., repository, subdirectory, API, test, issue, PR, Slack channel) is intended to be owned by some SIG. At the time of inception of this organizational structure, the following SIGs will be present:
 
 * Architecture & Infra
     * This SIG is responsible for defining and maintaining the core ONNX format, the build and CI/CD systems for ONNX repositories, publishing release packages for ONNX, the onnx-docker repository, and creating tools to help integrate with and test against the ONNX standard. This SIG is also the defacto owner of files in the main ONNX repository unless explicitly owned by another SIG.
@@ -119,7 +119,7 @@ A primary reason that SIGs exist is as forums for collaboration. Much work in a 
 
 * Meet regularly, at least monthly
 * Keep up-to-date meeting notes, linked from the SIG's page in the community repo
-* Announce meeting agenda and minutes after each meeting, on their SIG mailing list and/or Gitter channel
+* Announce meeting agenda and minutes after each meeting, on their SIG mailing list and/or Slack channel
 * Ensure the SIG's mailing list is archived (i.e on GitHub)
 * Report activity in overall ONNX community meetings
 * Participate in release planning meetings, retrospective, etc (if relevant) 

--- a/community/sigs.md
+++ b/community/sigs.md
@@ -4,15 +4,15 @@ As described in the ONNX [governance](https://github.com/onnx/onnx/tree/master/c
 
 ## Joining a SIG
 
-If you are interested in participating, please [join the discussion](https://gitter.im/onnx) in the respective Gitter room. Details about any upcoming meetings will also be shared in the Gitter rooms. SIG artifacts can be found in the [sigs repository](https://github.com/onnx/sigs).
+If you are interested in participating, please [join the discussion](https://slack.lfai.foundation/) in the respective Slack channels. Details about any upcoming meetings will also be shared in the Slack channels. SIG artifacts can be found in the [sigs repository](https://github.com/onnx/sigs).
 
 You can find the schedule of SIG meetings on the [LF AI calendar](https://wiki.lfai.foundation/pages/viewpage.action?pageId=18481196)
 
 ## Current SIGs
 
-| Name      | Responsibilities    |
-| ------------------ | ------------- |
-| [Architecture & Infra](https://gitter.im/onnx/infra) | Defining and maintaining the core ONNX format, the build and CI/CD systems for ONNX repositories, publishing release packages for ONNX, the onnx-docker repository, and creating tools to help integrate with and test against the ONNX standard. This SIG is also the defacto owner of files in the main ONNX repository unless explicitly owned by another SIG. |
-| [Operators](https://gitter.im/onnx/operators) | Determining the operators that are part of the ONNX spec (ONNX and ONNX-ML domains), ensuring high quality operator definitions and documentation, establishing criteria for adding new operators, managing ops domains and compliance tiers, and enforcing versioning mechanisms. |
-| [Converters](https://gitter.im/onnx/converters) | Developing and maintaining the various converter repositories under ONNX. |
-| [Models and tutorials](https://gitter.im/onnx/modelzoo) | Providing a comprehensive collection of state of the art ONNX models from a variety of sources and making it easy for users to get started with ONNX and the ecosystem around it. |
+| Name | Responsibilities |
+| ---- | ---------------- |
+| [Architecture & Infra](https://lfaifoundation.slack.com/archives/C018Y2QG7V2) | Defining and maintaining the core ONNX format, the build and CI/CD systems for ONNX repositories, publishing release packages for ONNX, the onnx-docker repository, and creating tools to help integrate with and test against the ONNX standard. This SIG is also the defacto owner of files in the main ONNX repository unless explicitly owned by another SIG. |
+| [Operators](https://lfaifoundation.slack.com/archives/C018Y2RAY4C) | Determining the operators that are part of the ONNX spec (ONNX and ONNX-ML domains), ensuring high quality operator definitions and documentation, establishing criteria for adding new operators, managing ops domains and compliance tiers, and enforcing versioning mechanisms. |
+| [Converters](https://lfaifoundation.slack.com/archives/C0171FSKZBN) | Developing and maintaining the various converter repositories under ONNX. |
+| [Models and tutorials](https://lfaifoundation.slack.com/archives/C018RE2BRBL) | Providing a comprehensive collection of state of the art ONNX models from a variety of sources and making it easy for users to get started with ONNX and the ecosystem around it. |

--- a/community/working-groups.md
+++ b/community/working-groups.md
@@ -6,7 +6,7 @@ As described in the ONNX [governance](https://github.com/onnx/onnx/tree/master/c
 New Working Groups are created when there is sufficient interest in a topic area and someone volunteers to be the chair for the group and submits a proposal to the steering committee. The chair facilitates the discussion and helps synthesize proposals and decisions. 
 
 ## Joining a working group
-Working Groups have most of their discussions on Gitter. If you are interested in participating, please join the discussion in the respective Gitter room. Details about any upcoming meetings will also be shared in the Gitter rooms. Working Group artifacts can be found in the [working-groups repository](https://github.com/onnx/working-groups).
+Working Groups have most of their discussions on Slack. If you are interested in participating, please join the discussion in the respective Slack channels. Details about any upcoming meetings will also be shared in the Slack channel. Working Group artifacts can be found in the [working-groups repository](https://github.com/onnx/working-groups).
 
 You can find the schedule of meetings on the [LF AI wiki](https://wiki.lfai.foundation/pages/viewpage.action?pageId=18481196)
 
@@ -14,8 +14,8 @@ You can find the schedule of meetings on the [LF AI wiki](https://wiki.lfai.foun
 
 | Working Group      | Objectives    |
 | ------------------ | ------------- |
-| [Release](https://gitter.im/onnx/Releases) | Improve the release process for ONNX |
-| [Training](https://gitter.im/onnx/training) | Expand ONNX to support training as well as inference |
+| [Release](https://lfaifoundation.slack.com/archives/C018VGGJUGK) | Improve the release process for ONNX |
+| [Training](https://lfaifoundation.slack.com/archives/C018K560U14) | Expand ONNX to support training as well as inference |
 
 ## Completed working groups
 

--- a/docs/OnnxReleases.md
+++ b/docs/OnnxReleases.md
@@ -6,7 +6,7 @@ Release Checklist:
 
 * Install Twine, a utility tool to interact with pypi. Do  - ``pip install twine``
 * Get hold of the username and password for the ‘onnx’ pypi account.
-* Pick a release tag for the new release through mutual consent – Gitter Room for Releases (https://gitter.im/onnx/Releases)
+* Pick a release tag for the new release through mutual consent – Slack channel for Releases (https://lfaifoundation.slack.com/archives/C018VGGJUGK)
 * Prepare a change log for the release – 
     * ``git log --pretty=format:"%h - %s" <tag of the previous release>...<new tag>``
     * And draft a new release statement - https://github.com/onnx/onnx/releases listing out the new features and bug fixes, and potential changes being introduced in the release.


### PR DESCRIPTION
Hi All, I noticed that all Gitter rooms are marked as deprecated
Therefore, updated all Gitter links to corresponding Slack links

However, I did leave Gitter links associated with [Completed working groups](https://github.com/onnx/onnx/blob/master/community/working-groups.md#completed-working-groups) and [Inactive working group](https://github.com/onnx/onnx/blob/master/community/working-groups.md#inactive-working-groups) as is.

Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>