### PR TITLE
[ONNX 1.10] Fix for compilation error on older compilers

### DIFF
--- a/onnx/shape_inference/implementation.h
+++ b/onnx/shape_inference/implementation.h
@@ -273,7 +273,7 @@ struct DataPropagationContextImpl : public DataPropagationContext {
       const std::unordered_map<std::string, TypeProto*>& valueTypesByName,
       const std::unordered_map<std::string, const TensorProto*>& inputDataByName,
       std::unordered_map<std::string, TensorShapeProto>& generatedShapeData)
-      : generatedShapeData_{generatedShapeData} {
+      : generatedShapeData_(generatedShapeData) {
     size_t input_idx = 0;
   
     for (auto& attr : *n.mutable_attribute()) {


### PR DESCRIPTION
**Description**

ONNX 1.10 fails to compile when using older versions of `gcc`, for example on CentOS, with the following error:

```
In file included from /onnx/onnx/shape_inference/implementation.cc:5:0:
/onnx/onnx/shape_inference/implementation.h: In constructor 'onnx::shape_inference::DataPropagationContextImpl::DataPropagationContextImpl(onnx::NodeProto&, const std::unordered_map<std::basic_string<char>, onnx::TypeProto*>&, const std::unordered_map<std::basic_string<char>, const onnx::TensorProto*>&, std::unordered_map<std::basic_string<char>, onnx::TensorShapeProto>&)':
/onnx/onnx/shape_inference/implementation.h:276:47: error: invalid initialization of non-const reference of type 'std::unordered_map<std::basic_string<char>, onnx::TensorShapeProto>&' from an rvalue of type '<brace-enclosed initializer list>'
       : generatedShapeData_{generatedShapeData} {
                                               ^
gmake[2]: *** [CMakeFiles/onnx.dir/onnx/shape_inference/implementation.cc.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
gmake[1]: *** [CMakeFiles/onnx.dir/all] Error 2
gmake: *** [all] Error 2  
```

**Steps to reproduce**

Build the following `Dockerfile` to observe the issue:

```Dockerfile
FROM centos:7.6.1810

RUN yum -y update
RUN yum -y install gcc gcc-c++ make openssl-devel
RUN yum -y install python3 python3-devel
RUN yum -y install git wget

WORKDIR /root/

# Build and install Cmake
RUN wget https://cmake.org/files/v3.21/cmake-3.21.1.tar.gz
RUN tar zxvf cmake-3.21.1.tar.gz
RUN cd cmake-3.21.1 && ./bootstrap --prefix=/usr/local && make -j$(nproc) && make install

# Build and install protobuf
RUN git clone https://github.com/protocolbuffers/protobuf.git
RUN mkdir /root/protobuf/build
RUN cd protobuf/build && cmake ../cmake \
    -Dprotobuf_BUILD_SHARED_LIBS=OFF \
    -DCMAKE_INSTALL_PREFIX=/usr \
    -DCMAKE_INSTALL_SYSCONFDIR=/etc \
    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
    -Dprotobuf_BUILD_TESTS=OFF \
    -DCMAKE_BUILD_TYPE=Release
RUN cd protobuf/build && make -j$(nproc) && make install

# Create and activate virtualenv
RUN python3 -m pip install virtualenv
RUN python3 -m virtualenv /root/venv
ENV PATH=/root/venv/bin:$PATH

RUN git clone https://github.com/onnx/onnx.git 
WORKDIR /root/onnx
RUN git checkout v1.10.1
RUN git submodule update --init --recursive
RUN pip install -U pip
RUN pip install -r requirements-release.txt

RUN python setup.py install
```


**Motivation and Context**

This small change fixes the issue.

It may be a reason to make another point-release of ONNX 1.10