### PR TITLE
Make Windows release use numpy 1.16.6

### DIFF
--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -54,7 +54,7 @@ jobs:
         python -m pip install --upgrade pip
         # pytest 6.0 made deprecation warnings fail by default, pinning pytest to 5.4.3.
         # TODO replace deprecated function with the suggested one. https://docs.pytest.org/en/stable/deprecations.html#id5
-        pip install pytest==5.4.3 nbval numpy wheel          
+        pip install pytest==5.4.3 nbval numpy==1.16.6 wheel          
             
     - name: Build ONNX wheel
       run: |        

--- a/setup.py
+++ b/setup.py
@@ -297,7 +297,7 @@ packages = setuptools.find_packages()
 
 install_requires.extend([
     'protobuf',
-    'numpy',
+    'numpy>=1.16.6',
     'six',
     'typing>=3.6.4; python_version < "3.5"',
     'typing-extensions>=3.6.2.1',


### PR DESCRIPTION
**Description**
- Sync numpy version (1.16.6) in all release pipelines. Mac and Linux were done. This PR is for Windows release pipeline.
- Set numpy 1.16.6 as the minimum install dependency.
- 
**Motivation**
https://github.com/onnx/onnx/pull/3181
To prevent potential version conflict, use fixed version numpy 1.16.6 as build dependency.