### PR TITLE
Fix CI Python 3.6 failing due to .ipynb

### DIFF
--- a/.azure-pipelines/Linux-CI.yml
+++ b/.azure-pipelines/Linux-CI.yml
@@ -102,8 +102,8 @@ jobs:
       # onnx python api tests
       # pytest 6.0 made deprecation warnings fail by default, pinning pytest to 5.4.3.
       # TODO replace deprecated function with the suggested one. https://docs.pytest.org/en/stable/deprecations.html#id5
-      # TODO Remove fixed ipython
-      python -m pip install --quiet pytest==5.4.3 nbval ipython==7.21.0
+      # TODO Remove fixed ipython 7.16.1 once ONNX remove Python 3.6
+      python -m pip install --quiet pytest==5.4.3 nbval ipython==7.16.1
 
       pytest
       if [ $? -ne 0 ]; then

--- a/.azure-pipelines/Linux-CI.yml
+++ b/.azure-pipelines/Linux-CI.yml
@@ -102,7 +102,8 @@ jobs:
       # onnx python api tests
       # pytest 6.0 made deprecation warnings fail by default, pinning pytest to 5.4.3.
       # TODO replace deprecated function with the suggested one. https://docs.pytest.org/en/stable/deprecations.html#id5
-      python -m pip install --quiet pytest==5.4.3 nbval
+      # TODO Remove fixed ipython
+      python -m pip install --quiet pytest==5.4.3 nbval ipython==7.21.0
 
       pytest
       if [ $? -ne 0 ]; then

--- a/.azure-pipelines/MacOS-CI.yml
+++ b/.azure-pipelines/MacOS-CI.yml
@@ -82,7 +82,8 @@ jobs:
       # onnx python api tests
       # pytest 6.0 made deprecation warnings fail by default, pinning pytest to 5.4.3.
       # TODO replace deprecated function with the suggested one. https://docs.pytest.org/en/stable/deprecations.html#id5
-      pip install --quiet pytest==5.4.3 nbval
+      # TODO Remove fixed ipython
+      pip install --quiet pytest==5.4.3 nbval ipython==7.21.0
 
       pytest
       if [ $? -ne 0 ]; then

--- a/.azure-pipelines/MacOS-CI.yml
+++ b/.azure-pipelines/MacOS-CI.yml
@@ -82,8 +82,8 @@ jobs:
       # onnx python api tests
       # pytest 6.0 made deprecation warnings fail by default, pinning pytest to 5.4.3.
       # TODO replace deprecated function with the suggested one. https://docs.pytest.org/en/stable/deprecations.html#id5
-      # TODO Remove fixed ipython
-      pip install --quiet pytest==5.4.3 nbval ipython==7.21.0
+      # TODO Remove fixed ipython 7.16.1 once ONNX has removed Python 3.6
+      pip install --quiet pytest==5.4.3 nbval ipython==7.16.1
 
       pytest
       if [ $? -ne 0 ]; then

--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -43,8 +43,8 @@ jobs:
       python -m pip install --upgrade pip
       # pytest 6.0 made deprecation warnings fail by default, pinning pytest to 5.4.3.
       # TODO replace deprecated function with the suggested one. https://docs.pytest.org/en/stable/deprecations.html#id5
-      # TODO Remove fixed ipython
-      python -m pip install --quiet pytest==5.4.3 nbval numpy ipython==7.21.0
+      # TODO Remove fixed ipython 7.16.1 once ONNX has removed Python 3.6
+      python -m pip install --quiet pytest==5.4.3 nbval numpy ipython==7.16.1
 
       git submodule update --init --recursive
       set ONNX_BUILD_TESTS=1

--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -43,7 +43,8 @@ jobs:
       python -m pip install --upgrade pip
       # pytest 6.0 made deprecation warnings fail by default, pinning pytest to 5.4.3.
       # TODO replace deprecated function with the suggested one. https://docs.pytest.org/en/stable/deprecations.html#id5
-      python -m pip install --quiet pytest==5.4.3 nbval numpy
+      # TODO Remove fixed ipython
+      python -m pip install --quiet pytest==5.4.3 nbval numpy ipython==7.21.0
 
       git submodule update --init --recursive
       set ONNX_BUILD_TESTS=1


### PR DESCRIPTION
**Description**
To support Python 3.6 in ONNX, fix ipython version as 7.16.1, which is the latest version for Python 3.6. Will remove it in the future once ONNX has deprecated Python 3.6.

**Motivation**
https://github.com/ipython/ipython#overview ipython 7.17+ does not support Python 3.6 anymore. It causes test errors of .ipynb. To support Python 3.6, ONNX CI will use an old version of IPython.