### PR TITLE
Fix QuantizeLinear shape inference

### DIFF
--- a/onnx/defs/quantization/defs.cc
+++ b/onnx/defs/quantization/defs.cc
@@ -55,7 +55,11 @@ ONNX_OPERATOR_SET_SCHEMA(
         .SetDoc(QuantizeLinear_ver13_doc)
         .TypeAndShapeInferenceFunction(
             [](ONNX_NAMESPACE::InferenceContext& ctx) {
-              propagateElemTypeFromInputToOutput(ctx, 2, 0);
+              if (ctx.getNumInputs() == 3) {
+                propagateElemTypeFromInputToOutput(ctx, 2, 0);
+              } else {
+                updateOutputElemType(ctx, 0, TensorProto::UINT8);
+              }
 
               if (!hasInputShape(ctx, 0))
                 return;

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -2310,6 +2310,14 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.UINT8, (30, 4, 5))])
 
+    def test_quantizelinear_default_zp(self):  # type: () -> None
+        graph = self._make_graph(
+            [('x', TensorProto.FLOAT, (30, 4, 5)),
+             ('y_scale', TensorProto.FLOAT, ())],
+            [make_node('QuantizeLinear', ['x', 'y_scale'], ['y'])],
+            [])
+        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.UINT8, (30, 4, 5))])
+
     def test_dequantizelinear(self):  # type: () -> None
         graph = self._make_graph(
             [('x', TensorProto.UINT8, (30, 4, 5)),


### PR DESCRIPTION
**Description**
This PR fixes the out of range bug in QuantizeLinear shape inference.
The 3rd input (y_zero_point) of QuantizeLinear is optional and can be null. Needs to check if it exists when inferring the output type.
