### PR TITLE
Upgrade Windows version in AzurePipeline since 2017 was deprecated

### DIFF
--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -5,7 +5,7 @@ jobs:
 
 - job: 'Test'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   strategy:
     matrix:
       py37:


### PR DESCRIPTION
**Description**
Upgrade Windows version in AzurePipeline.

**Motivation and Context**
vs2017-win2016 was just deprecated from AzurePipeline.
