### PR TITLE
Fix Linux release CI: Correct manylinux wheel name

### DIFF
--- a/.github/workflows/manylinux/entrypoint.sh
+++ b/.github/workflows/manylinux/entrypoint.sh
@@ -72,8 +72,8 @@ if [[ -f "$failed_wheels" ]]; then
     exit 1
 fi
 
-# Remove useless *-linux*.whl; only keep -manylinux*.whl
+# Remove useless *-linux*.whl; only keep manylinux*.whl
 rm -f dist/*-linux*.whl
 
 echo "Succesfully build wheels:"
-find . -type f -iname "*-manylinux*.whl"
+find . -type f -iname "*manylinux*.whl"

--- a/.github/workflows/manylinux/test_package_i686.sh
+++ b/.github/workflows/manylinux/test_package_i686.sh
@@ -19,7 +19,7 @@ PYTEST_COMMAND="${PYTHON_BIN}pytest"
 
 $PIP_INTALL_COMMAND --upgrade pip
 $PIP_INTALL_COMMAND numpy protobuf==3.11.3
-$PIP_INTALL_COMMAND dist/*-manylinux2010_i686.whl
+$PIP_INTALL_COMMAND dist/*manylinux2010_i686.whl
 
 # pytest with the built wheel
 # TODO Remove fixed ipython 7.16.1 once ONNX has removed Python 3.6
@@ -35,12 +35,12 @@ $PYTHON_COMAND workflow_scripts/test_generated_backend.py
 
 # Verify ONNX with the latest numpy
 $PIP_UNINTALL_COMMAND numpy onnx && $PIP_INTALL_COMMAND numpy
-$PIP_INTALL_COMMAND dist/*-manylinux2010_i686.whl
+$PIP_INTALL_COMMAND dist/*manylinux2010_i686.whl
 $PYTEST_COMMAND
 
 # Verify ONNX with the latest protobuf
 $PIP_UNINTALL_COMMAND protobuf onnx && $PIP_INTALL_COMMAND protobuf
-$PIP_INTALL_COMMAND dist/*-manylinux2010_i686.whl
+$PIP_INTALL_COMMAND dist/*manylinux2010_i686.whl
 $PYTEST_COMMAND
 
 echo "Succesfully test the wheel"

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Test wheel with Python ${{ matrix.python-version }}
       run: |
-        python -m pip install dist/*-manylinux2010_x86_64.whl
+        python -m pip install dist/*manylinux2010_x86_64.whl
         # TODO Remove fixed ipython 7.16.1 once ONNX has removed Python 3.6
         python -m pip install pytest==5.4.3 nbval ipython==7.16.1
         pytest
@@ -75,14 +75,14 @@ jobs:
       if: ${{ always() }}
       run: |
         python -m pip uninstall -y numpy onnx && python -m pip install numpy
-        python -m pip install dist/*-manylinux2010_x86_64.whl
+        python -m pip install dist/*manylinux2010_x86_64.whl
         pytest
 
     - name: Verify ONNX with the latest protobuf
       if: ${{ always() }}
       run: |
         python -m pip uninstall -y protobuf onnx && python -m pip install protobuf
-        python -m pip install dist/*-manylinux2010_x86_64.whl
+        python -m pip install dist/*manylinux2010_x86_64.whl
         pytest        
 
     - name: Verify ONNX with ort-nightly


### PR DESCRIPTION
**Description**
To detect the produced wheel correctly, change the naming match for the Linux wheel. (`*-manylinux*` to `*.manylinux*`)

**Motivation**
Linux release CI fails without any related code change. This error is caused by the produced wheel cannot be detected. The naming convention of the wheel has been changed from `onnx-*.manylinux*.whl` into `onnx-*.manylinux*.whl`.