### PR TITLE
Add support for 16-bit quantization, in QuantizeLinear and DequantizeLinear

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -19860,6 +19860,50 @@ This version of the operator has been available since version 15 of the default 
 </dl>
 
 ## Version 16 of the default ONNX operator set
+### <a name="DequantizeLinear-16"></a>**DequantizeLinear-16**</a>
+
+  The linear dequantization operator. It consumes a quantized tensor, a scale, and a zero point to compute the full precision tensor.
+  The dequantization formula is y = (x - x_zero_point) * x_scale. 'x_scale' and 'x_zero_point' must have same shape, and can be either a scalar
+  for per-tensor / per layer quantization, or a 1-D tensor for per-axis quantization.
+  'x_zero_point' and 'x' must have same type. 'x' and 'y' must have same shape. In the case of dequantizing int32,
+  there's no zero point (zero point is supposed to be 0).
+
+#### Version
+
+This version of the operator has been available since version 16 of the default ONNX operator set.
+
+#### Attributes
+
+<dl>
+<dt><tt>axis</tt> : int (default is 1)</dt>
+<dd>(Optional) The axis of the dequantizing dimension of the input tensor. Ignored for per-tensor quantization. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(input).</dd>
+</dl>
+
+#### Inputs (2 - 3)
+
+<dl>
+<dt><tt>x</tt> : T</dt>
+<dd>N-D quantized input tensor to be de-quantized.</dd>
+<dt><tt>x_scale</tt> : tensor(float)</dt>
+<dd>Scale for input 'x'. It can be a scalar, which means a per-tensor/layer dequantization, or a 1-D tensor for per-axis dequantization.</dd>
+<dt><tt>x_zero_point</tt> (optional) : T</dt>
+<dd>Zero point for input 'x'. Shape must match x_scale. It's optional. Zero point is 0 when it's not specified.</dd>
+</dl>
+
+#### Outputs
+
+<dl>
+<dt><tt>y</tt> : tensor(float)</dt>
+<dd>N-D full precision output tensor. It has same shape as input 'x'.</dd>
+</dl>
+
+#### Type Constraints
+
+<dl>
+<dt><tt>T</tt> : tensor(int8), tensor(uint8), tensor(int16), tensor(uint16), tensor(int32)</dt>
+<dd>Constrain 'x_zero_point' and 'x' to 8-bit/16-bit/32-bit integer tensor.</dd>
+</dl>
+
 ### <a name="GridSample-16"></a>**GridSample-16**</a>
 
   Given an `input` and a flow-field `grid`, computes the `output` using `input` values and pixel locations from `grid`.
@@ -20156,6 +20200,52 @@ This version of the operator has been available since version 16 of the default 
 <dd>tensor of int64, which should be a scalar.</dd>
 <dt><tt>B</tt> : tensor(bool)</dt>
 <dd>tensor of bool, which should be a scalar.</dd>
