### PR TITLE
Clarify CONTRIBUTING.md documentation generation steps

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -32,9 +32,11 @@ Then, after you have made changes to Python and C++ files:
 
 ## Generated operator documentation
 
-[Operator docs in Operators.md](Operators.md) are automatically generated based on C++ operator definitions. To refresh these docs, remember to re-install (see above) and then run the following command from the repo root and commit the results:
+[Operator docs in Operators.md](Operators.md) are automatically generated based on C++ operator definitions and backend Python snippets. To refresh these docs, run the following commands from the repo root and commit the results. Note `ONNX_ML=0` updates Operators.md whereas `ONNX_ML=1` updates Operators-ml.md:
 
 ```
+set ONNX_ML=0
+pip install setup.py
 python onnx/defs/gen_doc.py
 ```
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -54,13 +54,19 @@ ONNX uses [pytest](https://docs.pytest.org) as a test driver. To run tests, you'
 pip install pytest nbval
 ```
 
-After installing pytest, run
+After installing pytest, run from the root of the repo:
 
 ```
 pytest
 ```
 
 to begin the tests.
+
+You'll need to regenerate test coverage too, by running this command from the root of the repo:
+
+```
+python onnx\backend\test\stat_coverage.py
+```
 
 # Static typing (mypy)
 


### PR DESCRIPTION
Let's make this clearer so people don't waste an hour (like me 😅) wondering why running the script yields no changes to Operators.md. For some reason, the much more rarely updated Operators-ml.md is the default update target when `ONNX_ML` is not defined, rather than the one everyone typically wants to update. 🙃 Also, explicitly relist the install step rather than referring back to an earlier step which is actually executed from a different directory (which confuses things).

FYI @jcwchen