### PR TITLE
Fix IR gap for version_converter: update node input from initializer directly 

### DIFF
--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -542,6 +542,10 @@ public:
     return inputs_.at(i);
   }
 
+  int inputSize() const {
+    return inputs_.size();
+  }
+
   // Graphs
 
   // Note [Topological invariant]

--- a/onnx/common/ir_pb_converter.cc
+++ b/onnx/common/ir_pb_converter.cc
@@ -323,7 +323,7 @@ std::unique_ptr<Graph> graphProtoToGraph(const ONNX_NAMESPACE::GraphProto& gp,
         } else if (tensor_by_name_of.count(input)) {
           // If the node input can be found in the initializers
           // Convert this initializer tensor into a Value
-          // And add it into node inputs
+          // and add it into node inputs
           Tensor init_tensor = tensor_by_name_of.at(input);
           Value* init_value = new Value(n, n->inputSize());
           std::vector<Dimension> dim_sizes{init_tensor.sizes().cbegin(),


### PR DESCRIPTION
**Description**
Similar to an old PR https://github.com/onnx/onnx/pull/3007, but instead of adding initializer into input and removing (sort of hacky), this PR creates a Value directly.
-  Enable node to find input from initializers: create a tensor map from initializers, convert it (Tensor) into a Value if the name is matched and add it into node inputs
- (WIP) Add a test

**Motivation and Context**
Solve input not found issue for version converter since initializers are not included in inputs for newer model (IR >= 4): https://github.com/onnx/onnx/issues/2873