### PR TITLE
Fix arm crash due to unaligned raw_data buffer of initializer tensors

### DIFF
--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -267,16 +267,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           // In this case, we extract the shape values from input tensor
           // and create output tensor of that shape.
           // First, extract target shape value.
-          std::vector<int64_t> targetShape;
-          if (targetShapeInitializer->has_raw_data()) {
-            const std::string& bytes = targetShapeInitializer->raw_data();
-            const size_t raw_data_size = bytes.size();
-            targetShape.resize(raw_data_size / sizeof(int64_t));
-            memcpy(reinterpret_cast<char*>(targetShape.data()), bytes.c_str(), raw_data_size);
-          } else {
-            const auto& data = targetShapeInitializer->int64_data();
-            targetShape.insert(targetShape.end(), data.begin(), data.end());
-          }
+          std::vector<int64_t> targetShape = ParseData<int64_t>(targetShapeInitializer);
+
           // Next, set output shape to the target shape.
           auto final_output_shape =
               ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -270,10 +270,9 @@ ONNX_OPERATOR_SET_SCHEMA(
           std::vector<int64_t> targetShape;
           if (targetShapeInitializer->has_raw_data()) {
             const std::string& bytes = targetShapeInitializer->raw_data();
-            targetShape.insert(
-                targetShape.end(),
-                reinterpret_cast<const int64_t*>(bytes.c_str()),
-                reinterpret_cast<const int64_t*>(bytes.c_str() + bytes.size()));
+            const size_t raw_data_size = bytes.size();
+            targetShape.resize(raw_data_size / sizeof(int64_t));
+            memcpy(reinterpret_cast<char*>(targetShape.data()), bytes.c_str(), raw_data_size);
           } else {
             const auto& data = targetShapeInitializer->int64_data();
             targetShape.insert(targetShape.end(), data.begin(), data.end());

--- a/onnx/defs/tensor/old.cc
+++ b/onnx/defs/tensor/old.cc
@@ -139,17 +139,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
           // Make targetShape (0 -> same as originalShape, -1 -> inferred).
           // The targetShape vector represents the specified shape for output.
-          std::vector<int64_t> targetShape;
-          if (targetShapeInitializer->has_raw_data()) {
-            const std::string& bytes = targetShapeInitializer->raw_data();
-            const size_t raw_data_size = bytes.size();
-            targetShape.resize(raw_data_size / sizeof(int64_t));
-            memcpy(reinterpret_cast<char*>(targetShape.data()), bytes.c_str(), raw_data_size);
-          } else {
-            const auto& data = targetShapeInitializer->int64_data();
-            targetShape.insert(targetShape.end(), data.begin(), data.end());
-          }
-
+          std::vector<int64_t> targetShape = ParseData<int64_t>(targetShapeInitializer);
           // Iterate through targetShape, adding dimensions in the outputShape
           // TensorProto. If the targertShape dimension is -1, we do not set the
           // dimension value in this iteration, but we record the Dimension. If
@@ -277,16 +267,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
           // Make targetShape (0 -> same as originalShape, -1 -> inferred).
           // The targetShape vector represents the specified shape for output.
-          std::vector<int64_t> targetShape;
-          if (targetShapeInitializer->has_raw_data()) {
-            const std::string& bytes = targetShapeInitializer->raw_data();
-            const size_t raw_data_size = bytes.size();
-            targetShape.resize(raw_data_size / sizeof(int64_t));
-            memcpy(reinterpret_cast<char*>(targetShape.data()), bytes.c_str(), raw_data_size);
-          } else {
-            const auto& data = targetShapeInitializer->int64_data();
-            targetShape.insert(targetShape.end(), data.begin(), data.end());
-          }
+          std::vector<int64_t> targetShape = ParseData<int64_t>(targetShapeInitializer);
 
           // Iterate through targetShape, adding dimensions in the outputShape
           // TensorProto. If the targertShape dimension is -1, we do not set the

--- a/onnx/defs/tensor/old.cc
+++ b/onnx/defs/tensor/old.cc
@@ -142,10 +142,9 @@ ONNX_OPERATOR_SET_SCHEMA(
           std::vector<int64_t> targetShape;
           if (targetShapeInitializer->has_raw_data()) {
             const std::string& bytes = targetShapeInitializer->raw_data();
-            targetShape.insert(
-                targetShape.end(),
-                reinterpret_cast<const int64_t*>(bytes.c_str()),
-                reinterpret_cast<const int64_t*>(bytes.c_str() + bytes.size()));
+            const size_t raw_data_size = bytes.size();
+            targetShape.resize(raw_data_size / sizeof(int64_t));
+            memcpy(reinterpret_cast<char*>(targetShape.data()), bytes.c_str(), raw_data_size);
           } else {
             const auto& data = targetShapeInitializer->int64_data();
             targetShape.insert(targetShape.end(), data.begin(), data.end());
@@ -281,10 +280,9 @@ ONNX_OPERATOR_SET_SCHEMA(
           std::vector<int64_t> targetShape;
           if (targetShapeInitializer->has_raw_data()) {
             const std::string& bytes = targetShapeInitializer->raw_data();
-            targetShape.insert(
-                targetShape.end(),
-                reinterpret_cast<const int64_t*>(bytes.c_str()),
-                reinterpret_cast<const int64_t*>(bytes.c_str() + bytes.size()));
+            const size_t raw_data_size = bytes.size();
+            targetShape.resize(raw_data_size / sizeof(int64_t));
+            memcpy(reinterpret_cast<char*>(targetShape.data()), bytes.c_str(), raw_data_size);
           } else {
             const auto& data = targetShapeInitializer->int64_data();
             targetShape.insert(targetShape.end(), data.begin(), data.end());

--- a/onnx/defs/tensor_proto_util.cc
+++ b/onnx/defs/tensor_proto_util.cc
@@ -60,10 +60,9 @@ namespace ONNX_NAMESPACE {
         }                                                                  \
       }                                                                    \
     }                                                                      \
-    res.insert(                                                            \
-        res.end(),                                                         \
-        reinterpret_cast<const type*>(bytes),                              \
-        reinterpret_cast<const type*>(bytes + raw_data.size()));           \
+    const size_t raw_data_size = raw_data.size();                          \
+    res.resize(raw_data_size / sizeof(type));                              \
+    memcpy(reinterpret_cast<char*>(res.data()), bytes, raw_data_size);     \
     return res;                                                            \
   }
 

--- a/onnx/defs/tensor_proto_util.cc
+++ b/onnx/defs/tensor_proto_util.cc
@@ -60,6 +60,11 @@ namespace ONNX_NAMESPACE {
         }                                                                  \
       }                                                                    \
     }                                                                      \
+    /* raw_data.c_str()/bytes is a byte array and may not be properly  */  \
+    /* aligned for the underlying type */                                  \
+    /* We need to copy the raw_data.c_str()/bytes as byte instead of  */   \
+    /* copying as the underlying type, otherwise we may hit memory   */    \
+    /* misalignment issues on certain platforms, such as arm32-v7a */      \
     const size_t raw_data_size = raw_data.size();                          \
     res.resize(raw_data_size / sizeof(type));                              \
     memcpy(reinterpret_cast<char*>(res.data()), bytes, raw_data_size);     \

--- a/onnx/defs/tensor_util.cc
+++ b/onnx/defs/tensor_util.cc
@@ -39,10 +39,9 @@ namespace ONNX_NAMESPACE {
         }                                                                  \
       }                                                                    \
     }                                                                      \
