### PR TITLE
Fix build failure using XCode new build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ if(ONNX_USE_PROTOBUF_SHARED_LIBS)
     add_definitions(-DPROTOBUF_USE_DLLS)
   endif()
   set(Protobuf_USE_STATIC_LIBS OFF)
-else() 
+else()
   set(Protobuf_USE_STATIC_LIBS ON)
 endif()
 
@@ -360,6 +360,7 @@ list(REMOVE_ITEM __tmp_srcs ${onnx_gtests_src})
 list(APPEND ONNX_SRCS ${__tmp_srcs})
 
 add_library(onnx_proto ${ONNX_PROTO_SRCS} ${ONNX_PROTO_HDRS})
+add_dependencies(onnx_proto gen_onnx_operators_proto gen_onnx_data_proto)
 target_include_directories(onnx_proto PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
   $<INSTALL_INTERFACE:include>


### PR DESCRIPTION
**Description**
- Fix build failure using XCode new build system

**Motivation and Context**
- XCode has 2 build systems (legacy and new), they coexist from XCode 10, see https://developer.apple.com/documentation/xcode-release-notes/build-system-release-notes-for-xcode-10
- The legacy build system will be deprecated in XCode 13, see, https://developer.apple.com/documentation/xcode-release-notes/xcode-13-beta-release-notes
- ONNX build will fail if using new build system, using XCode is required to build for macOS arm and iOS, a typical failure can be seen here, https://dev.azure.com/onnxruntime/onnxruntime/_build/results?buildId=463519&view=logs&j=f7cc61a9-cc70-56e7-b06c-4668ca17e426&t=94d8905a-2b2a-5234-7c64-ea82d695b352
- The fix is to make `gen_onnx_operators_proto` and `gen_onnx_data_proto` the dependencies of `onnx_proto`, to prevent circular dependency 