+</dl>
+
+### <a name="QuantizeLinear-16"></a>**QuantizeLinear-16**</a>
+
+  The linear quantization operator. It consumes a high precision tensor, a scale, and a zero point to compute the low precision / quantized tensor.
+  The scale factor and zero point must have same shape, and can be either a scalar for per-tensor / per layer quantization, or a 1-D tensor for per-axis quantization.
+  The quantization formula is y = saturate ((x / y_scale) + y_zero_point).
+  For saturation, it saturates to [0, 255] if it's uint8, [-128, 127] if it's int8, [0, 65535] if it's uint16, and [-32768, 32767] if it's int16.
+  For (x / y_scale), it's rounding to nearest ties to even. Refer to https://en.wikipedia.org/wiki/Rounding for details. 'y_zero_point' and 'y' must have same type.
+
+#### Version
+
+This version of the operator has been available since version 16 of the default ONNX operator set.
+
+#### Attributes
+
+<dl>
+<dt><tt>axis</tt> : int (default is 1)</dt>
+<dd>(Optional) The axis of the quantization dimension of the input tensor. Ignored for per-tensor quantization. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(input).</dd>
+</dl>
+
+#### Inputs (2 - 3)
+
+<dl>
+<dt><tt>x</tt> : T1</dt>
+<dd>N-D full precision Input tensor to be quantized.</dd>
+<dt><tt>y_scale</tt> : tensor(float)</dt>
+<dd>Scale for doing quantization to get 'y'. It can be a scalar, which means per-tensor/layer quantization, or a 1-D Tensor for per-axis quantization.</dd>
+<dt><tt>y_zero_point</tt> (optional) : T2</dt>
+<dd>Zero point for doing quantization to get 'y'. Shape must match y_scale. Default is uint8 with zero point of 0 if it's not specified.</dd>
+</dl>
+
+#### Outputs
+
+<dl>
+<dt><tt>y</tt> : T2</dt>
+<dd>N-D quantized output tensor. It has same shape as input 'x'.</dd>
+</dl>
+
+#### Type Constraints
+
+<dl>
+<dt><tt>T1</tt> : tensor(float), tensor(int32)</dt>
+<dd>Constrain 'x' to float or int32 tensor.</dd>
+<dt><tt>T2</tt> : tensor(int8), tensor(uint8), tensor(int16), tensor(uint16)</dt>
+<dd>Constrain 'y_zero_point' and 'y' to 8-bit/16-bit integer tensor.</dd>
 </dl>
 
 ### <a name="RoiAlign-16"></a>**RoiAlign-16**</a>

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -40,7 +40,7 @@ For an operator input/output's differentiability, it can be differentiable,
 |<a href="#Cosh">Cosh</a>|<a href="Changelog.md#Cosh-9">9</a>|
 |<a href="#CumSum">CumSum</a>|<a href="Changelog.md#CumSum-14">14</a>, <a href="Changelog.md#CumSum-11">11</a>|
 |<a href="#DepthToSpace">DepthToSpace</a>|<a href="Changelog.md#DepthToSpace-13">13</a>, <a href="Changelog.md#DepthToSpace-11">11</a>, <a href="Changelog.md#DepthToSpace-1">1</a>|
-|<a href="#DequantizeLinear">DequantizeLinear</a>|<a href="Changelog.md#DequantizeLinear-13">13</a>, <a href="Changelog.md#DequantizeLinear-10">10</a>|
+|<a href="#DequantizeLinear">DequantizeLinear</a>|<a href="Changelog.md#DequantizeLinear-16">16</a>, <a href="Changelog.md#DequantizeLinear-13">13</a>, <a href="Changelog.md#DequantizeLinear-10">10</a>|
 |<a href="#Det">Det</a>|<a href="Changelog.md#Det-11">11</a>|
 |<a href="#Div">Div</a>|<a href="Changelog.md#Div-14">14</a>, <a href="Changelog.md#Div-13">13</a>, <a href="Changelog.md#Div-7">7</a>, <a href="Changelog.md#Div-6">6</a>, <a href="Changelog.md#Div-1">1</a>|
 |<a href="#Dropout">Dropout</a>|<a href="Changelog.md#Dropout-13">13</a>, <a href="Changelog.md#Dropout-12">12</a>, <a href="Changelog.md#Dropout-10">10</a>, <a href="Changelog.md#Dropout-7">7</a>, <a href="Changelog.md#Dropout-6">6</a>, <a href="Changelog.md#Dropout-1">1</a>|
@@ -103,7 +103,7 @@ For an operator input/output's differentiability, it can be differentiable,
 |<a href="#Pow">Pow</a>|<a href="Changelog.md#Pow-15">15</a>, <a href="Changelog.md#Pow-13">13</a>, <a href="Changelog.md#Pow-12">12</a>, <a href="Changelog.md#Pow-7">7</a>, <a href="Changelog.md#Pow-1">1</a>|
 |<a href="#QLinearConv">QLinearConv</a>|<a href="Changelog.md#QLinearConv-10">10</a>|
 |<a href="#QLinearMatMul">QLinearMatMul</a>|<a href="Changelog.md#QLinearMatMul-10">10</a>|
