### PR TITLE
Fix ort failure in CI and add manually trigger

### DIFF
--- a/.github/workflows/release_linux_i686.yml
+++ b/.github/workflows/release_linux_i686.yml
@@ -8,6 +8,7 @@ on:
     branches: [master, rel-*]
   pull_request:
     branches: [rel-*]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [master, rel-*]
   pull_request:
-    branches: [rel-*]
+    branches: [rel-*, master]
   workflow_dispatch:
     inputs:
       tags:

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [master, rel-*]
   pull_request:
-    branches: [rel-*,]
+    branches: [rel-*]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -8,6 +8,14 @@ on:
     branches: [master, rel-*]
   pull_request:
     branches: [rel-*]
+  workflow_dispatch:
+    inputs:
+      purpose:
+        description: 'Purpose'     
+        required: false
+        default: 'What's your purpose to test?'
+      tags:
+        description: 'Manually trigger CI'  
 
 jobs:
   build:
@@ -87,5 +95,6 @@ jobs:
     - name: Verify ONNX with ort-nightly
       if: ${{ always() }}
       run: |
+        pip install flatbuffer
         python -m pip install -i https://test.pypi.org/simple/ ort-nightly
         python onnx/test/test_with_ort.py

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -7,13 +7,9 @@ on:
   push:
     branches: [master, rel-*]
   pull_request:
-    branches: [rel-*, master]
+    branches: [rel-*,]
+  # Enable manually trigger
   workflow_dispatch:
-    inputs:
-      tags:
-        description: 'Manually trigger CI'
-        required: false
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -92,6 +88,6 @@ jobs:
     - name: Verify ONNX with ort-nightly
       if: ${{ always() }}
       run: |
-        pip install flatbuffer
+        pip install flatbuffers
         python -m pip install -i https://test.pypi.org/simple/ ort-nightly
         python onnx/test/test_with_ort.py

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -8,8 +8,8 @@ on:
     branches: [master, rel-*]
   pull_request:
     branches: [rel-*,]
-  # Enable manually trigger
   workflow_dispatch:
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -88,6 +88,6 @@ jobs:
     - name: Verify ONNX with ort-nightly
       if: ${{ always() }}
       run: |
-        pip install flatbuffers
+        python -m pip install flatbuffers
         python -m pip install -i https://test.pypi.org/simple/ ort-nightly
         python onnx/test/test_with_ort.py

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -10,12 +10,9 @@ on:
     branches: [rel-*]
   workflow_dispatch:
     inputs:
-      purpose:
-        description: 'Purpose'     
-        required: false
-        default: 'What's your purpose to test?'
       tags:
-        description: 'Manually trigger CI'  
+        description: 'Manually trigger CI'
+        required: false
 
 jobs:
   build:

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -8,6 +8,7 @@ on:
     branches: [master, rel-*]
   pull_request:
     branches: [rel-*]
+  workflow_dispatch:
 
 # Use MACOSX_DEPLOYMENT_TARGET=10.12 to produce compatible wheel
 env:
@@ -117,5 +118,6 @@ jobs:
     - name: Verify ONNX with ort-nightly
       if: ${{ always() }}
       run: |
+        python -m pip install flatbuffers
         python -m pip install -i https://test.pypi.org/simple/ ort-nightly
         python onnx/test/test_with_ort.py

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -8,6 +8,7 @@ on:
     branches: [master, rel-*]
   pull_request:
     branches: [rel-*]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -148,6 +149,7 @@ jobs:
       run: |
         # ort-nightly does not support x86
         if ('${{ matrix.architecture }}' -eq 'x64') {
+          python -m pip install flatbuffers
           python -m pip install -i https://test.pypi.org/simple/ ort-nightly
           python onnx\onnx\test\test_with_ort.py
         }

--- a/.github/workflows/weekly_mac_ci.yml
+++ b/.github/workflows/weekly_mac_ci.yml
@@ -7,6 +7,7 @@ on:
   schedule:
     # run weekly on Sunday 23:59
     - cron:  '59 23 * * SUN'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
**Description**
- Install flatbuffers (ort's dependency) before pip install ort-nightly to prevent version conflict issue 
- Add `workflow_dispatch` to manually trigger CI

**Motivation**
Current release CIs are failing due to installing ort-nightly