### PR TITLE
Remind release manager to remove old onnx-weekly packages after release

### DIFF
--- a/docs/OnnxReleases.md
+++ b/docs/OnnxReleases.md
@@ -117,3 +117,4 @@ The ONNX project, going forward, will plan to release roughly on a four month ca
 
 **Remove old onnx-weekly packages on TestPyPI**
 * Once ONNX has been released on PyPI, remove all previous versions of [onnx-weekly package](https://test.pypi.org/project/onnx-weekly/#history) on TestPyPI to save space.
+* Steps: Login and go [here](https://test.pypi.org/manage/project/onnx-weekly/releases/) -> Choose target package -> Options -> Delete.

--- a/docs/OnnxReleases.md
+++ b/docs/OnnxReleases.md
@@ -115,8 +115,5 @@ The ONNX project, going forward, will plan to release roughly on a four month ca
 **Merge into main branch**
 * After everything above is done, merge the release branch into the main branch to make it consistent.
 
-## TODO list for next release
-* Remove `onnx.optimizer` in ONNX 1.9
-* Be aware of protobuf version gap issue (like building onnx with protobuf>=3.12 is not compatible with older protobuf)
-* (Optional) Deprecate Python 3.5 and add Python 3.9.
-* (Optional) Automatically upload created wheels for Windows
+**Remove old onnx-weekly packages on TestPyPI**
+* Once ONNX has been released on PyPI, remove all previous versions of [onnx-weekly package](https://test.pypi.org/project/onnx-weekly/#history) on TestPyPI to save space.


### PR DESCRIPTION
**Description**
- Remind release manager to remove old onnx-weekly packages after release
- Remove old instructions (1.9) since they have been done

**Motivation and Context**
Space on TestPyPI is limited and onnx-weekly package keeps using more and more space because it releases packages weekly. To save space, this time I manually removed some old packages. In the future, it would be better for release managers to handle it after every release.
