### PR TITLE
Add shape inference function for dynamic quantize linear

### DIFF
--- a/onnx/defs/quantization/defs.cc
+++ b/onnx/defs/quantization/defs.cc
@@ -179,6 +179,20 @@ ONNX_OPERATOR_SET_SCHEMA(
            {{"Zeropoint"}, "Cast", {"Rounded_ZeroPoint_FP"}, {MakeAttribute("to", int64_t(2))}},
            {{"y_scale"}, "Identity", {"Scale"}},
            {{"y_zero_point"}, "Identity", {"Zeropoint"}},
-           {{"y"}, "QuantizeLinear", {"x", "Scale", "Zeropoint"}}})));
+           {{"y"}, "QuantizeLinear", {"x", "Scale", "Zeropoint"}}}))
+        .TypeAndShapeInferenceFunction(
+            [](ONNX_NAMESPACE::InferenceContext& ctx) {
+              updateOutputElemType(ctx, 0, TensorProto::UINT8);
+              updateOutputElemType(ctx, 1, TensorProto::FLOAT);
+              updateOutputElemType(ctx, 2, TensorProto::UINT8);
+
+              if (!hasInputShape(ctx, 0))
+                return;
+
+              auto& input_shape = getInputShape(ctx, 0);
+              updateOutputShape(ctx, 0, input_shape);
+              ctx.getOutputType(1)->mutable_tensor_type()->mutable_shape();
+              ctx.getOutputType(2)->mutable_tensor_type()->mutable_shape();
+            }));
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/quantization/defs.cc
+++ b/onnx/defs/quantization/defs.cc
@@ -186,13 +186,14 @@ ONNX_OPERATOR_SET_SCHEMA(
               updateOutputElemType(ctx, 1, TensorProto::FLOAT);
               updateOutputElemType(ctx, 2, TensorProto::UINT8);
 
+              ctx.getOutputType(1)->mutable_tensor_type()->mutable_shape();
+              ctx.getOutputType(2)->mutable_tensor_type()->mutable_shape();
+
               if (!hasInputShape(ctx, 0))
                 return;
 
               auto& input_shape = getInputShape(ctx, 0);
               updateOutputShape(ctx, 0, input_shape);
-              ctx.getOutputType(1)->mutable_tensor_type()->mutable_shape();
-              ctx.getOutputType(2)->mutable_tensor_type()->mutable_shape();
             }));
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -2317,6 +2317,15 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (30, 4, 5))])
 
+    def test_dynamicquantizelinear(self):  # type: () -> None
+        graph = self._make_graph(
+            [('x', TensorProto.FLOAT, (30, 4, 5))],
+            [make_node('DynamicQuantizeLinear', ['x'], ['y', 'y_scale', 'y_zero_point'])],
+            [])
+        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.UINT8, (30, 4, 5)),
+                                      make_tensor_value_info('y_scale', TensorProto.FLOAT, ()),
+                                      make_tensor_value_info('y_zero_point', TensorProto.UINT8, ())])
+
     def test_reversesequence(self):  # type: () -> None
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (4, 5, 6)),


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

**Description**
- Add shape inference function to dynamic quantize linear

**Motivation and Context**
- Why is this change required? What problem does it solve? 
explicitly add shape inference function

- If it fixes an open issue, please link to the issue here.
fixes #3505 