### PR TITLE
Fix onnx_proto target visibility on Windows and make onnx target always static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,7 +409,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "AIX")
   # So, create a object library
   add_library(onnx OBJECT ${ONNX_SRCS})
 else()
-  add_library(onnx ${ONNX_SRCS})
+  # onnx target doesn't export symbols
+  add_library(onnx STATIC ${ONNX_SRCS})
 endif()
 
 target_include_directories(onnx PUBLIC

--- a/onnx/onnx_pb.h
+++ b/onnx/onnx_pb.h
@@ -42,7 +42,7 @@
 //
 // This solution is similar to
 // https://github.com/pytorch/pytorch/blob/master/caffe2/core/common.h
-#if defined(ONNX_BUILD_SHARED_LIBS) || defined(ONNX_BUILD_MAIN_LIB)
+#if defined(ONNX_BUILD_MAIN_LIB)
 #define ONNX_API ONNX_EXPORT
 #else
 #define ONNX_API ONNX_IMPORT


### PR DESCRIPTION
Based on description from https://github.com/onnx/onnx/issues/3319 I'm proposing solution for enablement using `onnx_proto` as shared lib.

The main doubt is `ONNX_BUILD_SHARED_LIBS` meaning. If we cannot change it, please for suggestions what should we do in order to set `__declspec(dllexport)` linking symbols decorator.

On Windows we have 3 states of linking to handle: dllexport, dllimport and none (for static lib case).
Current `onnx_pb` flag configurations handle only 2 states:
- `ONNX_BUILD_SHARED_LIBS=ON` or `ONNX_BUILD_MAIN_LIB=ON`: `__declspec(dllexport)` is set
- `ONNX_BUILD_SHARED_LIBS=OFF` and `ONNX_BUILD_MAIN_LIB=OFF`: no linking decorator is set (static lib case)

The question is how to handle `__declspec(dllimport)` case?