-    res.insert(                                                            \
-        res.end(),                                                         \
-        reinterpret_cast<const type*>(bytes),                              \
-        reinterpret_cast<const type*>(bytes + raw_data.size()));           \
+    const size_t raw_data_size = raw_data.size();                          \
+    res.resize(raw_data_size / sizeof(type));                              \
+    memcpy(reinterpret_cast<char*>(res.data()), bytes, raw_data_size);     \
     return res;                                                            \
   }
 

--- a/onnx/defs/tensor_util.cc
+++ b/onnx/defs/tensor_util.cc
@@ -39,6 +39,11 @@ namespace ONNX_NAMESPACE {
         }                                                                  \
       }                                                                    \
     }                                                                      \
+    /* raw_data.c_str()/bytes is a byte array and may not be properly  */  \
+    /* aligned for the underlying type */                                  \
+    /* We need to copy the raw_data.c_str()/bytes as byte instead of  */   \
+    /* copying as the underlying type, otherwise we may hit memory   */    \
+    /* misalignment issues on certain platforms, such as arm32-v7a */      \
     const size_t raw_data_size = raw_data.size();                          \
     res.resize(raw_data_size / sizeof(type));                              \
     memcpy(reinterpret_cast<char*>(res.data()), bytes, raw_data_size);     \

