### PR TITLE
Fix release failure with Python 3.5: downgrade setuptools_scm

### DIFF
--- a/.github/workflows/manylinux/entrypoint.sh
+++ b/.github/workflows/manylinux/entrypoint.sh
@@ -6,7 +6,9 @@ set -e -x
 PY_VERSION=$1
 PLAT=$2
 GITHUB_EVENT_NAME=$3
-BUILD_REQUIREMENTS='numpy==1.16.6 protobuf==3.11.3'
+# Latest setuptools-scm-6.0.1 (dependency of setuptools) does not support Python 3.5 anymore
+# TODO: Remove this line if Python 3.5 is deprecated
+BUILD_REQUIREMENTS='numpy==1.16.6 protobuf==3.11.3 setuptools-scm==5.0.2'
 SYSTEM_PACKAGES='cmake3'
 
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib

--- a/.github/workflows/release_linux_i686.yml
+++ b/.github/workflows/release_linux_i686.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [master, rel-*]
   pull_request:
-    branches: [rel-*]
+    branches: [rel-*, master] # TODO: For testing, remove it before merge
 
 jobs:
   build:

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [master, rel-*]
   pull_request:
-    branches: [rel-*]
+    branches: [rel-*, master] # TODO: For testing, remove it before merge
 
 jobs:
   build:

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [master, rel-*]
   pull_request:
-    branches: [rel-*]
+    branches: [rel-*, master] # TODO: For testing, remove it before merge
 
 # Use MACOSX_DEPLOYMENT_TARGET=10.12 to produce compatible wheel
 env:
@@ -39,6 +39,9 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install -q --upgrade pip
+        # Latest setuptools-scm-6.0.1 (dependency of setuptools) does not support Python 3.5 anymore
+        # TODO: Remove this line if Python 3.5 is deprecated
+        python -m pip install -q setuptools-scm==5.0.2
         python -m pip install -q numpy==1.16.6 setuptools wheel
 
     - name: Install protobuf dependencies

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -57,6 +57,9 @@ jobs:
     - name: Install python dependencies
       run: |
         python -m pip install --upgrade pip
+        # Latest setuptools-scm-6.0.1 (dependency of setuptools) does not support Python 3.5 anymore
+        # TODO: Remove this line if Python 3.5 is deprecated
+        python -m pip install -q setuptools-scm==5.0.2
         pip install numpy==1.16.6 wheel          
             
     - name: Build ONNX wheel


### PR DESCRIPTION
**Description**
Downgrade setuptools_scm for now. Will remove it if ONNX deprecates Python 3.5 in the future

**Motivation**
https://github.com/pypa/setuptools_scm/issues/542 Latest setuptools does not support Python 3.5 anymore