### PR TITLE
Update Pad documentation to be consistent with schema

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -16942,7 +16942,7 @@ This version of the operator has been available since version 13 of the default 
   
   The three supported `modes` are (similar to corresponding modes supported by `numpy.pad`):
   
-  1) `constant`(default) - pads with a given constant value as specified by `constant_value` (which defaults to 0)
+  1) `constant`(default) - pads with a given constant value as specified by `constant_value` (which defaults to 0, empty string, or False)
   
   2) `reflect` - pads with the reflection of the vector mirrored on the first and last values of the vector along each axis
   
@@ -17032,7 +17032,7 @@ This version of the operator has been available since version 13 of the default 
 <dt><tt>pads</tt> (non-differentiable) : tensor(int64)</dt>
 <dd>Tensor of integers indicating the number of padding elements to add or remove (if negative) at the beginning and end of each axis. For 2D input tensor, it is the number of pixels. `pads` should be a 1D tensor of shape [2 * input_rank]. `pads` format should be: [x1_begin, x2_begin,...,x1_end, x2_end,...], where xi_begin is the number of pad values added at the beginning of axis `i` and xi_end, the number of pad values added at the end of axis `i`.</dd>
 <dt><tt>constant_value</tt> (optional, non-differentiable) : T</dt>
-<dd>(Optional) A scalar value to be used if the mode chosen is `constant` (by default it is 0).</dd>
+<dd>(Optional) A scalar value to be used if the mode chosen is `constant` (by default it is 0, empty string or False).</dd>
 </dl>
 
 #### Outputs
@@ -17046,7 +17046,7 @@ This version of the operator has been available since version 13 of the default 
 
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128)</dt>
-<dd>Constrains input and output to only numeric types.</dd>
+<dd>Constrain input and output types to all tensor types.</dd>
 </dl>
 
 ### <a name="Pow-13"></a>**Pow-13**</a>

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -12480,7 +12480,7 @@ expect(node, inputs=[x, slope], outputs=[y],
   
   The three supported `modes` are (similar to corresponding modes supported by `numpy.pad`):
   
-  1) `constant`(default) - pads with a given constant value as specified by `constant_value` (which defaults to 0)
+  1) `constant`(default) - pads with a given constant value as specified by `constant_value` (which defaults to 0, empty string, or False)
   
   2) `reflect` - pads with the reflection of the vector mirrored on the first and last values of the vector along each axis
   
@@ -12572,7 +12572,7 @@ Other versions of this operator: <a href="Changelog.md#Pad-1">1</a>, <a href="Ch
 <dt><tt>pads</tt> (non-differentiable) : tensor(int64)</dt>
 <dd>Tensor of integers indicating the number of padding elements to add or remove (if negative) at the beginning and end of each axis. For 2D input tensor, it is the number of pixels. `pads` should be a 1D tensor of shape [2 * input_rank]. `pads` format should be: [x1_begin, x2_begin,...,x1_end, x2_end,...], where xi_begin is the number of pad values added at the beginning of axis `i` and xi_end, the number of pad values added at the end of axis `i`.</dd>
 <dt><tt>constant_value</tt> (optional, non-differentiable) : T</dt>
-<dd>(Optional) A scalar value to be used if the mode chosen is `constant` (by default it is 0).</dd>
+<dd>(Optional) A scalar value to be used if the mode chosen is `constant` (by default it is 0, empty string or False).</dd>
 </dl>
 
 #### Outputs
@@ -12586,7 +12586,7 @@ Other versions of this operator: <a href="Changelog.md#Pad-1">1</a>, <a href="Ch
 
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128)</dt>
-<dd>Constrains input and output to only numeric types.</dd>
+<dd>Constrain input and output types to all tensor types.</dd>
 </dl>
 
 

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -3174,7 +3174,7 @@ a padded tensor (`output`) is generated.
 
 The three supported `modes` are (similar to corresponding modes supported by `numpy.pad`):
 
-1) `constant`(default) - pads with a given constant value as specified by `constant_value` (which defaults to 0)
+1) `constant`(default) - pads with a given constant value as specified by `constant_value` (which defaults to 0, empty string, or False)
 
 2) `reflect` - pads with the reflection of the vector mirrored on the first and last values of the vector along each axis
 
@@ -3282,7 +3282,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Input(
             2,
             "constant_value",
-            "(Optional) A scalar value to be used if the mode chosen is `constant` (by default it is 0).",
+            "(Optional) A scalar value to be used if the mode chosen is `constant` (by default it is 0, "
+            "empty string or False).",
             "T",
             OpSchema::Optional,
             true,
@@ -3300,7 +3301,7 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             OpSchema::all_tensor_types_with_bfloat(),
-            "Constrains input and output to only numeric types.")
+            "Constrain input and output types to all tensor types.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           // Type inference
           propagateElemTypeFromInputToOutput(ctx, 0, 0);


### PR DESCRIPTION
Update Pad documentation to be consistent with schema, stating the
acceptable input and output types are all tensor types, not limited
to numeric types. Also document the recommended defaults for string
and bool types.

Signed-off-by: Chin Huang <chhuang@us.ibm.com>