### PR TITLE
Set minimum supported Protobuf version as 3.12 since lower versions do not work

### DIFF
--- a/.github/workflows/manylinux/test_package_i686.sh
+++ b/.github/workflows/manylinux/test_package_i686.sh
@@ -43,4 +43,9 @@ $PIP_UNINSTALL_COMMAND protobuf onnx && $PIP_INSTALL_COMMAND protobuf
 $PIP_INSTALL_COMMAND dist/*manylinux2010_i686.whl
 $PYTEST_COMMAND
 
+# Verify ONNX the minimum supported protobuf (from requirements.txt)
+$PIP_UNINSTALL_COMMAND protobuf onnx && $PIP_INSTALL_COMMAND protobuf==3.12.0
+$PIP_INSTALL_COMMAND dist/*manylinux2010_i686.whl
+$PYTEST_COMMAND
+
 echo "Succesfully test the wheel"

--- a/.github/workflows/manylinux/test_package_i686.sh
+++ b/.github/workflows/manylinux/test_package_i686.sh
@@ -44,7 +44,7 @@ $PIP_INSTALL_COMMAND dist/*manylinux2010_i686.whl
 $PYTEST_COMMAND
 
 # Verify ONNX the minimum supported protobuf (from requirements.txt)
-$PIP_UNINSTALL_COMMAND protobuf onnx && $PIP_INSTALL_COMMAND protobuf==3.12.0
+$PIP_UNINSTALL_COMMAND protobuf onnx && $PIP_INSTALL_COMMAND protobuf==3.12.2
 $PIP_INSTALL_COMMAND dist/*manylinux2010_i686.whl
 $PYTEST_COMMAND
 

--- a/.github/workflows/release_linux_aarch64.yml
+++ b/.github/workflows/release_linux_aarch64.yml
@@ -104,7 +104,20 @@ jobs:
           ${{ env.img }} \
           bash -exc '\
           source .env/bin/activate && \
-          python -m pip uninstall -y numpy onnx && python -m pip install numpy && \
+          python -m pip uninstall -y numpy onnx protobuf && python -m pip install numpy protobuf && \
+          python -m pip install dist/*manylinux2014_aarch64.whl && \
+          python -m pip install pytest && \
+          pytest && \
+          deactivate'
+
+    - name: Verify ONNX with the minimum supported protobuf (from requirements.txt)
+      if: ${{ always() }}
+      run: |
+         docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
+          ${{ env.img }} \
+          bash -exc '\
+          source .env/bin/activate && \
+          python -m pip uninstall -y onnx && python -m pip install protobuf==3.12.0 && \
           python -m pip install dist/*manylinux2014_aarch64.whl && \
           python -m pip install pytest && \
           pytest && \

--- a/.github/workflows/release_linux_aarch64.yml
+++ b/.github/workflows/release_linux_aarch64.yml
@@ -117,7 +117,7 @@ jobs:
           ${{ env.img }} \
           bash -exc '\
           source .env/bin/activate && \
-          python -m pip uninstall -y onnx && python -m pip install protobuf==3.12.0 && \
+          python -m pip uninstall -y onnx && python -m pip install protobuf==3.12.2 && \
           python -m pip install dist/*manylinux2014_aarch64.whl && \
           python -m pip install pytest && \
           pytest && \

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -95,6 +95,13 @@ jobs:
         python -m pip install dist/*manylinux2010_x86_64.whl
         pytest        
 
+    - name: Verify ONNX with the minimum supported protobuf (from requirements.txt)
+      if: ${{ always() }}
+      run: |
+        python -m pip uninstall -y protobuf onnx && python -m pip install protobuf==3.12.0
+        python -m pip install dist/*manylinux2010_x86_64.whl
+        pytest
+
     - name: Verify ONNX with ort-nightly
       if: ${{ always() }}
       run: |

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Verify ONNX with the minimum supported protobuf (from requirements.txt)
       if: ${{ always() }}
       run: |
-        python -m pip uninstall -y protobuf onnx && python -m pip install protobuf==3.12.0
+        python -m pip uninstall -y protobuf onnx && python -m pip install protobuf==3.12.2
         python -m pip install dist/*manylinux2010_x86_64.whl
         pytest
 

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -121,7 +121,14 @@ jobs:
       run: |
         python -m pip uninstall -y protobuf onnx && python -m pip install protobuf
         for file in dist/*.whl; do python -m pip install --upgrade $file; done
-        pytest        
+        pytest
+
+    - name: Verify ONNX with the minimum supported protobuf (from requirements.txt)
+      if: ${{ always() }}
+      run: |
+        python -m pip uninstall -y protobuf onnx && python -m pip install protobuf==3.12.0
+        for file in dist/*.whl; do python -m pip install --upgrade $file; done
+        pytest
 
     - name: Verify ONNX with ort-nightly
       if: ${{ always() }}

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -126,7 +126,7 @@ jobs:
     - name: Verify ONNX with the minimum supported protobuf (from requirements.txt)
       if: ${{ always() }}
       run: |
-        python -m pip uninstall -y protobuf onnx && python -m pip install protobuf==3.12.0
+        python -m pip uninstall -y protobuf onnx && python -m pip install protobuf==3.12.2
         for file in dist/*.whl; do python -m pip install --upgrade $file; done
         pytest
 

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -140,7 +140,15 @@ jobs:
         cd onnx
         python -m pip uninstall -y protobuf onnx && python -m pip install protobuf
         Get-ChildItem -Path dist/*.whl | foreach {python -m pip install --upgrade $_.fullname}
-        pytest        
+        pytest
+
+    - name: Verify ONNX with the minimum supported protobuf (from requirements.txt)
+      if: ${{ always() }}
+      run: |
+        cd onnx
+        python -m pip uninstall -y protobuf onnx && python -m pip install protobuf==3.11.3
+        Get-ChildItem -Path dist/*.whl | foreach {python -m pip install --upgrade $_.fullname}
+        pytest  
 
     - name: Verify ONNX with ort-nightly
       if: ${{ always() }}

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -146,7 +146,7 @@ jobs:
       if: ${{ always() }}
       run: |
         cd onnx
-        python -m pip uninstall -y protobuf onnx && python -m pip install protobuf==3.11.3
+        python -m pip uninstall -y protobuf onnx && python -m pip install protobuf==3.12.2
         Get-ChildItem -Path dist/*.whl | foreach {python -m pip install --upgrade $_.fullname}
         pytest  
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Stay up to date with the latest ONNX news. [[Facebook](https://www.facebook.com/
 
 ```
 numpy >= 1.16.6
-protobuf >= 3.12.0
+protobuf >= 3.12.2
 six
 typing-extensions >= 3.6.2.1
 ```

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ Stay up to date with the latest ONNX news. [[Facebook](https://www.facebook.com/
 
 # Installation
 
+## Prerequisites
+
+```
+numpy >= 1.16.6
+protobuf >= 3.12.0
+six
+typing-extensions >= 3.6.2.1
+```
+
 ## Official Python packages
 ONNX released packages are published in PyPi.
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy >= 1.16.6
-protobuf >= 3.12.0
+protobuf >= 3.12.2
 six
 typing-extensions >= 3.6.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy >= 1.16.6
-protobuf
+protobuf >= 3.12.0
 six
-typing-extensions>=3.6.2.1
+typing-extensions >= 3.6.2.1


### PR DESCRIPTION
**Description**
- Set minimum supported Protobuf version as 3.12 in requirements.txt
- Mention minimum supported dependencies in ReadMe
- Make CIs test with minimum supported Protobuf

**Motivation and Context**
https://github.com/onnx/onnx/issues/3656 The latest ONNX package doesn't work with some old protobuf package
