### PR TITLE
Add test case container type

### DIFF
--- a/onnx/backend/test/cmd_tools.py
+++ b/onnx/backend/test/cmd_tools.py
@@ -56,35 +56,13 @@ def generate_data(args):  # type: (argparse.Namespace) -> None
                 for j, input in enumerate(inputs):
                     with open(os.path.join(
                             data_set_dir, 'input_{}.pb'.format(j)), 'wb') as f:
-                        if case.model.graph.input[j].type.HasField('map_type'):
-                            f.write(numpy_helper.from_dict(
-                                input, case.model.graph.input[j].name).SerializeToString())
-                        elif case.model.graph.input[j].type.HasField('sequence_type'):
-                            f.write(numpy_helper.from_list(
-                                input, case.model.graph.input[j].name).SerializeToString())
-                        elif case.model.graph.input[j].type.HasField('optional_type'):
-                            f.write(numpy_helper.from_optional(
-                                input, case.model.graph.input[j].name).SerializeToString())
-                        else:
-                            assert case.model.graph.input[j].type.HasField('tensor_type')
-                            f.write(numpy_helper.from_array(
-                                input, case.model.graph.input[j].name).SerializeToString())
+                        f.write(numpy_helper.wrap_with_container(
+                            input, case.model.graph.input[j]).SerializeToString())
                 for j, output in enumerate(outputs):
                     with open(os.path.join(
                             data_set_dir, 'output_{}.pb'.format(j)), 'wb') as f:
-                        if case.model.graph.output[j].type.HasField('map_type'):
-                            f.write(numpy_helper.from_dict(
-                                output, case.model.graph.output[j].name).SerializeToString())
-                        elif case.model.graph.output[j].type.HasField('sequence_type'):
-                            f.write(numpy_helper.from_list(
-                                output, case.model.graph.output[j].name).SerializeToString())
-                        elif case.model.graph.output[j].type.HasField('optional_type'):
-                            f.write(numpy_helper.from_optional(
-                                output, case.model.graph.output[j].name).SerializeToString())
-                        else:
-                            assert case.model.graph.output[j].type.HasField('tensor_type')
-                            f.write(numpy_helper.from_array(
-                                output, case.model.graph.output[j].name).SerializeToString())
+                        f.write(numpy_helper.wrap_with_container(
+                            output, case.model.graph.output[j]).SerializeToString())
 
 
 def parse_args():  # type: () -> argparse.Namespace

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -356,12 +356,18 @@ def convert_endian(tensor):  # type: (TensorProto) -> None
 
 
 def wrap_with_container(v, value_proto):  # type: (Any, str) -> InOutContainerProto
+    ret = InOutContainerProto()
+    ret.name = value_proto.name
+    ret.reserved_for_container = 100
+
     if value_proto.type.HasField('map_type'):
-        return from_dict(v, value_proto.name)
+        ret.map_value.CopyFrom(from_dict(v, value_proto.name))
     elif value_proto.type.HasField('sequence_type'):
-        return from_list(v, value_proto.name)
+        ret.sequence_value.CopyFrom(from_list(v, value_proto.name))
     elif value_proto.type.HasField('optional_type'):
-        return from_optional(v, value_proto.name)
+        ret.optional_value.CopyFrom(from_optional(v, value_proto.name))
     else:
         assert value_proto.type.HasField('tensor_type')
-        return from_array(v, value_proto.name)
+        ret.tensor_value.CopyFrom(from_array(v, value_proto.name))
+
+    return ret

--- a/onnx/onnx-data.in.proto
+++ b/onnx/onnx-data.in.proto
@@ -68,6 +68,7 @@ message SequenceProto {
   // When this field is present, the elem_type field MUST be Optional.
   repeated OptionalProto optional_values = 7;
 
+  optional int32 reserved_for_container = 21;
 }
 
 
@@ -103,6 +104,8 @@ message MapProto {
   // repeated keys field and have to be one of the following data types
   // TENSOR, SPARSE_TENSOR, MAP, SEQUENCE.
   optional SequenceProto values = 5;
+
+  optional int32 reserved_for_container = 21;
 }
 
 // Optional
@@ -147,4 +150,20 @@ message OptionalProto {
   // When this field is present, the elem_type field MUST be OPTIONAL.
   optional OptionalProto optional_value = 7;
 
+  optional int32 reserved_for_container = 21;
 }
+
+// Container
+//
+//
+message InOutContainer {
+  optional string name = 1;
+  oneof value {
+    TensorProto tensor_value = 22;
+    SparseTensorProto sparse_tensor_value = 23;
+    SequenceProto sequence_value = 24;
+    MapProto map_value = 25;
+    OptionalProto optional_value = 26;
+  }
+  optional int32 reserved_for_container = 21;
+};

--- a/onnx/onnx-data.in.proto
+++ b/onnx/onnx-data.in.proto
@@ -158,6 +158,8 @@ message OptionalProto {
 //
 message InOutContainerProto {
   optional string name = 1;
+  optional int32 reserved_for_container = 21;
+
   oneof value {
     TensorProto tensor_value = 22;
     SparseTensorProto sparse_tensor_value = 23;
@@ -165,6 +167,4 @@ message InOutContainerProto {
     MapProto map_value = 25;
     OptionalProto optional_value = 26;
   }
-
-  optional int32 reserved_for_container = 21;
 };

--- a/onnx/onnx-data.in.proto
+++ b/onnx/onnx-data.in.proto
@@ -156,7 +156,7 @@ message OptionalProto {
 // Container
 //
 //
-message InOutContainer {
+message InOutContainerProto {
   optional string name = 1;
   oneof value {
     TensorProto tensor_value = 22;
@@ -165,5 +165,6 @@ message InOutContainer {
     MapProto map_value = 25;
     OptionalProto optional_value = 26;
   }
+
   optional int32 reserved_for_container = 21;
 };

--- a/onnx/onnx.in.proto
+++ b/onnx/onnx.in.proto
@@ -618,6 +618,8 @@ message TensorProto {
   // When this field is present, the data_type field MUST be
   // UINT32 or UINT64
   repeated uint64 uint64_data = 11 [packed = true];
+
+  optional int32 reserved_for_container = 21;
 }
 
 // A serialized sparse-tensor value
@@ -642,6 +644,8 @@ message SparseTensorProto {
 
   // The shape of the underlying dense-tensor: [dim_1, dim_2, ... dim_rank]
   repeated int64 dims = 3;
+
+  optional int32 reserved_for_container = 21;
 }
 
 // Defines a tensor shape. A dimension can be either an integer value


### PR DESCRIPTION
**Description**
Adds `InOutContainerProto` to store test case in/out data so that we don't need to look inside model's input/output type.

**Motivation and Context**
When optional type was added in https://github.com/onnx/onnx/pull/3567 , loading test case data got more difficult because the structure of SequenceProto and OptionalProto are very similar and undeterminable when we read the message.
I would like to add `InOutContainerProto` message type to store in/out data of onnx test cases to make loading of it easier.
In addition I've add `reserved_for_container` to check difference with current in/out message type.

I haven't run `python onnx/backend/test/cmd_tools.py generate-data` since there could be more improvements to names