### PR TITLE
fix bugs in external data helpers and add add size thresholds for ser…

### DIFF
--- a/.azure-pipelines/Linux-CI.yml
+++ b/.azure-pipelines/Linux-CI.yml
@@ -68,7 +68,7 @@ jobs:
       source py$(python.version)/bin/activate
 
       # lint python code
-      pip install --quiet flake8
+      python -m pip install --quiet flake8
       flake8 onnx
       if [ $? -ne 0 ]; then
         echo "flake8 returned failures"
@@ -103,7 +103,7 @@ jobs:
       # onnx python api tests
       # pytest 6.0 made deprecation warnings fail by default, pinning pytest to 5.4.3.
       # TODO replace deprecated function with the suggested one. https://docs.pytest.org/en/stable/deprecations.html#id5
-      pip install --quiet pytest==5.4.3 nbval
+      python -m pip install --quiet pytest==5.4.3 nbval
 
       pytest
       if [ $? -ne 0 ]; then
@@ -126,15 +126,15 @@ jobs:
       fi
 
       # Mypy only works with our generated _pb.py files when we install in develop mode, so let's do that
-      pip uninstall -y onnx
-      pip install --no-use-pep517 -e .[mypy]
+      python -m pip uninstall -y onnx
+      python -m pip install --no-use-pep517 -e .[mypy]
       python setup.py --quiet typecheck
       if [ $? -ne 0 ]; then
         echo "type check failed"
         exit 1
       fi
-      pip uninstall -y onnx
+      python -m pip uninstall -y onnx
       rm -rf .setuptools-cmake-build
-      pip install .
+      python -m pip install .
 
     displayName: 'Run ONNX tests'

