### PR TITLE
Modify existing function in external data helper

### DIFF
--- a/docs/ExternalData.md
+++ b/docs/ExternalData.md
@@ -22,6 +22,27 @@ load_external_data_for_model(onnx_model, 'data/directory/path/')
 # Then the onnx_model has loaded the external data from the specific directory
 ```
 
+## Converting an ONNX Model to External Data
+```python
+import onnx
+from onnx.external_data_helper import convert_model_to_external_data
+
+onnx_model = ... # Your model in memory as ModelProto
+convert_model_to_external_data(onnx_model, all_tensors_to_one_file=True, location='filename', size_threshold=1024, convert_attribute=False)
+# Must be followed by save_model to save the converted model to a specific path
+onnx.save_model(onnx_model, 'path/to/save/the/model.onnx')
+# Then the onnx_model has converted raw data as external data and saved to specific directory
+```
+
+## Converting and Saving an ONNX Model to External Data
+```python
+from onnx.external_data_helper import covert_and_save_model_to_external_data
+
+onnx_model = ... # Your model in memory as ModelProto
+covert_and_save_model_to_external_data(onnx_model, 'path/to/save/the/model.onnx', all_tensors_to_one_file=True, location='filename', size_threshold=1024, convert_attribute=False)
+# Then the onnx_model has converted raw data as external data and saved to specific directory
+```
+
 ## onnx.checker for Models with External Data
 
 ### Models with External Data (<2GB)

--- a/docs/ExternalData.md
+++ b/docs/ExternalData.md
@@ -36,10 +36,10 @@ onnx.save_model(onnx_model, 'path/to/save/the/model.onnx')
 
 ## Converting and Saving an ONNX Model to External Data
 ```python
-from onnx.external_data_helper import covert_and_save_model_to_external_data
+import onnx
 
 onnx_model = ... # Your model in memory as ModelProto
-covert_and_save_model_to_external_data(onnx_model, 'path/to/save/the/model.onnx', all_tensors_to_one_file=True, location='filename', size_threshold=1024, convert_attribute=False)
+onnx.save_model(onnx_model, 'path/to/save/the/model.onnx', save_as_external_data=True, all_tensors_to_one_file=True, location='filename', size_threshold=1024, convert_attribute=False)
 # Then the onnx_model has converted raw data as external data and saved to specific directory
 ```
 

--- a/docs/PythonAPIOverview.md
+++ b/docs/PythonAPIOverview.md
@@ -59,10 +59,9 @@ Runnable IPython notebooks:
 ## Converting and Saving an ONNX Model to External Data
 ```python
 import onnx
-from onnx.external_data_helper import covert_and_save_model_to_external_data
 
 onnx_model = ... # Your model in memory as ModelProto
-covert_and_save_model_to_external_data(onnx_model, 'path/to/save/the/model.onnx', all_tensors_to_one_file=True, location='filename', size_threshold=1024, convert_attribute=False)
+onnx.save_model(onnx_model, 'path/to/save/the/model.onnx', save_as_external_data=True, all_tensors_to_one_file=True, location='filename', size_threshold=1024, convert_attribute=False)
 # Then the onnx_model has converted raw data as external data and saved to specific directory
 ```
 

--- a/docs/PythonAPIOverview.md
+++ b/docs/PythonAPIOverview.md
@@ -33,6 +33,16 @@ load_external_data_for_model(onnx_model, 'data/directory/path/')
 # Then the onnx_model has loaded the external data from the specific directory
 ```
 
