### PR TITLE
Fix Squeeze shape inference

### DIFF
--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -1631,7 +1631,6 @@ ONNX_OPERATOR_SET_SCHEMA(
               axes_not_specified = true;
           }
   
-          ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
           const auto& input_shape = ctx.getInputType(0)->tensor_type().shape();
           const auto input_ndim = input_shape.dim_size();
           std::transform(
@@ -1648,6 +1647,8 @@ ONNX_OPERATOR_SET_SCHEMA(
                 return;
             }
           }
+
+          ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
 
           for (int i = 0; i < input_ndim; ++i) {
             if (axes_not_specified && input_shape.dim(i).dim_value() == 1) {

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -1641,10 +1641,11 @@ ONNX_OPERATOR_SET_SCHEMA(
               [&](int64_t axis) -> int64_t {
                 return axis < 0 ? axis + input_ndim : axis;
               });
-          // if input consists a symbolic value, return early since shape cannot be inferred
+
           for (int i = 0; i < input_ndim; ++i) {
-            if (!input_shape.dim(i).has_dim_value()) {
-              return;
+            if(!input_shape.dim(i).has_dim_value() && (axes_not_specified || std::find(axes.begin(), axes.end(), i) != axes.end())) {
+                // if dim has a symbolic value and the axes spec want to act on dim, return early because we can't infer the shape
+                return;
             }
           }
 


### PR DESCRIPTION
Fixes https://github.com/onnx/onnx/issues/3515

There seem to be 2 problems here:
1) Shape inference should not give up as soon as a symbolic dimension is found, but only if the axes spec wants to act on that dimension, i.e. if it's absent or if it contains that dimension explicitly
2) In case shape inference gives up, it should not predict a rank of 0 

I have fixed (1) but (2) still remains to be addressed.