### PR TITLE
Fix compilation warnings.

### DIFF
--- a/onnx/common/graph_node_list.h
+++ b/onnx/common/graph_node_list.h
@@ -54,6 +54,8 @@ struct generic_graph_node_list_iterator final {
     : cur(cur), d(d) {}
   generic_graph_node_list_iterator(const generic_graph_node_list_iterator & rhs)
     : cur(rhs.cur), d(rhs.d) {}
+  generic_graph_node_list_iterator & operator=(
+    const generic_graph_node_list_iterator&) = default;
   T * operator*() const { return cur; }
   T * operator->() const { return cur; }
   generic_graph_node_list_iterator & operator++() {

--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -116,7 +116,7 @@ Status OnnxParser::ParseInput(ValueInfoList& inputs, TensorList& initializers) {
           // default value for input
           TensorProto& tp = *initializers.Add();
           tp.set_name(vi.name());
-          CHECK_PARSER_STATUS (Parse(tp, vi.type()));
+          CHECK_PARSER_STATUS(Parse(tp, vi.type()));
         }
       } while (Matches(','));
       MATCH(')');
@@ -139,7 +139,7 @@ Status OnnxParser::ParseValueInfo(ValueInfoList& value_infos, TensorList& initia
           // initializer
           TensorProto& tp = *initializers.Add();
           tp.set_name(vi.name());
-          CHECK_PARSER_STATUS (Parse(tp, vi.type()));
+          CHECK_PARSER_STATUS(Parse(tp, vi.type()));
         } else {
           // valueinfo
           *value_infos.Add() = vi;
@@ -391,8 +391,8 @@ Status OnnxParser::Parse(ModelProto& model) {
               import->set_version(intval);
             } while (Matches(','));
             MATCH(']');
-            break;
           }
+          break;
         }
         case KeyWordMap::KeyWord::PRODUCER_NAME:
           PARSE_TOKEN(strval);


### PR DESCRIPTION
Warnings fixed:

* `onnx/version_converter/convert.cc:93:63: error: implicitly-declared ‘onnx::generic_graph_node_list_iterator<onnx::Node>& onnx::generic_graph_node_list_iterator<onnx::Node>::operator=(const onnx::generic_graph_node_list_iterator<onnx::Node>&)’ is deprecated [-Werror=deprec
ated-copy]`
* `onnx/defs/parser.cc:395:11: error: this statement may fall through [-Werror=implicit-fallthrough=]`

Before this, building with `ONNX_WERROR=ON` failed for me on Linux.
After this, it succeeds.