### PR TITLE
checker updates for model local functions

### DIFF
--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -720,14 +720,23 @@ void check_opset_compatibility(
     return;
   }
 
+  if (func_opset_version == model_opset_version) {
+    // both versions are same, no need to verify schema.
+    return;
+  }
+
   const auto* schema_for_model_import =
       ctx.get_schema_registry()->GetSchema(node.op_type(), model_opset_version, node.domain());
 
   const auto* schema_for_function_import =
       ctx.get_schema_registry()->GetSchema(node.op_type(), func_opset_version, node.domain());
 
-  if (schema_for_model_import && schema_for_function_import &&
-      schema_for_function_import->since_version() == schema_for_model_import->since_version()) {
+  if (!schema_for_model_import || !schema_for_function_import) {
+    // the op belongs to a custom domain so we cannot verify schema
+    return;
+  }
+
+  if (schema_for_function_import->since_version() == schema_for_model_import->since_version()) {
     // The since versions of schema for both opset imports match. This means they are compatible.
     return;
   }
@@ -737,6 +746,34 @@ void check_opset_compatibility(
       "is not compatible with the version imported by model. FunctionOp imports version " +
       ONNX_NAMESPACE::to_string(func_opset_version) + "whereas model imports version " +
       ONNX_NAMESPACE::to_string(model_opset_version));
+}
+
+void check_model_local_functions(
+    const ModelProto& model,
+    const CheckerContext& ctx,
+    const LexicalScopeContext& parent_lex) {
+    // make a copy of model opset imports to maintain a master copy of opset imports across the model and 
+    // all model local functions to verify opset compatibility
+    std::unordered_map<std::string, int> model_opset_imports(ctx.get_opset_imports());
+
+    // merge the opset imports from every function in model_opset_imports
+    // only add the opset import if an entry for it does not exist in model_opset_imports
+    // if there is an entry then the compatibility will be checked later on in check_opset_compatibility
+    // called by check_function.
+    for (const auto& function_proto : model.functions()) {
+      for (const auto& opset_import : function_proto.opset_import()) {
+        if (get_version_for_domain(opset_import.domain(), model_opset_imports) == -1) {
+          model_opset_imports[opset_import.domain()] = opset_import.version();
+        }
+      }
+    }
+
+    CheckerContext ctx_copy = ctx;
+    ctx_copy.set_opset_imports(model_opset_imports);
+
+    for (const auto& function_proto : model.functions()) {
+        check_function(function_proto, ctx_copy, parent_lex);
+    }
 }
 
 void check_function(const FunctionProto& function, const CheckerContext& ctx, const LexicalScopeContext& parent_lex) {
@@ -865,9 +902,7 @@ void check_model(const ModelProto& model, CheckerContext& ctx) {
   check_graph(model.graph(), ctx, lex_ctx);
 
   if (ctx.get_ir_version() >= 0x00000008) {
-    for (const auto& function_proto : model.functions()) {
-      check_function(function_proto, ctx, lex_ctx);
-    }
+    check_model_local_functions(model, ctx, lex_ctx);
   }
 }
 

--- a/onnx/checker.h
+++ b/onnx/checker.h
@@ -136,6 +136,12 @@ void check_opset_compatibility(
     const std::unordered_map<std::string, int>& func_opset_imports,
     const std::unordered_map<std::string, int>& model_opset_imports);
 
+// Checks all model local functions present in ModelProto
+void check_model_local_functions(
+    const ModelProto& model,
+    const CheckerContext& ctx,
+    const LexicalScopeContext& parent_lex);
+
 void check_model(const ModelProto& model);
 void check_model(const std::string& model_path);
 


### PR DESCRIPTION
Signed-off-by: Ashwini Khade <askhade@microsoft.com>

**Description**
Adding checks for opset compatibility between different model local functions and relaxing schema check in opset compatibility when the ops do not belong to onnx standard domains.
- Describe your changes.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
