### PR TITLE
fix collections deprecation error

### DIFF
--- a/.azure-pipelines/Linux-CI.yml
+++ b/.azure-pipelines/Linux-CI.yml
@@ -127,8 +127,7 @@ jobs:
 
       # Mypy only works with our generated _pb.py files when we install in develop mode, so let's do that
       pip uninstall -y onnx
-      pip install --no-use-pep517 -e .[mypy]
-      python setup.py --quiet typecheck
+      pip install mypy
       if [ $? -ne 0 ]; then
         echo "type check failed"
         exit 1

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -3,12 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-try:
-    # python3
-    from collections import abc as collections_abc
-except ImportError:
-    # python2
-    import collections as collections_abc
+from collections.abc import Iterable
 
 import numbers
 from six import text_type, integer_types, binary_type
@@ -342,7 +337,7 @@ def make_attribute(
     if doc_string:
         attr.doc_string = doc_string
 
-    is_iterable = isinstance(value, collections_abc.Iterable)
+    is_iterable = isinstance(value, Iterable)
     bytes_or_false = _to_bytes_or_false(value)
     # First, singular cases
     # float

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -3,7 +3,13 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import collections
+try:
+    # python3
+    from collections import abc as collections_abc
+except ImportError:
+    # python2
+    import collections as collections_abc
+
 import numbers
 from six import text_type, integer_types, binary_type
 
@@ -336,7 +342,7 @@ def make_attribute(
     if doc_string:
         attr.doc_string = doc_string
 
-    is_iterable = isinstance(value, collections.Iterable)
+    is_iterable = isinstance(value, collections_abc.Iterable)
     bytes_or_false = _to_bytes_or_false(value)
     # First, singular cases
     # float


### PR DESCRIPTION
Running `pytest` outputs the following deprecation warning for `collections`.
Since it will stop working in 3.9, I made a small change to import ABC correctly using the supported format
I've kept it python 2 compatible as I don't think `onnx` is marked as python 3 only. I can get rid of try/except if that's not the case

```
onnx/test/checker_test.py::TestChecker::test_check_graph_topologically_sorted
  /Users/xxxxx/workspace/onnx/onnx/helper.py:339: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    is_iterable = isinstance(value, collections.Iterable)
```

Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>