### PR TITLE
Update spec for model local functions

### DIFF
--- a/onnx/onnx-ml.proto
+++ b/onnx/onnx-ml.proto
@@ -397,10 +397,10 @@ message ModelProto {
 
   // A list of function protos local to the model.
   //
-  // Model local functions override standard operator sets. Meaning, 
-  // if a model local function exists for op_type + domain combination
-  // then it will be preferred over the operator or function present in 
-  // standard defined or cutom operator sets.
+  // Name of the function "FunctionProto.name" should be unique within the domain "FunctionProto.domain".
+  // In case of any conflicts the behavior (whether the model local functions are given higher priority,
+  // or standard opserator sets are given higher priotity or this is treated as error) is defined by 
+  // the runtimes.
   // 
   // The operator sets imported by FunctionProto should be compatible with the ones
   // imported by ModelProto and other model local FunctionProtos. 
@@ -408,7 +408,7 @@ message ModelProto {
   // or by 2 FunctionProtos then versions for the operator set may be different but, 
   // the operator schema returned for op_type, domain, version combination
   // for both the versions should be same for every node in the function body.
-
+  //
   // One FunctionProto can reference other FunctionProto in the model, however, recursive reference
   // is not allowed.
   repeated FunctionProto functions = 25;
@@ -809,7 +809,6 @@ message FunctionProto {
   optional string doc_string = 8;
 
   // The OperatorSets this function body (graph) relies on.
-  // All FunctionProtos implicitly import the operator set which the function operator is part of.
   //
   // All nodes in the function body (graph) will bind against the operator
   // with the same-domain/same-op_type operator with the HIGHEST version

--- a/onnx/onnx-ml.proto3
+++ b/onnx/onnx-ml.proto3
@@ -397,10 +397,10 @@ message ModelProto {
 
   // A list of function protos local to the model.
   //
-  // Model local functions override standard operator sets. Meaning, 
-  // if a model local function exists for op_type + domain combination
-  // then it will be preferred over the operator or function present in 
-  // standard defined or cutom operator sets.
+  // Name of the function "FunctionProto.name" should be unique within the domain "FunctionProto.domain".
+  // In case of any conflicts the behavior (whether the model local functions are given higher priority,
+  // or standard opserator sets are given higher priotity or this is treated as error) is defined by 
+  // the runtimes.
   // 
   // The operator sets imported by FunctionProto should be compatible with the ones
   // imported by ModelProto and other model local FunctionProtos. 
@@ -408,7 +408,7 @@ message ModelProto {
   // or by 2 FunctionProtos then versions for the operator set may be different but, 
   // the operator schema returned for op_type, domain, version combination
   // for both the versions should be same for every node in the function body.
-
+  //
   // One FunctionProto can reference other FunctionProto in the model, however, recursive reference
   // is not allowed.
   repeated FunctionProto functions = 25;
@@ -809,7 +809,6 @@ message FunctionProto {
   string doc_string = 8;
 
   // The OperatorSets this function body (graph) relies on.
-  // All FunctionProtos implicitly import the operator set which the function operator is part of.
   //
   // All nodes in the function body (graph) will bind against the operator
   // with the same-domain/same-op_type operator with the HIGHEST version

--- a/onnx/onnx.in.proto
+++ b/onnx/onnx.in.proto
@@ -394,10 +394,10 @@ message ModelProto {
 
   // A list of function protos local to the model.
   //
-  // Model local functions override standard operator sets. Meaning, 
-  // if a model local function exists for op_type + domain combination
-  // then it will be preferred over the operator or function present in 
-  // standard defined or cutom operator sets.
+  // Name of the function "FunctionProto.name" should be unique within the domain "FunctionProto.domain".
+  // In case of any conflicts the behavior (whether the model local functions are given higher priority,
+  // or standard opserator sets are given higher priotity or this is treated as error) is defined by 
+  // the runtimes.
   // 
   // The operator sets imported by FunctionProto should be compatible with the ones
   // imported by ModelProto and other model local FunctionProtos. 
@@ -405,7 +405,7 @@ message ModelProto {
   // or by 2 FunctionProtos then versions for the operator set may be different but, 
   // the operator schema returned for op_type, domain, version combination
   // for both the versions should be same for every node in the function body.
-
+  //
   // One FunctionProto can reference other FunctionProto in the model, however, recursive reference
   // is not allowed.
   repeated FunctionProto functions = 25;
@@ -810,7 +810,6 @@ message FunctionProto {
   optional string doc_string = 8;
 
   // The OperatorSets this function body (graph) relies on.
-  // All FunctionProtos implicitly import the operator set which the function operator is part of.
   //
   // All nodes in the function body (graph) will bind against the operator
   // with the same-domain/same-op_type operator with the HIGHEST version

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -395,10 +395,10 @@ message ModelProto {
 
   // A list of function protos local to the model.
   //
-  // Model local functions override standard operator sets. Meaning, 
-  // if a model local function exists for op_type + domain combination
-  // then it will be preferred over the operator or function present in 
-  // standard defined or cutom operator sets.
+  // Name of the function "FunctionProto.name" should be unique within the domain "FunctionProto.domain".
+  // In case of any conflicts the behavior (whether the model local functions are given higher priority,
+  // or standard opserator sets are given higher priotity or this is treated as error) is defined by 
+  // the runtimes.
   // 
   // The operator sets imported by FunctionProto should be compatible with the ones
   // imported by ModelProto and other model local FunctionProtos. 
@@ -406,7 +406,7 @@ message ModelProto {
   // or by 2 FunctionProtos then versions for the operator set may be different but, 
   // the operator schema returned for op_type, domain, version combination
   // for both the versions should be same for every node in the function body.
-
+  //
   // One FunctionProto can reference other FunctionProto in the model, however, recursive reference
   // is not allowed.
   repeated FunctionProto functions = 25;
@@ -793,7 +793,6 @@ message FunctionProto {
   optional string doc_string = 8;
 
   // The OperatorSets this function body (graph) relies on.
-  // All FunctionProtos implicitly import the operator set which the function operator is part of.
   //
   // All nodes in the function body (graph) will bind against the operator
   // with the same-domain/same-op_type operator with the HIGHEST version

--- a/onnx/onnx.proto3
+++ b/onnx/onnx.proto3
@@ -395,10 +395,10 @@ message ModelProto {
 
   // A list of function protos local to the model.
   //
-  // Model local functions override standard operator sets. Meaning, 
-  // if a model local function exists for op_type + domain combination
-  // then it will be preferred over the operator or function present in 
-  // standard defined or cutom operator sets.
+  // Name of the function "FunctionProto.name" should be unique within the domain "FunctionProto.domain".
+  // In case of any conflicts the behavior (whether the model local functions are given higher priority,
+  // or standard opserator sets are given higher priotity or this is treated as error) is defined by 
+  // the runtimes.
   // 
   // The operator sets imported by FunctionProto should be compatible with the ones
   // imported by ModelProto and other model local FunctionProtos. 
@@ -406,7 +406,7 @@ message ModelProto {
   // or by 2 FunctionProtos then versions for the operator set may be different but, 
   // the operator schema returned for op_type, domain, version combination
   // for both the versions should be same for every node in the function body.
-
+  //
   // One FunctionProto can reference other FunctionProto in the model, however, recursive reference
   // is not allowed.
   repeated FunctionProto functions = 25;
@@ -793,7 +793,6 @@ message FunctionProto {
   string doc_string = 8;
 
   // The OperatorSets this function body (graph) relies on.
-  // All FunctionProtos implicitly import the operator set which the function operator is part of.
   //
   // All nodes in the function body (graph) will bind against the operator
   // with the same-domain/same-op_type operator with the HIGHEST version


### PR DESCRIPTION
Signed-off-by: Ashwini Khade <askhade@microsoft.com>

**Description**
Change the expected behavior when an operator with the same name as model local function exists in the domain specified by the model local function.
- Describe your changes.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
