### PR TITLE
Test source distribution in CI; Add a label for manually trigger testing ONNX Model Zoo CI

### DIFF
--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -106,7 +106,7 @@ jobs:
         
         # Test the uploaded source distribution
         python -m pip uninstall -y onnx
-        python -m pip install -i https://test.pypi.org/simple/ --no-binary :all: onnx
+        python -m pip install -i https://test.pypi.org/simple/ --no-binary :all: onnx-weekly
         pytest
 
     - name: Verify ONNX with the latest numpy

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -94,10 +94,20 @@ jobs:
         name: wheels
         path: dist
 
-    - name: Upload wheel to TestPyPI weekly
+    - name: Upload wheel/source distribution to TestPyPI weekly
       if: (github.event_name == 'schedule') # Only triggered by weekly event
       run: |
-        twine upload --verbose dist/*.whl --repository-url https://test.pypi.org/legacy/ -u ${{ secrets.TESTPYPI_USERNAME }} -p ${{ secrets.TESTPYPI_PASSWORD }}
+        twine upload --verbose onnx/dist/*.whl --repository-url https://test.pypi.org/legacy/ -u ${{ secrets.TESTPYPI_USERNAME }} -p ${{ secrets.TESTPYPI_PASSWORD }}
+        
+        # Build and upload source distribution to TestPyPI
+        git clean -xdf
+        python setup.py sdist
+        twine upload dist/* --repository-url https://test.pypi.org/legacy/ -u ${{ secrets.TESTPYPI_USERNAME }} -p ${{ secrets.TESTPYPI_PASSWORD }}
+        
+        # Test the uploaded source distribution
+        python -m pip uninstall -y onnx
+        python -m pip install -i https://test.pypi.org/simple/ --no-binary :all: onnx
+        pytest
 
     - name: Verify ONNX with the latest numpy
       if: ${{ always() }}

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -121,10 +121,20 @@ jobs:
         name: wheels
         path: ./onnx/dist
   
-    - name: Upload wheel to TestPyPI weekly
+    - name: Upload wheel/source distribution to TestPyPI weekly
       if: (github.event_name == 'schedule') # Only triggered by weekly event
       run: |
         twine upload --verbose onnx/dist/*.whl --repository-url https://test.pypi.org/legacy/ -u ${{ secrets.TESTPYPI_USERNAME }} -p ${{ secrets.TESTPYPI_PASSWORD }}
+        
+        # Build and upload source distribution to TestPyPI
+        git clean -xdf
+        python setup.py sdist
+        twine upload dist/* https://test.pypi.org/legacy/ -u ${{ secrets.TESTPYPI_USERNAME }} -p ${{ secrets.TESTPYPI_PASSWORD }}
+        
+        # Test the uploaded source distribution
+        python -m pip uninstall -y onnx
+        python -m pip install -i https://test.pypi.org/simple/ --no-binary :all: onnx
+        pytest
 
     - name: Verify ONNX with the latest numpy
       if: ${{ always() }}

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -121,20 +121,10 @@ jobs:
         name: wheels
         path: ./onnx/dist
   
-    - name: Upload wheel/source distribution to TestPyPI weekly
+    - name: Upload wheel to TestPyPI weekly
       if: (github.event_name == 'schedule') # Only triggered by weekly event
       run: |
         twine upload --verbose onnx/dist/*.whl --repository-url https://test.pypi.org/legacy/ -u ${{ secrets.TESTPYPI_USERNAME }} -p ${{ secrets.TESTPYPI_PASSWORD }}
-        
-        # Build and upload source distribution to TestPyPI
-        git clean -xdf
-        python setup.py sdist
-        twine upload dist/* https://test.pypi.org/legacy/ -u ${{ secrets.TESTPYPI_USERNAME }} -p ${{ secrets.TESTPYPI_PASSWORD }}
-        
-        # Test the uploaded source distribution
-        python -m pip uninstall -y onnx
-        python -m pip install -i https://test.pypi.org/simple/ --no-binary :all: onnx
-        pytest
 
     - name: Verify ONNX with the latest numpy
       if: ${{ always() }}

--- a/.github/workflows/weekly_mac_ci.yml
+++ b/.github/workflows/weekly_mac_ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    if: github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'test with ONNX Model Zoo')
+    if: github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'test ONNX Model Zoo')
     runs-on: macos-latest
     strategy:
       matrix:

--- a/.github/workflows/weekly_mac_ci.yml
+++ b/.github/workflows/weekly_mac_ci.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   build:
+    if: github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'test with ONNX Model Zoo')
     runs-on: macos-latest
     strategy:
       matrix:

--- a/.github/workflows/weekly_mac_ci.yml
+++ b/.github/workflows/weekly_mac_ci.yml
@@ -7,15 +7,17 @@ on:
   schedule:
     # run weekly on Sunday 23:59
     - cron:  '59 23 * * SUN'
+  pull_request:
+    branches: [master, rel-*]
   workflow_dispatch:
 
 jobs:
   build:
-    if: github.event_name == 'schedule' || contains( github.event.pull_request.labels.*.name, 'test ONNX Model Zoo')
+    if: github.event_name != 'pull_request' || contains( github.event.pull_request.labels.*.name, 'test ONNX Model Zoo')
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
         architecture: ['x64']
     steps:
     - uses: actions/checkout@v2

--- a/docs/OnnxReleases.md
+++ b/docs/OnnxReleases.md
@@ -50,7 +50,7 @@ The ONNX project, going forward, will plan to release roughly on a two month cad
         * onnx/onnx.pb.h
     * If they are present run ``git clean -ixd`` and remove those files from your local branch
 * Do ``python setup.py sdist`` to generate the source distribution.
-* Do ``twine upload dist/* https://test.pypi.org/legacy/ -u PYPI_USERNAME -p PYPI_PASSWORD`` to upload it to the test instance of PyPI.
+* Do ``twine upload dist/* --repository-url https://test.pypi.org/legacy/ -u PYPI_USERNAME -p PYPI_PASSWORD`` to upload it to the test instance of PyPI.
 
 ## TestPyPI package verification
 **Test ONNX itself**


### PR DESCRIPTION
**Description**
- Build and test source distribution in CI weekly (in one environment should be sufficient); Also onnx-weekly TestPyPI package will have source distribution as well
- Add a new label "test ONNX Model Zoo" to manually trigger CI testing the PR with all models from ONNX Model Zoo (use it with caution because it will waste git-lfs quota in onnx/models)

**Motivation and Context**
Enhance CIs