### PR TITLE
Fix weekly-CI failure: correct the path for twine upload

### DIFF
--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -97,8 +97,8 @@ jobs:
     - name: Upload wheel/source distribution to TestPyPI weekly
       if: (github.event_name == 'schedule') # Only triggered by weekly event
       run: |
-        twine upload --verbose onnx/dist/*.whl --repository-url https://test.pypi.org/legacy/ -u ${{ secrets.TESTPYPI_USERNAME }} -p ${{ secrets.TESTPYPI_PASSWORD }}
-        
+        twine upload --verbose dist/*.whl --repository-url https://test.pypi.org/legacy/ -u ${{ secrets.TESTPYPI_USERNAME }} -p ${{ secrets.TESTPYPI_PASSWORD }}
+
         # Build and upload source distribution to TestPyPI
         git clean -xdf
         python setup.py sdist

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -98,12 +98,10 @@ jobs:
       if: (github.event_name == 'schedule') # Only triggered by weekly event
       run: |
         twine upload --verbose dist/*.whl --repository-url https://test.pypi.org/legacy/ -u ${{ secrets.TESTPYPI_USERNAME }} -p ${{ secrets.TESTPYPI_PASSWORD }}
-
         # Build and upload source distribution to TestPyPI
         git clean -xdf
         python setup.py sdist
         twine upload dist/* --repository-url https://test.pypi.org/legacy/ -u ${{ secrets.TESTPYPI_USERNAME }} -p ${{ secrets.TESTPYPI_PASSWORD }}
-        
         # Test the uploaded source distribution
         python -m pip uninstall -y onnx
         python -m pip install -i https://test.pypi.org/simple/ --no-binary :all: onnx-weekly


### PR DESCRIPTION
**Description**
Fix weekly-CI failure (https://github.com/onnx/onnx/actions/runs/1180353371): twine upload from the right place: `dist/*.whl`.

**Motivation and Context**
https://github.com/onnx/onnx/pull/3666 My PR brought a wrong update: the built wheel should be under `dist/*.whl` instead of `onnx/dist/*.whl`.
