### PR TITLE
Update mypy version and fix deprecation warning

### DIFF
--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -5,7 +5,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import collections
+from collections.abc import Iterable
 import numbers
 from six import text_type, integer_types, binary_type
 
@@ -338,7 +338,7 @@ def make_attribute(
     if doc_string:
         attr.doc_string = doc_string
 
-    is_iterable = isinstance(value, collections.Iterable)
+    is_iterable = isinstance(value, Iterable)
     bytes_or_false = _to_bytes_or_false(value)
     # First, singular cases
     # float

--- a/setup.py
+++ b/setup.py
@@ -311,10 +311,7 @@ setup_requires.append('pytest-runner')
 tests_require.append('pytest')
 tests_require.append('nbval')
 tests_require.append('tabulate')
-
-if sys.version_info[0] == 3:
-    # Mypy doesn't work with Python 2
-    extras_require['mypy'] = ['mypy==0.600']
+extras_require['mypy'] = ['mypy==0.790']
 
 ################################################################################
 # Final


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

This is a follow up on https://github.com/onnx/onnx/pull/3106 after a break

Running `pytest` outputs a warning for wrong use of import for `collections`. Since the current way of import will not be supported in 3.9, this PR addresses the import issue with the collections abstract base class by changing the way collections are imported. 

Based on the previous PR created, the Linux build will fail without `mypy` version change due to not being able to support the new way of import https://github.com/onnx/onnx/pull/3106#issuecomment-725691861.

This PR upgrades mypy version to 0.790 and fixes import for collections

fixes https://github.com/onnx/onnx/issues/3110



