### PR TITLE
Fix Cppcheck warning about memset on NULL backend_ids

### DIFF
--- a/onnx/onnxifi_wrapper.c
+++ b/onnx/onnxifi_wrapper.c
@@ -347,11 +347,12 @@ ONNXIFI_PUBLIC onnxStatus ONNXIFI_ABI
     if (backend_ids == NULL) {
       status = ONNXIFI_STATUS_NO_SYSTEM_MEMORY;
       goto error;
+    } else {
+      /* Safety precaution to avoid dangling pointer bugs */
+      memset(backend_ids, 0, num_expected_ids * sizeof(onnxBackendID));
     }
   }
 
-  /* Safety precaution to avoid dangling pointer bugs */
-  memset(backend_ids, 0, num_expected_ids * sizeof(onnxBackendID));
   for (size_t l = 0; l < num_libraries; l++) {
     if (num_expected_ids > num_available_ids) {
       /* Query and wrap backend IDs from ONNXIFI library */


### PR DESCRIPTION
**Description**
Only zero out `backend_ids` if it is not `NULL`

**Motivation and Context**
When we run ONNX through [Cppcheck](https://cppcheck.sourceforge.io/) we get the following warning:
```
<error id="nullPointer" severity="warning" msg="Possible null pointer dereference: backend_ids" verbose="Possible null pointer dereference: backend_ids" cwe="476">
<location file="DLCpp/third_party/onnx-mlir/third_party/onnx/onnx/onnxifi_wrapper.c" line="354" column="10" info="Null pointer dereference"/>
<location file="DLCpp/third_party/onnx-mlir/third_party/onnx/onnx/onnxifi_wrapper.c" line="344" column="32" info="Assignment 'backend_ids=NULL', assigned value is 0"/>
``` 
This PR avoids the warning by only doing the memset when `backend_ids` was successfully malloced and is no longer NULL.
