### PR TITLE
fix for naming mismatch between fusion node's outputs and subgraph's

### DIFF
--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -503,6 +503,8 @@ public:
     ONNX_ASSERT(outputs().size() == n->outputs().size());
     size_t nOutputs = outputs().size();
     for(size_t i = 0; i < nOutputs; i++) {
+      std::string unique_name = outputs()[i]->uniqueName();
+      n->outputs()[i]->setUniqueName(unique_name);
       outputs()[i]->replaceAllUsesWith(n->outputs()[i]);
     }
   }


### PR DESCRIPTION
when we fuses a subgraph, we notice that  output names of  new fusion nodes  are randomly generated in a fixed range of number. Therefore a naming conflicts may occur if origin graph contains a large number of nodes , and  nodes wiring would be disturbed. The following pictures shows the result of processing a graph containing 2000 nodes with a fuse_bn_into_conv passes. 
To avoid this, we rewrite the output names of  new fusion nodes with these of fused subgraph. 

![image](https://user-images.githubusercontent.com/31062802/106839572-6eee9d00-66d9-11eb-8c2a-b75af6322b85.png)
![image](https://user-images.githubusercontent.com/31062802/106839504-4d8db100-66d9-11eb-9a3c-eaab9e442a58.png)
