### PR TITLE
Document that Where supports multidirectional broadcasting.

### DIFF
--- a/docs/Broadcasting.md
+++ b/docs/Broadcasting.md
@@ -44,6 +44,7 @@ Multidirectional broadcasting is supported by the following operators in ONNX:
 - [Pow](Operators.md#Pow)
 - [Sub](Operators.md#Sub)
 - [Sum](Operators.md#Sum)
+- [Where](Operators.md#Where)
 - [Xor](Operators.md#Xor)
 
 ## Unidirectional Broadcasting

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -9224,10 +9224,12 @@ This version of the operator has been available since version 9 of the default O
 
 ### <a name="Where-9"></a>**Where-9**</a>
 
-  Return elements, either from X or Y, depending on condition
-      (with Numpy-style broadcasting support).
-      Where behaves like numpy.where with three parameters:
-      https://docs.scipy.org/doc/numpy/reference/generated/numpy.where.html
+  Return elements, either from X or Y, depending on condition.
+  Where behaves like
+  [numpy.where](https://docs.scipy.org/doc/numpy/reference/generated/numpy.where.html)
+  with three parameters.
+  
+  This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
 #### Version
 
@@ -20385,11 +20387,14 @@ This version of the operator has been available since version 16 of the default 
 ### <a name="Where-16"></a>**Where-16**</a>
 
   Return elements, either from X or Y, depending on condition.
-      Where behaves like
-      [numpy.where](https://docs.scipy.org/doc/numpy/reference/generated/numpy.where.html)
-      with three parameters.
+  Where behaves like
+  [numpy.where](https://docs.scipy.org/doc/numpy/reference/generated/numpy.where.html)
+  with three parameters.
   
   This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+  
+  **History**
+    - Version 16 adds bfloat16 to the types allowed (for the second and third parameter).
 
 #### Version
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -20394,7 +20394,7 @@ This version of the operator has been available since version 16 of the default 
   This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
   
   **History**
-    - Version 16 adds bfloat16 to the types allowed (for the second and third parameter).
+  - Version 16 adds bfloat16 to the types allowed (for the second and third parameter).
 
 #### Version
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -20384,13 +20384,12 @@ This version of the operator has been available since version 16 of the default 
 
 ### <a name="Where-16"></a>**Where-16**</a>
 
-  Return elements, either from X or Y, depending on condition
-      (with Numpy-style broadcasting support).
-      Where behaves like numpy.where with three parameters:
-      https://docs.scipy.org/doc/numpy/reference/generated/numpy.where.html
+  Return elements, either from X or Y, depending on condition.
+      Where behaves like
+      [numpy.where](https://docs.scipy.org/doc/numpy/reference/generated/numpy.where.html)
+      with three parameters.
   
-  **History**
-  - Version 16 adds bfloat16 to the types allowed (for the second and third parameter).
+  This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
 #### Version
 

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -24099,11 +24099,14 @@ expect(node, inputs=[data, scales], outputs=[output],
 ### <a name="Where"></a><a name="where">**Where**</a>
 
   Return elements, either from X or Y, depending on condition.
-      Where behaves like
-      [numpy.where](https://docs.scipy.org/doc/numpy/reference/generated/numpy.where.html)
-      with three parameters.
+  Where behaves like
+  [numpy.where](https://docs.scipy.org/doc/numpy/reference/generated/numpy.where.html)
+  with three parameters.
   
   This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+  
+  **History**
+    - Version 16 adds bfloat16 to the types allowed (for the second and third parameter).
 
 #### Version
 

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -24098,13 +24098,12 @@ expect(node, inputs=[data, scales], outputs=[output],
 
 ### <a name="Where"></a><a name="where">**Where**</a>
 
-  Return elements, either from X or Y, depending on condition
-      (with Numpy-style broadcasting support).
-      Where behaves like numpy.where with three parameters:
-      https://docs.scipy.org/doc/numpy/reference/generated/numpy.where.html
+  Return elements, either from X or Y, depending on condition.
+      Where behaves like
+      [numpy.where](https://docs.scipy.org/doc/numpy/reference/generated/numpy.where.html)
+      with three parameters.
   
-  **History**
-  - Version 16 adds bfloat16 to the types allowed (for the second and third parameter).
+  This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
 #### Version
 

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -24106,7 +24106,7 @@ expect(node, inputs=[data, scales], outputs=[output],
   This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
   
   **History**
-    - Version 16 adds bfloat16 to the types allowed (for the second and third parameter).
+  - Version 16 adds bfloat16 to the types allowed (for the second and third parameter).
 
 #### Version
 

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -2911,7 +2911,7 @@ with three parameters.
 static const char* Where_ver16_history = R"DOC(
 
 **History**
-  - Version 16 adds bfloat16 to the types allowed (for the second and third parameter).
+- Version 16 adds bfloat16 to the types allowed (for the second and third parameter).
 )DOC";
 
 ONNX_OPERATOR_SET_SCHEMA(

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -2901,11 +2901,17 @@ ONNX_OPERATOR_SET_SCHEMA(
         }));
 
 static const char* Where_ver16_doc = R"DOC(
-    Return elements, either from X or Y, depending on condition.
-    Where behaves like
-    [numpy.where](https://docs.scipy.org/doc/numpy/reference/generated/numpy.where.html)
-    with three parameters.
+Return elements, either from X or Y, depending on condition.
+Where behaves like
+[numpy.where](https://docs.scipy.org/doc/numpy/reference/generated/numpy.where.html)
+with three parameters.
 
+)DOC";
+
+static const char* Where_ver16_history = R"DOC(
+
+**History**
+  - Version 16 adds bfloat16 to the types allowed (for the second and third parameter).
 )DOC";
 
 ONNX_OPERATOR_SET_SCHEMA(
@@ -2913,7 +2919,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     16,
     OpSchema()
         .SetDoc(GET_OP_DOC_STR(
-            std::string(Where_ver16_doc) + GenerateBroadcastingDocMul()))
+            std::string(Where_ver16_doc) + GenerateBroadcastingDocMul()) +
+            std::string(Where_ver16_history))
         .Input(
             0,
             "condition",

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -2901,20 +2901,19 @@ ONNX_OPERATOR_SET_SCHEMA(
         }));
 
 static const char* Where_ver16_doc = R"DOC(
-    Return elements, either from X or Y, depending on condition
-    (with Numpy-style broadcasting support).
-    Where behaves like numpy.where with three parameters:
-    https://docs.scipy.org/doc/numpy/reference/generated/numpy.where.html
+    Return elements, either from X or Y, depending on condition.
+    Where behaves like
+    [numpy.where](https://docs.scipy.org/doc/numpy/reference/generated/numpy.where.html)
+    with three parameters.
 
-**History**
-- Version 16 adds bfloat16 to the types allowed (for the second and third parameter).
 )DOC";
 
 ONNX_OPERATOR_SET_SCHEMA(
     Where,
     16,
     OpSchema()
-        .SetDoc(Where_ver16_doc)
+        .SetDoc(GET_OP_DOC_STR(
+            std::string(Where_ver16_doc) + GenerateBroadcastingDocMul()))
         .Input(
             0,
             "condition",

--- a/onnx/defs/tensor/old.cc
+++ b/onnx/defs/tensor/old.cc
@@ -4418,17 +4418,18 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
 
 static const char* Where_ver9_doc = R"DOC(
-    Return elements, either from X or Y, depending on condition
-    (with Numpy-style broadcasting support).
-    Where behaves like numpy.where with three parameters:
-    https://docs.scipy.org/doc/numpy/reference/generated/numpy.where.html
+Return elements, either from X or Y, depending on condition.
+Where behaves like
+[numpy.where](https://docs.scipy.org/doc/numpy/reference/generated/numpy.where.html)
+with three parameters.
+
 )DOC";
 
 ONNX_OPERATOR_SET_SCHEMA(
     Where,
     9,
     OpSchema()
-        .SetDoc(Where_ver9_doc)
+        .SetDoc(Where_ver9_doc + GenerateBroadcastingDocMul())
         .Input(
             0,
             "condition",


### PR DESCRIPTION
**Description**

Remove the history section. Although this is useful information, it made
it tricky to insert the broadcasting text at the right place, and it's
inconsistent with all the other operators, which don't have a history
section.

Also hide the numpy URL behind a link.

**Motivation and Context**

Makes it clear that the operator supports multidirectional broadcasting.

Signed-off-by: Gary Miguel <garymiguel@microsoft.com>