### PR TITLE
Fix weekly/Linux CI failures: correct skip list and remove old numpy related code

### DIFF
--- a/onnx/examples/np_array_tensorproto.ipynb
+++ b/onnx/examples/np_array_tensorproto.ipynb
@@ -10,8 +10,8 @@
      "output_type": "stream",
      "text": [
       "Original Numpy array:\n",
-      "[[ 1.  2.  3.]\n",
-      " [ 4.  5.  6.]]\n",
+      "[[1. 2. 3.]\n",
+      " [4. 5. 6.]]\n",
       "\n"
      ]
     }
@@ -26,10 +26,7 @@
     "\n",
     "# Preprocessing: create a Numpy array\n",
     "numpy_array = numpy.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=float)\n",
-    "if LooseVersion(numpy.version.version) < LooseVersion('1.14'):\n",
-    "    print('Original Numpy array:\\n{}\\n'.format(numpy.array2string(numpy_array)))\n",
-    "else:\n",
-    "    print('Original Numpy array:\\n{}\\n'.format(numpy.array2string(numpy_array, legacy='1.13')))"
+    "print('Original Numpy array:\\n{}\\n'.format(numpy.array2string(numpy_array)))"
    ]
   },
   {
@@ -66,8 +63,8 @@
      "output_type": "stream",
      "text": [
       "After round trip, Numpy array:\n",
-      "[[ 1.  2.  3.]\n",
-      " [ 4.  5.  6.]]\n",
+      "[[1. 2. 3.]\n",
+      " [4. 5. 6.]]\n",
       "\n"
      ]
     }
@@ -75,10 +72,7 @@
    "source": [
     "# Convert the TensorProto to a Numpy array\n",
     "new_array = numpy_helper.to_array(tensor)\n",
-    "if LooseVersion(numpy.version.version) < LooseVersion('1.14'):\n",
-    "    print('After round trip, Numpy array:\\n{}\\n'.format(numpy.array2string(numpy_array)))\n",
-    "else:\n",
-    "    print('After round trip, Numpy array:\\n{}\\n'.format(numpy.array2string(numpy_array, legacy='1.13')))"
+    "print('After round trip, Numpy array:\\n{}\\n'.format(numpy.array2string(numpy_array)))"
    ]
   },
   {

--- a/workflow_scripts/config.py
+++ b/workflow_scripts/config.py
@@ -4,6 +4,7 @@
 # Skip them in test_model_zoo.py for now
 # TODO: fix these checker failures
 SKIP_CHECKER_MODELS = {'vision/classification/alexnet/model/bvlcalexnet-3.onnx',  # opset1 typeinference function missing
+                       'vision/classification/caffenet/model/caffenet-3.onnx',  # opset1 typeinference function missing
                        'vision/classification/densenet-121/model/densenet-3.onnx',  # opset1 typeinference function missing
                        'vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-3.onnx',  # opset1 typeinference function missing
                        'vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-3.onnx',  # opset1 typeinference function missing


### PR DESCRIPTION
**Description**
- Revert: Add caffe3 model into skip list again
- Try to retire code related to old numpy (1.13) since now ONNX requires numpy >=1.16

**Motivation and Context**
- Weekly-ci for testing ONNX model zoo failed due to removing caffe3 model for testing accidentally
- Linux-CI failed due to numpy