### PR TITLE
Fix old ConvTranspose shape inference and softmax upgrader

### DIFF
--- a/onnx/defs/nn/old.cc
+++ b/onnx/defs/nn/old.cc
@@ -1261,20 +1261,7 @@ void convTransposeShapeInference1(InferenceContext& ctx) {
     if ((nullptr != auto_pad_attr) && (auto_pad_attr->s() != "VALID")) {
       int input_dims_size = static_cast<int>(n_input_dims);
       for (int i = 0; i < input_dims_size; ++i) {
-        int64_t residual = 0;
-        int64_t stride = strides[i];
-        if (stride > 1) {
-          if (!input_shape.dim(2 + i).has_dim_value()) {
-            continue;
-          }
-          residual = input_shape.dim(2 + i).dim_value();
-          while (residual >= stride) {
-            residual -= stride;
-          }
-        }
-        int64_t total_pad = residual == 0
-            ? effective_kernel_shape[i] - stride
-            : effective_kernel_shape[i] - residual;
+        int64_t total_pad = effective_kernel_shape[i] - strides[i];
         if (total_pad < 0)
           total_pad = 0;
         int64_t half_pad_small = total_pad >> 1;

--- a/onnx/version_converter/adapters/softmax_12_13.h
+++ b/onnx/version_converter/adapters/softmax_12_13.h
@@ -19,7 +19,7 @@ class Softmax_12_13 final : public Adapter {
       int old_axis = node->hasAttribute(kaxis) ? node->i(kaxis) : 1;
       int input_rank = node->inputs()[0]->sizes().size();
 
-      if(old_axis < 0) old_axis = input_rank + old_axis + 1;
+      if(old_axis < 0) old_axis = input_rank + old_axis;
 
       if(old_axis == input_rank - 1)
         node->i_(kaxis, -1);


### PR DESCRIPTION
ConvTranspose shape inference fails in theis example for opset 10:
```
import onnx
from onnx import helper, TensorProto, shape_inference

node = helper.make_node(
	'ConvTranspose', 
	['in', 'w'], 
	['out'], 
	auto_pad='SAME_UPPER',
	strides=[2, 1]
)
nodes = [node]
inputs = [
    helper.make_tensor_value_info('in', TensorProto.FLOAT, [1, 3, 7, 5]),
    helper.make_tensor_value_info('w', TensorProto.INT64,  [3, 3, 2, 3])
]
outputs = [helper.make_tensor_value_info('out', TensorProto.FLOAT, [1, 3, 14, 5])]
graph = helper.make_graph(nodes, "g", inputs, outputs, [])

model = helper.make_model(graph, opset_imports=[helper.make_opsetid('', 11)])
shape_inference.infer_shapes(model)
print('ok!')

model = helper.make_model(graph, opset_imports=[helper.make_opsetid('', 10)])
shape_inference.infer_shapes(model)
print('ok!')
```
```
ok!
Traceback (most recent call last):
  File "script_convtranspose.py", line 24, in <module>
    shape_inference.infer_shapes(model)
  File "/home/matteo/.local/lib/python3.8/site-packages/onnx-1.10.2-py3.8-linux-x86_64.egg/onnx/shape_inference.py", line 42, in infer_shapes
    inferred_model_str = C.infer_shapes(model_str, check_type, strict_mode, data_prop)
onnx.onnx_cpp2py_export.shape_inference.InferenceError: [ShapeInferenceError] (op_type:ConvTranspose): [ShapeInferenceError] Inferred shape and existing shape differ in dimension 2: (13) vs (14)
```
ConvTranspose-11 expects a shape of `[1, 3, 14, 5]` while ConvTranspose-10 expects `[1, 3, 13, 5]`. The answer expected by ConvTranspose-10 is neither what one should normally expect from ConvTranspose nor what [the documentation states](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#convtranspose-1): "SAME_UPPER or SAME_LOWER mean pad the input so that the output spatial size match the input", in which case it should expect a size of 7 for the third dimension.

I think this is both a documentation bug (correct documentation should be "SAME_UPPER or SAME_LOWER mean pad the input so that `output_shape[i] = input_shape[i] * strides[i]` for each axis `i`" [as in ConvTranspose-11](https://github.com/onnx/onnx/blob/master/docs/Changelog.md#ConvTranspose-11)) and a shape inference bug. So I have fixed the latter by bringing [this change](https://github.com/onnx/onnx/pull/3188/files#diff-b9e98b88715e8a7e56c0dfa317f21a39582f919c87185f827c4a011ad9010639L1228) into the old shape inference code.

This PR also fixed a bug with with the softmax_12_13 adapter:
```
import onnx
from onnx import helper, TensorProto, version_converter

node = helper.make_node('Softmax', ['in'], ['out'], axis=-1)
nodes = [node]
inputs = [helper.make_tensor_value_info('in', TensorProto.FLOAT, [3])]
outputs = [helper.make_tensor_value_info('out', TensorProto.FLOAT, [3])]
graph = helper.make_graph(nodes, "g", inputs, outputs, [])

model = helper.make_model(graph, opset_imports=[helper.make_opsetid('', 12)])
converted = version_converter.convert_version(model, 15)

print('******** ORIGINAL MODEL ********')
print(model)

print('******** CONVERTED MODEL ********')
print(converted)
```
```
******** ORIGINAL MODEL ********
ir_version: 8
graph {
  node {
    input: "in"
    output: "out"
    op_type: "Softmax"
    attribute {
      name: "axis"
      i: -1
      type: INT
    }
  }
  name: "g"
  input {
    name: "in"
    type {
      tensor_type {
        elem_type: 1
        shape {
          dim {
            dim_value: 3
          }
        }
      }
    }
  }
  output {
    name: "out"
    type {
      tensor_type {
        elem_type: 1
        shape {
          dim {
            dim_value: 3
          }
        }
      }
    }
  }
}
opset_import {
  domain: ""
  version: 12
}

******** CONVERTED MODEL ********
ir_version: 8
graph {
  node {
    input: "in"
    output: "4"
    op_type: "Flatten"
    attribute {
      name: "axis"
      i: 1
      type: INT
    }
  }
  node {
    output: "6"
    op_type: "Constant"
    attribute {
      name: "value"
      t {
        dims: 1
        data_type: 7
        int64_data: 3
      }
      type: TENSOR
    }
  }
  node {
    input: "4"
    output: "out_intermediate"
    op_type: "Softmax"
    attribute {
      name: "axis"
      i: -1
      type: INT
    }
  }
  node {
    input: "out_intermediate"
    input: "6"
    output: "out"
    op_type: "Reshape"
  }
  name: "g"
  input {
    name: "in"
    type {
      tensor_type {
        elem_type: 1
        shape {
          dim {
            dim_value: 3
          }
        }
      }
    }
  }
  output {
    name: "out"
    type {
      tensor_type {
        elem_type: 1
        shape {
          dim {
            dim_value: 3
          }
        }
      }
    }
  }
  value_info {
    name: "out_intermediate"
    type {
      tensor_type {
        elem_type: 1
      }
    }
  }
}
opset_import {
  domain: ""
  version: 15
}
```
The converted model is wrong because Softmax-12 and Softmax-13 perform the same exact operation for axis=-1, so the upgraded model should be unchanged.