### PR TITLE
Fix Linux i686 Release CI failure due to the latest NumPy

### DIFF
--- a/.github/workflows/manylinux/test_package_i686.sh
+++ b/.github/workflows/manylinux/test_package_i686.sh
@@ -29,9 +29,12 @@ $PYTEST_COMMAND
 # Test backend test data
 # onnx.checker all existing backend data
 $PYTHON_COMAND workflow_scripts/test_generated_backend.py
+# onnx.checker all generated backend data
+$PYTHON_COMAND onnx/backend/test/cmd_tools.py generate-data
+$PYTHON_COMAND workflow_scripts/test_generated_backend.py
 
 # Verify ONNX with the latest numpy
-$PIP_UNINSTALL_COMMAND numpy onnx && $PIP_INSTALL_COMMAND numpy
+$PIP_UNINSTALL_COMMAND numpy onnx && $PIP_INSTALL_COMMAND numpy==1.21.5
 $PIP_INSTALL_COMMAND dist/*manylinux2010_i686.whl
 $PYTEST_COMMAND
 

--- a/.github/workflows/manylinux/test_package_i686.sh
+++ b/.github/workflows/manylinux/test_package_i686.sh
@@ -20,7 +20,11 @@ PYTEST_COMMAND="${PYTHON_BIN}pytest"
 $PIP_INSTALL_COMMAND --upgrade pip
 
 # pip install -r requirements-release will bump into issue in i686 due to pip install cryptography failure
-$PIP_INSTALL_COMMAND numpy protobuf==3.16.0 pytest==5.4.3 nbval ipython==7.16.1 || { echo "Installing Python requirements failed."; exit 1; }
+if [ "PY_VERSION" == "3.8" ] || [ "PY_VERSION" == "3.9" ]; then
+    $PIP_INSTALL_COMMAND numpy==1.21.5 protobuf==3.16.0 pytest==5.4.3 nbval ipython==7.16.1 || { echo "Installing Python requirements failed."; exit 1; }
+else
+    $PIP_INSTALL_COMMAND numpy==1.16.6 protobuf==3.16.0 pytest==5.4.3 nbval ipython==7.16.1 || { echo "Installing Python requirements failed."; exit 1; }
+fi
 $PIP_INSTALL_COMMAND dist/*manylinux2010_i686.whl
 
 # pytest with the built wheel
@@ -34,7 +38,11 @@ $PYTHON_COMAND onnx/backend/test/cmd_tools.py generate-data
 $PYTHON_COMAND workflow_scripts/test_generated_backend.py
 
 # Verify ONNX with the latest numpy
-$PIP_UNINSTALL_COMMAND numpy onnx && $PIP_INSTALL_COMMAND numpy
+if [ "PY_VERSION" == "3.8" ] || [ "PY_VERSION" == "3.9" ]; then
+    $PIP_UNINSTALL_COMMAND numpy==1.21.5 onnx && $PIP_INSTALL_COMMAND numpy
+else
+    $PIP_UNINSTALL_COMMAND numpy onnx && $PIP_INSTALL_COMMAND numpy
+fi
 $PIP_INSTALL_COMMAND dist/*manylinux2010_i686.whl
 $PYTEST_COMMAND
 

--- a/.github/workflows/manylinux/test_package_i686.sh
+++ b/.github/workflows/manylinux/test_package_i686.sh
@@ -20,7 +20,12 @@ PYTEST_COMMAND="${PYTHON_BIN}pytest"
 $PIP_INSTALL_COMMAND --upgrade pip
 
 # pip install -r requirements-release will bump into issue in i686 due to pip install cryptography failure
-$PIP_INSTALL_COMMAND numpy==1.16.6 protobuf==3.16.0 pytest==5.4.3 nbval ipython==7.16.1 || { echo "Installing Python requirements failed."; exit 1; }
+# Verify ONNX with the latest numpy
+if [ "$PY_VERSION" == "3.8" ] || [ "$PY_VERSION" == "3.9" ]; then
+    $PIP_INSTALL_COMMAND numpy==1.21.5 protobuf==3.16.0 pytest==5.4.3 nbval ipython==7.16.1 || { echo "Installing Python requirements failed."; exit 1; }
+else
+    $PIP_INSTALL_COMMAND numpy==1.16.6 protobuf==3.16.0 pytest==5.4.3 nbval ipython==7.16.1 || { echo "Installing Python requirements failed."; exit 1; }
+fi
 $PIP_INSTALL_COMMAND dist/*manylinux2010_i686.whl
 
 # pytest with the built wheel

--- a/.github/workflows/manylinux/test_package_i686.sh
+++ b/.github/workflows/manylinux/test_package_i686.sh
@@ -20,11 +20,7 @@ PYTEST_COMMAND="${PYTHON_BIN}pytest"
 $PIP_INSTALL_COMMAND --upgrade pip
 
 # pip install -r requirements-release will bump into issue in i686 due to pip install cryptography failure
-if [ "PY_VERSION" == "3.8" ] || [ "PY_VERSION" == "3.9" ]; then
-    $PIP_INSTALL_COMMAND numpy==1.21.4 protobuf==3.16.0 pytest==5.4.3 nbval ipython==7.16.1 || { echo "Installing Python requirements failed."; exit 1; }
-else
-    $PIP_INSTALL_COMMAND numpy==1.16.6 protobuf==3.16.0 pytest==5.4.3 nbval ipython==7.16.1 || { echo "Installing Python requirements failed."; exit 1; }
-fi
+$PIP_INSTALL_COMMAND numpy protobuf==3.16.0 pytest==5.4.3 nbval ipython==7.16.1 || { echo "Installing Python requirements failed."; exit 1; }
 $PIP_INSTALL_COMMAND dist/*manylinux2010_i686.whl
 
 # pytest with the built wheel
@@ -38,11 +34,7 @@ $PYTHON_COMAND onnx/backend/test/cmd_tools.py generate-data
 $PYTHON_COMAND workflow_scripts/test_generated_backend.py
 
 # Verify ONNX with the latest numpy
-if [ "PY_VERSION" == "3.8" ] || [ "PY_VERSION" == "3.9" ]; then
-    $PIP_UNINSTALL_COMMAND numpy==1.21.4 onnx && $PIP_INSTALL_COMMAND numpy
-else
-    $PIP_UNINSTALL_COMMAND numpy onnx && $PIP_INSTALL_COMMAND numpy
-fi
+$PIP_UNINSTALL_COMMAND numpy onnx && $PIP_INSTALL_COMMAND numpy
 $PIP_INSTALL_COMMAND dist/*manylinux2010_i686.whl
 $PYTEST_COMMAND
 

--- a/.github/workflows/manylinux/test_package_i686.sh
+++ b/.github/workflows/manylinux/test_package_i686.sh
@@ -34,7 +34,11 @@ $PYTHON_COMAND onnx/backend/test/cmd_tools.py generate-data
 $PYTHON_COMAND workflow_scripts/test_generated_backend.py
 
 # Verify ONNX with the latest numpy
-$PIP_UNINSTALL_COMMAND numpy onnx && $PIP_INSTALL_COMMAND numpy==1.21.5
+if [ "PY_VERSION" == "3.8" ] || [ "PY_VERSION" == "3.9" ]; then
+    $PIP_UNINSTALL_COMMAND numpy onnx && $PIP_INSTALL_COMMAND numpy==1.21.5
+else
+    $PIP_UNINSTALL_COMMAND numpy onnx && $PIP_INSTALL_COMMAND numpy
+fi
 $PIP_INSTALL_COMMAND dist/*manylinux2010_i686.whl
 $PYTEST_COMMAND
 

--- a/.github/workflows/manylinux/test_package_i686.sh
+++ b/.github/workflows/manylinux/test_package_i686.sh
@@ -29,9 +29,6 @@ $PYTEST_COMMAND
 # Test backend test data
 # onnx.checker all existing backend data
 $PYTHON_COMAND workflow_scripts/test_generated_backend.py
-# onnx.checker all generated backend data
-$PYTHON_COMAND onnx/backend/test/cmd_tools.py generate-data
-$PYTHON_COMAND workflow_scripts/test_generated_backend.py
 
 # Verify ONNX with the latest numpy
 if [ "PY_VERSION" == "3.8" ] || [ "PY_VERSION" == "3.9" ]; then

--- a/.github/workflows/manylinux/test_package_i686.sh
+++ b/.github/workflows/manylinux/test_package_i686.sh
@@ -29,6 +29,9 @@ $PYTEST_COMMAND
 # Test backend test data
 # onnx.checker all existing backend data
 $PYTHON_COMAND workflow_scripts/test_generated_backend.py
+# onnx.checker all generated backend data
+$PYTHON_COMAND onnx/backend/test/cmd_tools.py generate-data
+$PYTHON_COMAND workflow_scripts/test_generated_backend.py
 
 # Verify ONNX with the latest numpy
 if [ "$PY_VERSION" == "3.8" ] || [ "$PY_VERSION" == "3.9" ]; then

--- a/.github/workflows/manylinux/test_package_i686.sh
+++ b/.github/workflows/manylinux/test_package_i686.sh
@@ -29,9 +29,6 @@ $PYTEST_COMMAND
 # Test backend test data
 # onnx.checker all existing backend data
 $PYTHON_COMAND workflow_scripts/test_generated_backend.py
-# onnx.checker all generated backend data
-$PYTHON_COMAND onnx/backend/test/cmd_tools.py generate-data
-$PYTHON_COMAND workflow_scripts/test_generated_backend.py
 
 # Verify ONNX with the latest numpy
 $PIP_UNINSTALL_COMMAND numpy onnx && $PIP_INSTALL_COMMAND numpy

--- a/.github/workflows/manylinux/test_package_i686.sh
+++ b/.github/workflows/manylinux/test_package_i686.sh
@@ -21,7 +21,7 @@ $PIP_INSTALL_COMMAND --upgrade pip
 
 # pip install -r requirements-release will bump into issue in i686 due to pip install cryptography failure
 if [ "PY_VERSION" == "3.8" ] || [ "PY_VERSION" == "3.9" ]; then
-    $PIP_INSTALL_COMMAND numpy==1.21.5 protobuf==3.16.0 pytest==5.4.3 nbval ipython==7.16.1 || { echo "Installing Python requirements failed."; exit 1; }
+    $PIP_INSTALL_COMMAND numpy==1.21.4 protobuf==3.16.0 pytest==5.4.3 nbval ipython==7.16.1 || { echo "Installing Python requirements failed."; exit 1; }
 else
     $PIP_INSTALL_COMMAND numpy==1.16.6 protobuf==3.16.0 pytest==5.4.3 nbval ipython==7.16.1 || { echo "Installing Python requirements failed."; exit 1; }
 fi
@@ -39,7 +39,7 @@ $PYTHON_COMAND workflow_scripts/test_generated_backend.py
 
 # Verify ONNX with the latest numpy
 if [ "PY_VERSION" == "3.8" ] || [ "PY_VERSION" == "3.9" ]; then
-    $PIP_UNINSTALL_COMMAND numpy==1.21.5 onnx && $PIP_INSTALL_COMMAND numpy
+    $PIP_UNINSTALL_COMMAND numpy==1.21.4 onnx && $PIP_INSTALL_COMMAND numpy
 else
     $PIP_UNINSTALL_COMMAND numpy onnx && $PIP_INSTALL_COMMAND numpy
 fi

--- a/.github/workflows/manylinux/test_package_i686.sh
+++ b/.github/workflows/manylinux/test_package_i686.sh
@@ -24,7 +24,7 @@ $PIP_INSTALL_COMMAND --upgrade pip
 if [ "$PY_VERSION" == "3.8" ] || [ "$PY_VERSION" == "3.9" ]; then
     $PIP_INSTALL_COMMAND numpy==1.21.5 protobuf==3.16.0 pytest==5.4.3 nbval ipython==7.16.1 || { echo "Installing Python requirements failed."; exit 1; }
 else
-    $PIP_INSTALL_COMMAND numpy==1.16.6 protobuf==3.16.0 pytest==5.4.3 nbval ipython==7.16.1 || { echo "Installing Python requirements failed."; exit 1; }
+    $PIP_INSTALL_COMMAND numpy protobuf==3.16.0 pytest==5.4.3 nbval ipython==7.16.1 || { echo "Installing Python requirements failed."; exit 1; }
 fi
 $PIP_INSTALL_COMMAND dist/*manylinux2010_i686.whl
 

--- a/.github/workflows/manylinux/test_package_i686.sh
+++ b/.github/workflows/manylinux/test_package_i686.sh
@@ -20,11 +20,7 @@ PYTEST_COMMAND="${PYTHON_BIN}pytest"
 $PIP_INSTALL_COMMAND --upgrade pip
 
 # pip install -r requirements-release will bump into issue in i686 due to pip install cryptography failure
-if [ "PY_VERSION" == "3.8" ] || [ "PY_VERSION" == "3.9" ]; then
-    $PIP_INSTALL_COMMAND numpy==1.21.5 protobuf==3.16.0 pytest==5.4.3 nbval ipython==7.16.1 || { echo "Installing Python requirements failed."; exit 1; }
-else
-    $PIP_INSTALL_COMMAND numpy==1.16.6 protobuf==3.16.0 pytest==5.4.3 nbval ipython==7.16.1 || { echo "Installing Python requirements failed."; exit 1; }
-fi
+$PIP_INSTALL_COMMAND numpy==1.16.6 protobuf==3.16.0 pytest==5.4.3 nbval ipython==7.16.1 || { echo "Installing Python requirements failed."; exit 1; }
 $PIP_INSTALL_COMMAND dist/*manylinux2010_i686.whl
 
 # pytest with the built wheel
@@ -39,7 +35,7 @@ $PYTHON_COMAND workflow_scripts/test_generated_backend.py
 
 # Verify ONNX with the latest numpy
 if [ "PY_VERSION" == "3.8" ] || [ "PY_VERSION" == "3.9" ]; then
-    $PIP_UNINSTALL_COMMAND numpy==1.21.5 onnx && $PIP_INSTALL_COMMAND numpy
+    $PIP_UNINSTALL_COMMAND numpy onnx && $PIP_INSTALL_COMMAND numpy==1.21.5
 else
     $PIP_UNINSTALL_COMMAND numpy onnx && $PIP_INSTALL_COMMAND numpy
 fi

--- a/.github/workflows/manylinux/test_package_i686.sh
+++ b/.github/workflows/manylinux/test_package_i686.sh
@@ -31,7 +31,7 @@ $PYTEST_COMMAND
 $PYTHON_COMAND workflow_scripts/test_generated_backend.py
 
 # Verify ONNX with the latest numpy
-if [ "PY_VERSION" == "3.8" ] || [ "PY_VERSION" == "3.9" ]; then
+if [ "$PY_VERSION" == "3.8" ] || [ "$PY_VERSION" == "3.9" ]; then
     $PIP_UNINSTALL_COMMAND numpy onnx && $PIP_INSTALL_COMMAND numpy==1.21.5
 else
     $PIP_UNINSTALL_COMMAND numpy onnx && $PIP_INSTALL_COMMAND numpy

--- a/.github/workflows/manylinux/test_package_i686.sh
+++ b/.github/workflows/manylinux/test_package_i686.sh
@@ -34,11 +34,7 @@ $PYTHON_COMAND onnx/backend/test/cmd_tools.py generate-data
 $PYTHON_COMAND workflow_scripts/test_generated_backend.py
 
 # Verify ONNX with the latest numpy
-if [ "PY_VERSION" == "3.8" ] || [ "PY_VERSION" == "3.9" ]; then
-    $PIP_UNINSTALL_COMMAND numpy onnx && $PIP_INSTALL_COMMAND numpy==1.21.5
-else
-    $PIP_UNINSTALL_COMMAND numpy onnx && $PIP_INSTALL_COMMAND numpy
-fi
+$PIP_UNINSTALL_COMMAND numpy onnx && $PIP_INSTALL_COMMAND numpy
 $PIP_INSTALL_COMMAND dist/*manylinux2010_i686.whl
 $PYTEST_COMMAND
 

--- a/.github/workflows/release_linux_i686.yml
+++ b/.github/workflows/release_linux_i686.yml
@@ -41,13 +41,13 @@ jobs:
         sudo apt-get install protobuf-compiler libprotoc-dev
 
     - name: Build manylinux2010_i686
-      uses: docker://quay.io/pypa/manylinux2010_i686
+      uses: docker://quay.io/pypa/manylinux2010_i686:6be8011a073feeca08d256ac64335a19fc8eee4c6312668b6781ace71db0de20
       with:
         entrypoint: bash
         args: .github/workflows/manylinux/entrypoint.sh ${{ matrix.python-version }} manylinux2010_i686 ${{ github.event_name }}
 
     - name: Test manylinux2010_i686 package in a clean docker environment
-      uses: docker://quay.io/pypa/manylinux2010_i686
+      uses: docker://quay.io/pypa/manylinux2010_i686:6be8011a073feeca08d256ac64335a19fc8eee4c6312668b6781ace71db0de20
       with:
         entrypoint: bash
         args: .github/workflows/manylinux/test_package_i686.sh ${{ matrix.python-version }}

--- a/.github/workflows/release_linux_i686.yml
+++ b/.github/workflows/release_linux_i686.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install python dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install numpy protobuf==3.16.0
+        python -m pip install numpy==1.16.6 protobuf==3.16.0
         sudo apt-get install protobuf-compiler libprotoc-dev
 
     - name: Build manylinux2010_i686

--- a/.github/workflows/release_linux_i686.yml
+++ b/.github/workflows/release_linux_i686.yml
@@ -34,20 +34,14 @@ jobs:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.architecture }}
 
-    - name: Install python dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install numpy==1.16.6 protobuf==3.16.0
-        sudo apt-get install protobuf-compiler libprotoc-dev
-
     - name: Build manylinux2010_i686
-      uses: docker://quay.io/pypa/manylinux2010_i686:2021-12-19-a4d7f5a
+      uses: docker://quay.io/pypa/manylinux2010_i686
       with:
         entrypoint: bash
         args: .github/workflows/manylinux/entrypoint.sh ${{ matrix.python-version }} manylinux2010_i686 ${{ github.event_name }}
 
     - name: Test manylinux2010_i686 package in a clean docker environment
-      uses: docker://quay.io/pypa/manylinux2010_i686:2021-12-19-a4d7f5a
+      uses: docker://quay.io/pypa/manylinux2010_i686
       with:
         entrypoint: bash
         args: .github/workflows/manylinux/test_package_i686.sh ${{ matrix.python-version }}

--- a/.github/workflows/release_linux_i686.yml
+++ b/.github/workflows/release_linux_i686.yml
@@ -41,13 +41,13 @@ jobs:
         sudo apt-get install protobuf-compiler libprotoc-dev
 
     - name: Build manylinux2010_i686
-      uses: docker://quay.io/pypa/manylinux2010_i686:6be8011a073feeca08d256ac64335a19fc8eee4c6312668b6781ace71db0de20
+      uses: docker://quay.io/pypa/manylinux2010_i686:2021-12-19-a4d7f5a
       with:
         entrypoint: bash
         args: .github/workflows/manylinux/entrypoint.sh ${{ matrix.python-version }} manylinux2010_i686 ${{ github.event_name }}
 
     - name: Test manylinux2010_i686 package in a clean docker environment
-      uses: docker://quay.io/pypa/manylinux2010_i686:6be8011a073feeca08d256ac64335a19fc8eee4c6312668b6781ace71db0de20
+      uses: docker://quay.io/pypa/manylinux2010_i686:2021-12-19-a4d7f5a
       with:
         entrypoint: bash
         args: .github/workflows/manylinux/test_package_i686.sh ${{ matrix.python-version }}


### PR DESCRIPTION
**Description**
Froze NumPy version as previous version (1.21.5) for Python 3.8 and Python 3.9.

**Motivation and Context**
Linux-i686-release CI is failing.