### PR TITLE
Set 1.8.1 in version related files

### DIFF
--- a/docs/OnnxReleases.md
+++ b/docs/OnnxReleases.md
@@ -19,7 +19,7 @@ The ONNX project, going forward, will plan to release roughly on a two month cad
 [ONNX proto files](../onnx/onnx.in.proto),
 [Versioning.md](Versioning.md),
 [schema.h](../onnx/defs/schema.h),
-[helper.py](../onnx/helper.py) and [helper_test.py](../onnx/helper_test.py). Please note that this also needs to be happened in the main branch before creating the release branch.
+[helper.py](../onnx/helper.py) and [helper_test.py](../onnx/test/helper_test.py). Please note that this also needs to be happened in the main branch before creating the release branch.
 
 * Create a release branch (please use rel-* as the branch name) from master. Checkout the release tag in a clean branch on your local repo. Make sure all tests pass on that branch.
 * Create an issue in onnxruntime to update onnx commit in onnxruntime to the release branch commit and run all the CI and packaging pipelines.

--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -172,6 +172,7 @@ ONNX version|File format version|Opset version ai.onnx|Opset version ai.onnx.ml|
 1.6.0|6|11|2|-
 1.7.0|7|12|2|1
 1.8.0|7|13|2|1
+1.8.1|7|13|2|1
 
 A programmatically accessible version of the above table is available [here](../onnx/helper.py). Limited version number
 information is also maintained in [version.h](../onnx/common/version.h) and [schema.h](../onnx/defs/schema.h).

--- a/onnx/common/version.h
+++ b/onnx/common/version.h
@@ -8,6 +8,6 @@
 namespace ONNX_NAMESPACE {
 
 // Represents the most recent release version. Updated with every release.
-constexpr const char* LAST_RELEASE_VERSION = "1.8.0";
+constexpr const char* LAST_RELEASE_VERSION = "1.8.1";
 
 }

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -36,7 +36,8 @@ VERSION_TABLE = [
     ('1.5.0', 5, 10, 1),
     ('1.6.0', 6, 11, 2),
     ('1.7.0', 7, 12, 2, 1),
-    ('1.8.0', 7, 13, 2, 1)
+    ('1.8.0', 7, 13, 2, 1),
+    ('1.8.1', 7, 13, 2, 1)
 ]  # type: VersionTableType
 
 VersionMapType = Dict[Tuple[Text, int], int]


### PR DESCRIPTION
**Description**
Set 1.8.1 in version related files.
Fix broken url in ONNX release doc.

**Motivation**
ONNX 1.8.1 has been released.
https://github.com/onnx/onnx/issues/3287