--- a/onnx/version_converter/adapters/upsample_9_8.h
+++ b/onnx/version_converter/adapters/upsample_9_8.h
@@ -29,10 +29,9 @@ struct Upsample_9_8 final : public Adapter {
             std::vector<float> value = initializers[i].floats();
             if (initializers[i].is_raw_data()){
               const std::string& bytes = initializers[i].raw();
-              value.insert(
-                  value.end(),
-                  reinterpret_cast<const float*>(bytes.c_str()),
-                  reinterpret_cast<const float*>(bytes.c_str() + bytes.size()));
+              const size_t raw_data_size = bytes.size();
+              value.resize(raw_data_size / sizeof(float));
+              memcpy(reinterpret_cast<char*>(value.data()), bytes.c_str(), raw_data_size);
             }
             std::vector<double> d_values;
             d_values.reserve(value.size());
@@ -63,10 +62,9 @@ struct Upsample_9_8 final : public Adapter {
           std::vector<float> value = op->t(kvalue).floats();
           if (op->t(kvalue).is_raw_data()){
             const std::string& bytes = op->t(kvalue).raw();
-            value.insert(
-                value.end(),
-                reinterpret_cast<const float*>(bytes.c_str()),
-                reinterpret_cast<const float*>(bytes.c_str() + bytes.size()));
+            const size_t raw_data_size = bytes.size();
+            value.resize(raw_data_size / sizeof(float));
+            memcpy(reinterpret_cast<char*>(value.data()), bytes.c_str(), raw_data_size);
           }
           std::vector<double> d_values;
           d_values.reserve(value.size());

--- a/onnx/version_converter/adapters/upsample_9_8.h
+++ b/onnx/version_converter/adapters/upsample_9_8.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include "onnx/defs/tensor_proto_util.h"
+#include "onnx/defs/tensor_util.h"
 #include "onnx/version_converter/adapters/adapter.h"
 
 namespace ONNX_NAMESPACE { namespace version_conversion {
@@ -26,13 +28,7 @@ struct Upsample_9_8 final : public Adapter {
       {
           if(initializers[i].name() == inputs[1]->uniqueName())
           {
-            std::vector<float> value = initializers[i].floats();
-            if (initializers[i].is_raw_data()){
-              const std::string& bytes = initializers[i].raw();
-              const size_t raw_data_size = bytes.size();
-              value.resize(raw_data_size / sizeof(float));
-              memcpy(reinterpret_cast<char*>(value.data()), bytes.c_str(), raw_data_size);
-            }
+            std::vector<float> value = ParseData<float>(&initializers[i]);
             std::vector<double> d_values;
             d_values.reserve(value.size());
             for (size_t j = 0; j < value.size(); j++)
@@ -59,13 +55,7 @@ struct Upsample_9_8 final : public Adapter {
       {
         if (op->kind() == kConstant && op->outputs()[0]->uniqueName() == scale_input_name)
         {
-          std::vector<float> value = op->t(kvalue).floats();
-          if (op->t(kvalue).is_raw_data()){
-            const std::string& bytes = op->t(kvalue).raw();
-            const size_t raw_data_size = bytes.size();
-            value.resize(raw_data_size / sizeof(float));
-            memcpy(reinterpret_cast<char*>(value.data()), bytes.c_str(), raw_data_size);
-          }
+          std::vector<float> value = ParseData<float>(&op->t(kvalue));
           std::vector<double> d_values;
           d_values.reserve(value.size());
           for (size_t j = 0; j < value.size(); j++)


### PR DESCRIPTION
**Description**
- Fix arm crash due to unaligned raw_data buffer of initializer tensors

**Motivation and Context**
- This issue was first reported #2813, and was reported by internal users of onnxruntime
- For now this issue only repros on arm32 but not arm64, this does not repro on x86 or x86_64
- The initializer tensors for slice are usually tensors with a single int64_t element, if the data is store in the raw_data, which is represented as a std::string, where the internal data (`std::string::c_str()`) is aligned as char*, so the reinterpret_cast<const int64_t*> of the raw_data will crash due to misalignment, (`Fatal signal 7 (SIGBUS), code 1 (BUS_ADRALN)`)
- The fix is to copy the raw_data by byte instead of copying by the destination type (`int64_t` in this crash)

