### PR TITLE
Add default value for type-context in FunctionBodyBuildContextImpl constructor 

### DIFF
--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -38,7 +38,10 @@ struct FunctionBodyBuildContext {
 struct FunctionBodyBuildContextImpl : public FunctionBodyBuildContext {
   // Input_types: use a default TypeProto for missing types. We use a different convention
   // here (from FunctionBodyBuildContext) to simplify python interoperability.
-  FunctionBodyBuildContextImpl(const NodeProto& node_proto, const std::vector<TypeProto>& input_types)
+  // The default value for input_types is included only for backward compatibility.
+  // It can be used for functions that do not depend on the type-context, but
+  // will not be sufficient for functions that do use the type-context.
+  FunctionBodyBuildContextImpl(const NodeProto& node_proto, const std::vector<TypeProto>& input_types = {})
       : node_proto_(node_proto), input_types_(input_types) {
     for (auto& attr : node_proto.attribute()) {
       attributesByName_[attr.name()] = &attr;

--- a/onnx/test/cpp/function_context_test.cc
+++ b/onnx/test/cpp/function_context_test.cc
@@ -59,6 +59,63 @@ bool BuildFunctionProto(
   return true;
 }
 
+// A monomorphic context-dependent function test-case.
+
+static bool
+BuildTwiceFloatFunctionBody(const FunctionBodyBuildContext& ctx, const OpSchema& schema, FunctionProto& functionProto) {
+  // Create a scalar-tensor constant 2.0 of float type:
+  auto two_as_tensor = ToTensor(2.0, TensorProto_DataType::TensorProto_DataType_FLOAT);
+
+  std::vector<FunctionBodyHelper::NodeDef> body{// nodes: {outputs, op, inputs, attributes}
+                                                {{"Two"}, "Constant", {}, {{"value", two_as_tensor}}},
+                                                {{"Y"}, "Mul", {"X", "Two"}}};
+
+  return BuildFunctionProto(functionProto, schema, body);
+}
+
+void RegisterTwiceFloatSchema() {
+  ONNX_NAMESPACE::OpSchema schema;
+  schema.SetName("CustomFunTwice")
+      .SetDomain(ONNX_DOMAIN)
+      .SinceVersion(12)
+      .SetDoc("This operator returns an output tensor that is twice the input tensor.")
+      .Input(0, "X", "Input tensor", "T", OpSchema::Single)
+      .Output(0, "Y", "Output tensor", "T", OpSchema::Single)
+      .TypeConstraint("T", {"tensor(float)"}, "Type of the input and output values")
+      .SetContextDependentFunctionBodyBuilder(BuildTwiceFloatFunctionBody);
+  ONNX_NAMESPACE::OpSchemaRegistry::OpSchemaRegisterOnce unused(schema);
+  (void)unused;
+}
+
+TEST(FunctionAPITest, ContextDependentFunctionTest) {
+  RegisterTwiceFloatSchema();
+
+  const auto* schema = OpSchemaRegistry::Schema("CustomFunTwice", 12, "");
+  EXPECT_TRUE(schema);
+  EXPECT_FALSE(schema->HasFunction());
+  EXPECT_TRUE(schema->HasContextDependentFunction());
+
+  NodeProto nodeProto;
+  nodeProto.set_op_type("CustomFunTwice");
+  nodeProto.add_input("X");
+  nodeProto.add_output("Y");
+
+  TypeProto floatTypeProto;
+  floatTypeProto.mutable_tensor_type()->set_elem_type(TensorProto_DataType::TensorProto_DataType_FLOAT);
+
+  FunctionBodyBuildContextImpl ctx(nodeProto);
+  FunctionProto fnProto;
+  EXPECT_TRUE(schema->BuildContextDependentFunction(ctx, fnProto));
+  EXPECT_EQ(fnProto.node_size(), 2);
+
+  LexicalScopeContext lexicalScope;
+  CheckerContext checkerCtx;
+  checkerCtx.set_ir_version(7);
+  check_function(fnProto, checkerCtx, lexicalScope);
+}
+
+// A polymorphic context-dependent function test-case.
+
 static bool
 BuildTwiceFunctionBody(const FunctionBodyBuildContext& ctx, const OpSchema& schema, FunctionProto& functionProto) {
   // Create a scalar-tensor constant 2.0 of input-type:


### PR DESCRIPTION
Add a default-value for type-context in FunctionBodyBuildContextImpl constructor for backward-compatibility.

This will allow users to upgrade to this version of ONNX without breaking existing usage, allowing them to add the type-context when needed.

Add a test-case to test the usage as well.