### PR TITLE
Add compose utils

### DIFF
--- a/docs/PythonAPIOverview.md
+++ b/docs/PythonAPIOverview.md
@@ -268,6 +268,100 @@ Note: For control-flow operators, e.g. If and Loop, the _boundary of sub-model_,
 which is defined by the input and output tensors, should not _cut through_ the
 subgraph that is connected to the _main graph_ as attributes of these operators.
 
+### ONNX Compose
+
+`onnx.compose` module provides tools to create combined models.
+
+`onnx.compose.merge_models` can be used to merge two models, by connecting some of the outputs
+from the first model with inputs from the second model. By default, inputs/outputs not present in the
+`io_map` argument will remain as inputs/outputs of the combined model.
+
+In this example we merge two models by connecting each output of the first model to an output in the second. The resulting model will have the same inputs as the first model and the same outputs as the second:
+```python
+import onnx
+
+model1 = onnx.load('path/to/model1.onnx')
+# agraph (float[N] A, float[N] B) => (float[N] C, float[N] D)
+#   {
+#      C = Add(A, B)
+#      D = Sub(A, B)
+#   }
+
+model2 = onnx.load('path/to/model2.onnx')
+#   agraph (float[N] X, float[N] Y) => (float[N] Z)
+#   {
+#      Z = Mul(X, Y)
+#   }
+
+combined_model = onnx.compose.merge_models(
+    model1, model2,
+    io_map=[('C', 'X'), ('D', 'Y')]
+)
+```
+
+Additionally, a user can specify a list of `inputs`/`outputs` to be included in the combined model,
+effectively dropping the part of the graph that doesn't contribute to the combined model outputs.
+In the following example, we are connecting only one of the two outputs in the first model
+to both inputs in the second. By specifying the outputs of the combined model explicitly, we are dropping the output not consumed from the first model, and the relevant part of the graph:
+```python
+import onnx
+
+# Default case. Include all outputs in the combined model
+combined_model = onnx.compose.merge_models(
+    model1, model2,
+    io_map=[('C', 'X'), ('C', 'Y')],
+)  # outputs: 'D', 'Z'
+
+# Explicit outputs. 'Y' output and the Sub node are not present in the combined model
+combined_model = onnx.compose.merge_models(
+    model1, model2,
+    io_map=[('C', 'X'), ('C', 'Y')],
+    outputs=['Z'],
+)  # outputs: 'Z'
+```
+
+`onnx.compose.add_prefix` allows you to add a prefix to names in the model, to avoid a name collision
+when merging them. By default, it renames all names in the graph: inputs, outputs, edges, nodes,
+initializers, sparse initializers and value infos.
+
+```python
+import onnx
+
+model = onnx.load('path/to/the/model.onnx')
+# model - outputs: ['out0', 'out1'], inputs: ['in0', 'in1']
+
+new_model = onnx.compose.add_prefix(model, prefix='m1/')
+# new_model - outputs: ['m1/out0', 'm1/out1'], inputs: ['m1/in0', 'm1/in1']
+
+# Can also be run in-place
+onnx.compose.add_prefix(model, prefix='m1/', inplace=True)
+```
+
+`onnx.compose.expand_out_dim` can be used to connect models that expect a different number
+ of dimensions by inserting dimensions with extent one. This can be useful, when combining a
+ model producing samples with a model that works with batches of samples.
+
+```python
+import onnx
+
+# outputs: 'out0', shape=[200, 200, 3]
+model1 = onnx.load('path/to/the/model1.onnx')
+
+# outputs: 'in0', shape=[N, 200, 200, 3]
+model2 = onnx.load('path/to/the/model2.onnx')
+
+# outputs: 'out0', shape=[1, 200, 200, 3]
+new_model1 = onnx.compose.expand_out_dims(model1, dim_idx=0)
+
+# Models can now be merged
+combined_model = onnx.compose.merge_models(
+    new_model1, model2, io_map=[('out0', 'in0')]
+)
+
+# Can also be run in-place
+onnx.compose.expand_out_dims(model1, dim_idx=0, inplace=True)
+```
+
 ## Tools
 ### Updating Model's Inputs Outputs Dimension Sizes with Variable Length
 Function `update_inputs_outputs_dims` updates the dimension of the inputs and outputs of the model,

--- a/onnx/__init__.py
+++ b/onnx/__init__.py
@@ -19,6 +19,7 @@ import onnx.checker  # noqa
 import onnx.defs  # noqa
 import onnx.helper  # noqa
 import onnx.utils  # noqa
+import onnx.compose  # noqa
 
 import google.protobuf.message
 

--- a/onnx/compose.py
+++ b/onnx/compose.py
@@ -5,8 +5,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import copy
 from typing import List, Tuple, Text, Optional
