### PR TITLE
Fix some examples for ArgMax

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -669,7 +669,7 @@ node = onnx.helper.make_node(
     outputs=['result'],
     keepdims=keepdims)
 
-# result: [[1], [1]]
+# result: [[1, 1]]
 result = argmax_use_numpy(data, keepdims=keepdims)
 expect(node, inputs=[data], outputs=[result], name='test_argmax_default_axis_example')
 
@@ -827,7 +827,7 @@ node = onnx.helper.make_node(
     outputs=['result'],
     axis=axis,
     keepdims=keepdims)
-# result: [[0, 1]]
+# result: [0, 1]
 result = argmax_use_numpy(data, axis=axis, keepdims=keepdims)
 expect(node, inputs=[data], outputs=[result], name='test_argmax_no_keepdims_example')
 
@@ -854,7 +854,7 @@ node = onnx.helper.make_node(
     axis=axis,
     keepdims=keepdims,
     select_last_index=True)
-# result: [[1, 1]]
+# result: [1, 1]
 result = argmax_use_numpy_select_last_index(data, axis=axis, keepdims=keepdims)
 expect(node, inputs=[data], outputs=[result], name='test_argmax_no_keepdims_example_select_last_index')
 

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -426,7 +426,7 @@ node = onnx.helper.make_node(
     outputs=['result'],
     keepdims=keepdims)
 
-# result: [[1], [1]]
+# result: [[1, 1]]
 result = argmax_use_numpy(data, keepdims=keepdims)
 expect(node, inputs=[data], outputs=[result], name='test_argmax_default_axis_example')
 
@@ -572,7 +572,7 @@ node = onnx.helper.make_node(
     outputs=['result'],
     axis=axis,
     keepdims=keepdims)
-# result: [[0, 1]]
+# result: [0, 1]
 result = argmax_use_numpy(data, axis=axis, keepdims=keepdims)
 expect(node, inputs=[data], outputs=[result], name='test_argmax_no_keepdims_example')
 
@@ -597,7 +597,7 @@ node = onnx.helper.make_node(
     axis=axis,
     keepdims=keepdims,
     select_last_index=True)
-# result: [[1, 1]]
+# result: [1, 1]
 result = argmax_use_numpy_select_last_index(data, axis=axis, keepdims=keepdims)
 expect(node, inputs=[data], outputs=[result], name='test_argmax_no_keepdims_example_select_last_index')
 

--- a/onnx/backend/test/case/node/argmax.py
+++ b/onnx/backend/test/case/node/argmax.py
@@ -41,7 +41,7 @@ class ArgMax(Base):
             outputs=['result'],
             axis=axis,
             keepdims=keepdims)
-        # result: [[0, 1]]
+        # result: [0, 1]
         result = argmax_use_numpy(data, axis=axis, keepdims=keepdims)
         expect(node, inputs=[data], outputs=[result], name='test_argmax_no_keepdims_example')
 
@@ -80,7 +80,7 @@ class ArgMax(Base):
             outputs=['result'],
             keepdims=keepdims)
 
-        # result: [[1], [1]]
+        # result: [[1, 1]]
         result = argmax_use_numpy(data, keepdims=keepdims)
         expect(node, inputs=[data], outputs=[result], name='test_argmax_default_axis_example')
 
@@ -121,7 +121,7 @@ class ArgMax(Base):
             axis=axis,
             keepdims=keepdims,
             select_last_index=True)
-        # result: [[1, 1]]
+        # result: [1, 1]
         result = argmax_use_numpy_select_last_index(data, axis=axis, keepdims=keepdims)
         expect(node, inputs=[data], outputs=[result], name='test_argmax_no_keepdims_example_select_last_index')
 


### PR DESCRIPTION
- test_argmax_no_keepdims_example
- test_argmax_default_axis_example
- test_argmax_no_keepdims_example_select_last_index

Signed-off-by: Yi-Hong Lyu <yilyu@microsoft.com>