### PR TITLE
Honor existing dim_param in shape inference

### DIFF
--- a/onnx/shape_inference/implementation.cc
+++ b/onnx/shape_inference/implementation.cc
@@ -172,13 +172,8 @@ void mergeShapesAndTypes(const TypeProto_Tensor& inferredType, TypeProto_Tensor*
   }
 
   if (!existingType->has_shape()) {
-    // Ensure the shape is initialized. Note that this must be done
-    // even for (zero-dimensional) scalars.
-    existingType->mutable_shape();
-
-    for (int j = 0; j < inferredType.shape().dim_size(); ++j) {
-      existingType->mutable_shape()->add_dim();
-    }
+    *existingType->mutable_shape() = inferredType.shape();
+    return;
   }
 
   for (int i = 0; i < inferredType.shape().dim_size(); ++i) {
@@ -201,13 +196,8 @@ void mergeShapesAndTypes(const TypeProto_SparseTensor& inferredType, TypeProto_S
   }
 
   if (!existingType->has_shape()) {
-    // Ensure the shape is initialized. Note that this must be done
-    // even for (zero-dimensional) scalars.
-    existingType->mutable_shape();
-
-    for (int j = 0; j < inferredType.shape().dim_size(); ++j) {
-      existingType->mutable_shape()->add_dim();
-    }
+    *existingType->mutable_shape() = inferredType.shape();
+    return;
   }
 
   for (int i = 0; i < inferredType.shape().dim_size(); ++i) {

--- a/onnx/shape_inference/implementation.cc
+++ b/onnx/shape_inference/implementation.cc
@@ -184,7 +184,8 @@ void mergeShapesAndTypes(const TypeProto_Tensor& inferredType, TypeProto_Tensor*
   for (int i = 0; i < inferredType.shape().dim_size(); ++i) {
     const auto& inferredDim = inferredType.shape().dim(i);
     auto* existingDim = existingType->mutable_shape()->mutable_dim(i);
-    if (!existingDim->has_dim_value()) {
+    if ((!existingDim->has_dim_value() && !existingDim->has_dim_param()) ||
+        inferredDim.has_dim_value()) {
       *existingDim = inferredDim;
     }
   }
@@ -212,7 +213,8 @@ void mergeShapesAndTypes(const TypeProto_SparseTensor& inferredType, TypeProto_S
   for (int i = 0; i < inferredType.shape().dim_size(); ++i) {
     const auto& inferredDim = inferredType.shape().dim(i);
     auto* existingDim = existingType->mutable_shape()->mutable_dim(i);
-    if (!existingDim->has_dim_value()) {
+    if ((!existingDim->has_dim_value() && !existingDim->has_dim_param()) ||
+        inferredDim.has_dim_value()) {
       *existingDim = inferredDim;
     }
   }

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -74,7 +74,7 @@ class TestShapeInference(unittest.TestCase):
                 inferred_dim = inferred_vi_type.tensor_type.shape.dim[dim_i]
                 # if it is a symbolic shape, make sure the inferred symbol has generated (dim_param)
                 if dim.dim_param:
-                    assert inferred_dim.dim_param, '\n%s\n%s\n' % (vi_type, inferred_vi_type)
+                    assert dim.dim_param == inferred_dim.dim_param, '\n%s\n%s\n' % (vi_type, inferred_vi_type)
                 else:
                     assert dim.dim_value == inferred_dim.dim_value, '\n%s\n%s\n' % (vi_type, inferred_vi_type)
         elif vi_type.HasField('sequence_type'):
@@ -3774,6 +3774,13 @@ class TestShapeInference(unittest.TestCase):
             [make_node('NonZero', ['x'], ['out'])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.INT64, (None, None))])  # type: ignore
+
+    def test_nonzero_existing_dim_param(self):  # type: () -> None
+        graph = self._make_graph(
+            [('x', TensorProto.FLOAT, (3,))],
+            [make_node('NonZero', ['x'], ['y'])],
+            [make_tensor_value_info('y', TensorProto.INT64, (None, 'NZ'))])
+        self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, (1, 'NZ'))])  # type: ignore
 
     def test_optional_construct_empty_tensor(self):  # type: () -> None
         tensor_type_proto = helper.make_tensor_type_proto(elem_type=TensorProto.FLOAT, shape=[1, 2, 3])

--- a/onnx/test/symbolic_shape_test.py
+++ b/onnx/test/symbolic_shape_test.py
@@ -76,14 +76,14 @@ class TestSymbolicShape(unittest.TestCase):
             nodes=[concat, cast],
             inputs=[helper.make_tensor_value_info('A', TensorProto.FLOAT, [2, 'A']),
                 helper.make_tensor_value_info('B', TensorProto.FLOAT, [2, 3])],
-            outputs=[helper.make_tensor_value_info('output', TensorProto.FLOAT, [2, 'M'])]
+            outputs=[helper.make_tensor_value_info('output', TensorProto.FLOAT, [2, None])]
         )
 
         onnx_model = make_model(graph_def)
         inferred_model = onnx.shape_inference.infer_shapes(onnx_model, strict_mode=True)
-        self._assert_valueinfo_shape(inferred_model, [
-            make_tensor_value_info("C", TensorProto.FLOAT, (2, -1)),
-            make_tensor_value_info("output", TensorProto.FLOAT, (2, 'M'))])
+        self._assert_valueinfo_shape(inferred_model, [make_tensor_value_info("C", TensorProto.FLOAT, (2, -1))])
+        # the symbolic shape of C and output should be the same
+        assert self._get_shape_from_name(inferred_model, 'C') == self._get_shape_from_name(inferred_model, 'output')
 
     def test_two_symbolic_concat(self):  # type: () -> None
         concat1 = helper.make_node('Concat', inputs=['A', 'B'], outputs=['C'], name='Concat', axis=1)