--- a/onnx/external_data_helper.py
+++ b/onnx/external_data_helper.py
@@ -98,7 +98,7 @@ def set_external_data(tensor,  # type: TensorProto
 
 
 def convert_model_to_external_data(model, all_tensors_to_one_file=True, location=None, size_threshold=1024):
-    # type: (ModelProto, bool, Optional[Text], Optional[int]) -> None
+    # type: (ModelProto, bool, Optional[Text], int) -> None
     """
     Call to set all tensors with raw data as external data. This call should preceed 'save_model'.
     'save_model' saves all the tensors data as external data after calling this function.

--- a/onnx/external_data_helper.py
+++ b/onnx/external_data_helper.py
@@ -98,7 +98,7 @@ def set_external_data(tensor,  # type: TensorProto
 
 
 def convert_model_to_external_data(model, all_tensors_to_one_file=True, location=None, size_threshold=1024):
-    # type: (ModelProto, bool, Optional[Text]) -> None
+    # type: (ModelProto, bool, Optional[Text], Optional[int]) -> None
     """
     Call to set all tensors with raw data as external data. This call should preceed 'save_model'.
     'save_model' saves all the tensors data as external data after calling this function.
@@ -220,7 +220,7 @@ def uses_external_data(tensor):  # type: (TensorProto) -> bool
     return tensor.HasField("data_location") and tensor.data_location == TensorProto.EXTERNAL
 
 
-def _remove_external_data_field(tensor, field_key):  # type: (TensorProto, Text) -> None
+def remove_external_data_field(tensor, field_key):  # type: (TensorProto, Text) -> None
     """
     Remove a field from a Tensor's external_data key-value store.
 

--- a/onnx/external_data_helper.py
+++ b/onnx/external_data_helper.py
@@ -208,7 +208,7 @@ def _sanitize_path(path):  # type: (Text) -> Text
 def _is_valid_filename(filename):  # type: (Text) -> bool
     """Utility to check whether the provided filename is valid."""
     exp = re.compile("^[^<>:;,?\"*|/]+$")
-    match = exp.fullmatch(filename)
+    match = exp.match(filename)
     if match:
         return True
     else:

--- a/onnx/external_data_helper.py
+++ b/onnx/external_data_helper.py
@@ -97,7 +97,7 @@ def set_external_data(tensor,  # type: TensorProto
             entry.value = str(v)
 
 
-def convert_model_to_external_data(model, all_tensors_to_one_file=True, location=None, size_threshold=0):
+def convert_model_to_external_data(model, all_tensors_to_one_file=True, location=None, size_threshold=1024):
     # type: (ModelProto, bool, Optional[Text]) -> None
     """
     Call to set all tensors with raw data as external data. This call should preceed 'save_model'.
@@ -109,9 +109,7 @@ def convert_model_to_external_data(model, all_tensors_to_one_file=True, location
     location: specify the external file that all tensors to save to.
               If not specified, will use the model name.
     size_threshold: Threshold for size of data. Only when tensor's data is >= the size_threshold
-    specified it will be converted to external data. Default = 0 means all tensor's with raw data
-    will be converted to external data. Can be used to skip tensor's with small data to be converted
-    to external data.
+    it will be converted to external data. To convert every tensor with raw data to external data set size_threshold=0.
     """
     if all_tensors_to_one_file:
         file_name = Text(uuid.uuid1())

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -204,7 +204,7 @@ class TestSaveAllTensorsAsExternalData(TestLoadExternalDataBase):
     def test_convert_model_to_from_one_file(self):  # type: () -> None
         model_file_path = self.get_temp_model_filename()
         external_data_file = str(uuid.uuid4())
-        convert_model_to_external_data(self.model, location=external_data_file)
+        convert_model_to_external_data(self.model, location=external_data_file, size_threshold=0)
         onnx.save_model(self.model, model_file_path)
         self.assertTrue(Path.isfile(model_file_path))
         self.assertTrue(Path.isfile(os.path.join(self.temp_dir, external_data_file)))
@@ -232,7 +232,7 @@ class TestSaveAllTensorsAsExternalData(TestLoadExternalDataBase):
 
     def test_convert_model_to_external_data_one_file_per_tensor(self):  # type: () -> None
         model_file_path = self.get_temp_model_filename()
-        convert_model_to_external_data(self.model, all_tensors_to_one_file=False)
+        convert_model_to_external_data(self.model, all_tensors_to_one_file=False, size_threshold=0)
         onnx.save_model(self.model, model_file_path)
         self.assertTrue(Path.isfile(model_file_path))
         self.assertTrue(Path.isfile(os.path.join(self.temp_dir, "input_value")))
@@ -244,6 +244,19 @@ class TestSaveAllTensorsAsExternalData(TestLoadExternalDataBase):
         attribute_tensor = model.graph.node[0].attribute[0].t
         self.assertTrue(np.allclose(to_array(attribute_tensor), self.attribute_value))
 
+    def test_convert_model_to_external_data_with_size_threshold(self):  # type: () -> None
+        model_file_path = self.get_temp_model_filename()
+        convert_model_to_external_data(self.model, all_tensors_to_one_file=False, size_threshold=1024)
+        onnx.save_model(self.model, model_file_path)
+        self.assertTrue(Path.isfile(model_file_path))
+        self.assertFalse(Path.isfile(os.path.join(self.temp_dir, "input_value")))
+        self.assertFalse(Path.isfile(os.path.join(self.temp_dir, "attribute_value")))
+        model = onnx.load_model(model_file_path)
+        initializer_tensor = model.graph.initializer[0]
+        self.assertTrue(np.allclose(to_array(initializer_tensor), self.initializer_value))
+
+        attribute_tensor = model.graph.node[0].attribute[0].t
+        self.assertTrue(np.allclose(to_array(attribute_tensor), self.attribute_value))
 
 # The following test will fail in some platforms
 # because >2GB proto python object is not allowed

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -258,6 +258,7 @@ class TestSaveAllTensorsAsExternalData(TestLoadExternalDataBase):
         attribute_tensor = model.graph.node[0].attribute[0].t
         self.assertTrue(np.allclose(to_array(attribute_tensor), self.attribute_value))
 
+
 # The following test will fail in some platforms
 # because >2GB proto python object is not allowed
 # Disable it for now and it should be fixed after 1.8 Release


### PR DESCRIPTION
This PR addresses issues mentioned in https://github.com/onnx/onnx/pull/2332 and a few more.

1. Current code marks all tensors to be serialized as external data. Fixing this to only mark the ones which have raw data.
2. Add a threshold for tensor data size. Only tensor's with size >= threshold will be serialized to external data. This feature was designed to work with model >2GB and with current approach it tries to serialize every single tensor to external file. Therefore adding a threshold so that callers can choose which tensors to serialize
3. Add checks for filename correctness. Current code uses tensor names as filenames. This fails when the names contains illegal characters.


Signed-off-by: Ashwini Khade <askhade@microsoft.com>