### PR TITLE
Bump to 10.15 in AzurePipeline because 10.14 was deprecated

### DIFF
--- a/.azure-pipelines/MacOS-CI.yml
+++ b/.azure-pipelines/MacOS-CI.yml
@@ -4,7 +4,7 @@ trigger:
 jobs:
 - job: 'Test'
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   strategy:
     matrix:
       py36:

--- a/.github/workflows/weekly_mac_ci.yml
+++ b/.github/workflows/weekly_mac_ci.yml
@@ -2,7 +2,7 @@
 # Runs model checker for all models
 name: Weekly CI with latest onnx.checker
 
-# Triggers the workflow on push or pull request events but only for the master branch
+# Triggers the workflow on push or pull request events but only for the main branch
 on:
   schedule:
     # run weekly on Sunday 23:59

--- a/onnx/backend/base.py
+++ b/onnx/backend/base.py
@@ -100,7 +100,7 @@ class Backend(object):
             outputs_info: a list of tuples, which contains the element type and
             shape of each output. First element of the tuple is the dtype, and
             the second element is the shape. More use case can be found in
-            https://github.com/onnx/onnx/blob/master/onnx/backend/test/runner/__init__.py
+            https://github.com/onnx/onnx/blob/main/onnx/backend/test/runner/__init__.py
         '''
         # TODO Remove Optional from return type
         if 'opset_version' in kwargs:


### PR DESCRIPTION
**Description**
- Bump to 10.15 in AzurePipeline 
- There are two more places need branch renaming

**Motivation and Context**
Mac-CI in AzurePipeline is failing due to unsupported 10.14