-|<a href="#QuantizeLinear">QuantizeLinear</a>|<a href="Changelog.md#QuantizeLinear-13">13</a>, <a href="Changelog.md#QuantizeLinear-10">10</a>|
+|<a href="#QuantizeLinear">QuantizeLinear</a>|<a href="Changelog.md#QuantizeLinear-16">16</a>, <a href="Changelog.md#QuantizeLinear-13">13</a>, <a href="Changelog.md#QuantizeLinear-10">10</a>|
 |<a href="#RNN">RNN</a>|<a href="Changelog.md#RNN-14">14</a>, <a href="Changelog.md#RNN-7">7</a>, <a href="Changelog.md#RNN-1">1</a>|
 |<a href="#RandomNormal">RandomNormal</a>|<a href="Changelog.md#RandomNormal-1">1</a>|
 |<a href="#RandomNormalLike">RandomNormalLike</a>|<a href="Changelog.md#RandomNormalLike-1">1</a>|
@@ -4625,9 +4625,9 @@ expect(node, inputs=[x], outputs=[y],
 
 #### Version
 
-This version of the operator has been available since version 13 of the default ONNX operator set.
+This version of the operator has been available since version 16 of the default ONNX operator set.
 
-Other versions of this operator: <a href="Changelog.md#DequantizeLinear-10">10</a>
+Other versions of this operator: <a href="Changelog.md#DequantizeLinear-10">10</a>, <a href="Changelog.md#DequantizeLinear-13">13</a>
 
 #### Attributes
 
@@ -4657,8 +4657,8 @@ Other versions of this operator: <a href="Changelog.md#DequantizeLinear-10">10</
 #### Type Constraints
 
 <dl>
-<dt><tt>T</tt> : tensor(int8), tensor(uint8), tensor(int32)</dt>
-<dd>Constrain 'x_zero_point' and 'x' to 8-bit/32-bit integer tensor.</dd>
+<dt><tt>T</tt> : tensor(int8), tensor(uint8), tensor(int16), tensor(uint16), tensor(int32)</dt>
+<dd>Constrain 'x_zero_point' and 'x' to 8-bit/16-bit/32-bit integer tensor.</dd>
 </dl>
 
 
@@ -14461,14 +14461,14 @@ expect(node, inputs=[a, a_scale, a_zero_point, b, b_scale, b_zero_point, y_scale
   The linear quantization operator. It consumes a high precision tensor, a scale, and a zero point to compute the low precision / quantized tensor.
   The scale factor and zero point must have same shape, and can be either a scalar for per-tensor / per layer quantization, or a 1-D tensor for per-axis quantization.
   The quantization formula is y = saturate ((x / y_scale) + y_zero_point).
-  For saturation, it saturates to [0, 255] if it's uint8, or [-128, 127] if it's int8.
+  For saturation, it saturates to [0, 255] if it's uint8, [-128, 127] if it's int8, [0, 65535] if it's uint16, and [-32768, 32767] if it's int16.
   For (x / y_scale), it's rounding to nearest ties to even. Refer to https://en.wikipedia.org/wiki/Rounding for details. 'y_zero_point' and 'y' must have same type.
 
 #### Version
 
-This version of the operator has been available since version 13 of the default ONNX operator set.
+This version of the operator has been available since version 16 of the default ONNX operator set.
 
-Other versions of this operator: <a href="Changelog.md#QuantizeLinear-10">10</a>
+Other versions of this operator: <a href="Changelog.md#QuantizeLinear-10">10</a>, <a href="Changelog.md#QuantizeLinear-13">13</a>
 
 #### Attributes
 
@@ -14500,8 +14500,8 @@ Other versions of this operator: <a href="Changelog.md#QuantizeLinear-10">10</a>
 <dl>
 <dt><tt>T1</tt> : tensor(float), tensor(int32)</dt>
 <dd>Constrain 'x' to float or int32 tensor.</dd>
-<dt><tt>T2</tt> : tensor(int8), tensor(uint8)</dt>
-<dd>Constrain 'y_zero_point' and 'y' to 8-bit integer tensor.</dd>
+<dt><tt>T2</tt> : tensor(int8), tensor(uint8), tensor(int16), tensor(uint16)</dt>
+<dd>Constrain 'y_zero_point' and 'y' to 8-bit/16-bit integer tensor.</dd>
 </dl>
 
 

--- a/onnx/defs/operator_sets.h
+++ b/onnx/defs/operator_sets.h
@@ -1000,6 +1000,8 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 16, Loop);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 16, Identity);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 16, Where);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 16, GridSample);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 16, QuantizeLinear);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 16, DequantizeLinear);
 
 // Iterate over schema from ai.onnx version 16
 class OpSet_Onnx_ver16 {
@@ -1013,6 +1015,8 @@ class OpSet_Onnx_ver16 {
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 16, Identity)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 16, Where)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 16, GridSample)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 16, QuantizeLinear)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 16, DequantizeLinear)>());
   }
 };
 inline void RegisterOnnxOperatorSetSchema() {
@@ -1037,7 +1041,7 @@ inline void RegisterOnnxOperatorSetSchema() {
 }
 
 inline void RegisterOnnxOperatorSetSchema(int target_version) {
-  // Update here if opset_version bumps 
+  // Update here if opset_version bumps
   // These calls for schema registration here are required to be in descending order for this to work correctly
   RegisterOpSetSchema<OpSet_Onnx_ver16>(target_version);
   RegisterOpSetSchema<OpSet_Onnx_ver15>(target_version);

--- a/onnx/defs/quantization/defs.cc
+++ b/onnx/defs/quantization/defs.cc
@@ -8,17 +8,17 @@
 
 namespace ONNX_NAMESPACE {
 
-static const char* QuantizeLinear_ver13_doc = R"DOC(
+static const char* QuantizeLinear_ver16_doc = R"DOC(
 The linear quantization operator. It consumes a high precision tensor, a scale, and a zero point to compute the low precision / quantized tensor.
 The scale factor and zero point must have same shape, and can be either a scalar for per-tensor / per layer quantization, or a 1-D tensor for per-axis quantization.
 The quantization formula is y = saturate ((x / y_scale) + y_zero_point).
-For saturation, it saturates to [0, 255] if it's uint8, or [-128, 127] if it's int8.
+For saturation, it saturates to [0, 255] if it's uint8, [-128, 127] if it's int8, [0, 65535] if it's uint16, and [-32768, 32767] if it's int16.
 For (x / y_scale), it's rounding to nearest ties to even. Refer to https://en.wikipedia.org/wiki/Rounding for details. 'y_zero_point' and 'y' must have same type.
 )DOC";
 
 ONNX_OPERATOR_SET_SCHEMA(
     QuantizeLinear,
-    13,
+    16,
     OpSchema()
         .Input(0, "x", "N-D full precision Input tensor to be quantized.", "T1")
         .Input(
@@ -50,9 +50,9 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Constrain 'x' to float or int32 tensor.")
         .TypeConstraint(
             "T2",
-            {"tensor(int8)", "tensor(uint8)"},
-            "Constrain 'y_zero_point' and 'y' to 8-bit integer tensor.")
-        .SetDoc(QuantizeLinear_ver13_doc)
+            {"tensor(int8)", "tensor(uint8)", "tensor(int16)", "tensor(uint16)"},
+            "Constrain 'y_zero_point' and 'y' to 8-bit/16-bit integer tensor.")
+        .SetDoc(QuantizeLinear_ver16_doc)
         .TypeAndShapeInferenceFunction(
             [](ONNX_NAMESPACE::InferenceContext& ctx) {
               if (ctx.getNumInputs() == 3 && ctx.getInputType(2) != nullptr) {
@@ -68,7 +68,7 @@ ONNX_OPERATOR_SET_SCHEMA(
               updateOutputShape(ctx, 0, input_shape);
         }));
 
-static const char* DequantizeLinear_ver13_doc = R"DOC(
+static const char* DequantizeLinear_ver16_doc = R"DOC(
 The linear dequantization operator. It consumes a quantized tensor, a scale, and a zero point to compute the full precision tensor.
 The dequantization formula is y = (x - x_zero_point) * x_scale. 'x_scale' and 'x_zero_point' must have same shape, and can be either a scalar
 for per-tensor / per layer quantization, or a 1-D tensor for per-axis quantization.
@@ -78,7 +78,7 @@ there's no zero point (zero point is supposed to be 0).
 
 ONNX_OPERATOR_SET_SCHEMA(
     DequantizeLinear,
-    13,
+    16,
     OpSchema()
         .Input(0, "x", "N-D quantized input tensor to be de-quantized.", "T")
         .Input(
@@ -106,9 +106,9 @@ ONNX_OPERATOR_SET_SCHEMA(
             static_cast<int64_t>(1))
         .TypeConstraint(
             "T",
-            {"tensor(int8)", "tensor(uint8)", "tensor(int32)"},
-            "Constrain 'x_zero_point' and 'x' to 8-bit/32-bit integer tensor.")
-        .SetDoc(DequantizeLinear_ver13_doc)
+            {"tensor(int8)", "tensor(uint8)", "tensor(int16)", "tensor(uint16)", "tensor(int32)"},
+            "Constrain 'x_zero_point' and 'x' to 8-bit/16-bit/32-bit integer tensor.")
+        .SetDoc(DequantizeLinear_ver16_doc)
         .TypeAndShapeInferenceFunction(
             [](ONNX_NAMESPACE::InferenceContext& ctx) {
               auto y_type = ctx.getOutputType(0);

--- a/onnx/defs/quantization/old.cc
+++ b/onnx/defs/quantization/old.cc
@@ -60,6 +60,66 @@ ONNX_OPERATOR_SET_SCHEMA(
               updateOutputShape(ctx, 0, input_shape);
         }));
 
+static const char* QuantizeLinear_ver13_doc = R"DOC(
+The linear quantization operator. It consumes a high precision tensor, a scale, and a zero point to compute the low precision / quantized tensor.
+The scale factor and zero point must have same shape, and can be either a scalar for per-tensor / per layer quantization, or a 1-D tensor for per-axis quantization.
+The quantization formula is y = saturate ((x / y_scale) + y_zero_point).
+For saturation, it saturates to [0, 255] if it's uint8, or [-128, 127] if it's int8.
+For (x / y_scale), it's rounding to nearest ties to even. Refer to https://en.wikipedia.org/wiki/Rounding for details. 'y_zero_point' and 'y' must have same type.
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(
+    QuantizeLinear,
+    13,
+    OpSchema()
+        .Input(0, "x", "N-D full precision Input tensor to be quantized.", "T1")
+        .Input(
+            1,
+            "y_scale",
+            "Scale for doing quantization to get 'y'. It can be a scalar, which means per-tensor/layer quantization, "
+            "or a 1-D Tensor for per-axis quantization.",
+            "tensor(float)")
+        .Input(
+            2,
+            "y_zero_point",
+            "Zero point for doing quantization to get 'y'. Shape must match y_scale. "
+            "Default is uint8 with zero point of 0 if it's not specified.",
+            "T2",
+            OpSchema::Optional)
+        .Output(
+            0,
+            "y",
+            "N-D quantized output tensor. It has same shape as input 'x'.",
+            "T2")
+        .Attr(
+            "axis",
+            "(Optional) The axis of the quantization dimension of the input tensor. Ignored for per-tensor quantization. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(input).",
+            AttributeProto::INT,
+            static_cast<int64_t>(1))
+        .TypeConstraint(
+            "T1",
+            {"tensor(float)", "tensor(int32)"},
+            "Constrain 'x' to float or int32 tensor.")
+        .TypeConstraint(
+            "T2",
+            {"tensor(int8)", "tensor(uint8)"},
+            "Constrain 'y_zero_point' and 'y' to 8-bit integer tensor.")
+        .SetDoc(QuantizeLinear_ver13_doc)
+        .TypeAndShapeInferenceFunction(
+            [](ONNX_NAMESPACE::InferenceContext& ctx) {
+              if (ctx.getNumInputs() == 3 && ctx.getInputType(2) != nullptr) {
+                propagateElemTypeFromInputToOutput(ctx, 2, 0);
+              } else {
+                updateOutputElemType(ctx, 0, TensorProto::UINT8);
+              }
+              if (!hasInputShape(ctx, 0)) {
+                return;
+              }
+
+              auto& input_shape = getInputShape(ctx, 0);
+              updateOutputShape(ctx, 0, input_shape);
+        }));
+
 static const char* DequantizeLinear_ver10_doc = R"DOC(
 The linear dequantization operator. It consumes a quantized tensor, a scale, a zero point to compute the full precision tensor.
 The dequantization formula is y = (x - x_zero_point) * x_scale. 'x_scale' and 'x_zero_point' are both scalars.
@@ -107,5 +167,61 @@ ONNX_OPERATOR_SET_SCHEMA(
               auto& input_shape = getInputShape(ctx, 0);
               updateOutputShape(ctx, 0, input_shape);
             }));
+
+static const char* DequantizeLinear_ver13_doc = R"DOC(
+The linear dequantization operator. It consumes a quantized tensor, a scale, and a zero point to compute the full precision tensor.
+The dequantization formula is y = (x - x_zero_point) * x_scale. 'x_scale' and 'x_zero_point' must have same shape, and can be either a scalar
+for per-tensor / per layer quantization, or a 1-D tensor for per-axis quantization.
+'x_zero_point' and 'x' must have same type. 'x' and 'y' must have same shape. In the case of dequantizing int32,
+there's no zero point (zero point is supposed to be 0).
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(
+    DequantizeLinear,
+    13,
+    OpSchema()
+        .Input(0, "x", "N-D quantized input tensor to be de-quantized.", "T")
+        .Input(
+            1,
+            "x_scale",
+            "Scale for input 'x'. It can be a scalar, which means a per-tensor/layer dequantization, "
+            "or a 1-D tensor for per-axis dequantization.",
+            "tensor(float)")
+        .Input(
+            2,
+            "x_zero_point",
+            "Zero point for input 'x'. Shape must match x_scale. "
+            "It's optional. Zero point is 0 when it's not specified.",
+            "T",
+            OpSchema::Optional)
+        .Output(
+            0,
+            "y",
+            "N-D full precision output tensor. It has same shape as input 'x'.",
+            "tensor(float)")
+        .Attr(
+            "axis",
+            "(Optional) The axis of the dequantizing dimension of the input tensor. Ignored for per-tensor quantization. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(input).",
+            AttributeProto::INT,
+            static_cast<int64_t>(1))
+        .TypeConstraint(
+            "T",
+            {"tensor(int8)", "tensor(uint8)", "tensor(int32)"},
+            "Constrain 'x_zero_point' and 'x' to 8-bit/32-bit integer tensor.")
+        .SetDoc(DequantizeLinear_ver13_doc)
+        .TypeAndShapeInferenceFunction(
+            [](ONNX_NAMESPACE::InferenceContext& ctx) {
+              auto y_type = ctx.getOutputType(0);
+              // only float is supported
+              y_type->mutable_tensor_type()->set_elem_type(
+                  ONNX_NAMESPACE::TensorProto::FLOAT);
+
+              if (!hasInputShape(ctx, 0))
+                return;
+
+              auto& input_shape = getInputShape(ctx, 0);
+              updateOutputShape(ctx, 0, input_shape);
+            }));
+
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/convert.h
+++ b/onnx/version_converter/convert.h
@@ -730,6 +730,10 @@ class DefaultVersionConverter : public BaseVersionConverter {
         OpSetID(15), OpSetID(16)));
       registerAdapter(make_unique<CompatibleAdapter>("Where",
         OpSetID(15), OpSetID(16)));
+      registerAdapter(make_unique<CompatibleAdapter>(
+        "DequantizeLinear", OpSetID(15), OpSetID(16)));
+      registerAdapter(make_unique<CompatibleAdapter>(
+        "QuantizeLinear", OpSetID(15), OpSetID(16)));
     }
 
     ModelProto convert_version(


### PR DESCRIPTION
**Description**
- Adds support for signed and unsigned 16-bit quantization in the QuantizeLinear and DequantizeLinear ops
- Generated new documentation via update_doc.sh script

**Motivation and Context**
- Today, ONNX only supports 8-bit quantization. 
- This change hopes to bring ONNX up to speed with the major NN frameworks and libraries that all support 16-bit.
