### PR TITLE
Sync protobuf version in every CI: Install protobuf 3.11.3 in LinuxRelease CI

### DIFF
--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -34,9 +34,22 @@ jobs:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.architecture }}
 
+    - name: Install python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install numpy protobuf==3.11.3
+
+    - name: Build manylinux2010_x86_64
+      uses: docker://quay.io/pypa/manylinux2010_x86_64
+      with:
+        entrypoint: bash
+        args: .github/workflows/manylinux/entrypoint.sh ${{ matrix.python-version }} manylinux2010_x86_64 ${{ github.event_name }}
+
     - name: Install protobuf
       run: |
-        # Build protobuf
+        # entrypoint.sh installs protobuf inside the docker for building the wheel. 
+        # The protobuf installation here is in the GitHub Action environment 
+        # for testing the wheel.
         cd ..
         git clone https://github.com/protocolbuffers/protobuf.git
         cd protobuf
@@ -48,16 +61,18 @@ jobs:
         sudo make -j$(nproc)
         sudo make install
 
-    - name: Install python dependencies
+    - name: Install protobuf in the GitHub Action environment for testing the wheel
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install numpy protobuf==3.11.3
+        cd ..
+        git clone https://github.com/protocolbuffers/protobuf.git
+        cd protobuf
+        git checkout v3.11.3
+        git submodule update --init --recursive
+        mkdir build_source && cd build_source
 
-    - name: Build manylinux2010_x86_64
-      uses: docker://quay.io/pypa/manylinux2010_x86_64
-      with:
-        entrypoint: bash
-        args: .github/workflows/manylinux/entrypoint.sh ${{ matrix.python-version }} manylinux2010_x86_64 ${{ github.event_name }}
+        cmake ../cmake -Dprotobuf_BUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_SYSCONFDIR=/etc -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release
+        sudo make -j$(nproc)
+        sudo make install
 
     - name: Test wheel with Python ${{ matrix.python-version }}
       run: |

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -45,8 +45,8 @@ jobs:
         mkdir build_source && cd build_source
 
         cmake ../cmake -Dprotobuf_BUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_SYSCONFDIR=/etc -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release
-        make -j$(nproc)
-        make install
+        sudo make -j$(nproc)
+        sudo make install
 
     - name: Install python dependencies
       run: |

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -34,11 +34,24 @@ jobs:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.architecture }}
 
+    - name: Install protobuf
+      run: |
+        # Build protobuf
+        cd ..
+        git clone https://github.com/protocolbuffers/protobuf.git
+        cd protobuf
+        git checkout v3.11.3
+        git submodule update --init --recursive
+        mkdir build_source && cd build_source
+
+        cmake ../cmake -Dprotobuf_BUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_SYSCONFDIR=/etc -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release
+        make -j$(nproc)
+        make install
+
     - name: Install python dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install numpy protobuf==3.11.3
-        sudo apt-get install protobuf-compiler libprotoc-dev
 
     - name: Build manylinux2010_x86_64
       uses: docker://quay.io/pypa/manylinux2010_x86_64

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -45,22 +45,6 @@ jobs:
         entrypoint: bash
         args: .github/workflows/manylinux/entrypoint.sh ${{ matrix.python-version }} manylinux2010_x86_64 ${{ github.event_name }}
 
-    - name: Install protobuf
-      run: |
-        # entrypoint.sh installs protobuf inside the docker for building the wheel. 
-        # The protobuf installation here is in the GitHub Action environment 
-        # for testing the wheel.
-        cd ..
-        git clone https://github.com/protocolbuffers/protobuf.git
-        cd protobuf
-        git checkout v3.11.3
-        git submodule update --init --recursive
-        mkdir build_source && cd build_source
-
-        cmake ../cmake -Dprotobuf_BUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_SYSCONFDIR=/etc -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release
-        sudo make -j$(nproc)
-        sudo make install
-
     - name: Install protobuf in the GitHub Action environment for testing the wheel
       run: |
         cd ..


### PR DESCRIPTION
**Description**
Previously apt-get version of protobuf should be an old version... To sync protobuf version in every CI, install protobuf 3.11.3 in LinuxRelease CI

**Motivation and Context**
Sync protobuf version in every CI