### PR TITLE
Handle float16/bfloat16 to uint16 properly in helper functions

### DIFF
--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -251,17 +251,16 @@ def make_tensor(
         raise ValueError("Number of values does not match tensor's size. Expected {}, but it is {}. "
             .format(expected_size, len(vals)))
 
-    if (data_type == TensorProto.COMPLEX64
-            or data_type == TensorProto.COMPLEX128):
-        vals = split_complex_to_pairs(vals)
-    # floa16/bfloat16 are stored as uint16
-    elif (data_type == TensorProto.FLOAT16
-            or data_type == TensorProto.BFLOAT16):
-        vals = np.array(vals).astype(np.float16).view(dtype=np.uint16).flatten().tolist()
-
     if raw:
         tensor.raw_data = vals
     else:
+        if (data_type == TensorProto.COMPLEX64
+                or data_type == TensorProto.COMPLEX128):
+            vals = split_complex_to_pairs(vals)
+        # floa16/bfloat16 are stored as uint16
+        elif (data_type == TensorProto.FLOAT16
+                or data_type == TensorProto.BFLOAT16):
+            vals = np.array(vals).astype(np.float16).view(dtype=np.uint16).flatten().tolist()
         field = mapping.STORAGE_TENSOR_TYPE_TO_FIELD[
             mapping.TENSOR_TYPE_TO_STORAGE_TENSOR_TYPE[data_type]]
         getattr(tensor, field).extend(vals)

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -240,15 +240,24 @@ def make_tensor(
         assert not raw, "Can not use raw_data to store string type"
 
     # Check number of vals specified equals tensor size
-    size = 1 if (not raw) else (mapping.TENSOR_TYPE_TO_NP_TYPE[data_type].itemsize)
+    expected_size = 1 if (not raw) else (mapping.TENSOR_TYPE_TO_NP_TYPE[data_type].itemsize)
+    # Flatten a numpy array if its rank > 1
+    if type(vals) is np.ndarray and len(vals.shape) > 1:
+        vals = vals.flatten()
     for d in dims:
-        size = size * d
-    if (len(vals) != size):
-        raise ValueError("Number of values does not match tensor's size.")
+        expected_size = expected_size * d
+
+    if len(vals) != expected_size:
+        raise ValueError("Number of values does not match tensor's size. Expected {}, but it is {}. "
+            .format(expected_size, len(vals)))
 
     if (data_type == TensorProto.COMPLEX64
             or data_type == TensorProto.COMPLEX128):
         vals = split_complex_to_pairs(vals)
+    # floa16/bfloat16 are stored as uint16
+    elif (data_type == TensorProto.FLOAT16
+            or data_type == TensorProto.BFLOAT16):
+        vals = np.array(vals).astype(np.float16).view(dtype=np.uint16).flatten().tolist()
 
     if raw:
         tensor.raw_data = vals

--- a/onnx/mapping.py
+++ b/onnx/mapping.py
@@ -19,6 +19,7 @@ TENSOR_TYPE_TO_NP_TYPE = {
     int(TensorProto.INT64): np.dtype('int64'),
     int(TensorProto.BOOL): np.dtype('bool'),
     int(TensorProto.FLOAT16): np.dtype('float16'),
+    int(TensorProto.BFLOAT16): np.dtype('float16'),
     int(TensorProto.DOUBLE): np.dtype('float64'),
     int(TensorProto.COMPLEX64): np.dtype('complex64'),
     int(TensorProto.COMPLEX128): np.dtype('complex128'),

--- a/onnx/mapping.py
+++ b/onnx/mapping.py
@@ -19,7 +19,7 @@ TENSOR_TYPE_TO_NP_TYPE = {
     int(TensorProto.INT64): np.dtype('int64'),
     int(TensorProto.BOOL): np.dtype('bool'),
     int(TensorProto.FLOAT16): np.dtype('float16'),
-    int(TensorProto.BFLOAT16): np.dtype('float16'),
+    int(TensorProto.BFLOAT16): np.dtype('float16'),  # native numpy does not support bfloat16
     int(TensorProto.DOUBLE): np.dtype('float64'),
     int(TensorProto.COMPLEX64): np.dtype('complex64'),
     int(TensorProto.COMPLEX128): np.dtype('complex128'),

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -68,7 +68,7 @@ def to_array(tensor, base_dir=""):  # type: (TensorProto, Text) -> np.ndarray[An
                     dtype=np.uint16)
                 .reshape(dims)
                 .view(np.float16))
-        data = getattr(tensor, storage_field),  # type: Sequence[np.complex64]
+        data = getattr(tensor, storage_field)
         if (tensor_dtype == TensorProto.COMPLEX64
                 or tensor_dtype == TensorProto.COMPLEX128):
             data = combine_pairs_to_complex(data)

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -58,7 +58,8 @@ def to_array(tensor):  # type: (TensorProto) -> np.ndarray[Any]
                 or tensor_dtype == TensorProto.COMPLEX128):
             data = combine_pairs_to_complex(data)
         # F16 is stored as int32; Need view to get the original value
-        if tensor_dtype == TensorProto.FLOAT16:
+        elif (tensor_dtype == TensorProto.FLOAT16
+                or tensor_dtype == TensorProto.BFLOAT16):
             return (
                 np.asarray(
                     tensor.int32_data,
@@ -66,14 +67,13 @@ def to_array(tensor):  # type: (TensorProto) -> np.ndarray[Any]
                 .reshape(dims)
                 .view(np.float16))
         # Otherwise simply use astype to convert; e.g., int->float, float->float
-        else:
-            return (
-                np.asarray(
-                    data,
-                    dtype=storage_np_dtype)
-                .astype(np_dtype)
-                .reshape(dims)
-            )
+        return (
+            np.asarray(
+                data,
+                dtype=storage_np_dtype)
+            .astype(np_dtype)
+            .reshape(dims)
+        )
 
 
 def from_array(arr, name=None):  # type: (np.ndarray[Any], Optional[Text]) -> TensorProto

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -53,12 +53,8 @@ def to_array(tensor):  # type: (TensorProto) -> np.ndarray[Any]
             tensor.raw_data,
             dtype=np_dtype).reshape(dims)
     else:
-        data = getattr(tensor, storage_field),  # type: Sequence[np.complex64]
-        if (tensor_dtype == TensorProto.COMPLEX64
-                or tensor_dtype == TensorProto.COMPLEX128):
-            data = combine_pairs_to_complex(data)
         # float16/bfloat16 is stored as int32 (uint16 type); Need view to get the original value
-        elif (tensor_dtype == TensorProto.FLOAT16
+        if (tensor_dtype == TensorProto.FLOAT16
                 or tensor_dtype == TensorProto.BFLOAT16):
             return (
                 np.asarray(
@@ -66,7 +62,11 @@ def to_array(tensor):  # type: (TensorProto) -> np.ndarray[Any]
                     dtype=np.uint16)
                 .reshape(dims)
                 .view(np.float16))
-        # Otherwise simply use astype to convert; e.g., int->float, float->float
+        data = getattr(tensor, storage_field),  # type: Sequence[np.complex64]
+        if (tensor_dtype == TensorProto.COMPLEX64
+                or tensor_dtype == TensorProto.COMPLEX128):
+            data = combine_pairs_to_complex(data)
+
         return (
             np.asarray(
                 data,

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -57,7 +57,7 @@ def to_array(tensor):  # type: (TensorProto) -> np.ndarray[Any]
         if (tensor_dtype == TensorProto.COMPLEX64
                 or tensor_dtype == TensorProto.COMPLEX128):
             data = combine_pairs_to_complex(data)
-        # float16/bloat16 is stored as int32 (uint16 type); Need view to get the original value
+        # float16/bfloat16 is stored as int32 (uint16 type); Need view to get the original value
         elif (tensor_dtype == TensorProto.FLOAT16
                 or tensor_dtype == TensorProto.BFLOAT16):
             return (

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -57,7 +57,7 @@ def to_array(tensor):  # type: (TensorProto) -> np.ndarray[Any]
         if (tensor_dtype == TensorProto.COMPLEX64
                 or tensor_dtype == TensorProto.COMPLEX128):
             data = combine_pairs_to_complex(data)
-        # F16 is stored as int32; Need view to get the original value
+        # float16/bloat16 is stored as int32 (uint16 type); Need view to get the original value
         elif (tensor_dtype == TensorProto.FLOAT16
                 or tensor_dtype == TensorProto.BFLOAT16):
             return (

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -391,6 +391,30 @@ class TestHelperTensorFunctions(unittest.TestCase):
         )
         self.assertEqual(string_list, list(tensor.string_data))
 
+    def test_make_float16_tensor(self):  # type: () -> None
+        np_array = np.random.randn(2, 3).astype(np.float16)
+
+        tensor = helper.make_tensor(
+            name='test',
+            data_type=TensorProto.FLOAT16,
+            dims=np_array.shape,
+            vals=np_array
+        )
+        self.assertEqual(tensor.name, 'test')
+        np.testing.assert_equal(np_array, numpy_helper.to_array(tensor))
+
+    def test_make_bfloat16_tensor(self):  # type: () -> None
+        np_array = np.random.randn(8, 7).astype(np.float16)
+
+        tensor = helper.make_tensor(
+            name='test',
+            data_type=TensorProto.BFLOAT16,
+            dims=np_array.shape,
+            vals=np_array
+        )
+        self.assertEqual(tensor.name, 'test')
+        np.testing.assert_equal(np_array, numpy_helper.to_array(tensor))
+
     def test_make_sparse_tensor(self):  # type: () -> None
         values = [1.1, 2.2, 3.3, 4.4, 5.5]
         values_tensor = helper.make_tensor(

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -112,13 +112,13 @@ class TestHelperAttributeFunctions(unittest.TestCase):
                 name='a',
                 data_type=TensorProto.FLOAT,
                 dims=(1,),
-                vals=np.ones(1).tolist()
+                vals=np.ones(1)
             ),
             helper.make_tensor(
                 name='b',
                 data_type=TensorProto.FLOAT,
                 dims=(1,),
-                vals=np.ones(1).tolist()
+                vals=np.ones(1)
             )]
         attr = helper.make_attribute("tensors", tensors)
         self.assertEqual(attr.name, "tensors")
@@ -366,7 +366,7 @@ class TestHelperTensorFunctions(unittest.TestCase):
             name='test',
             data_type=TensorProto.FLOAT,
             dims=(2, 3),
-            vals=np_array.reshape(6).tolist()
+            vals=np_array
         )
         self.assertEqual(tensor.name, 'test')
         np.testing.assert_equal(np_array, numpy_helper.to_array(tensor))
@@ -376,7 +376,7 @@ class TestHelperTensorFunctions(unittest.TestCase):
             name='test',
             data_type=TensorProto.FLOAT,
             dims=(2, 3),
-            vals=np_array.reshape(6).tobytes(),
+            vals=np_array.tobytes(),
             raw=True,
         )
         np.testing.assert_equal(np_array, numpy_helper.to_array(tensor))

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -403,6 +403,19 @@ class TestHelperTensorFunctions(unittest.TestCase):
         self.assertEqual(tensor.name, 'test')
         np.testing.assert_equal(np_array, numpy_helper.to_array(tensor))
 
+    def test_make_float16_tensor_with_raw(self):  # type: () -> None
+        np_array = np.random.randn(2, 3).astype(np.float16)
+
+        tensor = helper.make_tensor(
+            name='test',
+            data_type=TensorProto.FLOAT16,
+            dims=np_array.shape,
+            vals=np_array.view(dtype=np.uint16).flatten().tobytes(),
+            raw=True
+        )
+        self.assertEqual(tensor.name, 'test')
+        np.testing.assert_equal(np_array, numpy_helper.to_array(tensor))
+
     def test_make_bfloat16_tensor(self):  # type: () -> None
         np_array = np.random.randn(8, 7).astype(np.float16)
 
@@ -411,6 +424,19 @@ class TestHelperTensorFunctions(unittest.TestCase):
             data_type=TensorProto.BFLOAT16,
             dims=np_array.shape,
             vals=np_array
+        )
+        self.assertEqual(tensor.name, 'test')
+        np.testing.assert_equal(np_array, numpy_helper.to_array(tensor))
+
+    def test_make_bfloat16_tensor_with_raw(self):  # type: () -> None
+        np_array = np.random.randn(8, 7).astype(np.float16)
+
+        tensor = helper.make_tensor(
+            name='test',
+            data_type=TensorProto.BFLOAT16,
+            dims=np_array.shape,
+            vals=np_array.view(dtype=np.uint16).flatten().tobytes(),
+            raw=True
         )
         self.assertEqual(tensor.name, 'test')
         np.testing.assert_equal(np_array, numpy_helper.to_array(tensor))


### PR DESCRIPTION
**Description**
- Add conversion float16->uint16 in make_tensor so users can simply give it a float list or numpy array
- Do the same thing for bloat16
- Add tests

**Motivation and Context**
https://github.com/onnx/onnx/issues/3715 Currently users need additional code to convert float16 tensor. `make_tensor` should handle the conversion to simplify the usage.