-from onnx import GraphProto
+from onnx import GraphProto, helper
+from onnx import TensorProto as tp
 
 def merge(
         g1,  # type: GraphProto
@@ -41,8 +43,7 @@ def merge(
 
     # Connecting outputs of the first graph with the inputs of the second
     for io_pair in io_map:
-        g1_out_name = io_pair[0]
-        g2_in_name = io_pair[1]
+        g1_out_name, g2_in_name = io_pair
         found = False
         for node in g.node:
             for index, name in enumerate(node.input):
@@ -78,4 +79,97 @@ def merge(
         g.doc_string = f"Graph combining {g1.name} and {g2.name}\n" + \
             g1.name + "\n\n" + g1.doc_string + "\n\n" + g2.name + "\n\n" + g2.doc_string
 
+    return g
+
+
+def add_prefix(
+        g,  # type: GraphProto
+        prefix,  # type: Text
+        rename_nodes=True,  # type: Optional[bool]
+        rename_edges=True,  # type: Optional[bool]
+        rename_inputs=True,  # type: Optional[bool]
+        rename_outputs=True,  # type: Optional[bool]
+):  # type: (...) -> GraphProto
+    """Adds a prefix to names of elements in a graph: Nodes, Edges, Inputs, Outputs
+
+    It can be used as a utility before merging graphs that have overlapping names.
+    Empty names are not prefixed.
+
+    Arguments:
+        g (GraphProto): Graph
+        prefix (Text): Prefix to be added to each name in the graph
+        rename_nodes (bool): Whether to prefix node names
+        rename_edges (bool): Whether to prefix node edge names
+        rename_inputs (bool): Whether to prefix input names
+        rename_outputs (bool): Whether to prefix output names
+    """
+    g = copy.deepcopy(g)
+
+    def prefixed(prefix, name):
+        return prefix + name if len(name) > 0 else name
+
+    if rename_nodes:
+        for n in g.node:
+            n.name = prefixed(prefix, n.name)
+
+    if rename_edges:
+        def clear(lst):
+            for _ in range(len(lst)):
+                lst.pop()
+
+        for n in g.node:
+            out_names = [prefixed(prefix, name) for name in n.output]
+            clear(n.output)
+            n.output.extend(out_names)
+
+            in_names = [prefixed(prefix, name) for name in n.input]
+            clear(n.input)
+            n.input.extend(in_names)
+
+    if rename_inputs:
+        for i in g.input:
+            i.name = prefixed(prefix, i.name)
+
+    if rename_outputs:
+        for o in g.output:
+            o.name = prefixed(prefix, o.name)
+
+    return g
+
+
+def expand_out_dim(
+        g,  # type: GraphProto
+        dim_idx,  # type: int
+):  # type: (...) -> GraphProto
+    """Inserts an extra dimension with extent 1 to each output in the graph.
+
+    Inserts and Unsqueeze node for each output. It can be used as a utility before merging graphs,
+    for example when the second one expects a batch dimension.
+
+    Arguments:
+        g (GraphProto): Graph
+        dim_idx (int): Index of the dimension to be inserted.
+                       A negative value means counting dimensions from the back.
+    """
+    g = copy.deepcopy(g)
+
+    expand_dim_k = g.name + "_expand_dim_idx"
+    g.node.append(
+        helper.make_node(
+            'Constant', inputs=[], outputs=[expand_dim_k], name=f"{expand_dim_k}-constant",
+            value=helper.make_tensor(name="{expand_dim_k}-value", data_type=tp.INT64,
+                                     dims=[1,], vals=[dim_idx,]))
+    )
+
+    for _ in range(len(g.output)):
+        o = g.output.pop(0)
+        new_name = o.name + '_expanded'
+        g.node.append(
+            helper.make_node('Unsqueeze', inputs=[o.name, expand_dim_k],
+                             outputs=[new_name], name=f'unsqueeze-{o.name}')
+        )
+        new_shape = [d.dim_value for d in o.type.tensor_type.shape.dim]
+        new_shape.insert(dim_idx, 1)
+        g.output.append(
+            helper.make_tensor_value_info(new_name, o.type.tensor_type.elem_type, new_shape))
     return g

--- a/onnx/compose.py
+++ b/onnx/compose.py
@@ -10,6 +10,7 @@ from typing import List, Tuple, Text, Optional
 from onnx import ModelProto, GraphProto, OperatorSetIdProto, helper, checker
 from onnx import TensorProto as tp
 
+
 def merge_graphs(
         g1,  # type: GraphProto
         g2,  # type: GraphProto
@@ -86,6 +87,7 @@ def merge_graphs(
     g.doc_string = doc_string
 
     return g
+
 
 def merge_models(
         m1,  # type: ModelProto

--- a/onnx/compose.py
+++ b/onnx/compose.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from typing import List, Tuple, Text, Optional, MutableMapping
-from google.protobuf.internal.containers import RepeatedScalarFieldContainer
 from onnx import ModelProto, GraphProto, helper, checker
 from onnx import TensorProto as tp
 

--- a/onnx/compose.py
+++ b/onnx/compose.py
@@ -10,6 +10,7 @@ from onnx import ModelProto, GraphProto, helper, checker
 from onnx import TensorProto as tp
 from onnx import utils
 
+
 def check_overlapping_names(
     g1,  # type: GraphProto
     g2,  # type: GraphProto
@@ -75,6 +76,7 @@ def check_overlapping_names(
 
     return result
 
+
 def merge_graphs(
         g1,  # type: GraphProto
         g2,  # type: GraphProto
@@ -123,8 +125,8 @@ def merge_graphs(
             g2 = add_prefix_graph(g2, prefix=prefix2)
         io_map = [
             (prefix1 + io[0] if prefix1 else io[0],
-             prefix2 + io[1] if prefix2 else io[1]) \
-                for io in io_map]
+             prefix2 + io[1] if prefix2 else io[1])
+            for io in io_map]
 
     io_map_g1_outs = set([io[0] for io in io_map])
     io_map_g2_ins = set([io[1] for io in io_map])
@@ -171,8 +173,8 @@ def merge_graphs(
         category, names = overlapping_names[0]
         raise ValueError(
             "Cant merge two graphs with overlapping names. "
-            f"Found repeated {category} names: " + ", ".join(names) + "\n" +
-            "Consider using ``onnx.compose.add_prefix`` to add a prefix to names in one of the graphs."
+            f"Found repeated {category} names: " + ", ".join(names) + "\n"
+            + "Consider using ``onnx.compose.add_prefix`` to add a prefix to names in one of the graphs."
         )
 
     g = GraphProto()
@@ -326,13 +328,14 @@ def merge_models(
     if function_overlap:
         raise ValueError(
             "Can't merge models with overlapping local function names."
-            f" Found in both graphs: " + ', '.join(function_overlap)
+            " Found in both graphs: " + ', '.join(function_overlap)
         )
     model.functions.MergeFrom(m1.functions)
     model.functions.MergeFrom(m2.functions)
 
     checker.check_model(model)
     return model
+
 
 def add_prefix_graph(
         graph,  # type: GraphProto
@@ -485,6 +488,7 @@ def add_prefix(
     )
     return model
 
+
 def expand_out_dim_graph(
         graph,  # type: GraphProto
         dim_idx,  # type: int
@@ -541,6 +545,7 @@ def expand_out_dim_graph(
         g.output.append(
             helper.make_tensor_value_info(o.name, o.type.tensor_type.elem_type, new_shape))
     return g
+
 
 def expand_out_dim(
         model,  # type: ModelProto

--- a/onnx/compose.py
+++ b/onnx/compose.py
@@ -45,13 +45,10 @@ def merge(
         g2_in_name = io_pair[1]
         found = False
         for node in g.node:
-            if found:
-                break
             for index, name in enumerate(node.input):
                 if name == g2_in_name:
                     node.input[index] = g1_out_name
                     found = True
-                    break
         if not found:
             raise ValueError(f"Could not find an input named \"{g2_in_name}\" in g2")
 

--- a/onnx/compose.py
+++ b/onnx/compose.py
@@ -103,6 +103,9 @@ def add_prefix(
         rename_inputs (bool): Whether to prefix input names
         rename_outputs (bool): Whether to prefix output names
     """
+    if type(g) is not GraphProto:
+        raise ValueError("g argument is not an ONNX graph")
+
     g = copy.deepcopy(g)
 
     def prefixed(prefix, name):
@@ -151,6 +154,9 @@ def expand_out_dim(
         dim_idx (int): Index of the dimension to be inserted.
                        A negative value means counting dimensions from the back.
     """
+    if type(g) is not GraphProto:
+        raise ValueError("g argument is not an ONNX graph")
+
     g = copy.deepcopy(g)
 
     expand_dim_k = g.name + "_expand_dim_idx"

--- a/onnx/compose.py
+++ b/onnx/compose.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from typing import List, Tuple, Text, Optional
+from onnx import GraphProto
+
+def merge(
+        g1,  # type: GraphProto
+        g2,  # type: GraphProto
+        io_map,  # type: List[Tuple[Text, Text]]
+        name=None,  # type: Optional[Text]
+        doc_string=None,  # type: Optional[Text]
+):  # type: (...) -> GraphProto
+    """Combines two ONNX graphs into a single one.
+
+    The combined graph is defined by connecting the specified set of outputs/inputs.
+
+    Arguments:
+        g1 (GraphProto): First graph
+        g2 (GraphProto): Second graph
+        io_map (list of pairs of strings): The pairs of names [(out0, in0), (out1, in1), ...]
+                                           representing outputs of the first graph and inputs of the second
+                                           to be connected
+    """
+    if type(g1) is not GraphProto:
+        raise ValueError("g1 argument is not an ONNX graph")
+    if type(g2) is not GraphProto:
+        raise ValueError("g2 argument is not an ONNX graph")
+
+    g1_outs = [io[0] for io in io_map]
+    g2_ins = [io[1] for io in io_map]
+
+    g = GraphProto()
+
+    g.node.extend(g1.node)
+    g.node.extend(g2.node)
+
+    # Connecting outputs of the first graph with the inputs of the second
+    for io_pair in io_map:
+        g1_out_name = io_pair[0]
+        g2_in_name = io_pair[1]
+        found = False
+        for node in g.node:
+            if found:
+                break
+            for index, name in enumerate(node.input):
+                if name == g2_in_name:
+                    node.input[index] = g1_out_name
+                    found = True
+                    break
+        if not found:
+            raise ValueError(f"Could not find an input named \"{g2_in_name}\" in g2")
+
+    g.input.extend(g1.input)
+    g.input.extend([item for item in g2.input if item.name not in g2_ins])
+
+    g.output.extend([item for item in g1.output if item.name not in g1_outs])
+    g.output.extend(g2.output)
+
+    g.initializer.extend(g1.initializer)
+    g.initializer.extend(g2.initializer)
+
+    g.sparse_initializer.extend(g1.sparse_initializer)
+    g.sparse_initializer.extend(g2.sparse_initializer)
+
+    g.value_info.extend(g1.value_info)
+    g.value_info.extend(g2.value_info)
+
+    if name:
+        g.name = name
+    else:
+        g.name = g1.name + "__" + g2.name
+
+    if doc_string:
+        g.doc_string = doc_string
+    else:
+        g.doc_string = f"Graph combining {g1.name} and {g2.name}\n" + \
+            g1.name + "\n\n" + g1.doc_string + "\n\n" + g2.name + "\n\n" + g2.doc_string
+
+    return g

--- a/onnx/compose.py
+++ b/onnx/compose.py
@@ -8,7 +8,7 @@ from __future__ import unicode_literals
 import copy
 from typing import List, Tuple, Text, Optional, MutableMapping
 from google.protobuf.internal.containers import RepeatedScalarFieldContainer
-from onnx import ModelProto, GraphProto, OperatorSetIdProto, helper, checker
+from onnx import ModelProto, GraphProto, helper, checker
 from onnx import TensorProto as tp
 
 

--- a/onnx/compose.py
+++ b/onnx/compose.py
@@ -220,7 +220,7 @@ def merge_graphs(
         [init for init in g2.sparse_initializer if init.values.name not in io_map_g2_ins])
 
     g.value_info.extend(g1.value_info)
-    g.value_info.extend(g2.value_info)
+    g.value_info.extend([vi for vi in g2.value_info if vi.name not in io_map_g2_ins])
 
     g.name = name if name is not None else "_".join([g1.name, g2.name])
 

--- a/onnx/test/compose_test.py
+++ b/onnx/test/compose_test.py
@@ -143,7 +143,7 @@ class TestComposeFunctions(unittest.TestCase):
             return [out.type.tensor_type.shape.dim[d].dim_value \
                 for d in range(len(out.type.tensor_type.shape.dim))]
 
-        for dim_idx in [0]:
+        for dim_idx in [0, 2, -1, -3]:
             g1 = onnx.compose.expand_out_dim(g0, dim_idx)
 
             for out0, out1 in zip(g0.output, g1.output):

--- a/onnx/test/compose_test.py
+++ b/onnx/test/compose_test.py
@@ -38,8 +38,6 @@ class TestComposeFunctions(unittest.TestCase):
         B01 = create_tensor("B01")
         B11 = create_tensor("B11")
         B21 = create_tensor("B21")
-        C0 = create_tensor("C0")
-        C1 = create_tensor("C1")
         D0 = create_tensor("D0")
 
         L1_0 = helper.make_node("Add", ["B01", "B11"], ["C0"], "L1_0")

--- a/onnx/test/compose_test.py
+++ b/onnx/test/compose_test.py
@@ -10,79 +10,100 @@ import unittest
 from typing import Text, List
 
 import onnx
+from onnx.onnx_ml_pb2 import ModelProto
 import onnx.version_converter
-from onnx import helper, TensorProto, GraphProto, ValueInfoProto
+from onnx import helper, parser, checker, TensorProto, GraphProto, ValueInfoProto
 
 
-def _create_tensor(name, dtype=TensorProto.FLOAT, shape=[1, 2]):  # type: ignore
-    return helper.make_tensor_value_info(name, TensorProto.FLOAT, shape)
+def _load_model(m_def):  # type: (Text) -> ModelProto
+    '''
+    Parses a model from a string representation, including checking the model for correctness
+    '''
+    m = parser.parse_model(m_def)
+    checker.check_model(m)
+    return m
+
+
+def _prefixed(prefix, s):  # type: (Text, Text) -> Text
+    '''
+    Prefixes a string (if not empty)
+    '''
+    return prefix + s if len(s) > 0 else s
+
+
+def _get_shape(value_info):  # type: (ValueInfoProto) -> List[int]
+    '''
+    Returns a list of integers representing the shape of the provided ValueInfoProto
+    '''
+    return [value_info.type.tensor_type.shape.dim[d].dim_value
+            for d in range(len(value_info.type.tensor_type.shape.dim))]
+
+
+m1_def = '''
+    <
+        ir_version: 7,
+        opset_import: [ "": 10, "com.microsoft": 1]
+    >
+    agraph (float[N, M] A0, float[N, M] A1) => (float[N, M] B00, float[N, M] B10, float[N, M] B20)
+    {
+        B00 = Add(A0, A1)
+        B10 = Sub(A0, A1)
+        B20 = Mul(A0, A1)
+    }
+    '''
+
+m2_def = '''
+    <
+        ir_version: 7,
+        opset_import: [ "": 10, "com.microsoft": 1]
+    >
+    agraph (float[N, M] B01, float[N, M] B11, float[N, M] B21) => (float[N, M] D0)
+    {
+        C0 = Add(B01, B11)
+        C1 = Sub(B11, B21)
+        M1 = Mul(C0, C1)
+    }
+    '''
 
 
 class TestComposeFunctions(unittest.TestCase):
-    def test_merge(self):  # type: () -> None
-        A0 = _create_tensor("A0")
-        A1 = _create_tensor("A1")
-        B00 = _create_tensor("B00")
-        B10 = _create_tensor("B10")
-        B20 = _create_tensor("B20")
+    def test_case_connect_all_no_name_collision(self):  # type: () -> None
+        '''
+        Tests a simple scenario where two models without overlapping names are merged by
+        connecting all the outputs in the first models to all the inputs in the second model
+        '''
+        m1, m2 = _load_model(m1_def), _load_model(m2_def)
 
-        L0_0 = helper.make_node("Add", ["A0", "A1"], ["B00"], "L0_0")
-        L0_1 = helper.make_node("Sub", ["A0", "A1"], ["B10"], "L0_1")
-        L0_2 = helper.make_node("Mul", ["A0", "A1"], ["B20"], "L0_2")
+        io_map = [("B00", "B01"), ("B10", "B11"), ("B20", "B21")]
+        g3 = onnx.compose.merge_graphs(m1.graph, m2.graph, io_map=io_map)
+        checker.check_graph(g3)
 
-        g1 = helper.make_graph(
-            [L0_0, L0_1, L0_2],
-            "test1",
-            [A0, A1],
-            [B00, B10, B20])
-
-        B01 = _create_tensor("B01")
-        B11 = _create_tensor("B11")
-        B21 = _create_tensor("B21")
-        D0 = _create_tensor("D0")
-
-        L1_0 = helper.make_node("Add", ["B01", "B11"], ["C0"], "L1_0")
-        L1_1 = helper.make_node("Sub", ["B11", "B21"], ["C1"], "L1_1")
-        L2_0 = helper.make_node("Mul", ["C0", "C1"], ["D0"], "L2_0")
-
-        g2 = helper.make_graph(
-            [L1_0, L1_1, L2_0],
-            "test2",
-            [B01, B11, B21],
-            [D0])
-
-        # Test 1: Connecting all outputs/inputs
-        io_map_g3 = [("B00", "B01"), ("B10", "B11"), ("B20", "B21")]
-        g3 = onnx.compose.merge_graphs(
-            g1, g2, io_map=io_map_g3)
-
-        def check_g3(g1, g2, g3):  # type: (GraphProto, GraphProto, GraphProto) -> None
+        def check_graph(g1, g2, g3):  # type: (GraphProto, GraphProto, GraphProto) -> None
             self.assertEqual(g3.input, g1.input)
             self.assertEqual(g3.output, g2.output)
             # Edge names are different
             self.assertEqual([item.name for item in g3.node],
                              [item.name for item in g1.node] + [item.name for item in g2.node])
 
-        check_g3(g1, g2, g3)
-        m3 = helper.make_model(g3, producer_name='test',
-                               opset_imports=[onnx.helper.make_opsetid("", 15)])
-        onnx.checker.check_model(m3)
+        check_graph(m1.graph, m2.graph, g3)
 
-        # Test merge models API
-        m1 = helper.make_model(g1, producer_name='test',
-                               opset_imports=[onnx.helper.make_opsetid("", 15)])
-        m2 = helper.make_model(g2, producer_name='test',
-                               opset_imports=[onnx.helper.make_opsetid("", 15)])
+        m3 = onnx.compose.merge_models(m1, m2, io_map=io_map)
+        checker.check_model(m3)
+        check_graph(m1.graph, m2.graph, m3.graph)
 
-        m3 = onnx.compose.merge_models(m1, m2, io_map_g3)
-        onnx.checker.check_model(m3)
-        check_g3(m1.graph, m2.graph, m3.graph)
+    def test_case_connect_partially_no_name_collision(self):  # type: () -> None
+        '''
+        Tests a scenario where two models without overlapping names are merged by
+        connecting some outputs from the first model to some inputs in the second.
+        The remaining inputs/outputs should be present in the combined model
+        '''
+        m1, m2 = _load_model(m1_def), _load_model(m2_def)
 
-        # Test 2: Connecting some outputs/inputs
-        io_map_g4 = [("B00", "B01"), ("B10", "B11")]
-        g4 = onnx.compose.merge_graphs(g1, g2, io_map=io_map_g4)
+        io_map = [("B00", "B01"), ("B10", "B11")]
+        g3 = onnx.compose.merge_graphs(m1.graph, m2.graph, io_map=io_map)
+        checker.check_graph(g3)
 
-        def check_g4(g1, g2, g4):  # type: (GraphProto, GraphProto, GraphProto) -> None
+        def check_graph(g1, g2, g4):  # type: (GraphProto, GraphProto, GraphProto) -> None
             # B20 <-> B21 not connected. They should still be present in the intputs and outputs of the combined graph
             self.assertEqual(len(g4.input), 3)
             self.assertEqual(g4.input[0], g1.input[0])  # A0
@@ -93,123 +114,216 @@ class TestComposeFunctions(unittest.TestCase):
             self.assertEqual(g4.output[0], g1.output[2])  # B20
             self.assertEqual(g4.output[1], g2.output[0])  # D0
 
-        check_g4(g1, g2, g4)
-        m4 = helper.make_model(g4, producer_name='test')
-        onnx.checker.check_model(m4)
+        check_graph(m1.graph, m2.graph, g3)
 
-        # Test merge models API
-        m4 = onnx.compose.merge_models(m1, m2, io_map_g4)
-        onnx.checker.check_model(m4)
-        check_g4(m1.graph, m2.graph, m4.graph)
+        m3 = onnx.compose.merge_models(m1, m2, io_map=io_map)
+        checker.check_model(m3)
+        check_graph(m1.graph, m2.graph, m3.graph)
+
+    def test_merge_models_with_metadata_props(self):  # type: () -> None
+        m1 = _load_model(m1_def)
+        helper.set_model_props(m1, {'p1': 'v1', 'p2': 'v2'})
+
+        m2 = _load_model(m2_def)
+        helper.set_model_props(m2, {'p3': 'v3', 'p4': 'v4'})
+
+        io_map = [("B00", "B01")]
+        m3 = onnx.compose.merge_models(m1, m2, io_map=io_map)
+        assert len(m3.metadata_props) == 4
+
+        # Overlap, but same value
+        helper.set_model_props(m2, {'p1': 'v1', 'p4': 'v4'})
+        m3 = onnx.compose.merge_models(m1, m2, io_map=io_map)
+        assert len(m3.metadata_props) == 3
+
+        # Same keys but not same value. Error
+        helper.set_model_props(m2, {'p1': 'v5', 'p4': 'v4'})
+        self.assertRaises(ValueError,
+                          onnx.compose.merge_models, m1, m2, io_map=io_map)
+
+    def test_error_wrong_input_output_name(self):  # type: () -> None
+        '''
+        Tests that providing a non existing output/input name in the io_map argument produces an error.
+        '''
+        m1, m2 = _load_model(m1_def), _load_model(m2_def)
+
+        self.assertRaises(ValueError,
+                          onnx.compose.merge_models, m1, m2,
+                          io_map=[("wrong_outname", "B01"), ("B10", "B11"), ("B20", "B21")])
 
         # Wrong output name
         self.assertRaises(ValueError,
-                          onnx.compose.merge_graphs, g1, g2, io_map=[("wrong_outname", "B01"), ("B10", "B11"), ("B20", "B21")])
+                          onnx.compose.merge_models, m1, m2,
+                          io_map=[("B00", "wrong_input"), ("B10", "B11"), ("B20", "B21")])
 
-        # Wrong output name
+    def test_error_ir_version_mismatch(self):  # type: () -> None
+        m1 = _load_model('''
+    <
+        ir_version: 7,
+        opset_import: [ "": 13]
+    >
+    agraph (float[N, M] X0) => (float[N, M] Y0)
+    {
+        Y0 = Add(X0, X0)
+    }
+    ''')
+
+        m2 = _load_model('''
+    <
+        ir_version: 6,
+        opset_import: [ "": 13]
+    >
+    agraph (float[N, M] X1) => (float[N, M] Y1)
+    {
+        Y1 = Add(X1, X1)
+    }
+    ''')
+        # Wrong IR version name
         self.assertRaises(ValueError,
-                          onnx.compose.merge_graphs, g1, g2, io_map=[("B00", "wrong_input"), ("B10", "B11"), ("B20", "B21")])
+                          onnx.compose.merge_models, m1, m2,
+                          io_map=[("Y0", "X1")])
 
-        # Wrong IR version.
-        min_ir_version = helper.find_min_ir_version_for([entry for entry in m1.opset_import])
-        wrong_ir_version = min_ir_version - 1
+    def test_error_opset_import_mismatch(self):  # type: () -> None
+        '''
+        Tests that providing models with different operator set imported produces an error
+        '''
+        m1, m2 = _load_model(m1_def), _load_model(m2_def)
+        m1 = helper.make_model(m1.graph, producer_name='test',
+                               opset_imports=[onnx.helper.make_opsetid("", 10)])
+        m2 = helper.make_model(m2.graph, producer_name='test',
+                               opset_imports=[onnx.helper.make_opsetid("", 15)])
+
+        io_map = [("B00", "B01"), ("B10", "B11"), ("B20", "B21")]
         self.assertRaises(ValueError,
-                          onnx.compose.merge_models, m1, m2, io_map=io_map_g3, ir_version=wrong_ir_version)
-
-        # Minimum IR version should work
-        m3 = onnx.compose.merge_models(
-            m1, m2, io_map=io_map_g3, ir_version=min_ir_version)
-        onnx.checker.check_model(m3)
-        check_g3(m1.graph, m2.graph, m3.graph)
-
-        # Not compatible operator sets
-        m1_10 = helper.make_model(g1, producer_name='test',
-                                  opset_imports=[onnx.helper.make_opsetid("", 10)])
-        m2_15 = helper.make_model(g2, producer_name='test',
-                                  opset_imports=[onnx.helper.make_opsetid("", 15)])
-        self.assertRaises(ValueError,
-                          onnx.compose.merge_models, m1_10, m2_15, io_map=io_map_g3)
+                          onnx.compose.merge_models, m1, m2, io_map)
 
         # Converting to the same Operator set version, should work
-        m1_15 = onnx.version_converter.convert_version(m1_10, 15)
-        m3 = onnx.compose.merge_models(m1_15, m2_15, io_map=io_map_g3)
+        m1 = onnx.version_converter.convert_version(m1, 15)
+        m3 = onnx.compose.merge_models(m1, m2, io_map=io_map)
         onnx.checker.check_model(m3)
-        check_g3(m1.graph, m2.graph, m3.graph)
 
-    def test_add_prefix(self):  # type: () -> None
-        A0 = _create_tensor("A0")
-        A1 = _create_tensor("A1")
-        B00 = _create_tensor("B00")
-        B10 = _create_tensor("B10")
-        B20 = _create_tensor("B20")
+    def _test_add_prefix(self,
+                         rename_nodes=False, rename_edges=False,
+                         rename_inputs=False, rename_outputs=False,
+                         inplace=False):  # type: (bool, bool, bool, bool, bool) -> None
+        m1 = _load_model(m1_def)
 
-        L0_0 = helper.make_node("Add", ["A0", "A1"], ["B00"], "L0_0")
-        L0_1 = helper.make_node("Sub", ["A0", "A1"], ["B10"], "L0_1")
-        L0_2 = helper.make_node("Mul", ["A0", "A1"], ["B20"], "L0_2")
+        prefix = 'pre/'
 
-        g0 = helper.make_graph(
-            [L0_0, L0_1, L0_2],
-            "test1",
-            [A0, A1],
-            [B00, B10, B20])
+        if inplace:
+            m2 = ModelProto()
+            m2.CopyFrom(m1)
+            onnx.compose.add_prefix(m2, prefix,
+                                    rename_nodes=rename_nodes,
+                                    rename_edges=rename_edges,
+                                    rename_inputs=rename_inputs,
+                                    rename_outputs=rename_outputs,
+                                    inplace=True)
+        else:
+            m2 = onnx.compose.add_prefix(m1, prefix,
+                                        rename_nodes=rename_nodes,
+                                        rename_edges=rename_edges,
+                                        rename_inputs=rename_inputs,
+                                        rename_outputs=rename_outputs)
+        g_in = m1.graph
+        g_out = m2.graph
 
-        g1 = onnx.compose.add_prefix(g0, 'g0/')
+        if rename_edges or rename_inputs or rename_outputs:
+            name_mapping = {}
 
-        def prefixed(prefix, s):  # type: (Text, Text) -> Text
-            return prefix + s if len(s) > 0 else s
+            # Rename inputs/outputs/edges. Propagate name changes from and to edges
+            if rename_edges:
+                for n in g_in.node:
+                    for e in n.input:
+                        name_mapping[e] = _prefixed(prefix, e)
+                    for e in n.output:
+                        name_mapping[e] = _prefixed(prefix, e)
+            else:
+                if rename_inputs:
+                    for elem in g_in.input:
+                        name_mapping[elem.name] = _prefixed(prefix, elem.name)
+                if rename_outputs:
+                    for elem in g_in.output:
+                        name_mapping[elem.name] = _prefixed(prefix, elem.name)
 
-        for in1, in0 in zip(g1.input, g0.input):
-            self.assertEqual(in1.name, prefixed('g0/', in0.name))
+            for n1, n0 in zip(g_out.node, g_in.node):
+                for e1, e0 in zip(n1.input, n0.input):
+                    self.assertEqual(name_mapping.get(e0, e0), e1)
+                for e1, e0 in zip(n1.output, n0.output):
+                    self.assertEqual(name_mapping.get(e0, e0), e1)
+            for i1, i0 in zip(g_out.input, g_in.input):
+                self.assertEqual(name_mapping.get(i0.name, i0.name), i1.name)
+            for o1, o0 in zip(g_out.output, g_in.output):
+                self.assertEqual(name_mapping.get(o0.name, o0.name), o1.name)
 
-        for out1, out0 in zip(g1.output, g0.output):
-            self.assertEqual(out1.name, prefixed('g0/', out0.name))
+            if rename_nodes:
+                for n1, n0 in zip(g_out.node, g_in.node):
+                    self.assertEqual(_prefixed(prefix, n0.name), n1.name)
 
-        for n1, n0 in zip(g1.node, g0.node):
-            self.assertEqual(n1.name, prefixed('g0/', n0.name))
+    def test_add_prefix_nodes(self):  # type: () -> None
+        '''
+        Tests renaming nodes only
+        '''
+        self._test_add_prefix(rename_nodes=True)
 
-            for e1, e0 in zip(n1.input, n0.input):
-                self.assertEqual(e1, prefixed('g0/', e0))
+    def test_add_prefix_edges(self):  # type: () -> None
+        '''
+        Tests prefixing nodes edges. This will also rename inputs/outputs, since the names are shared
+        '''
+        self._test_add_prefix(rename_edges=True)
 
-            for e1, e0 in zip(n1.output, n0.output):
-                self.assertEqual(e1, prefixed('g0/', e0))
+    def test_add_prefix_inputs(self):  # type: () -> None
+        '''
+        Tests prefixing graph inputs only. Relevant node edges should be renamed as well
+        '''
+        self._test_add_prefix(rename_inputs=True)
 
-        m = helper.make_model(g1, producer_name='test')
-        onnx.checker.check_model(m)
+    def test_add_prefix_outputs(self):  # type: () -> None
+        '''
+        Tests prefixing graph outputs only. Relevant node edges should be renamed as well
+        '''
+        self._test_add_prefix(rename_outputs=True)
+
+    def test_add_prefix_all(self):  # type: () -> None
+        '''
+        Tests prefixing all names in the graph
+        '''
+        self._test_add_prefix(rename_nodes=True, rename_edges=True,
+                              rename_inputs=True, rename_outputs=True)
+
+    def test_add_prefix_inplace(self):  # type: () -> None
+        '''
+        Tests prefixing all names in the graph
+        '''
+        self._test_add_prefix(rename_nodes=True, rename_edges=True,
+                              rename_inputs=True, rename_outputs=True, inplace=True)
 
     def test_expand_out_dim(self):  # type: () -> None
-        A0 = _create_tensor("A0", shape=[5, 4])
-        A1 = _create_tensor("A1", shape=[5, 4])
-        B0 = _create_tensor("B0", shape=[3, 2])
-        B1 = _create_tensor("B1", shape=[3, 2])
-        C0 = _create_tensor("C0", shape=[5, 4])
-        C1 = _create_tensor("C1", shape=[3, 2])
+        '''
+        Tests expanding output dimensions. The resulting graph should have the same output names,
+        but with one more dimension at the specified index.
+        '''
+        m1 = _load_model(m1_def)
 
-        L0 = helper.make_node("Add", ["A0", "A1"], ["C0"], "L0")
-        L1 = helper.make_node("Sub", ["B0", "B1"], ["C1"], "L1")
-
-        g0 = helper.make_graph(
-            [L0, L1],
-            "test1",
-            [A0, A1, B0, B1],
-            [C0, C1])
-
-        def out_shape(out):  # type: (ValueInfoProto) -> List[int]
-            return [out.type.tensor_type.shape.dim[d].dim_value
-                    for d in range(len(out.type.tensor_type.shape.dim))]
+        def _check_model(m1, m2, dim_idx):  # type: (ModelProto, ModelProto, int) -> None
+            for out_g2, out_g1 in zip(m2.graph.output, m1.graph.output):
+                self.assertEqual(out_g2.name, out_g1.name)
+                self.assertEqual(out_g2.type.tensor_type.elem_type,
+                                 out_g1.type.tensor_type.elem_type)
+                expected_out_shape = _get_shape(out_g1)
+                expected_out_shape.insert(dim_idx, 1)
+                self.assertEqual(_get_shape(out_g2), expected_out_shape)
 
         for dim_idx in [0, 2, -1, -3]:
-            g1 = onnx.compose.expand_out_dim(g0, dim_idx)
+            m2 = onnx.compose.expand_out_dim(m1, dim_idx)
+            _check_model(m1, m2, dim_idx)
 
-            for out0, out1 in zip(g0.output, g1.output):
-                self.assertEqual(out1.name, out0.name + '_expanded')
-                self.assertEqual(out1.type.tensor_type.elem_type,
-                                 out0.type.tensor_type.elem_type)
-                expected_out_shape = out_shape(out0)
-                expected_out_shape.insert(dim_idx, 1)
-                self.assertEqual(out_shape(out1), expected_out_shape)
-
-            m = helper.make_model(g1, producer_name='test')
-            onnx.checker.check_model(m)
+        # Test inplace
+        m2 = ModelProto()
+        m2.CopyFrom(m1)
+        dim_idx = 0
+        onnx.compose.expand_out_dim(m2, dim_idx, inplace=True)
+        _check_model(m1, m2, dim_idx)
 
 
 if __name__ == '__main__':

--- a/onnx/test/compose_test.py
+++ b/onnx/test/compose_test.py
@@ -57,6 +57,9 @@ class TestComposeFunctions(unittest.TestCase):
         # Edge names are different
         self.assertEqual([item.name for item in g3.node], [item.name for item in g0.node] + [item.name for item in g1.node])
 
+        m3 = helper.make_model(g3, producer_name='test')
+        onnx.checker.check_model(m3)
+
         # Test 2: Connecting some outputs/inputs
         g4 = onnx.compose.merge(g0, g1, io_map=[("B00", "B01"), ("B10", "B11")])
 
@@ -69,6 +72,9 @@ class TestComposeFunctions(unittest.TestCase):
         self.assertEqual(len(g4.output), 2)
         self.assertEqual(g4.output[0], g0.output[2])  # B20
         self.assertEqual(g4.output[1], g1.output[0])  # D0
+
+        m4 = helper.make_model(g4, producer_name='test')
+        onnx.checker.check_model(m4)
 
 
 if __name__ == '__main__':

--- a/onnx/test/compose_test.py
+++ b/onnx/test/compose_test.py
@@ -11,7 +11,7 @@ import unittest
 from typing import Text, List, Optional, Tuple, Callable
 
 from onnx import helper, parser, checker, compose, version_converter, \
-                 ModelProto, GraphProto, ValueInfoProto, TensorProto, SparseTensorProto
+    ModelProto, GraphProto, ValueInfoProto, TensorProto, SparseTensorProto
 
 
 def _load_model(m_def):  # type: (Text) -> ModelProto
@@ -64,16 +64,18 @@ m2_def = '''
     }
     '''
 
+
 class TestComposeFunctions(unittest.TestCase):
-    def _test_merge_models(self,
-                           m1def,  # type: Text
-                           m2def,  # type: Text
-                           io_map,  # type: List[Tuple[Text, Text]]
-                           check_expectations,  # type: Callable[[GraphProto, GraphProto, GraphProto], None]
-                           inputs=None,  # type: Optional[List[Text]]
-                           outputs=None,  # type: Optional[List[Text]]
-                           prefix1=None,  # type: Optional[Text]
-                           prefix2=None,  # type: Optional[Text]
+    def _test_merge_models(
+        self,
+        m1def,  # type: Text
+        m2def,  # type: Text
+        io_map,  # type: List[Tuple[Text, Text]]
+        check_expectations,  # type: Callable[[GraphProto, GraphProto, GraphProto], None]
+        inputs=None,  # type: Optional[List[Text]]
+        outputs=None,  # type: Optional[List[Text]]
+        prefix1=None,  # type: Optional[Text]
+        prefix2=None  # type: Optional[Text]
     ):  # type: (...) -> None
         m1, m2 = _load_model(m1def), _load_model(m2def)
         g3 = compose.merge_graphs(
@@ -157,6 +159,7 @@ class TestComposeFunctions(unittest.TestCase):
             }
             '''
         io_map = [("B", "B")]
+
         def check_expectations(g1, g2, g3):  # type: (GraphProto, GraphProto, GraphProto) -> None
             self.assertEqual(['A'], [elem.name for elem in g3.input])
             self.assertEqual(['C'], [elem.name for elem in g3.output])
@@ -190,13 +193,14 @@ class TestComposeFunctions(unittest.TestCase):
             }
             '''
         io_map = [("A1", "B2")]
+
         def check_expectations(g1, g2, g3):  # type: (GraphProto, GraphProto, GraphProto) -> None
             self.assertEqual(['A0'], [elem.name for elem in g3.input])
             self.assertEqual(['B3'], [elem.name for elem in g3.output])
             self.assertEqual(['Add', 'Sub'], [elem.op_type for elem in g3.node])
 
-        inputs=['A0']
-        outputs=['B3']
+        inputs = ['A0']
+        outputs = ['B3']
         self._test_merge_models(
             m1_def, m2_def, io_map, check_expectations, inputs=inputs, outputs=outputs)
 
@@ -217,6 +221,7 @@ class TestComposeFunctions(unittest.TestCase):
             }
             '''
         io_map = [("C", "A")]
+
         def check_expectations(g1, g2, g3):  # type: (GraphProto, GraphProto, GraphProto) -> None
             self.assertEqual(['m1/A', 'm1/B', 'm2/B'], [elem.name for elem in g3.input])
             self.assertEqual(['m2/C'], [elem.name for elem in g3.output])
@@ -486,16 +491,16 @@ class TestComposeFunctions(unittest.TestCase):
         sparse_initializer0=['sparse_init0', 'sparse_init1'],  # type: List[Text]
         sparse_initializer1=['sparse_init2', 'sparse_init3'],  # type: List[Text]
     ):  # type: (...) -> None
-        n0 = [helper.make_node('Identity', inputs=[inputs0[i]], outputs=[outputs0[i]]) \
-            for i in range(len(inputs0))]
-        i0 = [helper.make_tensor_value_info(inputs0[i], TensorProto.FLOAT, []) \
-            for i in range(len(inputs0))]
-        o0 = [helper.make_tensor_value_info(outputs0[i], TensorProto.FLOAT, []) \
-            for i in range(len(outputs0))]
-        vi0 = [helper.make_tensor_value_info(value_info0[i], TensorProto.FLOAT, []) \
-            for i in range(len(value_info0))]
-        init0 = [helper.make_tensor(name=initializer0[i], data_type=TensorProto.INT64, dims=(), vals=[1]) \
-            for i in range(len(initializer0))]
+        n0 = [helper.make_node('Identity', inputs=[inputs0[i]], outputs=[outputs0[i]])
+              for i in range(len(inputs0))]
+        i0 = [helper.make_tensor_value_info(inputs0[i], TensorProto.FLOAT, [])
+              for i in range(len(inputs0))]
+        o0 = [helper.make_tensor_value_info(outputs0[i], TensorProto.FLOAT, [])
+              for i in range(len(outputs0))]
+        vi0 = [helper.make_tensor_value_info(value_info0[i], TensorProto.FLOAT, [])
+               for i in range(len(value_info0))]
+        init0 = [helper.make_tensor(name=initializer0[i], data_type=TensorProto.INT64, dims=(), vals=[1])
+                 for i in range(len(initializer0))]
 
         def _make_sparse_tensor(name):  # type: (Text) -> SparseTensorProto
             dense_shape = [3, 3]
@@ -507,24 +512,26 @@ class TestComposeFunctions(unittest.TestCase):
                 vals=np.array(sparse_values).astype(np.float32), raw=False)
 
             indices_tensor = helper.make_tensor(
-                name=name + "_idx" , data_type=TensorProto.INT64,
+                name=name + "_idx", data_type=TensorProto.INT64,
                 dims=[len(linear_indicies)],
                 vals=np.array(linear_indicies).astype(np.int64), raw=False)
             return helper.make_sparse_tensor(values_tensor, indices_tensor, dense_shape)
 
-        sparse_init0 = [_make_sparse_tensor(sparse_initializer0[i]) for i in range(len(sparse_initializer0))]
+        sparse_init0 = [_make_sparse_tensor(
+            sparse_initializer0[i]) for i in range(len(sparse_initializer0))]
 
-        n1 = [helper.make_node('Identity', inputs=[inputs1[i]], outputs=[outputs1[i]]) \
-            for i in range(len(inputs1))]
-        i1 = [helper.make_tensor_value_info(inputs1[i], TensorProto.FLOAT, []) \
-            for i in range(len(inputs1))]
-        o1 = [helper.make_tensor_value_info(outputs1[i], TensorProto.FLOAT, []) \
-            for i in range(len(outputs1))]
-        vi1 = [helper.make_tensor_value_info(value_info1[i], TensorProto.FLOAT, []) \
-            for i in range(len(value_info1))]
-        init1 = [helper.make_tensor(name=initializer1[i], data_type=TensorProto.INT64, dims=(), vals=[1]) \
-            for i in range(len(initializer1))]
-        sparse_init1 = [_make_sparse_tensor(sparse_initializer1[i]) for i in range(len(sparse_initializer1))]
+        n1 = [helper.make_node('Identity', inputs=[inputs1[i]], outputs=[outputs1[i]])
+              for i in range(len(inputs1))]
+        i1 = [helper.make_tensor_value_info(inputs1[i], TensorProto.FLOAT, [])
+              for i in range(len(inputs1))]
+        o1 = [helper.make_tensor_value_info(outputs1[i], TensorProto.FLOAT, [])
+              for i in range(len(outputs1))]
+        vi1 = [helper.make_tensor_value_info(value_info1[i], TensorProto.FLOAT, [])
+               for i in range(len(value_info1))]
+        init1 = [helper.make_tensor(name=initializer1[i], data_type=TensorProto.INT64, dims=(), vals=[1])
+                 for i in range(len(initializer1))]
+        sparse_init1 = [_make_sparse_tensor(sparse_initializer1[i])
+                        for i in range(len(sparse_initializer1))]
 
         ops = [helper.make_opsetid("", 10)]
         m0 = helper.make_model(

--- a/onnx/test/compose_test.py
+++ b/onnx/test/compose_test.py
@@ -10,9 +10,8 @@ import unittest
 from typing import Text, List
 
 import onnx
-from onnx.onnx_ml_pb2 import ModelProto
 import onnx.version_converter
-from onnx import helper, parser, checker, TensorProto, GraphProto, ValueInfoProto
+from onnx import helper, parser, checker, ModelProto, GraphProto, ValueInfoProto
 
 
 def _load_model(m_def):  # type: (Text) -> ModelProto

--- a/onnx/test/compose_test.py
+++ b/onnx/test/compose_test.py
@@ -13,6 +13,7 @@ import unittest
 import onnx
 from onnx import helper, TensorProto
 
+
 class TestComposeFunctions(unittest.TestCase):
     def test_merge(self):  # type: () -> None
         def create_tensor(name):  # type: ignore
@@ -52,11 +53,13 @@ class TestComposeFunctions(unittest.TestCase):
             [D0])
 
         # Test 1: Connecting all outputs/inputs
-        g3 = onnx.compose.merge(g0, g1, io_map=[("B00", "B01"), ("B10", "B11"), ("B20", "B21")])
+        g3 = onnx.compose.merge(
+            g0, g1, io_map=[("B00", "B01"), ("B10", "B11"), ("B20", "B21")])
         self.assertEqual(g3.input, g0.input)
         self.assertEqual(g3.output, g1.output)
         # Edge names are different
-        self.assertEqual([item.name for item in g3.node], [item.name for item in g0.node] + [item.name for item in g1.node])
+        self.assertEqual([item.name for item in g3.node],
+                         [item.name for item in g0.node] + [item.name for item in g1.node])
 
         m3 = helper.make_model(g3, producer_name='test')
         onnx.checker.check_model(m3)
@@ -76,6 +79,13 @@ class TestComposeFunctions(unittest.TestCase):
 
         m4 = helper.make_model(g4, producer_name='test')
         onnx.checker.check_model(m4)
+
+        # Wrong output name
+        self.assertRaises(ValueError,
+                          onnx.compose.merge, g0, g1, io_map=[("wrong_outname", "B01"), ("B10", "B11"), ("B20", "B21")])
+
+        self.assertRaises(ValueError,
+                          onnx.compose.merge, g0, g1, io_map=[("B00", "wrong_input"), ("B10", "B11"), ("B20", "B21")])
 
     def test_add_prefix(self):  # type: () -> None
         def create_tensor(name):  # type: ignore
@@ -100,13 +110,16 @@ class TestComposeFunctions(unittest.TestCase):
         g1 = onnx.compose.add_prefix(g0, 'g0/')
 
         for e1, e0 in zip(g1.input, g0.input):
-            self.assertEqual(e1.name, 'g0/' + e0.name if len(e0.name) > 0 else e0.name)
+            self.assertEqual(e1.name, 'g0/'
+                             + e0.name if len(e0.name) > 0 else e0.name)
 
         for e1, e0 in zip(g1.output, g0.output):
-            self.assertEqual(e1.name, 'g0/' + e0.name if len(e0.name) > 0 else e0.name)
+            self.assertEqual(e1.name, 'g0/'
+                             + e0.name if len(e0.name) > 0 else e0.name)
 
         for n1, n0 in zip(g1.node, g0.node):
-            self.assertEqual(n1.name, 'g0/' + n0.name if len(n0.name) > 0 else n0.name)
+            self.assertEqual(n1.name, 'g0/'
+                             + n0.name if len(n0.name) > 0 else n0.name)
 
             for e1, e0 in zip(n1.input, n0.input):
                 self.assertEqual(e1, 'g0/' + e0 if len(e0) > 0 else e0)
@@ -116,7 +129,6 @@ class TestComposeFunctions(unittest.TestCase):
 
         m = helper.make_model(g1, producer_name='test')
         onnx.checker.check_model(m)
-
 
     def test_expand_out_dim(self):  # type: () -> None
         def create_tensor(name, shape=[1, 2]):  # type: ignore
@@ -129,7 +141,6 @@ class TestComposeFunctions(unittest.TestCase):
         C0 = create_tensor("C0", shape=[5, 4])
         C1 = create_tensor("C1", shape=[3, 2])
 
-
         L0 = helper.make_node("Add", ["A0", "A1"], ["C0"], "L0")
         L1 = helper.make_node("Sub", ["B0", "B1"], ["C1"], "L1")
 
@@ -140,15 +151,16 @@ class TestComposeFunctions(unittest.TestCase):
             [C0, C1])
 
         def out_shape(out):
-            return [out.type.tensor_type.shape.dim[d].dim_value \
-                for d in range(len(out.type.tensor_type.shape.dim))]
+            return [out.type.tensor_type.shape.dim[d].dim_value
+                    for d in range(len(out.type.tensor_type.shape.dim))]
 
         for dim_idx in [0, 2, -1, -3]:
             g1 = onnx.compose.expand_out_dim(g0, dim_idx)
 
             for out0, out1 in zip(g0.output, g1.output):
                 self.assertEqual(out1.name, out0.name + '_expanded')
-                self.assertEqual(out1.type.tensor_type.elem_type, out0.type.tensor_type.elem_type)
+                self.assertEqual(out1.type.tensor_type.elem_type,
+                                 out0.type.tensor_type.elem_type)
                 expected_out_shape = out_shape(out0)
                 expected_out_shape.insert(dim_idx, 1)
                 self.assertEqual(out_shape(out1), expected_out_shape)

--- a/onnx/test/compose_test.py
+++ b/onnx/test/compose_test.py
@@ -11,8 +11,10 @@ import onnx
 import onnx.version_converter
 from onnx import helper, TensorProto
 
+
 def _create_tensor(name, dtype=TensorProto.FLOAT, shape=[1, 2]):  # type: ignore
     return helper.make_tensor_value_info(name, TensorProto.FLOAT, shape)
+
 
 class TestComposeFunctions(unittest.TestCase):
     def test_merge(self):  # type: () -> None
@@ -51,12 +53,13 @@ class TestComposeFunctions(unittest.TestCase):
         io_map_g3 = [("B00", "B01"), ("B10", "B11"), ("B20", "B21")]
         g3 = onnx.compose.merge_graphs(
             g1, g2, io_map=io_map_g3)
+
         def check_g3(g1, g2, g3):
             self.assertEqual(g3.input, g1.input)
             self.assertEqual(g3.output, g2.output)
             # Edge names are different
             self.assertEqual([item.name for item in g3.node],
-                            [item.name for item in g1.node] + [item.name for item in g2.node])
+                             [item.name for item in g1.node] + [item.name for item in g2.node])
 
         check_g3(g1, g2, g3)
         m3 = helper.make_model(g3, producer_name='test',
@@ -112,7 +115,8 @@ class TestComposeFunctions(unittest.TestCase):
                           onnx.compose.merge_models, m1, m2, io_map=io_map_g3, ir_version=wrong_ir_version)
 
         # Minimum IR version should work
-        m3 = onnx.compose.merge_models(m1, m2, io_map=io_map_g3, ir_version=min_ir_version)
+        m3 = onnx.compose.merge_models(
+            m1, m2, io_map=io_map_g3, ir_version=min_ir_version)
         onnx.checker.check_model(m3)
         check_g3(m1.graph, m2.graph, m3.graph)
 

--- a/onnx/test/compose_test.py
+++ b/onnx/test/compose_test.py
@@ -17,6 +17,7 @@ class TestComposeFunctions(unittest.TestCase):
     def test_merge(self):  # type: () -> None
         def create_tensor(name):  # type: ignore
             return helper.make_tensor_value_info(name, TensorProto.FLOAT, [1, 2])
+
         A0 = create_tensor("A0")
         A1 = create_tensor("A1")
         B00 = create_tensor("B00")
@@ -75,6 +76,85 @@ class TestComposeFunctions(unittest.TestCase):
 
         m4 = helper.make_model(g4, producer_name='test')
         onnx.checker.check_model(m4)
+
+    def test_add_prefix(self):  # type: () -> None
+        def create_tensor(name):  # type: ignore
+            return helper.make_tensor_value_info(name, TensorProto.FLOAT, [1, 2])
+
+        A0 = create_tensor("A0")
+        A1 = create_tensor("A1")
+        B00 = create_tensor("B00")
+        B10 = create_tensor("B10")
+        B20 = create_tensor("B20")
+
+        L0_0 = helper.make_node("Add", ["A0", "A1"], ["B00"], "L0_0")
+        L0_1 = helper.make_node("Sub", ["A0", "A1"], ["B10"], "L0_1")
+        L0_2 = helper.make_node("Mul", ["A0", "A1"], ["B20"], "L0_2")
+
+        g0 = helper.make_graph(
+            [L0_0, L0_1, L0_2],
+            "test1",
+            [A0, A1],
+            [B00, B10, B20])
+
+        g1 = onnx.compose.add_prefix(g0, 'g0/')
+
+        for e1, e0 in zip(g1.input, g0.input):
+            self.assertEqual(e1.name, 'g0/' + e0.name if len(e0.name) > 0 else e0.name)
+
+        for e1, e0 in zip(g1.output, g0.output):
+            self.assertEqual(e1.name, 'g0/' + e0.name if len(e0.name) > 0 else e0.name)
+
+        for n1, n0 in zip(g1.node, g0.node):
+            self.assertEqual(n1.name, 'g0/' + n0.name if len(n0.name) > 0 else n0.name)
+
+            for e1, e0 in zip(n1.input, n0.input):
+                self.assertEqual(e1, 'g0/' + e0 if len(e0) > 0 else e0)
+
+            for e1, e0 in zip(n1.output, n0.output):
+                self.assertEqual(e1, 'g0/' + e0 if len(e0) > 0 else e0)
+
+        m = helper.make_model(g1, producer_name='test')
+        onnx.checker.check_model(m)
+
+
+    def test_expand_out_dim(self):  # type: () -> None
+        def create_tensor(name, shape=[1, 2]):  # type: ignore
+            return helper.make_tensor_value_info(name, TensorProto.FLOAT, shape)
+
+        A0 = create_tensor("A0", shape=[5, 4])
+        A1 = create_tensor("A1", shape=[5, 4])
+        B0 = create_tensor("B0", shape=[3, 2])
+        B1 = create_tensor("B1", shape=[3, 2])
+        C0 = create_tensor("C0", shape=[5, 4])
+        C1 = create_tensor("C1", shape=[3, 2])
+
+
+        L0 = helper.make_node("Add", ["A0", "A1"], ["C0"], "L0")
+        L1 = helper.make_node("Sub", ["B0", "B1"], ["C1"], "L1")
+
+        g0 = helper.make_graph(
+            [L0, L1],
+            "test1",
+            [A0, A1, B0, B1],
+            [C0, C1])
+
+        def out_shape(out):
+            return [out.type.tensor_type.shape.dim[d].dim_value \
+                for d in range(len(out.type.tensor_type.shape.dim))]
+
+        for dim_idx in [0]:
+            g1 = onnx.compose.expand_out_dim(g0, dim_idx)
+
+            for out0, out1 in zip(g0.output, g1.output):
+                self.assertEqual(out1.name, out0.name + '_expanded')
+                self.assertEqual(out1.type.tensor_type.elem_type, out0.type.tensor_type.elem_type)
+                expected_out_shape = out_shape(out0)
+                expected_out_shape.insert(dim_idx, 1)
+                self.assertEqual(out_shape(out1), expected_out_shape)
+
+            m = helper.make_model(g1, producer_name='test')
+            onnx.checker.check_model(m)
 
 
 if __name__ == '__main__':

--- a/onnx/test/compose_test.py
+++ b/onnx/test/compose_test.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import onnx
+from onnx import helper, TensorProto
+
+class TestComposeFunctions(unittest.TestCase):
+    def test_merge(self):  # type: () -> None
+        def create_tensor(name):  # type: ignore
+            return helper.make_tensor_value_info(name, TensorProto.FLOAT, [1, 2])
+        A0 = create_tensor("A0")
+        A1 = create_tensor("A1")
+        B00 = create_tensor("B00")
+        B10 = create_tensor("B10")
+        B20 = create_tensor("B20")
+
+        L0_0 = helper.make_node("Add", ["A0", "A1"], ["B00"], "L0_0")
+        L0_1 = helper.make_node("Sub", ["A0", "A1"], ["B10"], "L0_1")
+        L0_2 = helper.make_node("Mul", ["A0", "A1"], ["B20"], "L0_2")
+
+        g0 = helper.make_graph(
+            [L0_0, L0_1, L0_2],
+            "test1",
+            [A0, A1],
+            [B00, B10, B20])
+
+        B01 = create_tensor("B01")
+        B11 = create_tensor("B11")
+        B21 = create_tensor("B21")
+        C0 = create_tensor("C0")
+        C1 = create_tensor("C1")
+        D0 = create_tensor("D0")
+
+        L1_0 = helper.make_node("Add", ["B01", "B11"], ["C0"], "L1_0")
+        L1_1 = helper.make_node("Sub", ["B11", "B21"], ["C1"], "L1_1")
+        L2_0 = helper.make_node("Mul", ["C0", "C1"], ["D0"], "L2_0")
+
+        g1 = helper.make_graph(
+            [L1_0, L1_1, L2_0],
+            "test2",
+            [B01, B11, B21],
+            [D0])
+
+        # Test 1: Connecting all outputs/inputs
+        g3 = onnx.compose.merge(g0, g1, io_map=[("B00", "B01"), ("B10", "B11"), ("B20", "B21")])
+        self.assertEqual(g3.input, g0.input)
+        self.assertEqual(g3.output, g1.output)
+        # Edge names are different
+        self.assertEqual([item.name for item in g3.node], [item.name for item in g0.node] + [item.name for item in g1.node])
+
+        # Test 2: Connecting some outputs/inputs
+        g4 = onnx.compose.merge(g0, g1, io_map=[("B00", "B01"), ("B10", "B11")])
+
+        # B20 <-> B21 not connected. They should still be present in the intputs and outputs of the combined graph
+        self.assertEqual(len(g4.input), 3)
+        self.assertEqual(g4.input[0], g0.input[0])  # A0
+        self.assertEqual(g4.input[1], g0.input[1])  # A1
+        self.assertEqual(g4.input[2], g1.input[2])  # B21
+
+        self.assertEqual(len(g4.output), 2)
+        self.assertEqual(g4.output[0], g0.output[2])  # B20
+        self.assertEqual(g4.output[1], g1.output[0])  # D0
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Description**
- Introduces a set of utilities under `onnx.compose` that help with creating combines models out of several graphs.

Usage example:
```
model_graph = ...   # Expects [N, H, W, C]
preprocessing_graph = ... # Expects [H, W, C]

# Add a leading dimension to the end of the preprocessing graph
preprocessing_graph = onnx.compose.expand_out_dim(preprocessing_graph, 0)

# Rename nodes/outputs/inputs/edges of the preprocessing graph, to avoid potential collisions with the main model
preprocessing_graph = onnx.compose.add_prefix(preprocessing_graph, 'preprocessing/')

# Merge the two graphs, by connecting the output "preprocessing/data" output from the first graph to the "data" input of the second
combined_graph = onnx.compose.merge_graphs(preprocessing_graph, model_graph, [("preprocessing/data_expanded", "data")])

# Similarly, merge two models, optionally specifying the target IR version
combined_model = onnx.compose.merge_models(m1, m2,  [("preprocessing/data_expanded", "data")], ir_version=15)
```

**Motivation and Context**
- ONNX preprocessing models can be distributed as separate ONNX models that are defined in terms of a single sample. ONNX compose utils can be used to create a combined model that includes both preprocessing and the network. The design should be kept open for future extensions: e.g. batch preprocessing, postprocessing, etc.
