### PR TITLE
Remove python 2.7 CI build tests

### DIFF
--- a/.azure-pipelines/Linux-CI.yml
+++ b/.azure-pipelines/Linux-CI.yml
@@ -7,11 +7,6 @@ jobs:
     vmImage: 'Ubuntu-16.04'
   strategy:
     matrix:
-      py27:
-        python.version: '2.7'
-        onnx_ml: 0
-        onnx_debug: 0
-        onnx_lite: 1
       py36:
         python.version: '3.6'
         onnx_ml: 0
@@ -106,13 +101,9 @@ jobs:
       ! grep -R --include='*.cc' --include='*.h' 'onnx::' .
 
       # onnx python api tests
-      if [ "$(python.version)" == "2.7" ]; then
-        pip install --quiet pytest nbval
-      else
-        # pytest 6.0 made deprecation warnings fail by default, pinning pytest to 5.4.3.
-        # TODO replace deprecated function with the suggested one. https://docs.pytest.org/en/stable/deprecations.html#id5
-        pip install --quiet pytest==5.4.3 nbval
-      fi
+      # pytest 6.0 made deprecation warnings fail by default, pinning pytest to 5.4.3.
+      # TODO replace deprecated function with the suggested one. https://docs.pytest.org/en/stable/deprecations.html#id5
+      pip install --quiet pytest==5.4.3 nbval
 
       pytest
       if [ $? -ne 0 ]; then
@@ -134,18 +125,16 @@ jobs:
         exit 1
       fi
 
-      # Mypy only works with Python 3
-      if [ "$(python.version)" != "2.7" ]; then
-        # Mypy only works with our generated _pb.py files when we install in develop mode, so let's do that
-        pip uninstall -y onnx
-        pip install --no-use-pep517 -e .[mypy]
-        python setup.py --quiet typecheck
-        if [ $? -ne 0 ]; then
-          echo "type check failed"
-          exit 1
-        fi
-        pip uninstall -y onnx
-        rm -rf .setuptools-cmake-build
-        pip install .
+      # Mypy only works with our generated _pb.py files when we install in develop mode, so let's do that
+      pip uninstall -y onnx
+      pip install --no-use-pep517 -e .[mypy]
+      python setup.py --quiet typecheck
+      if [ $? -ne 0 ]; then
+        echo "type check failed"
+        exit 1
       fi
+      pip uninstall -y onnx
+      rm -rf .setuptools-cmake-build
+      pip install .
+
     displayName: 'Run ONNX tests'

--- a/.azure-pipelines/MacOS-CI.yml
+++ b/.azure-pipelines/MacOS-CI.yml
@@ -7,16 +7,6 @@ jobs:
     vmImage: 'macOS-10.14'
   strategy:
     matrix:
-      py27:
-        python.version: '2.7'
-        onnx_ml: 0
-        onnx_debug: 0
-        onnx_lite: 1
-      py27-ml:
-        python.version: '2.7'
-        onnx_ml: 1
-        onnx_debug: 0
-        onnx_lite: 1
       py36:
         python.version: '3.6'
         onnx_ml: 0
@@ -91,13 +81,9 @@ jobs:
       ! grep -R --include='*.cc' --include='*.h' 'onnx::' .
 
       # onnx python api tests
-      if [ "$(python.version)" == "2.7" ]; then
-        pip install --quiet pytest nbval
-      else
-        # pytest 6.0 made deprecation warnings fail by default, pinning pytest to 5.4.3.
-        # TODO replace deprecated function with the suggested one. https://docs.pytest.org/en/stable/deprecations.html#id5
-        pip install --quiet pytest==5.4.3 nbval
-      fi
+      # pytest 6.0 made deprecation warnings fail by default, pinning pytest to 5.4.3.
+      # TODO replace deprecated function with the suggested one. https://docs.pytest.org/en/stable/deprecations.html#id5
+      pip install --quiet pytest==5.4.3 nbval
 
       pytest
       if [ $? -ne 0 ]; then

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -31,14 +31,9 @@ jobs:
     - name: Install python dependencies
       run: |
         python -m pip install --upgrade pip
-        if ('${{ matrix.python-version }}' -eq '2.7') {
-          pip install pytest nbval numpy wheel
-        }
-        else {
-          # pytest 6.0 made deprecation warnings fail by default, pinning pytest to 5.4.3.
-          # TODO replace deprecated function with the suggested one. https://docs.pytest.org/en/stable/deprecations.html#id5
-          pip install pytest==5.4.3 nbval numpy wheel
-        }
+        # pytest 6.0 made deprecation warnings fail by default, pinning pytest to 5.4.3.
+        # TODO replace deprecated function with the suggested one. https://docs.pytest.org/en/stable/deprecations.html#id5
+        pip install pytest==5.4.3 nbval numpy wheel
     - name: Build wheel
       run: |
         $Env:USE_MSVC_STATIC_RUNTIME=1


### PR DESCRIPTION
Follow up on https://github.com/onnx/onnx/pull/3106#issuecomment-725583770, with onnx deprecating support for python 2.7, modified builds to remove jobs that test python 2.7 compatability

Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>