### PR TITLE
Fix type mapping error for uint8/16 in mapping.py

### DIFF
--- a/onnx/mapping.py
+++ b/onnx/mapping.py
@@ -34,9 +34,9 @@ NP_TYPE_TO_TENSOR_TYPE = {v: k for k, v in TENSOR_TYPE_TO_NP_TYPE.items() if k !
 
 TENSOR_TYPE_TO_STORAGE_TENSOR_TYPE = {
     int(TensorProto.FLOAT): int(TensorProto.FLOAT),
-    int(TensorProto.UINT8): int(TensorProto.INT32),
+    int(TensorProto.UINT8): int(TensorProto.UINT32),
     int(TensorProto.INT8): int(TensorProto.INT32),
-    int(TensorProto.UINT16): int(TensorProto.INT32),
+    int(TensorProto.UINT16): int(TensorProto.UINT32),
     int(TensorProto.INT16): int(TensorProto.INT32),
     int(TensorProto.INT32): int(TensorProto.INT32),
     int(TensorProto.INT64): int(TensorProto.INT64),


### PR DESCRIPTION
**Description**
- Changed the `TENSOR_TYPE_TO_STORAGE_TENSOR_TYPE` mapping for UINT8 and UINT16 from INT32 to UINT32.

**Motivation and Context**
- Using INT32 instead of UINT32 will make `helper.make_tensor` unable to store values greater than 127 for UINT8/UINT16 tensors (unless saving raw data directly, i.e. with raw=True).
