### PR TITLE
fix test_identity_sequence issue

### DIFF
--- a/onnx/backend/test/runner/__init__.py
+++ b/onnx/backend/test/runner/__init__.py
@@ -170,7 +170,8 @@ class Runner(object):
         np.testing.assert_equal(len(outputs), len(ref_outputs))
         for i in range(len(outputs)):
             if isinstance(outputs[i], (list, tuple)):
-                np.testing.assert_array_equal(outputs[i], ref_outputs[i])
+                for j in range(len(outputs[i])):
+                    cls.assert_similar_outputs(ref_outputs[i][j], outputs[i][j], rtol, atol)
             else:
                 np.testing.assert_equal(outputs[i].dtype, ref_outputs[i].dtype)
                 if ref_outputs[i].dtype == np.object:

--- a/onnx/backend/test/runner/__init__.py
+++ b/onnx/backend/test/runner/__init__.py
@@ -169,15 +169,18 @@ class Runner(object):
     def assert_similar_outputs(cls, ref_outputs, outputs, rtol, atol):  # type: (Sequence[Any], Sequence[Any], float, float) -> None
         np.testing.assert_equal(len(outputs), len(ref_outputs))
         for i in range(len(outputs)):
-            np.testing.assert_equal(outputs[i].dtype, ref_outputs[i].dtype)
-            if ref_outputs[i].dtype == np.object:
+            if isinstance(outputs[i], (list, tuple)):
                 np.testing.assert_array_equal(outputs[i], ref_outputs[i])
             else:
-                np.testing.assert_allclose(
-                    outputs[i],
-                    ref_outputs[i],
-                    rtol=rtol,
-                    atol=atol)
+                np.testing.assert_equal(outputs[i].dtype, ref_outputs[i].dtype)
+                if ref_outputs[i].dtype == np.object:
+                    np.testing.assert_array_equal(outputs[i], ref_outputs[i])
+                else:
+                    np.testing.assert_allclose(
+                        outputs[i],
+                        ref_outputs[i],
+                        rtol=rtol,
+                        atol=atol)
 
     @classmethod
     @retry_excute(3)


### PR DESCRIPTION
Signed-off-by: degaochu <degaochu@cn.ibm.com>

**Description**
- update function assert_similar_outputs() in onnx/backend/test/runner/init.py to support sequence/list as model/node's output.

**Motivation and Context**
- To fix onnx backend test failed for sequence output operators like identity operator
- fix issue https://github.com/onnx/onnx/issues/3562
