### PR TITLE
Remove testing ort-nightly for Mac Python 3.6 due to unsupported ort-nightly

### DIFF
--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -120,6 +120,13 @@ jobs:
         for file in dist/*.whl; do python -m pip install --upgrade $file; done
         pytest
 
+    - name: Verify ONNX with ort-nightly
+      if: matrix.python-version != '3.6' # Do not test ort-nightly for Python 3.6 due to missing (unsupported) package
+      run: |
+        python -m pip install -q flatbuffers
+        python -m pip install -q -i https://test.pypi.org/simple/ ort-nightly
+        python onnx/test/test_with_ort.py
+
     - name: Build and upload source distribution to TestPyPI weekly
       if: github.event_name == 'schedule' && matrix.python-version == '3.9' # Only triggered by weekly event on Python 3.9
       run: |

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -120,13 +120,6 @@ jobs:
         for file in dist/*.whl; do python -m pip install --upgrade $file; done
         pytest
 
-    - name: Verify ONNX with ort-nightly
-      if: ${{ always() }}
-      run: |
-        python -m pip install -q flatbuffers
-        python -m pip install -q -i https://test.pypi.org/simple/ ort-nightly
-        python onnx/test/test_with_ort.py
-
     - name: Build and upload source distribution to TestPyPI weekly
       if: github.event_name == 'schedule' && matrix.python-version == '3.9' # Only triggered by weekly event on Python 3.9
       run: |


### PR DESCRIPTION
**Description**
Remove testing ort-nightly for Mac Python 3.6 due to unsupported ort-nightly

**Motivation and Context**
Currently mac release CI for Python 3.6 is failing due to missing Python 3.6 ort-nightly package for Mac: https://test.pypi.org/project/ort-nightly/1.11.0.dev20220118004/