### PR TITLE
Add default case to relied_opsets in BuildFunction

### DIFF
--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -786,8 +786,16 @@ void OpSchema::BuildFunction(FunctionProto& function_body, const std::vector<Ope
     function_body.add_attribute(a.first);
   }
 
-  for (auto& relied_opset : relied_opsets) {
-    *(function_body.mutable_opset_import()->Add()) = relied_opset;
+  if (!relied_opsets.empty()) {
+    for (auto& relied_opset : relied_opsets) {
+      *(function_body.mutable_opset_import()->Add()) = relied_opset;
+    }
+  } else {
+    // By default, the function body graph is relying on the OperatorSet this
+    // function belongs to.
+    auto relied_opset = function_body.mutable_opset_import()->Add();
+    relied_opset->set_domain(this->domain());
+    relied_opset->set_version(this->SinceVersion());
   }
 }
 


### PR DESCRIPTION
**Description**
https://github.com/onnx/onnx/pull/3137
Build function should consider the case of `relied_opsets` is empty.

**Motivation**
ORT will fail with the latest ONNX because of the following errors:
```
1: [  FAILED  ] GraphTransformationTests.DynamicQuantizeMatMulTest 
1: [  FAILED  ] GraphTransformationTests.DynamicQuantizeMatMulTest_With_Bias
1: [  FAILED  ] GraphTransformationTests.DynamicQuantizeMatMulTest_With_ND_bias
1: [  FAILED  ] GraphTransformationTests.DynamicQuantizeMatMulTest_With_Bias_No_B_ZP
1: [  FAILED  ] GraphTransformationTests.MatMulIntegerToFloatTest
```
The optimizer fusion (MatMulIntegerToFloat) does not happen normally. Something in build function breaks.
