### PR TITLE
Fix weekly-CI failure: correct protobuf installation and skip list

### DIFF
--- a/.github/workflows/weekly_mac_ci.yml
+++ b/.github/workflows/weekly_mac_ci.yml
@@ -30,17 +30,31 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.architecture }}
-    - name: Install dependencies
+    - name: Install Python dependencies
       shell: bash
       run: |
         set -e
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install numpy
-        pip install --quiet pytest==5.4.3 nbval
+        python -m pip -q install numpy==1.16.6 pytest==5.4.3 nbval setuptools wheel
+
+    - name: Install protobuf dependencies
+      run: |
         # Install protobuf 3.11.3 due to compatibility
-        wget https://raw.githubusercontent.com/Homebrew/homebrew-core/66613cae31ad29ac4b1af532220aeb9e11d9672f/Formula/protobuf.rb
-        brew install protobuf.rb
-        pip install protobuf==3.11.3           
+        export NUM_CORES=`sysctl -n hw.ncpu`
+        echo Using $NUM_CORES cores
+        brew update
+        brew install autoconf && brew install automake
+        export ONNX_PATH=$(pwd)
+        cd ..
+        wget https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protobuf-cpp-3.11.3.tar.gz
+        tar -xvf protobuf-cpp-3.11.3.tar.gz
+        cd protobuf-3.11.3
+        mkdir build_source && cd build_source
+        cmake ../cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release
+        make -j${NUM_CORES}
+        make install
+        export PATH=$(pwd)/bin:$PATH
+        cd $ONNX_PATH
+         
     - name: Build, install and test ONNX
       shell: bash
       run: |

--- a/workflow_scripts/config.py
+++ b/workflow_scripts/config.py
@@ -4,7 +4,7 @@
 # Skip them in test_model_zoo.py for now
 # TODO: fix these checker failures
 SKIP_CHECKER_MODELS = {'vision/classification/alexnet/model/bvlcalexnet-3.onnx',  # opset1 typeinference function missing
-                       'vision/classification/caffenet/model/caffenet-6.onnx',  # this should be caffenet-3.onnx; missing too
+                       'vision/classification/caffenet/model/caffenet-3.onnx',  # this should be caffenet-3.onnx; missing too
                        'vision/classification/densenet-121/model/densenet-3.onnx',  # opset1 typeinference function missing
                        'vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-3.onnx',  # opset1 typeinference function missing
                        'vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-3.onnx',  # opset1 typeinference function missing


### PR DESCRIPTION
**Description**
- To fix protobuf.rb not found, directly build protobuf 3.11.3 from source, just like what other CIs do
- Switch caffenet-3 and caffenet-6 in skip list due to the bug fix: https://github.com/onnx/models/pull/388

**Motivation and Context**
Weekly-CI has failed for a while