### PR TITLE
Extend parser to support model-local functions

### DIFF
--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -467,7 +467,13 @@ Status OnnxParser::Parse(ModelProto& model) {
     } while (Matches(','));
     MATCH('>');
   }
-  return Parse(*model.mutable_graph());
+  PARSE(*model.mutable_graph());
+
+  auto* functions = model.mutable_functions();
+  while (!EndOfInput()) {
+    PARSE (*functions->Add());
+  }
+  return Status::OK();
 }
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/parser.h
+++ b/onnx/defs/parser.h
@@ -356,6 +356,8 @@ class OnnxParser : public ParserBase {
 
   Status Parse(GraphProto& graph);
 
+  Status Parse(FunctionProto& fn);
+
   Status Parse(ModelProto& model);
 
   template <typename T>
@@ -368,6 +370,8 @@ class OnnxParser : public ParserBase {
   Status Parse(std::string name, GraphProto& graph);
 
   Status Parse(IdList& idlist);
+
+  Status Parse(char open, IdList& idlist, char close); 
 
   Status ParseSingleAttributeValue(AttributeProto& attr);
 

--- a/onnx/defs/parser.h
+++ b/onnx/defs/parser.h
@@ -32,6 +32,8 @@ using ValueInfoList = google::protobuf::RepeatedPtrField<ValueInfoProto>;
 
 using TensorList = google::protobuf::RepeatedPtrField<TensorProto>;
 
+using OpsetIdList = google::protobuf::RepeatedPtrField<OperatorSetIdProto>;
+
 #define CHECK_PARSER_STATUS(status) \
   {                                 \
     auto local_status_ = status;    \
@@ -384,6 +386,8 @@ class OnnxParser : public ParserBase {
   Status ParseValueInfo(ValueInfoList& vilist, TensorList& initializers); 
 
   Status Parse(TensorProto& tensorProto, const TypeProto& tensorTypeProto);
+
+  Status Parse(OpsetIdList& opsets);
 };
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/test/cpp/parser_test.cc
+++ b/onnx/test/cpp/parser_test.cc
@@ -236,10 +236,15 @@ agraph (float[N] y, float[N] z) => (float[N] w)
 
 TEST(ParserTest, FunctionTest) {
   const char* code = R"ONNX(
+<
+  opset_import: [ "" : 10 ],
+  domain: "ai.onnx.ml",
+  doc_string: "A function test case."
+>
 f (y, z) => (w)
 {
-    x = foo(y, z)
-    w = bar(x, y)
+    x = Add(y, z)
+    w = Mul(x, y)
 }
 )ONNX";
 
@@ -251,6 +256,7 @@ f (y, z) => (w)
   EXPECT_EQ(fp.output_size(), 1);
   EXPECT_EQ(fp.node_size(), 2);
   EXPECT_EQ(fp.attribute_size(), 0);
+  EXPECT_EQ(fp.opset_import_size(), 1);
 }
 
 TEST(ParserTest, InitializerTest) {
@@ -366,14 +372,22 @@ agraph (float[N, 128] X, float[128,10] W, float[10] B) => (float[N] C)
   C = local.foo (X, W, B)
 }
 
-local.foo (x, w, b) => (c) {
+<
+  opset_import: [ "" : 10 ],
+  domain: "local",
+  doc_string: "A function test case."
+>
+foo (x, w, b) => (c) {
   T = MatMul(x, w)
   S = Add(T, b)
   c = Softmax(S)
 }
 )ONNX";
 
-  CheckModel(code);
+  ModelProto model;
+  Parse(model, code);
+
+  EXPECT_EQ(model.functions_size(), 1);
 }
 
 } // namespace Test

--- a/onnx/test/cpp/parser_test.cc
+++ b/onnx/test/cpp/parser_test.cc
@@ -234,6 +234,25 @@ agraph (float[N] y, float[N] z) => (float[N] w)
   EXPECT_EQ(graph.value_info_size(), 1);
 }
 
+TEST(ParserTest, FunctionTest) {
+  const char* code = R"ONNX(
+f (y, z) => (w)
+{
+    x = foo(y, z)
+    w = bar(x, y)
+}
+)ONNX";
+
+  FunctionProto fp;
+  Parse(fp, code);
+
+  EXPECT_EQ(fp.name(), "f");
+  EXPECT_EQ(fp.input_size(), 2);
+  EXPECT_EQ(fp.output_size(), 1);
+  EXPECT_EQ(fp.node_size(), 2);
+  EXPECT_EQ(fp.attribute_size(), 0);
+}
+
 TEST(ParserTest, InitializerTest) {
   const char* code = R"ONNX(
 agraph (float y = {1.0}, float[N] z) => (float[N] w)

--- a/onnx/test/cpp/parser_test.cc
+++ b/onnx/test/cpp/parser_test.cc
@@ -355,5 +355,26 @@ iftest (bool b, float[128] X, float[128] Y) => (float[128] Z)
   CheckModel(code);
 }
 
+TEST(ParserTest, FunModelTest) {
+  const char* code = R"ONNX(
+<
+  ir_version: 8,
+  opset_import: [ "" : 10, "local" : 1 ]
+>
+agraph (float[N, 128] X, float[128,10] W, float[10] B) => (float[N] C)
+{
+  C = local.foo (X, W, B)
+}
+
+local.foo (x, w, b) => (c) {
+  T = MatMul(x, w)
+  S = Add(T, b)
+  c = Softmax(S)
+}
+)ONNX";
+
+  CheckModel(code);
+}
+
 } // namespace Test
 } // namespace ONNX_NAMESPACE


### PR DESCRIPTION
**Description**
Extend parser to support model-local functions

**Motivation and Context**
Model-local functions was added to ONNX proto recently, This PR extends the parser to support it.