@@ -97,15 +97,16 @@ class TestSymbolicShape(unittest.TestCase):
             inputs=[helper.make_tensor_value_info('A', TensorProto.FLOAT, [2, 'A']),
                 helper.make_tensor_value_info('B', TensorProto.FLOAT, [2, 3]),
                 helper.make_tensor_value_info('D', TensorProto.FLOAT, [2, 'D'])],
-            outputs=[helper.make_tensor_value_info('output', TensorProto.FLOAT, [2, 'M'])]
+            outputs=[helper.make_tensor_value_info('output', TensorProto.FLOAT, [2, None])]
         )
 
         onnx_model = make_model(graph_def)
         inferred_model = onnx.shape_inference.infer_shapes(onnx_model, strict_mode=True)
         self._assert_valueinfo_shape(inferred_model, [
             make_tensor_value_info("C", TensorProto.FLOAT, (2, -1)),
-            make_tensor_value_info("E", TensorProto.FLOAT, (2, -1)),
-            make_tensor_value_info("output", TensorProto.FLOAT, (2, 'M'))])
+            make_tensor_value_info("E", TensorProto.FLOAT, (2, -1))])
+        # the symbolic shape of E and output should be the same
+        assert self._get_shape_from_name(inferred_model, 'E') == self._get_shape_from_name(inferred_model, 'output')
 
     def test_duplicate_symbolic_shape(self):  # type: () -> None
         concat1 = helper.make_node('Concat', inputs=['A', 'B'], outputs=['C'], name='Concat', axis=1)

--- a/onnx/test/symbolic_shape_test.py
+++ b/onnx/test/symbolic_shape_test.py
@@ -81,9 +81,9 @@ class TestSymbolicShape(unittest.TestCase):
 
         onnx_model = make_model(graph_def)
         inferred_model = onnx.shape_inference.infer_shapes(onnx_model, strict_mode=True)
-        self._assert_valueinfo_shape(inferred_model, [make_tensor_value_info("C", TensorProto.FLOAT, (2, -1))])
-        # the symbolic shape of C and output should be the same
-        assert self._get_shape_from_name(inferred_model, 'C') == self._get_shape_from_name(inferred_model, 'output')
+        self._assert_valueinfo_shape(inferred_model, [
+            make_tensor_value_info("C", TensorProto.FLOAT, (2, -1)),
+            make_tensor_value_info("output", TensorProto.FLOAT, (2, 'M'))])
 
     def test_two_symbolic_concat(self):  # type: () -> None
         concat1 = helper.make_node('Concat', inputs=['A', 'B'], outputs=['C'], name='Concat', axis=1)
@@ -104,9 +104,8 @@ class TestSymbolicShape(unittest.TestCase):
         inferred_model = onnx.shape_inference.infer_shapes(onnx_model, strict_mode=True)
         self._assert_valueinfo_shape(inferred_model, [
             make_tensor_value_info("C", TensorProto.FLOAT, (2, -1)),
-            make_tensor_value_info("E", TensorProto.FLOAT, (2, -1))])
-        # the symbolic shape of E and output should be the same
-        assert self._get_shape_from_name(inferred_model, 'E') == self._get_shape_from_name(inferred_model, 'output')
+            make_tensor_value_info("E", TensorProto.FLOAT, (2, -1)),
+            make_tensor_value_info("output", TensorProto.FLOAT, (2, 'M'))])
 
     def test_duplicate_symbolic_shape(self):  # type: () -> None
         concat1 = helper.make_node('Concat', inputs=['A', 'B'], outputs=['C'], name='Concat', axis=1)


### PR DESCRIPTION
**Description**

Before this change, existing `dim_param` was overwritten by generated symbols like `unk__`. `NonZero` is used to test the behavior.



**Motivation and Context**

We'd like to annotate output values of ops which produce unknown dims (e.g., NonZero) by pre-setting `dim_param`s of such values. However, current ONNX overwrites them.

Reproduce script:

```
import onnx
import onnx.shape_inference
import torch


class NonZero(torch.nn.Module):
    def forward(self, x):
        return torch.nonzero(x)


x = torch.rand(7)
torch.onnx.export(NonZero(), x, "nonzero.onnx",
                  output_names=["y"],
                  dynamic_axes={"y": {0: "NZ"}})
model = onnx.load("nonzero.onnx")
model = onnx.shape_inference.infer_shapes(model)
print(model.graph.output)  # "NZ" is overwritten by "unk__0"
```


Previous behavior:

| inferred\existing | dim_value | dim_param | N/A |
| - | - | - | - |
| dim_value | error | inferred | inferred |
| dim_param | existing | inferred | inferred |
| unk__ | existing | inferred | inferred |

This PR:

| inferred\existing | dim_value | dim_param | N/A |
| - | - | - | - |
| dim_value | error | inferred | inferred |
| dim_param | existing | **existing** (1) | inferred |
| unk__ | existing | **existing** (2) | inferred |

I guess no one would object the change for (2) in the above table, which is the reason why I created this PR. I'm not sure about (1). To me, it is more natural to check if the existing `dim_param` is equal to the inferred one like what we do for `dim_value`, but it'd break backward compatibility. What do you think?
