### PR TITLE
Enable ConstantOfShape to get data from data propagation

### DIFF
--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -291,7 +291,6 @@ ONNX_OPERATOR_SET_SCHEMA(
               fail_shape_inference("Invalid shape value: ", targetShapeElem);
             }
           }
-
         }));
 
 static const char* EyeLike_ver9_doc = R"DOC(


### PR DESCRIPTION
**Description**
Enable ConstantOfShape to get data from data propagation.

**Motivation and Context**
https://github.com/onnx/onnx/issues/3929 ConstantOfShape cannot get the result from data propagation.