### PR TITLE
Consider multiple types for ParseData according to DataType definition

### DIFF
--- a/onnx/defs/tensor_proto_util.cc
+++ b/onnx/defs/tensor_proto_util.cc
@@ -32,77 +32,72 @@ namespace ONNX_NAMESPACE {
     return t;                                                   \
   }
 
-#define DEFINE_PARSE_DATA(type, typed_data_fetch, supported_tensorproto_datatypes)      \
-  template <>                                                                           \
-  const std::vector<type> ParseData(const TensorProto* tensor_proto) {                  \
-    if (!tensor_proto->has_data_type() ||                                               \
-      tensor_proto->data_type() == TensorProto_DataType_UNDEFINED) {                    \
-      fail_shape_inference("The data_type of tensor: ", tensor_proto->name(),           \
-        " is undefined so it cannot be parsed.");                                       \
-    } else if (supported_tensorproto_datatypes.count(tensor_proto->data_type()) == 0) { \
-      std::string supported_types = "{";                                                \
-      for (auto datatype: supported_tensorproto_datatypes) {                            \
-        supported_types += Utils::DataTypeUtils::ToDataTypeString(datatype) + ",";      \
-      }                                                                                 \
-      supported_types.replace(supported_types.length() - 1, 1, "}");                    \
-      fail_shape_inference("ParseData type mismatch for tensor: ",                      \
-        tensor_proto->name(), ". Expected: ", supported_types, ", Actual: ",            \
-        Utils::DataTypeUtils::ToDataTypeString(tensor_proto->data_type()));             \
-    }                                                                                   \
-    std::vector<type> res;                                                              \
-    if (tensor_proto->has_data_location() &&                                            \
-      tensor_proto->data_location() == TensorProto_DataLocation_EXTERNAL) {             \
-      fail_shape_inference("Cannot parse data from external tensors. Please ",          \
-        "load external data into raw data for tensor: ", tensor_proto->name());         \
-    } else if (!tensor_proto->has_raw_data()) {                                         \
-      const auto& data = tensor_proto->typed_data_fetch();                              \
-      int expected_size = 1;                                                            \
-      for (int i = 0; i < tensor_proto->dims_size(); ++i) {                             \
-        expected_size *= tensor_proto->dims(i);                                         \
-      }                                                                                 \
-      if (tensor_proto->dims_size() != 0 && data.size() != expected_size) {             \
-        fail_shape_inference("Data size mismatch. Tensor: ",                            \
-          tensor_proto->name(), " expected size ", expected_size,                       \
-          " does not match the actual size", data.size());                              \
-      }                                                                                 \
-      res.insert(res.end(), data.begin(), data.end());                                  \
-      return res;                                                                       \
-    }                                                                                   \
-    if (tensor_proto->data_type() == TensorProto_DataType_STRING) {                     \
-      fail_shape_inference("The data_type of tensor: ", tensor_proto->name(),           \
-      " cannot be string because it has raw_data which disallows string.");             \
-    }                                                                                   \
-    /* The given tensor does have raw_data itself so parse it by given type */          \
-    /* make copy as we may have to reverse bytes */                                     \
-    std::string raw_data = tensor_proto->raw_data();                                    \
-    /* okay to remove const qualifier as we have already made a copy */                 \
-    char* bytes = const_cast<char*>(raw_data.c_str());                                  \
-    /* onnx is little endian serialized always-tweak byte order if needed */            \
-    if (!is_processor_little_endian()) {                                                \
-      const size_t element_size = sizeof(type);                                         \
-      const size_t num_elements = raw_data.size() / element_size;                       \
-      for (size_t i = 0; i < num_elements; ++i) {                                       \
-        char* start_byte = bytes + i * element_size;                                    \
-        char* end_byte = start_byte + element_size - 1;                                 \
-        /* keep swapping */                                                             \
-        for (size_t count = 0; count < element_size / 2; ++count) {                     \
-          char temp = *start_byte;                                                      \
-          *start_byte = *end_byte;                                                      \
-          *end_byte = temp;                                                             \
-          ++start_byte;                                                                 \
-          --end_byte;                                                                   \
-        }                                                                               \
-      }                                                                                 \
-    }                                                                                   \
-    /* raw_data.c_str()/bytes is a byte array and may not be properly  */               \
-    /* aligned for the underlying type */                                               \
-    /* We need to copy the raw_data.c_str()/bytes as byte instead of  */                \
-    /* copying as the underlying type, otherwise we may hit memory   */                 \
-    /* misalignment issues on certain platforms, such as arm32-v7a */                   \
-    const size_t raw_data_size = raw_data.size();                                       \
-    res.resize(raw_data_size / sizeof(type));                                           \
-    memcpy(reinterpret_cast<char*>(res.data()), bytes, raw_data_size);                  \
-    return res;                                                                         \
+#define DEFINE_PARSE_DATA(type, typed_data_fetch, tensorproto_datatype)                  \
+  template <>                                                                            \
+  const std::vector<type> ParseData(const TensorProto* tensor_proto) {                   \
+    if (!tensor_proto->has_data_type() ||                                                \
+      tensor_proto->data_type() == TensorProto_DataType_UNDEFINED) {                     \
+      fail_shape_inference("The data_type of tensor: ", tensor_proto->name(),            \
+        " is undefined so it cannot be parsed.");                                        \
+    } else if (tensorproto_datatype != tensor_proto->data_type())                    {   \
+      fail_shape_inference("ParseData type mismatch for tensor: ", tensor_proto->name(), \
+        ". Expected: ", Utils::DataTypeUtils::ToDataTypeString(tensorproto_datatype),    \
+        ", Actual: ", Utils::DataTypeUtils::ToDataTypeString(tensor_proto->data_type()));\
+    }                                                                                    \
+    std::vector<type> res;                                                               \
+    if (tensor_proto->has_data_location() &&                                             \
+      tensor_proto->data_location() == TensorProto_DataLocation_EXTERNAL) {              \
+      fail_shape_inference("Cannot parse data from external tensors. Please ",           \
+        "load external data into raw data for tensor: ", tensor_proto->name());          \
+    } else if (!tensor_proto->has_raw_data()) {                                          \
+      const auto& data = tensor_proto->typed_data_fetch();                               \
+      int expected_size = 1;                                                             \
+      for (int i = 0; i < tensor_proto->dims_size(); ++i) {                              \
+        expected_size *= tensor_proto->dims(i);                                          \
+      }                                                                                  \
+      if (tensor_proto->dims_size() != 0 && data.size() != expected_size) {              \
+        fail_shape_inference("Data size mismatch. Tensor: ",                             \
+          tensor_proto->name(), " expected size ", expected_size,                        \
+          " does not match the actual size", data.size());                               \
+      }                                                                                  \
+      res.insert(res.end(), data.begin(), data.end());                                   \
+      return res;                                                                        \
+    }                                                                                    \
+    if (tensor_proto->data_type() == TensorProto_DataType_STRING) {                      \
+      fail_shape_inference("The data_type of tensor: ", tensor_proto->name(),            \
+      " cannot be string because it has raw_data which disallows string.");              \
+    }                                                                                    \
+    /* The given tensor does have raw_data itself so parse it by given type */           \
+    /* make copy as we may have to reverse bytes */                                      \
+    std::string raw_data = tensor_proto->raw_data();                                     \
+    /* okay to remove const qualifier as we have already made a copy */                  \
+    char* bytes = const_cast<char*>(raw_data.c_str());                                   \
+    /* onnx is little endian serialized always-tweak byte order if needed */             \
+    if (!is_processor_little_endian()) {                                                 \
+      const size_t element_size = sizeof(type);                                          \
+      const size_t num_elements = raw_data.size() / element_size;                        \
+      for (size_t i = 0; i < num_elements; ++i) {                                        \
+        char* start_byte = bytes + i * element_size;                                     \
+        char* end_byte = start_byte + element_size - 1;                                  \
+        /* keep swapping */                                                              \
+        for (size_t count = 0; count < element_size / 2; ++count) {                      \
+          char temp = *start_byte;                                                       \
+          *start_byte = *end_byte;                                                       \
+          *end_byte = temp;                                                              \
+          ++start_byte;                                                                  \
+          --end_byte;                                                                    \
+        }                                                                                \
+      }                                                                                  \
+    }                                                                                    \
+    /* raw_data.c_str()/bytes is a byte array and may not be properly  */                \
+    /* aligned for the underlying type */                                                \
+    /* We need to copy the raw_data.c_str()/bytes as byte instead of  */                 \
+    /* copying as the underlying type, otherwise we may hit memory   */                  \
+    /* misalignment issues on certain platforms, such as arm32-v7a */                    \
+    const size_t raw_data_size = raw_data.size();                                        \
+    res.resize(raw_data_size / sizeof(type));                                            \
+    memcpy(reinterpret_cast<char*>(res.data()), bytes, raw_data_size);                   \
+    return res;                                                                          \
   }
 
 DEFINE_TO_TENSOR_ONE(float, TensorProto_DataType_FLOAT, float)
@@ -132,20 +127,18 @@ const std::unordered_set<int> int32_support_types {
   TensorProto_DataType_UINT8,
   TensorProto_DataType_BOOL,
   TensorProto_DataType_FLOAT16};
-const std::unordered_set<int> string_support_types {TensorProto_DataType_STRING};
-const std::unordered_set<int> int64_support_types {TensorProto_DataType_INT64};
-const std::unordered_set<int> double_support_types {
-  TensorProto_DataType_DOUBLE,
-  TensorProto_DataType_COMPLEX128};
-const std::unordered_set<int> uint64_support_types {
-  TensorProto_DataType_UINT32,
-  TensorProto_DataType_UINT64};
 
-DEFINE_PARSE_DATA(float, float_data, float_support_types)
-DEFINE_PARSE_DATA(int32_t, int32_data, int32_support_types)
-DEFINE_PARSE_DATA(std::string, string_data, string_support_types)
-DEFINE_PARSE_DATA(int64_t, int64_data, int64_support_types)
-DEFINE_PARSE_DATA(double, double_data, double_support_types)
-DEFINE_PARSE_DATA(uint64_t, uint64_data, uint64_support_types)
+
+DEFINE_PARSE_DATA(float, float_data, TensorProto_DataType_FLOAT)
+DEFINE_PARSE_DATA(int32_t, int32_data, TensorProto_DataType_INT32)
+DEFINE_PARSE_DATA(int16_t, int32_data, TensorProto_DataType_INT16)
+DEFINE_PARSE_DATA(int8_t, int32_data, TensorProto_DataType_INT8)
+DEFINE_PARSE_DATA(uint16_t, int32_data, TensorProto_DataType_UINT16)
+DEFINE_PARSE_DATA(uint8_t, int32_data, TensorProto_DataType_UINT8)
+DEFINE_PARSE_DATA(std::string, string_data, TensorProto_DataType_STRING)
+DEFINE_PARSE_DATA(int64_t, int64_data, TensorProto_DataType_INT64)
+DEFINE_PARSE_DATA(double, double_data, TensorProto_DataType_DOUBLE)
+DEFINE_PARSE_DATA(uint32_t, uint64_data, TensorProto_DataType_UINT64)
+DEFINE_PARSE_DATA(uint64_t, uint64_data, TensorProto_DataType_UINT64)
 
 } // namespace ONNX_NAMESPACE


### PR DESCRIPTION
**Description**
Make ParseData can parse more types correctly according to the map as below:
string_data -- string
int32_data -- int32, int16, int8, uint16, uint8, bool, float16 
int64_data -- int64
float_data -- float, complex64
double_data -- double, complex128
uint64_data -- uint32, uintt64


**Motivation and Context**
https://github.com/onnx/onnx/pull/3702 This PR made ParseData check the type for parsing. It needs the type exactly the same. However, according to [DataType definition](https://github.com/onnx/onnx/blob/be76ca7148396176784ba8733133b9fb1186ea0d/onnx/onnx.proto3#L549), multiple types can be stored as the same type. For instance, INT32, INT16, INT8, UINT16, UINT8, BOOL, or FLOAT16 can be stored as int32_data. ONNX did not bump into any issue because ParseData in ONNX only parse data for int32, int64, float, double. However, other projects like ONNXRuntime might rely on ParseData for other types. For example, AttentionFusion uses ParseData for uint8. Therefore, to resolve that, this PR makes ParseData in ONNX accept multiple types according to DataType definition.