### PR TITLE
Fix Azurepipeline Linux CI failure: use 18.04 instead of deprecated 16.04

### DIFF
--- a/.azure-pipelines/Linux-CI.yml
+++ b/.azure-pipelines/Linux-CI.yml
@@ -4,7 +4,7 @@ trigger:
 jobs:
 - job: 'Test'
   pool:
-    vmImage: 'Ubuntu-16.04'
+    vmImage: 'Ubuntu-18.04'
   strategy:
     matrix:
       py36:


### PR DESCRIPTION
**Description**
16.04 is deprecated. Upgrade to 18.04. Action Linux CI has already used the latest ubuntu. To cover more environments, using 18.04 in AzurePipelines

**Motivation and Context**
Fix Azurepipeline Linux CI failure