+## Converting an ONNX Model to External Data
+```python
+from onnx.external_data_helper import convert_model_to_external_data
+
+onnx_model = ... # Your model in memory as ModelProto
+convert_model_to_external_data(onnx_model, all_tensors_to_one_file=True, location='filename', size_threshold=1024, convert_attribute=False)
+# Then the onnx_model has converted raw data as external data
+# Must be followed by save
+```
+
 ## Saving an ONNX Model
 ```python
 import onnx
@@ -44,6 +54,18 @@ onnx.save(onnx_model, 'path/to/the/model.onnx')
 ```
 Runnable IPython notebooks:
 - [save_model.ipynb](https://github.com/onnx/onnx/tree/master/onnx/examples/save_model.ipynb)
+
+
+## Converting and Saving an ONNX Model to External Data
+```python
+import onnx
+from onnx.external_data_helper import covert_and_save_model_to_external_data
+
+onnx_model = ... # Your model in memory as ModelProto
+covert_and_save_model_to_external_data(onnx_model, 'path/to/save/the/model.onnx', all_tensors_to_one_file=True, location='filename', size_threshold=1024, convert_attribute=False)
+# Then the onnx_model has converted raw data as external data and saved to specific directory
+```
+
 
 ## Manipulating TensorProto and Numpy Array
 ```python

--- a/onnx/__init__.py
+++ b/onnx/__init__.py
@@ -175,11 +175,11 @@ def load_tensor_from_string(s, format=None):  # type: (bytes, Optional[Any]) -> 
 def save_model(proto, f, format=None, save_as_external_data=False, all_tensors_to_one_file=True, location=None, size_threshold=1024, convert_attribute=False):
     # type: (Union[ModelProto, bytes], Union[IO[bytes], Text], Optional[Any], bool, bool, Optional[Text], int, bool) -> None
     '''
-    Saves the ModelProto to the specified path and optionally, set tensors with raw data as external data before saving.
+    Saves the ModelProto to the specified path and optionally, serialize tensors with raw data as external data before saving.
 
     @params
     proto: should be a in-memory ModelProto
-    f: can be a file-like object (has "write" function) or a string containing a file name format is for future use
+    f: can be a file-like object (has "write" function) or a string containing a file name format for future use
     all_tensors_to_one_file: If true, save all tensors to one external file specified by location.
                              If false, save each tensor to a file named with the tensor name.
     location: specify the external file that all tensors to save to.

--- a/onnx/external_data_helper.py
+++ b/onnx/external_data_helper.py
@@ -9,7 +9,9 @@ import os
 import re
 import sys
 from itertools import chain
-from typing import Iterable, Text, Optional
+from typing import Iterable, Text, Optional, Union, IO
+
+import onnx
 from .onnx_pb import TensorProto, ModelProto
 
 
@@ -99,8 +101,8 @@ def set_external_data(tensor,  # type: TensorProto
             entry.value = str(v)
 
 
-def convert_model_to_external_data(model, all_tensors_to_one_file=True, location=None, size_threshold=1024):
-    # type: (ModelProto, bool, Optional[Text], int) -> None
+def convert_model_to_external_data(model, all_tensors_to_one_file=True, location=None, size_threshold=1024, convert_attribute=False):
+    # type: (ModelProto, bool, Optional[Text], int, bool) -> None
     """
     Call to set all tensors with raw data as external data. This call should preceed 'save_model'.
     'save_model' saves all the tensors data as external data after calling this function.
@@ -112,21 +114,48 @@ def convert_model_to_external_data(model, all_tensors_to_one_file=True, location
               If not specified, will use the model name.
     size_threshold: Threshold for size of data. Only when tensor's data is >= the size_threshold
     it will be converted to external data. To convert every tensor with raw data to external data set size_threshold=0.
+    convert_attribute: If true, convert all tensors to external data
+                       If false, convert only non-attribute tensors to external data
     """
+    tensors = _get_initializer_tensors(model)
+    if convert_attribute:
+        tensors = _get_all_tensors(model)
+
     if all_tensors_to_one_file:
         file_name = Text(uuid.uuid1())
         if location:
             file_name = location
-        for tensor in _get_all_tensors(model):
+        for tensor in tensors:
             if tensor.HasField("raw_data") and sys.getsizeof(tensor.raw_data) >= size_threshold:
                 set_external_data(tensor, file_name)
     else:
-        for tensor in _get_all_tensors(model):
+        for tensor in tensors:
             if tensor.HasField("raw_data") and sys.getsizeof(tensor.raw_data) >= size_threshold:
                 tensor_location = tensor.name
                 if not _is_valid_filename(tensor_location):
                     tensor_location = Text(uuid.uuid1())
                 set_external_data(tensor, tensor_location)
+
+
+def covert_and_save_model_to_external_data(model, model_file_path, all_tensors_to_one_file=True, location=None, size_threshold=1024, convert_attribute=False):
+    # type: (ModelProto, Union[IO[bytes], Text], bool, Optional[Text], int, bool) -> None
+    """
+    Call to set tensors with raw data as external data and save to a specified path.
+
+    @params
+    model: ModelProto to be converted.
+    all_tensors_to_one_file: If true, save all tensors to one external file specified by location.
+                             If false, save each tensor to a file named with the tensor name.
+    location: specify the external file that all tensors to save to.
+              If not specified, will use the model name.
+    size_threshold: Threshold for size of data. Only when tensor's data is >= the size_threshold
+    it will be converted to external data. To convert every tensor with raw data to external data set size_threshold=0.
+    convert_attribute: If true, convert all tensors to external data
+                       If false, convert only non-attribute tensors to external data
+    model_file_path: A string containing a file name
+    """
+    convert_model_to_external_data(model, all_tensors_to_one_file, location, size_threshold, convert_attribute)
+    onnx.save_model(model, model_file_path)
 
 
 def convert_model_from_external_data(model):  # type: (ModelProto) -> None

--- a/onnx/external_data_helper.py
+++ b/onnx/external_data_helper.py
@@ -9,9 +9,8 @@ import os
 import re
 import sys
 from itertools import chain
-from typing import Iterable, Text, Optional, Union, IO
+from typing import Iterable, Text, Optional
 
-import onnx
 from .onnx_pb import TensorProto, ModelProto
 
 
@@ -135,27 +134,6 @@ def convert_model_to_external_data(model, all_tensors_to_one_file=True, location
                 if not _is_valid_filename(tensor_location):
                     tensor_location = Text(uuid.uuid1())
                 set_external_data(tensor, tensor_location)
-
-
-def covert_and_save_model_to_external_data(model, model_file_path, all_tensors_to_one_file=True, location=None, size_threshold=1024, convert_attribute=False):
-    # type: (ModelProto, Union[IO[bytes], Text], bool, Optional[Text], int, bool) -> None
-    """
-    Call to set tensors with raw data as external data and save to a specified path.
-
-    @params
-    model: ModelProto to be converted.
-    all_tensors_to_one_file: If true, save all tensors to one external file specified by location.
-                             If false, save each tensor to a file named with the tensor name.
-    location: specify the external file that all tensors to save to.
-              If not specified, will use the model name.
-    size_threshold: Threshold for size of data. Only when tensor's data is >= the size_threshold
-    it will be converted to external data. To convert every tensor with raw data to external data set size_threshold=0.
-    convert_attribute: If true, convert all tensors to external data
-                       If false, convert only non-attribute tensors to external data
-    model_file_path: A string containing a file name
-    """
-    convert_model_to_external_data(model, all_tensors_to_one_file, location, size_threshold, convert_attribute)
-    onnx.save_model(model, model_file_path)
 
 
 def convert_model_from_external_data(model):  # type: (ModelProto) -> None

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -15,6 +15,7 @@ from onnx import checker, helper
 from onnx import ModelProto, TensorProto
 from onnx.external_data_helper import set_external_data
 from onnx.external_data_helper import convert_model_to_external_data
+from onnx.external_data_helper import covert_and_save_model_to_external_data
 from onnx.external_data_helper import convert_model_from_external_data
 from onnx.external_data_helper import load_external_data_for_model
 from onnx.numpy_helper import to_array, from_array
@@ -203,19 +204,36 @@ class TestSaveAllTensorsAsExternalData(TestLoadExternalDataBase):
     def test_check_model(self):  # type: () -> None
         checker.check_model(self.model)
 
-    def test_convert_model_to_from_one_file(self):  # type: () -> None
+    def test_convert_model_to_external_data_with_size_threshold(self):  # type: () -> None
         model_file_path = self.get_temp_model_filename()
-        external_data_file = str(uuid.uuid4())
-        convert_model_to_external_data(self.model, location=external_data_file, size_threshold=0)
+
+        convert_model_to_external_data(self.model, size_threshold=1024)
         onnx.save_model(self.model, model_file_path)
-        self.assertTrue(Path.isfile(model_file_path))
-        self.assertTrue(Path.isfile(os.path.join(self.temp_dir, external_data_file)))
+
         model = onnx.load_model(model_file_path)
         initializer_tensor = model.graph.initializer[0]
+        self.assertFalse(initializer_tensor.HasField("data_location"))
+
+    def test_convert_model_to_external_data_without_size_threshold(self):  # type: () -> None
+        model_file_path = self.get_temp_model_filename()
+        convert_model_to_external_data(self.model, size_threshold=0)
+        onnx.save_model(self.model, model_file_path)
+
+        model = onnx.load_model(model_file_path)
+        initializer_tensor = model.graph.initializer[0]
+        self.assertTrue(initializer_tensor.HasField("data_location"))
         self.assertTrue(np.allclose(to_array(initializer_tensor), self.initializer_value))
 
-        attribute_tensor = model.graph.node[0].attribute[0].t
-        self.assertTrue(np.allclose(to_array(attribute_tensor), self.attribute_value))
+    def test_convert_model_to_external_data_from_one_file_with_location(self):  # type: () -> None
+        model_file_path = self.get_temp_model_filename()
+        external_data_file = str(uuid.uuid4())
+
+        convert_model_to_external_data(self.model, size_threshold=0, all_tensors_to_one_file=True, location=external_data_file)
+        onnx.save_model(self.model, model_file_path)
+
+        self.assertTrue(Path.isfile(os.path.join(self.temp_dir, external_data_file)))
+
+        model = onnx.load_model(model_file_path)
 
         # test convert model from external data
         convert_model_from_external_data(model)
@@ -228,36 +246,93 @@ class TestSaveAllTensorsAsExternalData(TestLoadExternalDataBase):
         self.assertTrue(np.allclose(to_array(initializer_tensor), self.initializer_value))
 
         attribute_tensor = model.graph.node[0].attribute[0].t
-        self.assertFalse(len(initializer_tensor.external_data))
+        self.assertFalse(len(attribute_tensor.external_data))
         self.assertEqual(attribute_tensor.data_location, TensorProto.DEFAULT)
         self.assertTrue(np.allclose(to_array(attribute_tensor), self.attribute_value))
 
-    def test_convert_model_to_external_data_one_file_per_tensor(self):  # type: () -> None
+    def test_convert_model_to_external_data_from_one_file_without_location_uses_model_name(self):  # type: () -> None
         model_file_path = self.get_temp_model_filename()
-        convert_model_to_external_data(self.model, all_tensors_to_one_file=False, size_threshold=0)
+
+        convert_model_to_external_data(self.model, size_threshold=0, all_tensors_to_one_file=True)
         onnx.save_model(self.model, model_file_path)
+
+        self.assertTrue(Path.isfile(model_file_path))
+        self.assertTrue(Path.isfile(os.path.join(self.temp_dir, model_file_path)))
+
+    def test_convert_model_to_external_data_one_file_per_tensor_without_attribute(self):  # type: () -> None
+        model_file_path = self.get_temp_model_filename()
+
+        convert_model_to_external_data(self.model, size_threshold=0, all_tensors_to_one_file=False, convert_attribute=False)
+        onnx.save_model(self.model, model_file_path)
+
+        self.assertTrue(Path.isfile(model_file_path))
+        self.assertTrue(Path.isfile(os.path.join(self.temp_dir, "input_value")))
+        self.assertFalse(Path.isfile(os.path.join(self.temp_dir, "attribute_value")))
+
+    def test_convert_model_to_external_data_one_file_per_tensor_with_attribute(self):  # type: () -> None
+        model_file_path = self.get_temp_model_filename()
+
+        convert_model_to_external_data(self.model, size_threshold=0, all_tensors_to_one_file=False, convert_attribute=True)
+        onnx.save_model(self.model, model_file_path)
+
         self.assertTrue(Path.isfile(model_file_path))
         self.assertTrue(Path.isfile(os.path.join(self.temp_dir, "input_value")))
         self.assertTrue(Path.isfile(os.path.join(self.temp_dir, "attribute_value")))
+
+    def test_convert_model_to_external_data_does_not_convert_attribute_values(self):  # type: () -> None
+        model_file_path = self.get_temp_model_filename()
+
+        convert_model_to_external_data(self.model, size_threshold=0, convert_attribute=False, all_tensors_to_one_file=False)
+        onnx.save_model(self.model, model_file_path)
+
+        self.assertTrue(Path.isfile(os.path.join(self.temp_dir, "input_value")))
+        self.assertFalse(Path.isfile(os.path.join(self.temp_dir, "attribute_value")))
+
         model = onnx.load_model(model_file_path)
         initializer_tensor = model.graph.initializer[0]
+        self.assertTrue(initializer_tensor.HasField("data_location"))
+
+        attribute_tensor = model.graph.node[0].attribute[0].t
+        self.assertFalse(attribute_tensor.HasField("data_location"))
+
+    def test_convert_model_to_external_data_converts_attribute_values(self):  # type: () -> None
+        model_file_path = self.get_temp_model_filename()
+
+        convert_model_to_external_data(self.model, size_threshold=0, convert_attribute=True)
+        onnx.save_model(self.model, model_file_path)
+
+        model = onnx.load_model(model_file_path)
+
+        initializer_tensor = model.graph.initializer[0]
         self.assertTrue(np.allclose(to_array(initializer_tensor), self.initializer_value))
+        self.assertTrue(initializer_tensor.HasField("data_location"))
 
         attribute_tensor = model.graph.node[0].attribute[0].t
         self.assertTrue(np.allclose(to_array(attribute_tensor), self.attribute_value))
+        self.assertTrue(attribute_tensor.HasField("data_location"))
 
-    def test_convert_model_to_external_data_with_size_threshold(self):  # type: () -> None
+    def test_convert_and_save_model_to_external_data_saves_the_model(self):  # type: () -> None
         model_file_path = self.get_temp_model_filename()
-        convert_model_to_external_data(self.model, all_tensors_to_one_file=False, size_threshold=1024)
-        onnx.save_model(self.model, model_file_path)
+        covert_and_save_model_to_external_data(self.model, model_file_path)
         self.assertTrue(Path.isfile(model_file_path))
-        self.assertFalse(Path.isfile(os.path.join(self.temp_dir, "input_value")))
-        self.assertFalse(Path.isfile(os.path.join(self.temp_dir, "attribute_value")))
+
+    def test_convert_and_save_model_to_external_data_converts_the_model(self):  # type: () -> None
+        model_file_path = self.get_temp_model_filename()
+        covert_and_save_model_to_external_data(self.model,
+                                               model_file_path,
+                                               all_tensors_to_one_file=True,
+                                               location=None,
+                                               size_threshold=0,
+                                               convert_attribute=False)
+
         model = onnx.load_model(model_file_path)
+
         initializer_tensor = model.graph.initializer[0]
+        self.assertTrue(initializer_tensor.HasField("data_location"))
         self.assertTrue(np.allclose(to_array(initializer_tensor), self.initializer_value))
 
         attribute_tensor = model.graph.node[0].attribute[0].t
+        self.assertFalse(attribute_tensor.HasField("data_location"))
         self.assertTrue(np.allclose(to_array(attribute_tensor), self.attribute_value))
 
 


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

Update external data helpers to modify an existing function `convert_model_to_external_data` to take a `model_file_path` and `convert_attribute` to convert attributes to external data only when specified to `true` and to save the model when `model_file_path` is specified

fixes #3228 

assign @askhade for review