### PR TITLE
typing: run com2ann

### DIFF
--- a/onnx/__init__.py
+++ b/onnx/__init__.py
@@ -27,7 +27,7 @@ from typing import Union, Text, IO, Optional, cast, TypeVar, Any
 
 
 # f should be either readable or a file path
-def _load_bytes(f):  # type: (Union[IO[bytes], Text]) -> bytes
+def _load_bytes(f: Union[IO[bytes], Text]) -> bytes:
     if hasattr(f, 'read') and callable(cast(IO[bytes], f).read):
         s = cast(IO[bytes], f).read()
     else:
@@ -38,7 +38,7 @@ def _load_bytes(f):  # type: (Union[IO[bytes], Text]) -> bytes
 
 # str should be bytes,
 # f should be either writable or a file path
-def _save_bytes(str, f):  # type: (bytes, Union[IO[bytes], Text]) -> None
+def _save_bytes(str: bytes, f: Union[IO[bytes], Text]) -> None:
     if hasattr(f, 'write') and callable(cast(IO[bytes], f).write):
         cast(IO[bytes], f).write(str)
     else:
@@ -47,7 +47,7 @@ def _save_bytes(str, f):  # type: (bytes, Union[IO[bytes], Text]) -> None
 
 
 # f should be either a readable file or a file path
-def _get_file_path(f):  # type: (Union[IO[bytes], Text]) -> Optional[Text]
+def _get_file_path(f: Union[IO[bytes], Text]) -> Optional[Text]:
     if isinstance(f, str):
         return os.path.abspath(f)
     if hasattr(f, 'name'):
@@ -55,7 +55,7 @@ def _get_file_path(f):  # type: (Union[IO[bytes], Text]) -> Optional[Text]
     return None
 
 
-def _serialize(proto):  # type: (Union[bytes, google.protobuf.message.Message]) -> bytes
+def _serialize(proto: Union[bytes, google.protobuf.message.Message]) -> bytes:
     '''
     Serialize a in-memory proto to bytes
 
@@ -78,7 +78,7 @@ def _serialize(proto):  # type: (Union[bytes, google.protobuf.message.Message]) 
 _Proto = TypeVar('_Proto', bound=google.protobuf.message.Message)
 
 
-def _deserialize(s, proto):  # type: (bytes, _Proto) -> _Proto
+def _deserialize(s: bytes, proto: _Proto) -> _Proto:
     '''
     Parse bytes into a in-memory proto
 
@@ -104,7 +104,7 @@ def _deserialize(s, proto):  # type: (bytes, _Proto) -> _Proto
     return proto
 
 
-def load_model(f, format=None, load_external_data=True):  # type: (Union[IO[bytes], Text], Optional[Any], bool) -> ModelProto
+def load_model(f: Union[IO[bytes], Text], format: Optional[Any] = None, load_external_data: bool = True) -> ModelProto:
     '''
     Loads a serialized ModelProto into memory
     load_external_data is true if the external data under the same directory of the model and load the external data
@@ -129,7 +129,7 @@ def load_model(f, format=None, load_external_data=True):  # type: (Union[IO[byte
     return model
 
 
-def load_tensor(f, format=None):  # type: (Union[IO[bytes], Text], Optional[Any]) -> TensorProto
+def load_tensor(f: Union[IO[bytes], Text], format: Optional[Any] = None) -> TensorProto:
     '''
     Loads a serialized TensorProto into memory
 
@@ -144,7 +144,7 @@ def load_tensor(f, format=None):  # type: (Union[IO[bytes], Text], Optional[Any]
     return load_tensor_from_string(s, format=format)
 
 
-def load_model_from_string(s, format=None):  # type: (bytes, Optional[Any]) -> ModelProto
+def load_model_from_string(s: bytes, format: Optional[Any] = None) -> ModelProto:
     '''
     Loads a binary string (bytes) that contains serialized ModelProto
 
@@ -158,7 +158,7 @@ def load_model_from_string(s, format=None):  # type: (bytes, Optional[Any]) -> M
     return _deserialize(s, ModelProto())
 
 
-def load_tensor_from_string(s, format=None):  # type: (bytes, Optional[Any]) -> TensorProto
+def load_tensor_from_string(s: bytes, format: Optional[Any] = None) -> TensorProto:
     '''
     Loads a binary string (bytes) that contains serialized TensorProto
 
@@ -172,8 +172,7 @@ def load_tensor_from_string(s, format=None):  # type: (bytes, Optional[Any]) -> 
     return _deserialize(s, TensorProto())
 
 
-def save_model(proto, f, format=None, save_as_external_data=False, all_tensors_to_one_file=True, location=None, size_threshold=1024, convert_attribute=False):
-    # type: (Union[ModelProto, bytes], Union[IO[bytes], Text], Optional[Any], bool, bool, Optional[Text], int, bool) -> None
+def save_model(proto: Union[ModelProto, bytes], f: Union[IO[bytes], Text], format: Optional[Any] = None, save_as_external_data: bool = False, all_tensors_to_one_file: bool = True, location: Optional[Text] = None, size_threshold: int = 1024, convert_attribute: bool = False) -> None:
     '''
     Saves the ModelProto to the specified path and optionally, serialize tensors with raw data as external data before saving.
 
@@ -204,7 +203,7 @@ def save_model(proto, f, format=None, save_as_external_data=False, all_tensors_t
     _save_bytes(s, f)
 
 
-def save_tensor(proto, f):  # type: (TensorProto, Union[IO[bytes], Text]) -> None
+def save_tensor(proto: TensorProto, f: Union[IO[bytes], Text]) -> None:
     '''
     Saves the TensorProto to the specified path.
 

--- a/onnx/backend/base.py
+++ b/onnx/backend/base.py
@@ -17,8 +17,8 @@ from onnx import ModelProto, NodeProto, IR_VERSION
 
 class DeviceType(object):
     _Type = NewType('_Type', int)
-    CPU = _Type(0)  # type: _Type
-    CUDA = _Type(1)  # type: _Type
+    CPU: _Type = _Type(0)
+    CUDA: _Type = _Type(1)
 
 
 class Device(object):
@@ -28,7 +28,7 @@ class Device(object):
     example: 'CPU', 'CUDA', 'CUDA:1'
     '''
 
-    def __init__(self, device):  # type: (Text) -> None
+    def __init__(self, device: Text) -> None:
         options = device.split(':')
         self.type = getattr(DeviceType, options[0])
         self.device_id = 0
@@ -36,13 +36,13 @@ class Device(object):
             self.device_id = int(options[1])
 
 
-def namedtupledict(typename, field_names, *args, **kwargs):  # type: (Text, Sequence[Text], *Any, **Any) -> Type[Tuple[Any, ...]]
+def namedtupledict(typename: Text, field_names: Sequence[Text], *args: Any, **kwargs: Any) -> Type[Tuple[Any, ...]]:
     field_names_map = {n: i for i, n in enumerate(field_names)}
     # Some output names are invalid python identifier, e.g. "0"
     kwargs.setdefault(str('rename'), True)
     data = namedtuple(typename, field_names, *args, **kwargs)  # type: ignore
 
-    def getitem(self, key):  # type: (Any, Any) -> Any
+    def getitem(self: Any, key: Any) -> Any:
         if isinstance(key, str):
             key = field_names_map[key]
         return super(type(self), self).__getitem__(key)  # type: ignore
@@ -51,49 +51,49 @@ def namedtupledict(typename, field_names, *args, **kwargs):  # type: (Text, Sequ
 
 
 class BackendRep(object):
-    def run(self, inputs, **kwargs):  # type: (Any, **Any) -> Tuple[Any, ...]
+    def run(self, inputs: Any, **kwargs: Any) -> Tuple[Any, ...]:
         pass
 
 
 class Backend(object):
     @classmethod
     def is_compatible(cls,
-                      model,  # type: ModelProto
-                      device='CPU',  # type: Text
-                      **kwargs  # type: Any
-                      ):  # type: (...) -> bool
+                      model: ModelProto,
+                      device: Text = 'CPU',
+                      **kwargs: Any
+                      ) -> bool:
         # Return whether the model is compatible with the backend.
         return True
 
     @classmethod
     def prepare(cls,
-                model,  # type: ModelProto
-                device='CPU',  # type: Text
-                **kwargs  # type: Any
-                ):  # type: (...) -> Optional[BackendRep]
+                model: ModelProto,
+                device: Text = 'CPU',
+                **kwargs: Any
+                ) -> Optional[BackendRep]:
         # TODO Remove Optional from return type
         onnx.checker.check_model(model)
         return None
 
     @classmethod
     def run_model(cls,
-                  model,  # type: ModelProto
-                  inputs,  # type: Any
-                  device='CPU',  # type: Text
-                  **kwargs  # type: Any
-                  ):  # type: (...) -> Tuple[Any, ...]
+                  model: ModelProto,
+                  inputs: Any,
+                  device: Text = 'CPU',
+                  **kwargs: Any
+                  ) -> Tuple[Any, ...]:
         backend = cls.prepare(model, device, **kwargs)
         assert backend is not None
         return backend.run(inputs)
 
     @classmethod
     def run_node(cls,
-                 node,  # type: NodeProto
-                 inputs,  # type: Any
-                 device='CPU',  # type: Text
-                 outputs_info=None,  # type: Optional[Sequence[Tuple[numpy.dtype, Tuple[int, ...]]]]
-                 **kwargs  # type: Dict[Text, Any]
-                 ):  # type: (...) -> Optional[Tuple[Any, ...]]
+                 node: NodeProto,
+                 inputs: Any,
+                 device: Text = 'CPU',
+                 outputs_info: Optional[Sequence[Tuple[numpy.dtype, Tuple[int, ...]]]] = None,
+                 **kwargs: Dict[Text, Any]
+                 ) -> Optional[Tuple[Any, ...]]:
         '''Simple run one operator and return the results.
         Args:
             outputs_info: a list of tuples, which contains the element type and
@@ -112,7 +112,7 @@ class Backend(object):
         return None
 
     @classmethod
-    def supports_device(cls, device):  # type: (Text) -> bool
+    def supports_device(cls, device: Text) -> bool:
         """
         Checks whether the backend is compiled with particular device support.
         In particular it's used in the testing suite.

--- a/onnx/backend/sample/ops/__init__.py
+++ b/onnx/backend/sample/ops/__init__.py
@@ -13,13 +13,13 @@ from typing import Dict, Text
 from types import ModuleType
 
 
-def collect_sample_implementations():  # type: () -> Dict[Text, Text]
-    dict = {}  # type: Dict[Text, Text]
+def collect_sample_implementations() -> Dict[Text, Text]:
+    dict: Dict[Text, Text] = {}
     _recursive_scan(sys.modules[__name__], dict)
     return dict
 
 
-def _recursive_scan(package, dict):  # type: (ModuleType, Dict[Text, Text]) -> None
+def _recursive_scan(package: ModuleType, dict: Dict[Text, Text]) -> None:
     pkg_dir = package.__path__  # type: ignore
     module_location = package.__name__
     for _module_loader, name, ispkg in pkgutil.iter_modules(pkg_dir):  # type: ignore

--- a/onnx/backend/sample/ops/abs.py
+++ b/onnx/backend/sample/ops/abs.py
@@ -8,5 +8,5 @@ from __future__ import unicode_literals
 import numpy as np  # type: ignore
 
 
-def abs(input):  # type: (np.ndarray) -> np.ndarray
+def abs(input: np.ndarray) -> np.ndarray:
     return np.abs(input)

--- a/onnx/backend/test/case/__init__.py
+++ b/onnx/backend/test/case/__init__.py
@@ -12,6 +12,6 @@ from .utils import import_recursive
 from typing import Dict, Text, List, Tuple
 
 
-def collect_snippets():  # type: () -> Dict[Text, List[Tuple[Text, Text]]]
+def collect_snippets() -> Dict[Text, List[Tuple[Text, Text]]]:
     import_recursive(sys.modules[__name__])
     return Snippets

--- a/onnx/backend/test/case/base.py
+++ b/onnx/backend/test/case/base.py
@@ -13,7 +13,7 @@ from typing import Dict, Text, List, Tuple, Type, Sequence, Any
 import numpy as np  # type: ignore
 
 
-def process_snippet(op_name, name, export):  # type: (Text, Text, Any) -> Tuple[Text, Text]
+def process_snippet(op_name: Text, name: Text, export: Any) -> Tuple[Text, Text]:
     snippet_name = name[len('export_'):] or op_name.lower()
     source_code = dedent(inspect.getsource(export))
     # remove the function signature line
@@ -23,13 +23,13 @@ def process_snippet(op_name, name, export):  # type: (Text, Text, Any) -> Tuple[
     return snippet_name, dedent("\n".join(lines[2:]))
 
 
-Snippets = defaultdict(list)  # type: Dict[Text, List[Tuple[Text, Text]]]
+Snippets: Dict[Text, List[Tuple[Text, Text]]] = defaultdict(list)
 
 
 class _Exporter(type):
-    exports = defaultdict(list)  # type: Dict[Text, List[Tuple[Text, Text]]]
+    exports: Dict[Text, List[Tuple[Text, Text]]] = defaultdict(list)
 
-    def __init__(cls, name, bases, dct):  # type: (str, Tuple[Type[Any], ...], Dict[str, Any]) -> None
+    def __init__(cls, name: str, bases: Tuple[Type[Any], ...], dct: Dict[str, Any]) -> None:
         for k, v in dct.items():
             if k.startswith('export'):
                 if not isinstance(v, staticmethod):

--- a/onnx/backend/test/case/model/__init__.py
+++ b/onnx/backend/test/case/model/__init__.py
@@ -17,11 +17,11 @@ from ..test_case import TestCase
 _SimpleModelTestCases = []
 
 
-def expect(model,  # type: ModelProto
-           inputs,  # type: Sequence[np.ndarray]
-           outputs,  # type: Sequence[np.ndarray]
-           name=None,  # type: Optional[Text]
-           ):  # type: (...) -> None
+def expect(model: ModelProto,
+           inputs: Sequence[np.ndarray],
+           outputs: Sequence[np.ndarray],
+           name: Optional[Text] = None,
+           ) -> None:
     name = name or model.graph.name
     _SimpleModelTestCases.append(
         TestCase(
@@ -42,7 +42,7 @@ BASE_URL = 'https://s3.amazonaws.com/download.onnx/models/opset_{}'.format(
     base_model_opset_version)
 
 
-def collect_testcases():  # type: () -> List[TestCase]
+def collect_testcases() -> List[TestCase]:
     '''Collect model test cases defined in python/numpy code and in model zoo.
     '''
 

--- a/onnx/backend/test/case/model/expand.py
+++ b/onnx/backend/test/case/model/expand.py
@@ -16,9 +16,9 @@ from typing import Sequence
 class ExpandDynamicShape(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
 
-        def make_graph(node, input_shape, shape_shape, output_shape):  # type: (onnx.helper.NodeProto, Sequence[int], Sequence[int], Sequence[int]) -> onnx.helper.GraphProto
+        def make_graph(node: onnx.helper.NodeProto, input_shape: Sequence[int], shape_shape: Sequence[int], output_shape: Sequence[int]) -> onnx.helper.GraphProto:
             graph = onnx.helper.make_graph(
                 nodes=[node],
                 name='Expand',

--- a/onnx/backend/test/case/model/gradient.py
+++ b/onnx/backend/test/case/model/gradient.py
@@ -16,7 +16,7 @@ from . import expect
 class Gradient(Base):
 
     @staticmethod
-    def export_gradient_scalar_add():  # type: () -> None
+    def export_gradient_scalar_add() -> None:
         add_node = onnx.helper.make_node('Add',
                                          ['a', 'b'], ['c'], name='my_add')
         gradient_node = onnx.helper.make_node(
@@ -59,7 +59,7 @@ class Gradient(Base):
                name='test_gradient_of_add')
 
     @staticmethod
-    def export_gradient_scalar_add_and_mul():  # type: () -> None
+    def export_gradient_scalar_add_and_mul() -> None:
         add_node = onnx.helper.make_node('Add',
                                          ['a', 'b'], ['c'], name='my_add')
         mul_node = onnx.helper.make_node('Mul',

--- a/onnx/backend/test/case/model/sequence.py
+++ b/onnx/backend/test/case/model/sequence.py
@@ -15,42 +15,37 @@ from onnx import TensorProto
 from typing import List, Optional, Text, Union
 
 
-def SequenceEmptyImpl():  # type: () -> List[Optional[np.ndarray]]
+def SequenceEmptyImpl() -> List[Optional[np.ndarray]]:
     return []
 
 
-def SequenceConstructImpl(*tensors):  # type: (*np.ndarray) -> List[np.ndarray]
+def SequenceConstructImpl(*tensors: np.ndarray) -> List[np.ndarray]:
     return list(tensors)
 
 
-def SequenceInsertImpl(sequence, tensor, position=None):
-    # type: (List[np.ndarray], np.ndarray, Optional[int]) -> List[np.ndarray]
+def SequenceInsertImpl(sequence: List[np.ndarray], tensor: np.ndarray, position: Optional[int] = None) -> List[np.ndarray]:
     if position is None:
         position = len(sequence)
     sequence.insert(position, tensor)
     return sequence
 
 
-def SequenceAtImpl(sequence, position):
-    # type: (List[np.ndarray], int) -> np.ndarray
+def SequenceAtImpl(sequence: List[np.ndarray], position: int) -> np.ndarray:
     return sequence[position]
 
 
-def SequenceEraseImpl(sequence, position=None):
-    # type: (List[np.ndarray], Optional[int]) -> List[Optional[np.ndarray]]
+def SequenceEraseImpl(sequence: List[np.ndarray], position: Optional[int] = None) -> List[Optional[np.ndarray]]:
     if position is None:
         position = -1
     del sequence[position]
     return sequence
 
 
-def SequenceLengthImpl(sequence):
-    # type: (List[np.ndarray]) -> np.int64
+def SequenceLengthImpl(sequence: List[np.ndarray]) -> np.int64:
     return np.int64(len(sequence))
 
 
-def SplitToSequenceImpl(tensor, split=None, axis=0, keepdims=1):
-    # type: (np.ndarray, Optional[Union[int, List[int]]], int, int) -> List[np.ndarray]
+def SplitToSequenceImpl(tensor: np.ndarray, split: Optional[Union[int, List[int]]] = None, axis: int = 0, keepdims: int = 1) -> List[np.ndarray]:
     dim_size = tensor.shape[axis]
     if split is None:
         split = 1
@@ -65,8 +60,7 @@ def SplitToSequenceImpl(tensor, split=None, axis=0, keepdims=1):
     return np.array_split(tensor, split_indices, axis)  # type: ignore
 
 
-def ConcatFromSequenceImpl(sequence, axis, new_axis=0):
-    # type: (List[np.ndarray], int, Optional[int]) -> np.ndarray
+def ConcatFromSequenceImpl(sequence: List[np.ndarray], axis: int, new_axis: Optional[int] = 0) -> np.ndarray:
     if not new_axis:
         return np.concatenate(sequence, axis)
     else:
@@ -76,18 +70,18 @@ def ConcatFromSequenceImpl(sequence, axis, new_axis=0):
 class Sequence(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
 
         def make_graph(
-                nodes,  # type: List[onnx.helper.NodeProto]
-                input_shapes,  # type: List[Optional[typing.Sequence[Union[Text, int]]]]
-                output_shapes,  # type: List[Optional[typing.Sequence[Union[Text, int]]]]
-                input_names,  # type: List[Text]
-                output_names,  # type: List[Text]
-                input_types,  # type: List[TensorProto.DataType]
-                output_types,  # type: List[TensorProto.DataType]
-                initializers=None  # type: Optional[List[TensorProto]]
-        ):  # type: (...) -> onnx.helper.GraphProto
+                nodes: List[onnx.helper.NodeProto],
+                input_shapes: List[Optional[typing.Sequence[Union[Text, int]]]],
+                output_shapes: List[Optional[typing.Sequence[Union[Text, int]]]],
+                input_names: List[Text],
+                output_names: List[Text],
+                input_types: List[TensorProto.DataType],
+                output_types: List[TensorProto.DataType],
+                initializers: Optional[List[TensorProto]] = None
+        ) -> onnx.helper.GraphProto:
             graph = onnx.helper.make_graph(
                 nodes=nodes,
                 name='Sequence',

--- a/onnx/backend/test/case/model/shrink.py
+++ b/onnx/backend/test/case/model/shrink.py
@@ -15,7 +15,7 @@ from . import expect
 class ShrinkTest(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
 
         node = onnx.helper.make_node(
             'Shrink', ['x'], ['y'], lambd=1.5, bias=1.5,)

--- a/onnx/backend/test/case/model/sign.py
+++ b/onnx/backend/test/case/model/sign.py
@@ -16,7 +16,7 @@ from typing import Sequence
 class SingleSign(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Sign', ['x'], ['y'], name='test')
 

--- a/onnx/backend/test/case/model/single-relu.py
+++ b/onnx/backend/test/case/model/single-relu.py
@@ -15,7 +15,7 @@ from . import expect
 class SingleRelu(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
 
         node = onnx.helper.make_node(
             'Relu', ['x'], ['y'], name='test')

--- a/onnx/backend/test/case/model/stringnormalizer.py
+++ b/onnx/backend/test/case/model/stringnormalizer.py
@@ -18,8 +18,8 @@ from typing import Sequence
 class NormalizeStrings(Base):
 
     @staticmethod
-    def export():  # type: () -> None
-        def make_graph(node, input_shape, output_shape):  # type: (onnx.helper.NodeProto, Sequence[int], Sequence[int]) -> onnx.helper.GraphProto
+    def export() -> None:
+        def make_graph(node: onnx.helper.NodeProto, input_shape: Sequence[int], output_shape: Sequence[int]) -> onnx.helper.GraphProto:
             graph = onnx.helper.make_graph(
                 nodes=[node],
                 name='StringNormalizer',

--- a/onnx/backend/test/case/node/__init__.py
+++ b/onnx/backend/test/case/node/__init__.py
@@ -25,10 +25,10 @@ from onnx.onnx_pb import NodeProto, AttributeProto, TypeProto, FunctionProto
 
 
 # FIXME(TMVector): Any reason we can't get rid of this and use the C++ helper directly?
-def function_expand_helper(node,  # type: NodeProto
-                           function_proto,  # type: FunctionProto
-                           op_prefix  # type:  Text
-                           ):  # type:  (...) -> List[NodeProto]
+def function_expand_helper(node: NodeProto,
+                           function_proto: FunctionProto,
+                           op_prefix: Text
+                           ) -> List[NodeProto]:
     node_list = []
     io_names_map = dict()
     attribute_map = dict((a.name, a) for a in node.attribute)
@@ -78,7 +78,7 @@ def function_expand_helper(node,  # type: NodeProto
     return node_list
 
 
-def function_testcase_helper(node, input_types, name):  # type: (NodeProto, List[TypeProto], Text) -> List[NodeProto]
+def function_testcase_helper(node: NodeProto, input_types: List[TypeProto], name: Text) -> List[NodeProto]:
     test_op = node.op_type
     op_prefix = test_op + "_" + name + "_expanded_function"
     schema = onnx.defs.get_schema(test_op, node.domain)
@@ -103,7 +103,7 @@ def function_testcase_helper(node, input_types, name):  # type: (NodeProto, List
     return node_list
 
 
-def _extract_value_info(input, name, type_proto=None):  # type: (Union[List[Any], np.ndarray, None], Text, Optional[TypeProto]) -> onnx.ValueInfoProto
+def _extract_value_info(input: Union[List[Any], np.ndarray, None], name: Text, type_proto: Optional[TypeProto] = None) -> onnx.ValueInfoProto:
     if type_proto is None:
         if input is None:
             raise NotImplementedError("_extract_value_info: both input and type_proto arguments cannot be None.")
@@ -126,12 +126,12 @@ def _extract_value_info(input, name, type_proto=None):  # type: (Union[List[Any]
 # E.g., for an op with 3 inputs, if the second parameter is optional and we wish to omit it,
 # node.inputs would look like ["Param1", "", "Param3"], while inputs would look like
 # [input-1-value, input-3-value]
-def expect(node,  # type: onnx.NodeProto
-           inputs,  # type: Sequence[np.ndarray]
-           outputs,  # type: Sequence[np.ndarray]
-           name,  # type: Text
-           **kwargs  # type: Any
-           ):  # type: (...) -> None
+def expect(node: onnx.NodeProto,
+           inputs: Sequence[np.ndarray],
+           outputs: Sequence[np.ndarray],
+           name: Text,
+           **kwargs: Any
+           ) -> None:
     # skip if the node's op_type is not same as the given one
     if _TargetOpType and node.op_type != _TargetOpType:
         return
@@ -171,7 +171,7 @@ def expect(node,  # type: onnx.NodeProto
 
     # Create list of types for node.input, filling a default TypeProto for missing inputs:
     # E.g. merge(["x", "", "y"], [x-value-info, y-value-info]) will return [x-type, default-type, y-type]
-    def merge(node_inputs, present_value_info):  # type: (List[Text], List[onnx.ValueInfoProto]) -> List[TypeProto]
+    def merge(node_inputs: List[Text], present_value_info: List[onnx.ValueInfoProto]) -> List[TypeProto]:
         if (node_inputs):
             if (node_inputs[0] != ''):
                 return [present_value_info[0].type] + merge(node_inputs[1:], present_value_info[1:])
@@ -202,14 +202,14 @@ def expect(node,  # type: onnx.NodeProto
         ))
 
 
-def collect_testcases():  # type: () -> List[TestCase]
+def collect_testcases() -> List[TestCase]:
     '''Collect node test cases defined in python/numpy code.
     '''
     import_recursive(sys.modules[__name__])
     return _NodeTestCases
 
 
-def collect_testcases_by_operator(op_type):  # type: (Text) -> List[TestCase]
+def collect_testcases_by_operator(op_type: Text) -> List[TestCase]:
     '''Collect node test cases which include specific operator
     '''
     # only keep those tests related to this operator

--- a/onnx/backend/test/case/node/abs.py
+++ b/onnx/backend/test/case/node/abs.py
@@ -17,7 +17,7 @@ from onnx.backend.sample.ops.abs import abs
 class Abs(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Abs',
             inputs=['x'],

--- a/onnx/backend/test/case/node/acos.py
+++ b/onnx/backend/test/case/node/acos.py
@@ -15,7 +15,7 @@ from . import expect
 class Acos(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Acos',
             inputs=['x'],

--- a/onnx/backend/test/case/node/acosh.py
+++ b/onnx/backend/test/case/node/acosh.py
@@ -15,7 +15,7 @@ from . import expect
 class Acosh(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Acosh',
             inputs=['x'],

--- a/onnx/backend/test/case/node/adagrad.py
+++ b/onnx/backend/test/case/node/adagrad.py
@@ -30,7 +30,7 @@ def apply_adagrad(r, t, x, g, h, norm_coefficient, epsilon, decay_factor):  # ty
 class Adagrad(Base):
 
     @staticmethod
-    def export_adagrad():  # type: () -> None
+    def export_adagrad() -> None:
         # Define operator attributes.
         norm_coefficient = 0.001
         epsilon = 1e-5
@@ -63,7 +63,7 @@ class Adagrad(Base):
                opset_imports=[onnx.helper.make_opsetid(AI_ONNX_PREVIEW_TRAINING_DOMAIN, 1)])
 
     @staticmethod
-    def export_adagrad_multiple():  # type: () -> None
+    def export_adagrad_multiple() -> None:
         # Define operator attributes.
         norm_coefficient = 0.001
         epsilon = 1e-5

--- a/onnx/backend/test/case/node/adam.py
+++ b/onnx/backend/test/case/node/adam.py
@@ -40,7 +40,7 @@ def apply_adam(r, t, x, g, v, h, norm_coefficient, norm_coefficient_post, alpha,
 class Adam(Base):
 
     @staticmethod
-    def export_adam():  # type: () -> None
+    def export_adam() -> None:
         # Define operator attributes.
         norm_coefficient = 0.001
         alpha = 0.95
@@ -77,7 +77,7 @@ class Adam(Base):
                opset_imports=[onnx.helper.make_opsetid(AI_ONNX_PREVIEW_TRAINING_DOMAIN, 1)])
 
     @staticmethod
-    def export_adam_multiple():  # type: () -> None
+    def export_adam_multiple() -> None:
         # Define operator attributes.
         norm_coefficient = 0.001
         alpha = 0.95

--- a/onnx/backend/test/case/node/add.py
+++ b/onnx/backend/test/case/node/add.py
@@ -15,7 +15,7 @@ from . import expect
 class Add(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Add',
             inputs=['x', 'y'],
@@ -28,7 +28,7 @@ class Add(Base):
                name='test_add')
 
     @staticmethod
-    def export_add_uint8():  # type: () -> None
+    def export_add_uint8() -> None:
         node = onnx.helper.make_node(
             'Add',
             inputs=['x', 'y'],
@@ -41,7 +41,7 @@ class Add(Base):
                name='test_add_uint8')
 
     @staticmethod
-    def export_add_broadcast():  # type: () -> None
+    def export_add_broadcast() -> None:
         node = onnx.helper.make_node(
             'Add',
             inputs=['x', 'y'],

--- a/onnx/backend/test/case/node/and.py
+++ b/onnx/backend/test/case/node/and.py
@@ -15,7 +15,7 @@ from . import expect
 class And(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'And',
             inputs=['x', 'y'],
@@ -44,7 +44,7 @@ class And(Base):
                name='test_and4d')
 
     @staticmethod
-    def export_and_broadcast():  # type: () -> None
+    def export_and_broadcast() -> None:
         node = onnx.helper.make_node(
             'And',
             inputs=['x', 'y'],

--- a/onnx/backend/test/case/node/argmax.py
+++ b/onnx/backend/test/case/node/argmax.py
@@ -12,14 +12,14 @@ from ..base import Base
 from . import expect
 
 
-def argmax_use_numpy(data, axis=0, keepdims=1):  # type: (np.ndarray, int, int) -> (np.ndarray)
+def argmax_use_numpy(data: np.ndarray, axis: int = 0, keepdims: int = 1) -> (np.ndarray):
     result = np.argmax(data, axis=axis)
     if (keepdims == 1):
         result = np.expand_dims(result, axis)
     return result.astype(np.int64)
 
 
-def argmax_use_numpy_select_last_index(data, axis=0, keepdims=True):  # type: (np.ndarray, int, int) -> (np.ndarray)
+def argmax_use_numpy_select_last_index(data: np.ndarray, axis: int = 0, keepdims: int = True) -> (np.ndarray):
     data = np.flip(data, axis)
     result = np.argmax(data, axis=axis)
     result = data.shape[axis] - result - 1
@@ -31,7 +31,7 @@ def argmax_use_numpy_select_last_index(data, axis=0, keepdims=True):  # type: (n
 class ArgMax(Base):
 
     @staticmethod
-    def export_no_keepdims():  # type: () -> None
+    def export_no_keepdims() -> None:
         data = np.array([[2, 1], [3, 10]], dtype=np.float32)
         axis = 1
         keepdims = 0
@@ -51,7 +51,7 @@ class ArgMax(Base):
         expect(node, inputs=[data], outputs=[result], name='test_argmax_no_keepdims_random')
 
     @staticmethod
-    def export_keepdims():  # type: () -> None
+    def export_keepdims() -> None:
         data = np.array([[2, 1], [3, 10]], dtype=np.float32)
         axis = 1
         keepdims = 1
@@ -71,7 +71,7 @@ class ArgMax(Base):
         expect(node, inputs=[data], outputs=[result], name='test_argmax_keepdims_random')
 
     @staticmethod
-    def export_default_axes_keepdims():  # type: () -> None
+    def export_default_axes_keepdims() -> None:
         data = np.array([[2, 1], [3, 10]], dtype=np.float32)
         keepdims = 1
         node = onnx.helper.make_node(
@@ -90,7 +90,7 @@ class ArgMax(Base):
         expect(node, inputs=[data], outputs=[result], name='test_argmax_default_axis_random')
 
     @staticmethod
-    def export_negative_axis_keepdims():  # type: () -> None
+    def export_negative_axis_keepdims() -> None:
         data = np.array([[2, 1], [3, 10]], dtype=np.float32)
         axis = -1
         keepdims = 1
@@ -110,7 +110,7 @@ class ArgMax(Base):
         expect(node, inputs=[data], outputs=[result], name='test_argmax_negative_axis_keepdims_random')
 
     @staticmethod
-    def export_no_keepdims_select_last_index():  # type: () -> None
+    def export_no_keepdims_select_last_index() -> None:
         data = np.array([[2, 2], [3, 10]], dtype=np.float32)
         axis = 1
         keepdims = 0
@@ -131,7 +131,7 @@ class ArgMax(Base):
         expect(node, inputs=[data], outputs=[result], name='test_argmax_no_keepdims_random_select_last_index')
 
     @staticmethod
-    def export_keepdims_select_last_index():  # type: () -> None
+    def export_keepdims_select_last_index() -> None:
         data = np.array([[2, 2], [3, 10]], dtype=np.float32)
         axis = 1
         keepdims = 1
@@ -152,7 +152,7 @@ class ArgMax(Base):
         expect(node, inputs=[data], outputs=[result], name='test_argmax_keepdims_random_select_last_index')
 
     @staticmethod
-    def export_default_axes_keepdims_select_last_index():  # type: () -> None
+    def export_default_axes_keepdims_select_last_index() -> None:
         data = np.array([[2, 2], [3, 10]], dtype=np.float32)
         keepdims = 1
         node = onnx.helper.make_node(
@@ -172,7 +172,7 @@ class ArgMax(Base):
         expect(node, inputs=[data], outputs=[result], name='test_argmax_default_axis_random_select_last_index')
 
     @staticmethod
-    def export_negative_axis_keepdims_select_last_index():  # type: () -> None
+    def export_negative_axis_keepdims_select_last_index() -> None:
         data = np.array([[2, 2], [3, 10]], dtype=np.float32)
         axis = -1
         keepdims = 1

--- a/onnx/backend/test/case/node/argmin.py
+++ b/onnx/backend/test/case/node/argmin.py
@@ -12,14 +12,14 @@ from ..base import Base
 from . import expect
 
 
-def argmin_use_numpy(data, axis=0, keepdims=1):  # type: (np.ndarray, int, int) -> (np.ndarray)
+def argmin_use_numpy(data: np.ndarray, axis: int = 0, keepdims: int = 1) -> (np.ndarray):
     result = np.argmin(data, axis=axis)
     if (keepdims == 1):
         result = np.expand_dims(result, axis)
     return result.astype(np.int64)
 
 
-def argmin_use_numpy_select_last_index(data, axis=0, keepdims=True):  # type: (np.ndarray, int, int) -> (np.ndarray)
+def argmin_use_numpy_select_last_index(data: np.ndarray, axis: int = 0, keepdims: int = True) -> (np.ndarray):
     data = np.flip(data, axis)
     result = np.argmin(data, axis=axis)
     result = data.shape[axis] - result - 1
@@ -31,7 +31,7 @@ def argmin_use_numpy_select_last_index(data, axis=0, keepdims=True):  # type: (n
 class ArgMin(Base):
 
     @staticmethod
-    def export_no_keepdims():  # type: () -> None
+    def export_no_keepdims() -> None:
         data = np.array([[2, 1], [3, 10]], dtype=np.float32)
         axis = 1
         keepdims = 0
@@ -51,7 +51,7 @@ class ArgMin(Base):
         expect(node, inputs=[data], outputs=[result], name='test_argmin_no_keepdims_random')
 
     @staticmethod
-    def export_keepdims():  # type: () -> None
+    def export_keepdims() -> None:
         data = np.array([[2, 1], [3, 10]], dtype=np.float32)
         axis = 1
         keepdims = 1
@@ -71,7 +71,7 @@ class ArgMin(Base):
         expect(node, inputs=[data], outputs=[result], name='test_argmin_keepdims_random')
 
     @staticmethod
-    def export_default_axes_keepdims():  # type: () -> None
+    def export_default_axes_keepdims() -> None:
         data = np.array([[2, 1], [3, 10]], dtype=np.float32)
         keepdims = 1
         node = onnx.helper.make_node(
@@ -90,7 +90,7 @@ class ArgMin(Base):
         expect(node, inputs=[data], outputs=[result], name='test_argmin_default_axis_random')
 
     @staticmethod
-    def export_negative_axis_keepdims():  # type: () -> None
+    def export_negative_axis_keepdims() -> None:
         data = np.array([[2, 1], [3, 10]], dtype=np.float32)
         axis = -1
         keepdims = 1
@@ -110,7 +110,7 @@ class ArgMin(Base):
         expect(node, inputs=[data], outputs=[result], name='test_argmin_negative_axis_keepdims_random')
 
     @staticmethod
-    def export_no_keepdims_select_last_index():  # type: () -> None
+    def export_no_keepdims_select_last_index() -> None:
         data = np.array([[2, 2], [3, 10]], dtype=np.float32)
         axis = 1
         keepdims = 0
@@ -131,7 +131,7 @@ class ArgMin(Base):
         expect(node, inputs=[data], outputs=[result], name='test_argmin_no_keepdims_random_select_last_index')
 
     @staticmethod
-    def export_keepdims_select_last_index():  # type: () -> None
+    def export_keepdims_select_last_index() -> None:
         data = np.array([[2, 2], [3, 10]], dtype=np.float32)
         axis = 1
         keepdims = 1
@@ -152,7 +152,7 @@ class ArgMin(Base):
         expect(node, inputs=[data], outputs=[result], name='test_argmin_keepdims_random_select_last_index')
 
     @staticmethod
-    def export_default_axes_keepdims_select_last_index():  # type: () -> None
+    def export_default_axes_keepdims_select_last_index() -> None:
         data = np.array([[2, 2], [3, 10]], dtype=np.float32)
         keepdims = 1
         node = onnx.helper.make_node(
@@ -172,7 +172,7 @@ class ArgMin(Base):
         expect(node, inputs=[data], outputs=[result], name='test_argmin_default_axis_random_select_last_index')
 
     @staticmethod
-    def export_negative_axis_keepdims_select_last_index():  # type: () -> None
+    def export_negative_axis_keepdims_select_last_index() -> None:
         data = np.array([[2, 2], [3, 10]], dtype=np.float32)
         axis = -1
         keepdims = 1

--- a/onnx/backend/test/case/node/asin.py
+++ b/onnx/backend/test/case/node/asin.py
@@ -15,7 +15,7 @@ from . import expect
 class Asin(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Asin',
             inputs=['x'],

--- a/onnx/backend/test/case/node/asinh.py
+++ b/onnx/backend/test/case/node/asinh.py
@@ -15,7 +15,7 @@ from . import expect
 class Asinh(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Asinh',
             inputs=['x'],

--- a/onnx/backend/test/case/node/atan.py
+++ b/onnx/backend/test/case/node/atan.py
@@ -15,7 +15,7 @@ from . import expect
 class Atan(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Atan',
             inputs=['x'],

--- a/onnx/backend/test/case/node/atanh.py
+++ b/onnx/backend/test/case/node/atanh.py
@@ -15,7 +15,7 @@ from . import expect
 class Atanh(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Atanh',
             inputs=['x'],

--- a/onnx/backend/test/case/node/averagepool.py
+++ b/onnx/backend/test/case/node/averagepool.py
@@ -16,7 +16,7 @@ from .pool_op_common import get_pad_shape, get_output_shape, pool
 class AveragePool(Base):
 
     @staticmethod
-    def export_averagepool_2d_precomputed_pads():  # type: () -> None
+    def export_averagepool_2d_precomputed_pads() -> None:
         """
         input_shape: [1, 1, 5, 5]
         output_shape: [1, 1, 5, 5]
@@ -46,7 +46,7 @@ class AveragePool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_averagepool_2d_precomputed_pads')
 
     @staticmethod
-    def export_averagepool_2d_precomputed_pads_count_include_pad():  # type: () -> None
+    def export_averagepool_2d_precomputed_pads_count_include_pad() -> None:
         """
         input_shape: [1, 1, 5, 5]
         output_shape: [1, 1, 5, 5]
@@ -76,7 +76,7 @@ class AveragePool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_averagepool_2d_precomputed_pads_count_include_pad')
 
     @staticmethod
-    def export_averagepool_2d_precomputed_strides():  # type: () -> None
+    def export_averagepool_2d_precomputed_strides() -> None:
         """
         input_shape: [1, 1, 5, 5]
         output_shape: [1, 1, 2, 2]
@@ -101,7 +101,7 @@ class AveragePool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_averagepool_2d_precomputed_strides')
 
     @staticmethod
-    def export_averagepool_2d_precomputed_same_upper():  # type: () -> None
+    def export_averagepool_2d_precomputed_same_upper() -> None:
         """
         input_shape: [1, 1, 5, 5]
         output_shape: [1, 1, 3, 3]
@@ -129,7 +129,7 @@ class AveragePool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_averagepool_2d_precomputed_same_upper')
 
     @staticmethod
-    def export_averagepool_1d_default():  # type: () -> None
+    def export_averagepool_1d_default() -> None:
         """
         input_shape: [1, 3, 32]
         output_shape: [1, 3, 31]
@@ -151,7 +151,7 @@ class AveragePool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_averagepool_1d_default')
 
     @staticmethod
-    def export_averagepool_2d_default():  # type: () -> None
+    def export_averagepool_2d_default() -> None:
         """
         input_shape: [1, 3, 32, 32]
         output_shape: [1, 3, 31, 31]
@@ -173,7 +173,7 @@ class AveragePool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_averagepool_2d_default')
 
     @staticmethod
-    def export_averagepool_3d_default():  # type: () -> None
+    def export_averagepool_3d_default() -> None:
         """
         input_shape: [1, 3, 32, 32, 32]
         output_shape: [1, 3, 31, 31, 31]
@@ -195,7 +195,7 @@ class AveragePool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_averagepool_3d_default')
 
     @staticmethod
-    def export_averagepool_2d_same_upper():  # type: () -> None
+    def export_averagepool_2d_same_upper() -> None:
         """
         input_shape: [1, 3, 32, 32]
         output_shape: [1, 3, 32, 32]
@@ -225,7 +225,7 @@ class AveragePool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_averagepool_2d_same_upper')
 
     @staticmethod
-    def export_averagepool_2d_same_lower():  # type: () -> None
+    def export_averagepool_2d_same_lower() -> None:
         """
         input_shape: [1, 3, 32, 32]
         output_shape: [1, 3, 32, 32]
@@ -255,7 +255,7 @@ class AveragePool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_averagepool_2d_same_lower')
 
     @staticmethod
-    def export_averagepool_2d_pads():  # type: () -> None
+    def export_averagepool_2d_pads() -> None:
         """
         input_shape: [1, 3, 28, 28]
         output_shape: [1, 3, 30, 30]
@@ -285,7 +285,7 @@ class AveragePool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_averagepool_2d_pads')
 
     @staticmethod
-    def export_averagepool_2d_pads_count_include_pad():  # type: () -> None
+    def export_averagepool_2d_pads_count_include_pad() -> None:
         """
         input_shape: [1, 3, 28, 28]
         output_shape: [1, 3, 30, 30]
@@ -316,7 +316,7 @@ class AveragePool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_averagepool_2d_pads_count_include_pad')
 
     @staticmethod
-    def export_averagepool_2d_strides():  # type: () -> None
+    def export_averagepool_2d_strides() -> None:
         """
         input_shape: [1, 3, 32, 32]
         output_shape: [1, 3, 10, 10]
@@ -339,7 +339,7 @@ class AveragePool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_averagepool_2d_strides')
 
     @staticmethod
-    def export_averagepool_2d_ceil():  # type: () -> None
+    def export_averagepool_2d_ceil() -> None:
         """
         input_shape: [1, 1, 4, 4]
         output_shape: [1, 1, 2, 2]

--- a/onnx/backend/test/case/node/batchnorm.py
+++ b/onnx/backend/test/case/node/batchnorm.py
@@ -34,7 +34,7 @@ def _batchnorm_training_mode(x, s, bias, mean, var, momentum=0.9, epsilon=1e-5):
 
 class BatchNormalization(Base):
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         # input size: (2, 3, 4, 5)
         x = np.random.randn(2, 3, 4, 5).astype(np.float32)
         s = np.random.randn(3).astype(np.float32)
@@ -74,7 +74,7 @@ class BatchNormalization(Base):
                name='test_batchnorm_epsilon')
 
     @staticmethod
-    def export_train():  # type: () -> None
+    def export_train() -> None:
         # input size: (2, 3, 4, 5)
         x = np.random.randn(2, 3, 4, 5).astype(np.float32)
         s = np.random.randn(3).astype(np.float32)

--- a/onnx/backend/test/case/node/bernoulli.py
+++ b/onnx/backend/test/case/node/bernoulli.py
@@ -22,7 +22,7 @@ def bernoulli_reference_implementation(x, dtype):  # type: ignore
 
 class Bernoulli(Base):
     @staticmethod
-    def export_bernoulli_without_dtype():  # type: () -> None
+    def export_bernoulli_without_dtype() -> None:
         node = onnx.helper.make_node(
             'Bernoulli',
             inputs=['x'],
@@ -34,7 +34,7 @@ class Bernoulli(Base):
         expect(node, inputs=[x], outputs=[y], name='test_bernoulli')
 
     @staticmethod
-    def export_bernoulli_with_dtype():  # type: () -> None
+    def export_bernoulli_with_dtype() -> None:
         node = onnx.helper.make_node(
             'Bernoulli',
             inputs=['x'],
@@ -47,7 +47,7 @@ class Bernoulli(Base):
         expect(node, inputs=[x], outputs=[y], name='test_bernoulli_double')
 
     @staticmethod
-    def export_bernoulli_with_seed():  # type: () -> None
+    def export_bernoulli_with_seed() -> None:
         seed = np.float(0)
         node = onnx.helper.make_node(
             'Bernoulli',

--- a/onnx/backend/test/case/node/bitshift.py
+++ b/onnx/backend/test/case/node/bitshift.py
@@ -15,7 +15,7 @@ from . import expect
 class BitShift(Base):
 
     @staticmethod
-    def export_right_unit8():  # type: () -> None
+    def export_right_unit8() -> None:
         node = onnx.helper.make_node(
             'BitShift',
             inputs=['x', 'y'],
@@ -30,7 +30,7 @@ class BitShift(Base):
                name='test_bitshift_right_uint8')
 
     @staticmethod
-    def export_right_unit16():  # type: () -> None
+    def export_right_unit16() -> None:
         node = onnx.helper.make_node(
             'BitShift',
             inputs=['x', 'y'],
@@ -45,7 +45,7 @@ class BitShift(Base):
                name='test_bitshift_right_uint16')
 
     @staticmethod
-    def export_right_unit32():  # type: () -> None
+    def export_right_unit32() -> None:
         node = onnx.helper.make_node(
             'BitShift',
             inputs=['x', 'y'],
@@ -60,7 +60,7 @@ class BitShift(Base):
                name='test_bitshift_right_uint32')
 
     @staticmethod
-    def export_right_unit64():  # type: () -> None
+    def export_right_unit64() -> None:
         node = onnx.helper.make_node(
             'BitShift',
             inputs=['x', 'y'],
@@ -75,7 +75,7 @@ class BitShift(Base):
                name='test_bitshift_right_uint64')
 
     @staticmethod
-    def export_left_unit8():  # type: () -> None
+    def export_left_unit8() -> None:
         node = onnx.helper.make_node(
             'BitShift',
             inputs=['x', 'y'],
@@ -90,7 +90,7 @@ class BitShift(Base):
                name='test_bitshift_left_uint8')
 
     @staticmethod
-    def export_left_unit16():  # type: () -> None
+    def export_left_unit16() -> None:
         node = onnx.helper.make_node(
             'BitShift',
             inputs=['x', 'y'],
@@ -105,7 +105,7 @@ class BitShift(Base):
                name='test_bitshift_left_uint16')
 
     @staticmethod
-    def export_left_unit32():  # type: () -> None
+    def export_left_unit32() -> None:
         node = onnx.helper.make_node(
             'BitShift',
             inputs=['x', 'y'],
@@ -120,7 +120,7 @@ class BitShift(Base):
                name='test_bitshift_left_uint32')
 
     @staticmethod
-    def export_left_unit64():  # type: () -> None
+    def export_left_unit64() -> None:
         node = onnx.helper.make_node(
             'BitShift',
             inputs=['x', 'y'],

--- a/onnx/backend/test/case/node/cast.py
+++ b/onnx/backend/test/case/node/cast.py
@@ -21,7 +21,7 @@ import sys
 class Cast(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         shape = (3, 4)
         test_cases = [
             ('FLOAT', 'FLOAT16'),

--- a/onnx/backend/test/case/node/castlike.py
+++ b/onnx/backend/test/case/node/castlike.py
@@ -21,7 +21,7 @@ import sys
 class CastLike(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         shape = (3, 4)
         test_cases = [
             ('FLOAT', 'FLOAT16'),

--- a/onnx/backend/test/case/node/ceil.py
+++ b/onnx/backend/test/case/node/ceil.py
@@ -15,7 +15,7 @@ from . import expect
 class Ceil(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Ceil',
             inputs=['x'],

--- a/onnx/backend/test/case/node/celu.py
+++ b/onnx/backend/test/case/node/celu.py
@@ -15,7 +15,7 @@ from . import expect
 class Celu(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         alpha = 2.0
         node = onnx.helper.make_node(
             'Celu',

--- a/onnx/backend/test/case/node/clip.py
+++ b/onnx/backend/test/case/node/clip.py
@@ -15,7 +15,7 @@ from . import expect
 class Clip(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Clip',
             inputs=['x', 'min', 'max'],
@@ -58,7 +58,7 @@ class Clip(Base):
                name='test_clip_splitbounds')
 
     @staticmethod
-    def export_clip_default():  # type: () -> None
+    def export_clip_default() -> None:
         node = onnx.helper.make_node(
             'Clip',
             inputs=['x', 'min'],
@@ -95,7 +95,7 @@ class Clip(Base):
                name='test_clip_default_inbounds')
 
     @staticmethod
-    def export_clip_default_int8():  # type: () -> None
+    def export_clip_default_int8() -> None:
         node = onnx.helper.make_node(
             'Clip',
             inputs=['x', 'min'],

--- a/onnx/backend/test/case/node/compress.py
+++ b/onnx/backend/test/case/node/compress.py
@@ -15,7 +15,7 @@ from . import expect
 class Compress(Base):
 
     @staticmethod
-    def export_compress_0():  # type: () -> None
+    def export_compress_0() -> None:
         node = onnx.helper.make_node(
             'Compress',
             inputs=['input', 'condition'],
@@ -33,7 +33,7 @@ class Compress(Base):
                name='test_compress_0')
 
     @staticmethod
-    def export_compress_1():  # type: () -> None
+    def export_compress_1() -> None:
         node = onnx.helper.make_node(
             'Compress',
             inputs=['input', 'condition'],
@@ -52,7 +52,7 @@ class Compress(Base):
                name='test_compress_1')
 
     @staticmethod
-    def export_compress_default_axis():  # type: () -> None
+    def export_compress_default_axis() -> None:
         node = onnx.helper.make_node(
             'Compress',
             inputs=['input', 'condition'],
@@ -68,7 +68,7 @@ class Compress(Base):
                name='test_compress_default_axis')
 
     @staticmethod
-    def export_compress_negative_axis():  # type: () -> None
+    def export_compress_negative_axis() -> None:
         node = onnx.helper.make_node(
             'Compress',
             inputs=['input', 'condition'],

--- a/onnx/backend/test/case/node/concat.py
+++ b/onnx/backend/test/case/node/concat.py
@@ -16,15 +16,15 @@ from typing import Dict, Sequence, Text, Any
 class Concat(Base):
 
     @staticmethod
-    def export():  # type: () -> None
-        test_cases = {
+    def export() -> None:
+        test_cases: Dict[Text, Sequence[Any]] = {
             '1d': ([1, 2],
                    [3, 4]),
             '2d': ([[1, 2], [3, 4]],
                    [[5, 6], [7, 8]]),
             '3d': ([[[1, 2], [3, 4]], [[5, 6], [7, 8]]],
                    [[[9, 10], [11, 12]], [[13, 14], [15, 16]]])
-        }  # type: Dict[Text, Sequence[Any]]
+        }
 
         for test_case, values_ in test_cases.items():
             values = [np.asarray(v, dtype=np.float32) for v in values_]

--- a/onnx/backend/test/case/node/constant.py
+++ b/onnx/backend/test/case/node/constant.py
@@ -15,7 +15,7 @@ from . import expect
 class Constant(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         values = np.random.randn(5, 5).astype(np.float32)
         node = onnx.helper.make_node(
             'Constant',

--- a/onnx/backend/test/case/node/constantofshape.py
+++ b/onnx/backend/test/case/node/constantofshape.py
@@ -15,7 +15,7 @@ from . import expect
 class ConstantOfShape(Base):
 
     @staticmethod
-    def export_float_ones():  # type: () -> None
+    def export_float_ones() -> None:
         x = np.array([4, 3, 2]).astype(np.int64)
         tensor_value = onnx.helper.make_tensor("value", onnx.TensorProto.FLOAT,
                                                [1], [1])
@@ -31,7 +31,7 @@ class ConstantOfShape(Base):
                name='test_constantofshape_float_ones')
 
     @staticmethod
-    def export_int32_zeros():  # type: () -> None
+    def export_int32_zeros() -> None:
         x = np.array([10, 6]).astype(np.int64)
         tensor_value = onnx.helper.make_tensor("value", onnx.TensorProto.INT32,
                                                [1], [0])
@@ -46,7 +46,7 @@ class ConstantOfShape(Base):
                name='test_constantofshape_int_zeros')
 
     @staticmethod
-    def export_int32_shape_zero():  # type: () -> None
+    def export_int32_shape_zero() -> None:
         x = np.array([0, ]).astype(np.int64)
         tensor_value = onnx.helper.make_tensor("value", onnx.TensorProto.INT32,
                                                [1], [0])

--- a/onnx/backend/test/case/node/conv.py
+++ b/onnx/backend/test/case/node/conv.py
@@ -15,7 +15,7 @@ from . import expect
 class Conv(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
 
         x = np.array([[[[0., 1., 2., 3., 4.],  # (1, 1, 5, 5) input tensor
                         [5., 6., 7., 8., 9.],
@@ -59,7 +59,7 @@ class Conv(Base):
                name='test_basic_conv_without_padding')
 
     @staticmethod
-    def export_conv_with_strides():  # type: () -> None
+    def export_conv_with_strides() -> None:
 
         x = np.array([[[[0., 1., 2., 3., 4.],  # (1, 1, 7, 5) input tensor
                         [5., 6., 7., 8., 9.],
@@ -120,7 +120,7 @@ class Conv(Base):
                name='test_conv_with_strides_and_asymmetric_padding')
 
     @staticmethod
-    def export_conv_with_autopad_same():  # type: () -> None
+    def export_conv_with_autopad_same() -> None:
 
         x = np.array([[[[0., 1., 2., 3., 4.],  # (1, 1, 5, 5) input tensor
                         [5., 6., 7., 8., 9.],

--- a/onnx/backend/test/case/node/convinteger.py
+++ b/onnx/backend/test/case/node/convinteger.py
@@ -14,7 +14,7 @@ from . import expect
 class ConvInteger(Base):
 
     @staticmethod
-    def export_without_padding():  # type: () -> None
+    def export_without_padding() -> None:
 
         x = np.array([2, 3, 4, 5, 6, 7, 8, 9, 10]).astype(np.uint8).reshape((1, 1, 3, 3))
         x_zero_point = np.uint8(1)
@@ -31,7 +31,7 @@ class ConvInteger(Base):
                name='test_convinteger_without_padding')
 
     @staticmethod
-    def export_with_padding():  # type: () -> None
+    def export_with_padding() -> None:
 
         x = np.array([2, 3, 4, 5, 6, 7, 8, 9, 10]).astype(np.uint8).reshape((1, 1, 3, 3))
         x_zero_point = np.uint8(1)

--- a/onnx/backend/test/case/node/convtranspose.py
+++ b/onnx/backend/test/case/node/convtranspose.py
@@ -15,7 +15,7 @@ from . import expect
 class ConvTranspose(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         x = np.array([[[[0., 1., 2.],  # (1, 1, 3, 3)
                         [3., 4., 5.],
                         [6., 7., 8.]]]]).astype(np.float32)
@@ -44,7 +44,7 @@ class ConvTranspose(Base):
         expect(node, inputs=[x, W], outputs=[y], name='test_convtranspose')
 
     @staticmethod
-    def export_convtranspose_1d():  # type: () -> None
+    def export_convtranspose_1d() -> None:
         x = np.array([[[0., 1., 2.]]]).astype(np.float32)  # (1, 1, 3)
 
         W = np.array([[[1., 1., 1.],  # (1, 2, 3)
@@ -58,7 +58,7 @@ class ConvTranspose(Base):
         expect(node, inputs=[x, W], outputs=[y], name='test_convtranspose_1d')
 
     @staticmethod
-    def export_convtranspose_3d():  # type: () -> None
+    def export_convtranspose_3d() -> None:
         x = np.array([[[[[0., 1., 2., 3., 4.],  # (1, 1, 3, 4, 5)
                          [5., 6., 7., 8., 9.],
                          [10., 11., 12., 13., 14.],
@@ -166,7 +166,7 @@ class ConvTranspose(Base):
         expect(node, inputs=[x, W], outputs=[y], name='test_convtranspose_3d')
 
     @staticmethod
-    def export_convtranspose_attributes():  # type: () -> None
+    def export_convtranspose_attributes() -> None:
         x = np.array([[[[0., 1., 2.],  # (1, 1, 3, 3)
                         [3., 4., 5.],
                         [6., 7., 8.]]]]).astype(np.float32)
@@ -222,7 +222,7 @@ class ConvTranspose(Base):
                name='test_convtranspose_kernel_shape')
 
     @staticmethod
-    def export_convtranspose_pads():  # type: () -> None
+    def export_convtranspose_pads() -> None:
         x = np.array([[[[0., 1., 2.],  # (1, 1, 3, 3)
                         [3., 4., 5.],
                         [6., 7., 8.]]]]).astype(np.float32)
@@ -257,7 +257,7 @@ class ConvTranspose(Base):
         expect(node, inputs=[x, W], outputs=[y], name='test_convtranspose_pads')
 
     @staticmethod
-    def export_convtranspose_dilations():  # type: () -> None
+    def export_convtranspose_dilations() -> None:
         x = np.array([[[[3., 8., 1.],  # (1, 1, 3, 3)
                         [9., 5., 7.],
                         [3., 2., 6.]]]]).astype(np.float32)
@@ -275,7 +275,7 @@ class ConvTranspose(Base):
         expect(node, inputs=[x, W], outputs=[y], name='test_convtranspose_dilations')
 
     @staticmethod
-    def export_convtranspose_autopad_same():  # type: () -> None
+    def export_convtranspose_autopad_same() -> None:
         x = np.array([[[[0., 1., 2.],  # (1, 1, 3, 3)
                         [3., 4., 5.],
                         [6., 7., 8.]]]]).astype(np.float32)

--- a/onnx/backend/test/case/node/cos.py
+++ b/onnx/backend/test/case/node/cos.py
@@ -15,7 +15,7 @@ from . import expect
 class Cos(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Cos',
             inputs=['x'],

--- a/onnx/backend/test/case/node/cosh.py
+++ b/onnx/backend/test/case/node/cosh.py
@@ -15,7 +15,7 @@ from . import expect
 class Cosh(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Cosh',
             inputs=['x'],

--- a/onnx/backend/test/case/node/cumsum.py
+++ b/onnx/backend/test/case/node/cumsum.py
@@ -15,7 +15,7 @@ from . import expect
 class CumSum(Base):
 
     @staticmethod
-    def export_cumsum_1d():  # type: () -> None
+    def export_cumsum_1d() -> None:
         node = onnx.helper.make_node(
             'CumSum',
             inputs=['x', 'axis'],
@@ -28,7 +28,7 @@ class CumSum(Base):
                name='test_cumsum_1d')
 
     @staticmethod
-    def export_cumsum_1d_exclusive():  # type: () -> None
+    def export_cumsum_1d_exclusive() -> None:
         node = onnx.helper.make_node(
             'CumSum',
             inputs=['x', 'axis'],
@@ -42,7 +42,7 @@ class CumSum(Base):
                name='test_cumsum_1d_exclusive')
 
     @staticmethod
-    def export_cumsum_1d_reverse():  # type: () -> None
+    def export_cumsum_1d_reverse() -> None:
         node = onnx.helper.make_node(
             'CumSum',
             inputs=['x', 'axis'],
@@ -56,7 +56,7 @@ class CumSum(Base):
                name='test_cumsum_1d_reverse')
 
     @staticmethod
-    def export_cumsum_1d_reverse_exclusive():  # type: () -> None
+    def export_cumsum_1d_reverse_exclusive() -> None:
         node = onnx.helper.make_node(
             'CumSum',
             inputs=['x', 'axis'],
@@ -71,7 +71,7 @@ class CumSum(Base):
                name='test_cumsum_1d_reverse_exclusive')
 
     @staticmethod
-    def export_cumsum_2d_axis_0():  # type: () -> None
+    def export_cumsum_2d_axis_0() -> None:
         node = onnx.helper.make_node(
             'CumSum',
             inputs=['x', 'axis'],
@@ -84,7 +84,7 @@ class CumSum(Base):
                name='test_cumsum_2d_axis_0')
 
     @staticmethod
-    def export_cumsum_2d_axis_1():  # type: () -> None
+    def export_cumsum_2d_axis_1() -> None:
         node = onnx.helper.make_node(
             'CumSum',
             inputs=['x', 'axis'],
@@ -97,7 +97,7 @@ class CumSum(Base):
                name='test_cumsum_2d_axis_1')
 
     @staticmethod
-    def export_cumsum_2d_negative_axis():  # type: () -> None
+    def export_cumsum_2d_negative_axis() -> None:
         node = onnx.helper.make_node(
             'CumSum',
             inputs=['x', 'axis'],

--- a/onnx/backend/test/case/node/depthtospace.py
+++ b/onnx/backend/test/case/node/depthtospace.py
@@ -15,7 +15,7 @@ from . import expect
 class DepthToSpace(Base):
 
     @staticmethod
-    def export_default_mode_example():  # type: () -> None
+    def export_default_mode_example() -> None:
         node = onnx.helper.make_node(
             'DepthToSpace',
             inputs=['x'],
@@ -55,7 +55,7 @@ class DepthToSpace(Base):
                name='test_depthtospace_example')
 
     @staticmethod
-    def export_crd_mode_example():  # type: () -> None
+    def export_crd_mode_example() -> None:
         node = onnx.helper.make_node(
             'DepthToSpace',
             inputs=['x'],

--- a/onnx/backend/test/case/node/dequantizelinear.py
+++ b/onnx/backend/test/case/node/dequantizelinear.py
@@ -14,7 +14,7 @@ from . import expect
 class DequantizeLinear(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node('DequantizeLinear',
                                      inputs=['x', 'x_scale', 'x_zero_point'],
                                      outputs=['y'],)
@@ -29,7 +29,7 @@ class DequantizeLinear(Base):
                name='test_dequantizelinear')
 
     @staticmethod
-    def export_axis():  # type: () -> None
+    def export_axis() -> None:
         node = onnx.helper.make_node('DequantizeLinear',
                                      inputs=['x', 'x_scale', 'x_zero_point'],
                                      outputs=['y'],)

--- a/onnx/backend/test/case/node/det.py
+++ b/onnx/backend/test/case/node/det.py
@@ -17,7 +17,7 @@ from . import expect
 class Det(Base):
 
     @staticmethod
-    def export_2d():  # type: () -> None
+    def export_2d() -> None:
         node = onnx.helper.make_node(
             'Det',
             inputs=['x'],
@@ -30,7 +30,7 @@ class Det(Base):
                name='test_det_2d')
 
     @staticmethod
-    def export_nd():  # type: () -> None
+    def export_nd() -> None:
         node = onnx.helper.make_node(
             'Det',
             inputs=['x'],

--- a/onnx/backend/test/case/node/div.py
+++ b/onnx/backend/test/case/node/div.py
@@ -15,7 +15,7 @@ from . import expect
 class Div(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Div',
             inputs=['x', 'y'],
@@ -41,7 +41,7 @@ class Div(Base):
                name='test_div_uint8')
 
     @staticmethod
-    def export_div_broadcast():  # type: () -> None
+    def export_div_broadcast() -> None:
         node = onnx.helper.make_node(
             'Div',
             inputs=['x', 'y'],

--- a/onnx/backend/test/case/node/dropout.py
+++ b/onnx/backend/test/case/node/dropout.py
@@ -34,7 +34,7 @@ class Dropout(Base):
 
     # Inferencing tests.
     @staticmethod
-    def export_default():  # type: () -> None
+    def export_default() -> None:
         seed = np.int64(0)
         node = onnx.helper.make_node(
             'Dropout',
@@ -48,7 +48,7 @@ class Dropout(Base):
         expect(node, inputs=[x], outputs=[y], name='test_dropout_default')
 
     @staticmethod
-    def export_default_ratio():  # type: () -> None
+    def export_default_ratio() -> None:
         seed = np.int64(0)
         node = onnx.helper.make_node(
             'Dropout',
@@ -63,7 +63,7 @@ class Dropout(Base):
         expect(node, inputs=[x, r], outputs=[y], name='test_dropout_default_ratio')
 
     @staticmethod
-    def export_default_mask():  # type: () -> None
+    def export_default_mask() -> None:
         seed = np.int64(0)
         node = onnx.helper.make_node(
             'Dropout',
@@ -77,7 +77,7 @@ class Dropout(Base):
         expect(node, inputs=[x], outputs=[y, z], name='test_dropout_default_mask')
 
     @staticmethod
-    def export_default_mask_ratio():  # type: () -> None
+    def export_default_mask_ratio() -> None:
         seed = np.int64(0)
         node = onnx.helper.make_node(
             'Dropout',
@@ -94,7 +94,7 @@ class Dropout(Base):
     # Training tests.
 
     @staticmethod
-    def export_training_default():  # type: () -> None
+    def export_training_default() -> None:
         seed = np.int64(0)
         node = onnx.helper.make_node(
             'Dropout',
@@ -110,7 +110,7 @@ class Dropout(Base):
         expect(node, inputs=[x, r, t], outputs=[y], name='test_training_dropout_default')
 
     @staticmethod
-    def export_training_default_ratio_mask():  # type: () -> None
+    def export_training_default_ratio_mask() -> None:
         seed = np.int64(0)
         node = onnx.helper.make_node(
             'Dropout',
@@ -126,7 +126,7 @@ class Dropout(Base):
         expect(node, inputs=[x, r, t], outputs=[y, z], name='test_training_dropout_default_mask')
 
     @staticmethod
-    def export_training():  # type: () -> None
+    def export_training() -> None:
         seed = np.int64(0)
         node = onnx.helper.make_node(
             'Dropout',
@@ -142,7 +142,7 @@ class Dropout(Base):
         expect(node, inputs=[x, r, t], outputs=[y], name='test_training_dropout')
 
     @staticmethod
-    def export_training_ratio_mask():  # type: () -> None
+    def export_training_ratio_mask() -> None:
         seed = np.int64(0)
         node = onnx.helper.make_node(
             'Dropout',
@@ -158,7 +158,7 @@ class Dropout(Base):
         expect(node, inputs=[x, r, t], outputs=[y, z], name='test_training_dropout_mask')
 
     @staticmethod
-    def export_training_default_zero_ratio():  # type: () -> None
+    def export_training_default_zero_ratio() -> None:
         seed = np.int64(0)
         node = onnx.helper.make_node(
             'Dropout',
@@ -174,7 +174,7 @@ class Dropout(Base):
         expect(node, inputs=[x, r, t], outputs=[y], name='test_training_dropout_zero_ratio')
 
     @staticmethod
-    def export_training_default_zero_ratio_mask():  # type: () -> None
+    def export_training_default_zero_ratio_mask() -> None:
         seed = np.int64(0)
         node = onnx.helper.make_node(
             'Dropout',
@@ -192,7 +192,7 @@ class Dropout(Base):
     # Old dropout tests
 
     @staticmethod
-    def export_default_old():  # type: () -> None
+    def export_default_old() -> None:
         node = onnx.helper.make_node(
             'Dropout',
             inputs=['x'],
@@ -205,7 +205,7 @@ class Dropout(Base):
                name='test_dropout_default_old', opset_imports=[helper.make_opsetid("", 11)])
 
     @staticmethod
-    def export_random_old():  # type: () -> None
+    def export_random_old() -> None:
         node = onnx.helper.make_node(
             'Dropout',
             inputs=['x'],

--- a/onnx/backend/test/case/node/dynamicquantizelinear.py
+++ b/onnx/backend/test/case/node/dynamicquantizelinear.py
@@ -16,7 +16,7 @@ from . import expect
 class DynamicQuantizeLinear(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node('DynamicQuantizeLinear',
             inputs=['x'],
             outputs=['y', 'y_scale', 'y_zero_point'],

--- a/onnx/backend/test/case/node/einsum.py
+++ b/onnx/backend/test/case/node/einsum.py
@@ -14,7 +14,7 @@ from . import expect
 from typing import Tuple, Text
 
 
-def einsum_reference_implementation(Eqn, Operands):  # type: (Text, Tuple[np.ndarray, ...]) -> np.ndarray
+def einsum_reference_implementation(Eqn: Text, Operands: Tuple[np.ndarray, ...]) -> np.ndarray:
     Z = np.einsum(Eqn, *Operands)
     return Z
 
@@ -22,7 +22,7 @@ def einsum_reference_implementation(Eqn, Operands):  # type: (Text, Tuple[np.nda
 class Einsum(Base):
 
     @staticmethod
-    def export_einsum_transpose():  # type: () -> None
+    def export_einsum_transpose() -> None:
         Eqn = 'ij->ji'
         node = onnx.helper.make_node(
             'Einsum',
@@ -37,7 +37,7 @@ class Einsum(Base):
         expect(node, inputs=[X], outputs=[Y], name='test_einsum_transpose')
 
     @staticmethod
-    def export_einsum_sum():  # type: () -> None
+    def export_einsum_sum() -> None:
         Eqn = 'ij->i'
         node = onnx.helper.make_node(
             'Einsum',
@@ -52,7 +52,7 @@ class Einsum(Base):
         expect(node, inputs=[X], outputs=[Z], name='test_einsum_sum')
 
     @staticmethod
-    def export_einsum_batch_diagonal():  # type: () -> None
+    def export_einsum_batch_diagonal() -> None:
         Eqn = '...ii ->...i'
         node = onnx.helper.make_node(
             'Einsum',
@@ -67,7 +67,7 @@ class Einsum(Base):
         expect(node, inputs=[X], outputs=[Z], name='test_einsum_batch_diagonal')
 
     @staticmethod
-    def export_einsum_inner_prod():  # type: () -> None
+    def export_einsum_inner_prod() -> None:
         Eqn = 'i,i'
         node = onnx.helper.make_node(
             'Einsum',
@@ -83,7 +83,7 @@ class Einsum(Base):
         expect(node, inputs=[X, Y], outputs=[Z], name='test_einsum_inner_prod')
 
     @staticmethod
-    def export_einsum_batch_matmul():  # type: () -> None
+    def export_einsum_batch_matmul() -> None:
         Eqn = 'bij, bjk -> bik'
         node = onnx.helper.make_node(
             'Einsum',

--- a/onnx/backend/test/case/node/elu.py
+++ b/onnx/backend/test/case/node/elu.py
@@ -15,7 +15,7 @@ from . import expect
 class Elu(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Elu',
             inputs=['x'],
@@ -35,7 +35,7 @@ class Elu(Base):
                name='test_elu')
 
     @staticmethod
-    def export_elu_default():  # type: () -> None
+    def export_elu_default() -> None:
         default_alpha = 1.0
         node = onnx.helper.make_node(
             'Elu',

--- a/onnx/backend/test/case/node/equal.py
+++ b/onnx/backend/test/case/node/equal.py
@@ -15,7 +15,7 @@ from . import expect
 class Equal(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Equal',
             inputs=['x', 'y'],
@@ -29,7 +29,7 @@ class Equal(Base):
                name='test_equal')
 
     @staticmethod
-    def export_equal_broadcast():  # type: () -> None
+    def export_equal_broadcast() -> None:
         node = onnx.helper.make_node(
             'Equal',
             inputs=['x', 'y'],

--- a/onnx/backend/test/case/node/erf.py
+++ b/onnx/backend/test/case/node/erf.py
@@ -17,7 +17,7 @@ from . import expect
 class Erf(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Erf',
             inputs=['x'],

--- a/onnx/backend/test/case/node/exp.py
+++ b/onnx/backend/test/case/node/exp.py
@@ -15,7 +15,7 @@ from . import expect
 class Exp(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Exp',
             inputs=['x'],

--- a/onnx/backend/test/case/node/expand.py
+++ b/onnx/backend/test/case/node/expand.py
@@ -15,7 +15,7 @@ from . import expect
 class Expand(Base):
 
     @staticmethod
-    def export_dim_changed():  # type: () -> None
+    def export_dim_changed() -> None:
         node = onnx.helper.make_node(
             'Expand',
             inputs=['data', 'new_shape'],
@@ -40,7 +40,7 @@ class Expand(Base):
                name='test_expand_dim_changed')
 
     @staticmethod
-    def export_dim_unchanged():  # type: () -> None
+    def export_dim_unchanged() -> None:
         node = onnx.helper.make_node(
             'Expand',
             inputs=['data', 'new_shape'],

--- a/onnx/backend/test/case/node/eyelike.py
+++ b/onnx/backend/test/case/node/eyelike.py
@@ -15,7 +15,7 @@ from . import expect
 class EyeLike(Base):
 
     @staticmethod
-    def export_without_dtype():  # type: () -> None
+    def export_without_dtype() -> None:
         shape = (4, 4)
         node = onnx.helper.make_node(
             'EyeLike',
@@ -28,7 +28,7 @@ class EyeLike(Base):
         expect(node, inputs=[x], outputs=[y], name='test_eyelike_without_dtype')
 
     @staticmethod
-    def export_with_dtype():  # type: () -> None
+    def export_with_dtype() -> None:
         shape = (3, 4)
         node = onnx.helper.make_node(
             'EyeLike',
@@ -42,7 +42,7 @@ class EyeLike(Base):
         expect(node, inputs=[x], outputs=[y], name='test_eyelike_with_dtype')
 
     @staticmethod
-    def export_populate_off_main_diagonal():  # type: () -> None
+    def export_populate_off_main_diagonal() -> None:
         shape = (4, 5)
         off_diagonal_offset = 1
         node = onnx.helper.make_node(

--- a/onnx/backend/test/case/node/flatten.py
+++ b/onnx/backend/test/case/node/flatten.py
@@ -15,7 +15,7 @@ from . import expect
 class Flatten(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         shape = (2, 3, 4, 5)
         a = np.random.random_sample(shape).astype(np.float32)
 
@@ -33,7 +33,7 @@ class Flatten(Base):
                    name='test_flatten_axis' + str(i))
 
     @staticmethod
-    def export_flatten_with_default_axis():  # type: () -> None
+    def export_flatten_with_default_axis() -> None:
         node = onnx.helper.make_node(
             'Flatten',
             inputs=['a'],
@@ -48,7 +48,7 @@ class Flatten(Base):
                name='test_flatten_default_axis')
 
     @staticmethod
-    def export_flatten_negative_axis():  # type: () -> None
+    def export_flatten_negative_axis() -> None:
         shape = (2, 3, 4, 5)
         a = np.random.random_sample(shape).astype(np.float32)
 

--- a/onnx/backend/test/case/node/floor.py
+++ b/onnx/backend/test/case/node/floor.py
@@ -15,7 +15,7 @@ from . import expect
 class Floor(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Floor',
             inputs=['x'],

--- a/onnx/backend/test/case/node/gather.py
+++ b/onnx/backend/test/case/node/gather.py
@@ -15,7 +15,7 @@ from . import expect
 class Gather(Base):
 
     @staticmethod
-    def export_gather_0():  # type: () -> None
+    def export_gather_0() -> None:
         node = onnx.helper.make_node(
             'Gather',
             inputs=['data', 'indices'],
@@ -30,7 +30,7 @@ class Gather(Base):
                name='test_gather_0')
 
     @staticmethod
-    def export_gather_1():  # type: () -> None
+    def export_gather_1() -> None:
         node = onnx.helper.make_node(
             'Gather',
             inputs=['data', 'indices'],
@@ -45,7 +45,7 @@ class Gather(Base):
                name='test_gather_1')
 
     @staticmethod
-    def export_gather_2d_indices():  # type: () -> None
+    def export_gather_2d_indices() -> None:
         node = onnx.helper.make_node(
             'Gather',
             inputs=['data', 'indices'],
@@ -60,7 +60,7 @@ class Gather(Base):
                name='test_gather_2d_indices')
 
     @staticmethod
-    def export_gather_negative_indices():  # type: () -> None
+    def export_gather_negative_indices() -> None:
         node = onnx.helper.make_node(
             'Gather',
             inputs=['data', 'indices'],

--- a/onnx/backend/test/case/node/gatherelements.py
+++ b/onnx/backend/test/case/node/gatherelements.py
@@ -24,7 +24,7 @@ def gather_elements(data, indices, axis=0):  # type: ignore
 class GatherElements(Base):
 
     @staticmethod
-    def export_gather_elements_0():  # type: () -> None
+    def export_gather_elements_0() -> None:
         axis = 1
         node = onnx.helper.make_node(
             'GatherElements',
@@ -46,7 +46,7 @@ class GatherElements(Base):
                name='test_gather_elements_0')
 
     @staticmethod
-    def export_gather_elements_1():  # type: () -> None
+    def export_gather_elements_1() -> None:
         axis = 0
         node = onnx.helper.make_node(
             'GatherElements',
@@ -69,7 +69,7 @@ class GatherElements(Base):
                name='test_gather_elements_1')
 
     @staticmethod
-    def export_gather_elements_negative_indices():  # type: () -> None
+    def export_gather_elements_negative_indices() -> None:
         axis = 0
         node = onnx.helper.make_node(
             'GatherElements',

--- a/onnx/backend/test/case/node/gathernd.py
+++ b/onnx/backend/test/case/node/gathernd.py
@@ -12,8 +12,7 @@ from ..base import Base
 from . import expect
 
 
-def gather_nd_impl(data, indices, batch_dims):
-    # type: (np.ndarray, np.ndarray, int) -> np.ndarray
+def gather_nd_impl(data: np.ndarray, indices: np.ndarray, batch_dims: int) -> np.ndarray:
     # Note the data rank - will be reused multiple times later
     data_rank = len(data.shape)
 
@@ -57,7 +56,7 @@ def gather_nd_impl(data, indices, batch_dims):
 class GatherND(Base):
 
     @staticmethod
-    def export_int32():  # type: () -> None
+    def export_int32() -> None:
         node = onnx.helper.make_node(
             'GatherND',
             inputs=['data', 'indices'],
@@ -73,7 +72,7 @@ class GatherND(Base):
                name='test_gathernd_example_int32')
 
     @staticmethod
-    def export_float32():  # type: () -> None
+    def export_float32() -> None:
         node = onnx.helper.make_node(
             'GatherND',
             inputs=['data', 'indices'],
@@ -89,7 +88,7 @@ class GatherND(Base):
                name='test_gathernd_example_float32')
 
     @staticmethod
-    def export_int32_batchdim_1():  # type: () -> None
+    def export_int32_batchdim_1() -> None:
         node = onnx.helper.make_node(
             'GatherND',
             inputs=['data', 'indices'],

--- a/onnx/backend/test/case/node/gemm.py
+++ b/onnx/backend/test/case/node/gemm.py
@@ -13,8 +13,8 @@ from ..base import Base
 from . import expect
 
 
-def gemm_reference_implementation(A, B, C=None, alpha=1., beta=1., transA=0,
-                                  transB=0):  # type: (np.ndarray, np.ndarray, Optional[np.ndarray], float, float, int, int) -> np.ndarray
+def gemm_reference_implementation(A: np.ndarray, B: np.ndarray, C: Optional[np.ndarray] = None, alpha: float = 1., beta: float = 1., transA: int = 0,
+                                  transB: int = 0) -> np.ndarray:
     A = A if transA == 0 else A.T
     B = B if transB == 0 else B.T
     C = C if C is not None else np.array(0)
@@ -27,7 +27,7 @@ def gemm_reference_implementation(A, B, C=None, alpha=1., beta=1., transA=0,
 class Gemm(Base):
 
     @staticmethod
-    def export_default_zero_bias():  # type: () -> None
+    def export_default_zero_bias() -> None:
         node = onnx.helper.make_node(
             'Gemm',
             inputs=['a', 'b', 'c'],
@@ -41,7 +41,7 @@ class Gemm(Base):
                name='test_gemm_default_zero_bias')
 
     @staticmethod
-    def export_default_no_bias():  # type: () -> None
+    def export_default_no_bias() -> None:
         node = onnx.helper.make_node(
             'Gemm',
             inputs=['a', 'b'],
@@ -54,7 +54,7 @@ class Gemm(Base):
                name='test_gemm_default_no_bias')
 
     @staticmethod
-    def export_default_scalar_bias():  # type: () -> None
+    def export_default_scalar_bias() -> None:
         node = onnx.helper.make_node(
             'Gemm',
             inputs=['a', 'b', 'c'],
@@ -68,7 +68,7 @@ class Gemm(Base):
                name='test_gemm_default_scalar_bias')
 
     @staticmethod
-    def export_default_single_elem_vector_bias():  # type: () -> None
+    def export_default_single_elem_vector_bias() -> None:
         node = onnx.helper.make_node(
             'Gemm',
             inputs=['a', 'b', 'c'],
@@ -82,7 +82,7 @@ class Gemm(Base):
                name='test_gemm_default_single_elem_vector_bias')
 
     @staticmethod
-    def export_default_vector_bias():  # type: () -> None
+    def export_default_vector_bias() -> None:
         node = onnx.helper.make_node(
             'Gemm',
             inputs=['a', 'b', 'c'],
@@ -96,7 +96,7 @@ class Gemm(Base):
                name='test_gemm_default_vector_bias')
 
     @staticmethod
-    def export_default_matrix_bias():  # type: () -> None
+    def export_default_matrix_bias() -> None:
         node = onnx.helper.make_node(
             'Gemm',
             inputs=['a', 'b', 'c'],
@@ -110,7 +110,7 @@ class Gemm(Base):
                name='test_gemm_default_matrix_bias')
 
     @staticmethod
-    def export_transposeA():  # type: () -> None
+    def export_transposeA() -> None:
         node = onnx.helper.make_node(
             'Gemm',
             inputs=['a', 'b', 'c'],
@@ -125,7 +125,7 @@ class Gemm(Base):
                name='test_gemm_transposeA')
 
     @staticmethod
-    def export_transposeB():  # type: () -> None
+    def export_transposeB() -> None:
         node = onnx.helper.make_node(
             'Gemm',
             inputs=['a', 'b', 'c'],
@@ -140,7 +140,7 @@ class Gemm(Base):
                name='test_gemm_transposeB')
 
     @staticmethod
-    def export_alpha():  # type: () -> None
+    def export_alpha() -> None:
         node = onnx.helper.make_node(
             'Gemm',
             inputs=['a', 'b', 'c'],
@@ -155,7 +155,7 @@ class Gemm(Base):
                name='test_gemm_alpha')
 
     @staticmethod
-    def export_beta():  # type: () -> None
+    def export_beta() -> None:
         node = onnx.helper.make_node(
             'Gemm',
             inputs=['a', 'b', 'c'],
@@ -170,7 +170,7 @@ class Gemm(Base):
                name='test_gemm_beta')
 
     @staticmethod
-    def export_all_attributes():  # type: () -> None
+    def export_all_attributes() -> None:
         node = onnx.helper.make_node(
             'Gemm',
             inputs=['a', 'b', 'c'],

--- a/onnx/backend/test/case/node/globalaveragepool.py
+++ b/onnx/backend/test/case/node/globalaveragepool.py
@@ -15,7 +15,7 @@ from . import expect
 class GlobalAveragePool(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'GlobalAveragePool',
             inputs=['x'],
@@ -26,7 +26,7 @@ class GlobalAveragePool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_globalaveragepool')
 
     @staticmethod
-    def export_globalaveragepool_precomputed():  # type: () -> None
+    def export_globalaveragepool_precomputed() -> None:
 
         node = onnx.helper.make_node(
             'GlobalAveragePool',

--- a/onnx/backend/test/case/node/globalmaxpool.py
+++ b/onnx/backend/test/case/node/globalmaxpool.py
@@ -15,7 +15,7 @@ from . import expect
 class GlobalMaxPool(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
 
         node = onnx.helper.make_node(
             'GlobalMaxPool',
@@ -27,7 +27,7 @@ class GlobalMaxPool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_globalmaxpool')
 
     @staticmethod
-    def export_globalmaxpool_precomputed():  # type: () -> None
+    def export_globalmaxpool_precomputed() -> None:
 
         node = onnx.helper.make_node(
             'GlobalMaxPool',

--- a/onnx/backend/test/case/node/greater.py
+++ b/onnx/backend/test/case/node/greater.py
@@ -15,7 +15,7 @@ from . import expect
 class Greater(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Greater',
             inputs=['x', 'y'],
@@ -29,7 +29,7 @@ class Greater(Base):
                name='test_greater')
 
     @staticmethod
-    def export_greater_broadcast():  # type: () -> None
+    def export_greater_broadcast() -> None:
         node = onnx.helper.make_node(
             'Greater',
             inputs=['x', 'y'],

--- a/onnx/backend/test/case/node/greater_equal.py
+++ b/onnx/backend/test/case/node/greater_equal.py
@@ -15,7 +15,7 @@ from . import expect
 class Greater(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'GreaterOrEqual',
             inputs=['x', 'y'],
@@ -29,7 +29,7 @@ class Greater(Base):
                name='test_greater_equal')
 
     @staticmethod
-    def export_greater_broadcast():  # type: () -> None
+    def export_greater_broadcast() -> None:
         node = onnx.helper.make_node(
             'GreaterOrEqual',
             inputs=['x', 'y'],

--- a/onnx/backend/test/case/node/gridsample.py
+++ b/onnx/backend/test/case/node/gridsample.py
@@ -15,7 +15,7 @@ from . import expect
 class GridSample(Base):
 
     @staticmethod
-    def export_gridsample():  # type: () -> None
+    def export_gridsample() -> None:
         node = onnx.helper.make_node(
             'GridSample',
             inputs=['X', 'Grid'],
@@ -114,7 +114,7 @@ class GridSample(Base):
                name='test_gridsample')
 
     @staticmethod
-    def export_gridsample_paddingmode():  # type: () -> None
+    def export_gridsample_paddingmode() -> None:
         # X shape, [N, C, H, W] - [1, 1, 3, 2]
         X = np.array(
             [
@@ -220,7 +220,7 @@ class GridSample(Base):
                name='test_gridsample_reflection_padding')
 
     @staticmethod
-    def export_gridsample_mode_aligncorners():  # type: () -> None
+    def export_gridsample_mode_aligncorners() -> None:
         # X shape, [N, C, H, W] - [1, 1, 3, 2]
         X = np.array(
             [

--- a/onnx/backend/test/case/node/gru.py
+++ b/onnx/backend/test/case/node/gru.py
@@ -14,7 +14,7 @@ from . import expect
 
 
 class GRU_Helper():
-    def __init__(self, **params):  # type: (*Any) -> None
+    def __init__(self, **params: Any) -> None:
         # GRU Input Names
         X = str('X')
         W = str('W')
@@ -57,13 +57,13 @@ class GRU_Helper():
         else:
             raise NotImplementedError()
 
-    def f(self, x):  # type: (np.ndarray) -> np.ndarray
+    def f(self, x: np.ndarray) -> np.ndarray:
         return 1 / (1 + np.exp(-x))
 
-    def g(self, x):  # type: (np.ndarray) -> np.ndarray
+    def g(self, x: np.ndarray) -> np.ndarray:
         return np.tanh(x)
 
-    def step(self):  # type: () -> Tuple[np.ndarray, np.ndarray]
+    def step(self) -> Tuple[np.ndarray, np.ndarray]:
         seq_length = self.X.shape[0]
         hidden_size = self.H_0.shape[-1]
         batch_size = self.X.shape[1]
@@ -107,7 +107,7 @@ class GRU_Helper():
 class GRU(Base):
 
     @staticmethod
-    def export_defaults():  # type: () -> None
+    def export_defaults() -> None:
         input = np.array([[[1., 2.], [3., 4.], [5., 6.]]]).astype(np.float32)
 
         input_size = 2
@@ -130,7 +130,7 @@ class GRU(Base):
         expect(node, inputs=[input, W, R], outputs=[Y_h.astype(np.float32)], name='test_gru_defaults')
 
     @staticmethod
-    def export_initial_bias():  # type: () -> None
+    def export_initial_bias() -> None:
         input = np.array([[[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]]).astype(np.float32)
 
         input_size = 3
@@ -159,7 +159,7 @@ class GRU(Base):
         expect(node, inputs=[input, W, R, B], outputs=[Y_h.astype(np.float32)], name='test_gru_with_initial_bias')
 
     @staticmethod
-    def export_seq_length():  # type: () -> None
+    def export_seq_length() -> None:
         input = np.array([[[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]],
                           [[10., 11., 12.], [13., 14., 15.], [16., 17., 18.]]]).astype(np.float32)
 
@@ -187,7 +187,7 @@ class GRU(Base):
         expect(node, inputs=[input, W, R, B], outputs=[Y_h.astype(np.float32)], name='test_gru_seq_length')
 
     @staticmethod
-    def export_batchwise():  # type: () -> None
+    def export_batchwise() -> None:
         input = np.array([[[1., 2.]], [[3., 4.]], [[5., 6.]]]).astype(np.float32)
 
         input_size = 2

--- a/onnx/backend/test/case/node/hardmax.py
+++ b/onnx/backend/test/case/node/hardmax.py
@@ -12,7 +12,7 @@ from ..base import Base
 from . import expect
 
 
-def hardmax(x, axis=-1):  # type: (np.ndarray, int) -> np.ndarray
+def hardmax(x: np.ndarray, axis: int = -1) -> np.ndarray:
     x_argmax = np.argmax(x, axis=axis)
     y = np.zeros_like(x)
     np.put_along_axis(y, np.expand_dims(x_argmax, axis=axis), 1, axis=axis)
@@ -21,7 +21,7 @@ def hardmax(x, axis=-1):  # type: (np.ndarray, int) -> np.ndarray
 
 class Hardmax(Base):
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Hardmax',
             inputs=['x'],
@@ -48,7 +48,7 @@ class Hardmax(Base):
                name='test_hardmax_one_hot')
 
     @staticmethod
-    def export_hardmax_axis():  # type: () -> None
+    def export_hardmax_axis() -> None:
         x = np.random.randn(3, 4, 5).astype(np.float32)
         node = onnx.helper.make_node(
             'Hardmax',

--- a/onnx/backend/test/case/node/hardsigmoid.py
+++ b/onnx/backend/test/case/node/hardsigmoid.py
@@ -15,7 +15,7 @@ from . import expect
 class HardSigmoid(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'HardSigmoid',
             inputs=['x'],
@@ -35,7 +35,7 @@ class HardSigmoid(Base):
                name='test_hardsigmoid')
 
     @staticmethod
-    def export_hardsigmoid_default():  # type: () -> None
+    def export_hardsigmoid_default() -> None:
         default_alpha = 0.2
         default_beta = 0.5
         node = onnx.helper.make_node(

--- a/onnx/backend/test/case/node/hardswish.py
+++ b/onnx/backend/test/case/node/hardswish.py
@@ -12,7 +12,7 @@ from ..base import Base
 from . import expect
 
 
-def hardswish(x):  # type: (np.ndarray) -> np.ndarray
+def hardswish(x: np.ndarray) -> np.ndarray:
     alfa = float(1 / 6)
     beta = 0.5
     return x * np.maximum(0, np.minimum(1, alfa * x + beta))
@@ -21,7 +21,7 @@ def hardswish(x):  # type: (np.ndarray) -> np.ndarray
 class HardSwish(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'HardSwish',
             inputs=['x'],

--- a/onnx/backend/test/case/node/identity.py
+++ b/onnx/backend/test/case/node/identity.py
@@ -15,7 +15,7 @@ from . import expect
 class Identity(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Identity',
             inputs=['x'],
@@ -31,7 +31,7 @@ class Identity(Base):
                name='test_identity')
 
     @staticmethod
-    def export_sequence():  # type: () -> None
+    def export_sequence() -> None:
         node = onnx.helper.make_node(
             'Identity',
             inputs=['x'],
@@ -51,7 +51,7 @@ class Identity(Base):
         expect(node, inputs=[data], outputs=[data], name='test_identity_sequence')
 
     @staticmethod
-    def export_identity_opt():  # type: () -> None
+    def export_identity_opt() -> None:
         ten_in_tp = onnx.helper.make_tensor_type_proto(onnx.TensorProto.FLOAT, shape=[5])
         seq_in_tp = onnx.helper.make_sequence_type_proto(ten_in_tp)
         opt_in_tp = onnx.helper.make_optional_type_proto(seq_in_tp)

--- a/onnx/backend/test/case/node/if.py
+++ b/onnx/backend/test/case/node/if.py
@@ -21,7 +21,7 @@ def compute_if_outputs(x, cond):  # type: ignore
 
 class If(Base):
     @staticmethod
-    def export_if():  # type: () -> None
+    def export_if() -> None:
         # Given a bool scalar input cond.
         # return constant tensor x if cond is True, otherwise return constant tensor y.
 
@@ -73,7 +73,7 @@ class If(Base):
                opset_imports=[onnx.helper.make_opsetid("", 11)])
 
     @staticmethod
-    def export_if_seq():  # type: () -> None
+    def export_if_seq() -> None:
         # Given a bool scalar input cond.
         # return constant sequence x if cond is True, otherwise return constant sequence y.
 
@@ -137,7 +137,7 @@ class If(Base):
                opset_imports=[onnx.helper.make_opsetid("", 13)])
 
     @staticmethod
-    def export_if_optional():  # type: () -> None
+    def export_if_optional() -> None:
         # Given a bool scalar input cond, return an empty optional sequence of
         # tensor if True, return an optional sequence with value x
         # (the input optional sequence) otherwise.

--- a/onnx/backend/test/case/node/instancenorm.py
+++ b/onnx/backend/test/case/node/instancenorm.py
@@ -15,7 +15,7 @@ from . import expect
 class InstanceNormalization(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         def _instancenorm_test_mode(x, s, bias, epsilon=1e-5):  # type: ignore
             dims_x = len(x.shape)
             axis = tuple(range(2, dims_x))

--- a/onnx/backend/test/case/node/isinf.py
+++ b/onnx/backend/test/case/node/isinf.py
@@ -15,7 +15,7 @@ from . import expect
 class IsInf(Base):
 
     @staticmethod
-    def export_infinity():  # type: () -> None
+    def export_infinity() -> None:
         node = onnx.helper.make_node('IsInf',
                                      inputs=['x'],
                                      outputs=['y'],
@@ -27,7 +27,7 @@ class IsInf(Base):
         expect(node, inputs=[x], outputs=[y], name='test_isinf')
 
     @staticmethod
-    def export_positive_infinity_only():  # type: () -> None
+    def export_positive_infinity_only() -> None:
         node = onnx.helper.make_node('IsInf',
                                      inputs=['x'],
                                      outputs=['y'],
@@ -40,7 +40,7 @@ class IsInf(Base):
         expect(node, inputs=[x], outputs=[y], name='test_isinf_positive')
 
     @staticmethod
-    def export_negative_infinity_only():  # type: () -> None
+    def export_negative_infinity_only() -> None:
         node = onnx.helper.make_node('IsInf',
                                      inputs=['x'],
                                      outputs=['y'],

--- a/onnx/backend/test/case/node/isnan.py
+++ b/onnx/backend/test/case/node/isnan.py
@@ -15,7 +15,7 @@ from . import expect
 class IsNaN(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'IsNaN',
             inputs=['x'],

--- a/onnx/backend/test/case/node/leakyrelu.py
+++ b/onnx/backend/test/case/node/leakyrelu.py
@@ -15,7 +15,7 @@ from . import expect
 class LeakyRelu(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'LeakyRelu',
             inputs=['x'],
@@ -35,7 +35,7 @@ class LeakyRelu(Base):
                name='test_leakyrelu')
 
     @staticmethod
-    def export_leakyrelu_default():  # type: () -> None
+    def export_leakyrelu_default() -> None:
         default_alpha = 0.01
         node = onnx.helper.make_node(
             'LeakyRelu',

--- a/onnx/backend/test/case/node/less.py
+++ b/onnx/backend/test/case/node/less.py
@@ -15,7 +15,7 @@ from . import expect
 class Less(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Less',
             inputs=['x', 'y'],
@@ -29,7 +29,7 @@ class Less(Base):
                name='test_less')
 
     @staticmethod
-    def export_less_broadcast():  # type: () -> None
+    def export_less_broadcast() -> None:
         node = onnx.helper.make_node(
             'Less',
             inputs=['x', 'y'],

--- a/onnx/backend/test/case/node/less_equal.py
+++ b/onnx/backend/test/case/node/less_equal.py
@@ -15,7 +15,7 @@ from . import expect
 class Less(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'LessOrEqual',
             inputs=['x', 'y'],
@@ -29,7 +29,7 @@ class Less(Base):
                name='test_less_equal')
 
     @staticmethod
-    def export_less_broadcast():  # type: () -> None
+    def export_less_broadcast() -> None:
         node = onnx.helper.make_node(
             'LessOrEqual',
             inputs=['x', 'y'],

--- a/onnx/backend/test/case/node/log.py
+++ b/onnx/backend/test/case/node/log.py
@@ -15,7 +15,7 @@ from . import expect
 class Log(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Log',
             inputs=['x'],

--- a/onnx/backend/test/case/node/logsoftmax.py
+++ b/onnx/backend/test/case/node/logsoftmax.py
@@ -12,7 +12,7 @@ from ..base import Base
 from . import expect
 
 
-def logsoftmax(x, axis=-1):  # type: (np.ndarray, int) -> np.ndarray
+def logsoftmax(x: np.ndarray, axis: int = -1) -> np.ndarray:
     x_max = np.max(x, axis=axis, keepdims=True)
     tmp = np.exp(x - x_max)
     s = np.sum(tmp, axis=axis, keepdims=True)
@@ -22,7 +22,7 @@ def logsoftmax(x, axis=-1):  # type: (np.ndarray, int) -> np.ndarray
 class LogSoftmax(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'LogSoftmax',
             inputs=['x'],
@@ -36,7 +36,7 @@ class LogSoftmax(Base):
                name='test_logsoftmax_example_1')
 
     @staticmethod
-    def export_logsoftmax_axis():  # type: () -> None
+    def export_logsoftmax_axis() -> None:
         x = np.array([[0, 1, 2, 3], [10000, 10001, 10002, 10003]]
                      ).astype(np.float32)
         # expected output

--- a/onnx/backend/test/case/node/loop.py
+++ b/onnx/backend/test/case/node/loop.py
@@ -24,7 +24,7 @@ def compute_loop_outputs(x, seq, trip_count):  # type: ignore
 class Loop(Base):
 
     @staticmethod
-    def export_loop_11():  # type: () -> None
+    def export_loop_11() -> None:
         # Given a tensor x of values [x1, ..., xN], and initial tensor y
         # sum up its elements using a scan
         # returning the final state (y+x1+x2+...+xN) as well the scan_output
@@ -132,7 +132,7 @@ class Loop(Base):
                name='test_loop11', opset_imports=[onnx.helper.make_opsetid("", 11)])
 
     @staticmethod
-    def export_loop_13():  # type: () -> None
+    def export_loop_13() -> None:
         # Given a tensor x of values [x1, ..., xN],
         # Return a sequence of tensors of
         #   [[x1], [x1, x2], ..., [x1, ..., xN]]
@@ -239,7 +239,7 @@ class Loop(Base):
         )
 
         trip_count = np.array(5).astype(np.int64)
-        seq_empty = []  # type: List[Any]
+        seq_empty: List[Any] = []
         seq_res = [x[:int(i)] for i in x]
         cond = np.array(1).astype(bool)
         expect(node, inputs=[trip_count, cond, seq_empty], outputs=[seq_res],
@@ -250,7 +250,7 @@ class Loop(Base):
                                       onnx.helper.make_tensor_type_proto(onnx.TensorProto.FLOAT, []))])
 
     @staticmethod
-    def export_loop_16_none():  # type: () -> None
+    def export_loop_16_none() -> None:
         # Given a tensor sequence of values [x1, ..., xN], and an initial optional sequence of tensors [x0],
         # Return a concatenated sequence of tensors of
         #   [x0, [x1], [x1, x2], ..., [x1, ..., xN]]
@@ -423,7 +423,7 @@ class Loop(Base):
         trip_count = np.array(5).astype(np.int64)
         cond = np.array(1).astype(bool)
         seq_res = compute_loop_outputs(x, [x0], trip_count)
-        opt_seq_in = [x0]  # type: List[Any]
+        opt_seq_in: List[Any] = [x0]
         expect(node, inputs=[trip_count, cond, opt_seq_in], outputs=[seq_res],
                name='test_loop16_seq_none', opset_imports=[onnx.helper.make_opsetid("", 16)],
                input_type_protos=[onnx.helper.make_tensor_type_proto(onnx.TensorProto.INT64, trip_count.shape),

--- a/onnx/backend/test/case/node/lrn.py
+++ b/onnx/backend/test/case/node/lrn.py
@@ -15,7 +15,7 @@ from . import expect
 class LRN(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         alpha = 0.0002
         beta = 0.5
         bias = 2.0
@@ -41,7 +41,7 @@ class LRN(Base):
                name='test_lrn')
 
     @staticmethod
-    def export_default():  # type: () -> None
+    def export_default() -> None:
         alpha = 0.0001
         beta = 0.75
         bias = 1.0

--- a/onnx/backend/test/case/node/lstm.py
+++ b/onnx/backend/test/case/node/lstm.py
@@ -14,7 +14,7 @@ from . import expect
 
 
 class LSTM_Helper():
-    def __init__(self, **params):  # type: (*Any) -> None
+    def __init__(self, **params: Any) -> None:
         # LSTM Input Names
         X = str('X')
         W = str('W')
@@ -61,16 +61,16 @@ class LSTM_Helper():
         else:
             raise NotImplementedError()
 
-    def f(self, x):  # type: (np.ndarray) -> np.ndarray
+    def f(self, x: np.ndarray) -> np.ndarray:
         return 1 / (1 + np.exp(-x))
 
-    def g(self, x):  # type: (np.ndarray) -> np.ndarray
+    def g(self, x: np.ndarray) -> np.ndarray:
         return np.tanh(x)
 
-    def h(self, x):  # type: (np.ndarray) -> np.ndarray
+    def h(self, x: np.ndarray) -> np.ndarray:
         return np.tanh(x)
 
-    def step(self):  # type: () -> Tuple[np.ndarray, np.ndarray]
+    def step(self) -> Tuple[np.ndarray, np.ndarray]:
         seq_length = self.X.shape[0]
         hidden_size = self.H_0.shape[-1]
         batch_size = self.X.shape[1]
@@ -111,7 +111,7 @@ class LSTM_Helper():
 class LSTM(Base):
 
     @staticmethod
-    def export_defaults():  # type: () -> None
+    def export_defaults() -> None:
         input = np.array([[[1., 2.], [3., 4.], [5., 6.]]]).astype(np.float32)
 
         input_size = 2
@@ -134,7 +134,7 @@ class LSTM(Base):
         expect(node, inputs=[input, W, R], outputs=[Y_h.astype(np.float32)], name='test_lstm_defaults')
 
     @staticmethod
-    def export_initial_bias():  # type: () -> None
+    def export_initial_bias() -> None:
         input = np.array([[[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]]).astype(np.float32)
 
         input_size = 3
@@ -163,7 +163,7 @@ class LSTM(Base):
         expect(node, inputs=[input, W, R, B], outputs=[Y_h.astype(np.float32)], name='test_lstm_with_initial_bias')
 
     @staticmethod
-    def export_peepholes():  # type: () -> None
+    def export_peepholes() -> None:
         input = np.array([[[1., 2., 3., 4.], [5., 6., 7., 8.]]]).astype(np.float32)
 
         input_size = 4
@@ -194,7 +194,7 @@ class LSTM(Base):
                name='test_lstm_with_peepholes')
 
     @staticmethod
-    def export_batchwise():  # type: () -> None
+    def export_batchwise() -> None:
         input = np.array([[[1., 2.]], [[3., 4.]], [[5., 6.]]]).astype(np.float32)
 
         input_size = 2

--- a/onnx/backend/test/case/node/matmul.py
+++ b/onnx/backend/test/case/node/matmul.py
@@ -15,7 +15,7 @@ from . import expect
 class MatMul(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'MatMul',
             inputs=['a', 'b'],

--- a/onnx/backend/test/case/node/matmulinteger.py
+++ b/onnx/backend/test/case/node/matmulinteger.py
@@ -14,7 +14,7 @@ from . import expect
 class MatMulInteger(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node('MatMulInteger',
             inputs=['A', 'B', 'a_zero_point', 'b_zero_point'],
             outputs=['Y'],)

--- a/onnx/backend/test/case/node/max.py
+++ b/onnx/backend/test/case/node/max.py
@@ -16,7 +16,7 @@ from ..utils import all_numeric_dtypes
 class Max(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         data_0 = np.array([3, 2, 1]).astype(np.float32)
         data_1 = np.array([1, 4, 4]).astype(np.float32)
         data_2 = np.array([2, 5, 3]).astype(np.float32)
@@ -47,7 +47,7 @@ class Max(Base):
                name='test_max_two_inputs')
 
     @staticmethod
-    def export_max_all_numeric_types():  # type: () -> None
+    def export_max_all_numeric_types() -> None:
         for op_dtype in all_numeric_dtypes:
             data_0 = np.array([3, 2, 1]).astype(op_dtype)
             data_1 = np.array([1, 4, 4]).astype(op_dtype)

--- a/onnx/backend/test/case/node/maxpool.py
+++ b/onnx/backend/test/case/node/maxpool.py
@@ -16,7 +16,7 @@ from .pool_op_common import get_output_shape, get_pad_shape, pool
 class MaxPool(Base):
 
     @staticmethod
-    def export_maxpool_2d_uint8():  # type: () -> None
+    def export_maxpool_2d_uint8() -> None:
         """
         input_shape: [1, 1, 5, 5]
         output_shape: [1, 1, 5, 5]
@@ -46,7 +46,7 @@ class MaxPool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_maxpool_2d_uint8')
 
     @staticmethod
-    def export_maxpool_2d_precomputed_pads():  # type: () -> None
+    def export_maxpool_2d_precomputed_pads() -> None:
         """
         input_shape: [1, 1, 5, 5]
         output_shape: [1, 1, 5, 5]
@@ -77,7 +77,7 @@ class MaxPool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_maxpool_2d_precomputed_pads')
 
     @staticmethod
-    def export_maxpool_with_argmax_2d_precomputed_pads():  # type: () -> None
+    def export_maxpool_with_argmax_2d_precomputed_pads() -> None:
         """
         input_shape: [1, 1, 5, 5]
         output_shape: [1, 1, 5, 5]
@@ -113,7 +113,7 @@ class MaxPool(Base):
         expect(node, inputs=[x], outputs=[y, z], name='test_maxpool_with_argmax_2d_precomputed_pads')
 
     @staticmethod
-    def export_maxpool_2d_precomputed_strides():  # type: () -> None
+    def export_maxpool_2d_precomputed_strides() -> None:
         """
         input_shape: [1, 1, 5, 5]
         output_shape: [1, 1, 2, 2]
@@ -138,7 +138,7 @@ class MaxPool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_maxpool_2d_precomputed_strides')
 
     @staticmethod
-    def export_maxpool_with_argmax_2d_precomputed_strides():  # type: () -> None
+    def export_maxpool_with_argmax_2d_precomputed_strides() -> None:
         """
         input_shape: [1, 1, 5, 5]
         output_shape: [1, 1, 2, 2]
@@ -166,7 +166,7 @@ class MaxPool(Base):
         expect(node, inputs=[x], outputs=[y, z], name='test_maxpool_with_argmax_2d_precomputed_strides')
 
     @staticmethod
-    def export_maxpool_2d_precomputed_same_upper():  # type: () -> None
+    def export_maxpool_2d_precomputed_same_upper() -> None:
         """
         input_shape: [1, 1, 5, 5]
         output_shape: [1, 1, 3, 3]
@@ -194,7 +194,7 @@ class MaxPool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_maxpool_2d_precomputed_same_upper')
 
     @staticmethod
-    def export_maxpool_1d_default():  # type: () -> None
+    def export_maxpool_1d_default() -> None:
         """
         input_shape: [1, 3, 32]
         output_shape: [1, 3, 31]
@@ -216,7 +216,7 @@ class MaxPool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_maxpool_1d_default')
 
     @staticmethod
-    def export_maxpool_2d_default():  # type: () -> None
+    def export_maxpool_2d_default() -> None:
         """
         input_shape: [1, 3, 32, 32]
         output_shape: [1, 3, 31, 31]
@@ -238,7 +238,7 @@ class MaxPool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_maxpool_2d_default')
 
     @staticmethod
-    def export_maxpool_3d_default():  # type: () -> None
+    def export_maxpool_3d_default() -> None:
         """
         input_shape: [1, 3, 32, 32, 32]
         output_shape: [1, 3, 31, 31, 31]
@@ -260,7 +260,7 @@ class MaxPool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_maxpool_3d_default')
 
     @staticmethod
-    def export_maxpool_2d_same_upper():  # type: () -> None
+    def export_maxpool_2d_same_upper() -> None:
         """
         input_shape: [1, 3, 32, 32]
         output_shape: [1, 3, 32, 32]
@@ -290,7 +290,7 @@ class MaxPool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_maxpool_2d_same_upper')
 
     @staticmethod
-    def export_maxpool_2d_same_lower():  # type: () -> None
+    def export_maxpool_2d_same_lower() -> None:
         """
         input_shape: [1, 3, 32, 32]
         output_shape: [1, 3, 32, 32]
@@ -320,7 +320,7 @@ class MaxPool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_maxpool_2d_same_lower')
 
     @staticmethod
-    def export_maxpool_2d_pads():  # type: () -> None
+    def export_maxpool_2d_pads() -> None:
         """
         input_shape: [1, 3, 28, 28]
         output_shape: [1, 3, 30, 30]
@@ -347,7 +347,7 @@ class MaxPool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_maxpool_2d_pads')
 
     @staticmethod
-    def export_maxpool_2d_strides():  # type: () -> None
+    def export_maxpool_2d_strides() -> None:
         """
         input_shape: [1, 3, 32, 32]
         output_shape: [1, 3, 10, 10]
@@ -370,7 +370,7 @@ class MaxPool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_maxpool_2d_strides')
 
     @staticmethod
-    def export_maxpool_2d_ceil():  # type: () -> None
+    def export_maxpool_2d_ceil() -> None:
         """
         input_shape: [1, 1, 4, 4]
         output_shape: [1, 1, 2, 2]
@@ -396,7 +396,7 @@ class MaxPool(Base):
         expect(node, inputs=[x], outputs=[y], name='test_maxpool_2d_ceil')
 
     @staticmethod
-    def export_maxpool_2d_dilations():  # type: () -> None
+    def export_maxpool_2d_dilations() -> None:
         """
         input_shape: [1, 1, 4, 4]
         output_shape: [1, 1, 2, 2]

--- a/onnx/backend/test/case/node/maxunpool.py
+++ b/onnx/backend/test/case/node/maxunpool.py
@@ -15,7 +15,7 @@ from . import expect
 class MaxUnpool(Base):
 
     @staticmethod
-    def export_without_output_shape():  # type: () -> None
+    def export_without_output_shape() -> None:
         node = onnx.helper.make_node(
             'MaxUnpool',
             inputs=['xT', 'xI'],
@@ -34,7 +34,7 @@ class MaxUnpool(Base):
         expect(node, inputs=[xT, xI], outputs=[y], name='test_maxunpool_export_without_output_shape')
 
     @staticmethod
-    def export_with_output_shape():  # type: () -> None
+    def export_with_output_shape() -> None:
         node = onnx.helper.make_node(
             'MaxUnpool',
             inputs=['xT', 'xI', 'output_shape'],

--- a/onnx/backend/test/case/node/mean.py
+++ b/onnx/backend/test/case/node/mean.py
@@ -15,7 +15,7 @@ from . import expect
 class Mean(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         data_0 = np.array([3, 0, 2]).astype(np.float32)
         data_1 = np.array([1, 3, 4]).astype(np.float32)
         data_2 = np.array([2, 6, 6]).astype(np.float32)

--- a/onnx/backend/test/case/node/meanvariancenormalization.py
+++ b/onnx/backend/test/case/node/meanvariancenormalization.py
@@ -15,7 +15,7 @@ from . import expect
 class MeanVarianceNormalization(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'MeanVarianceNormalization',
             inputs=['X'],

--- a/onnx/backend/test/case/node/min.py
+++ b/onnx/backend/test/case/node/min.py
@@ -16,7 +16,7 @@ from ..utils import all_numeric_dtypes
 class Min(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         data_0 = np.array([3, 2, 1]).astype(np.float32)
         data_1 = np.array([1, 4, 4]).astype(np.float32)
         data_2 = np.array([2, 5, 0]).astype(np.float32)
@@ -47,7 +47,7 @@ class Min(Base):
                name='test_min_two_inputs')
 
     @staticmethod
-    def export_min_all_numeric_types():  # type: () -> None
+    def export_min_all_numeric_types() -> None:
         for op_dtype in all_numeric_dtypes:
             data_0 = np.array([3, 2, 1]).astype(op_dtype)
             data_1 = np.array([1, 4, 4]).astype(op_dtype)

--- a/onnx/backend/test/case/node/mod.py
+++ b/onnx/backend/test/case/node/mod.py
@@ -15,7 +15,7 @@ from . import expect
 class Mod(Base):
 
     @staticmethod
-    def export_mod_mixed_sign_float64():  # type: () -> None
+    def export_mod_mixed_sign_float64() -> None:
         node = onnx.helper.make_node(
             'Mod',
             inputs=['x', 'y'],
@@ -30,7 +30,7 @@ class Mod(Base):
                name='test_mod_mixed_sign_float64')
 
     @staticmethod
-    def export_mod_mixed_sign_float32():  # type: () -> None
+    def export_mod_mixed_sign_float32() -> None:
         node = onnx.helper.make_node(
             'Mod',
             inputs=['x', 'y'],
@@ -45,7 +45,7 @@ class Mod(Base):
                name='test_mod_mixed_sign_float32')
 
     @staticmethod
-    def export_mod_mixed_sign_float16():  # type: () -> None
+    def export_mod_mixed_sign_float16() -> None:
         node = onnx.helper.make_node(
             'Mod',
             inputs=['x', 'y'],
@@ -60,7 +60,7 @@ class Mod(Base):
                name='test_mod_mixed_sign_float16')
 
     @staticmethod
-    def export_mod_mixed_sign_int64():  # type: () -> None
+    def export_mod_mixed_sign_int64() -> None:
         node = onnx.helper.make_node(
             'Mod',
             inputs=['x', 'y'],
@@ -74,7 +74,7 @@ class Mod(Base):
                name='test_mod_mixed_sign_int64')
 
     @staticmethod
-    def export_mod_mixed_sign_int32():  # type: () -> None
+    def export_mod_mixed_sign_int32() -> None:
         node = onnx.helper.make_node(
             'Mod',
             inputs=['x', 'y'],
@@ -88,7 +88,7 @@ class Mod(Base):
                name='test_mod_mixed_sign_int32')
 
     @staticmethod
-    def export_mod_mixed_sign_int16():  # type: () -> None
+    def export_mod_mixed_sign_int16() -> None:
         node = onnx.helper.make_node(
             'Mod',
             inputs=['x', 'y'],
@@ -102,7 +102,7 @@ class Mod(Base):
                name='test_mod_mixed_sign_int16')
 
     @staticmethod
-    def export_mod_mixed_sign_int8():  # type: () -> None
+    def export_mod_mixed_sign_int8() -> None:
         node = onnx.helper.make_node(
             'Mod',
             inputs=['x', 'y'],
@@ -116,7 +116,7 @@ class Mod(Base):
                name='test_mod_mixed_sign_int8')
 
     @staticmethod
-    def export_mod_uint8():  # type: () -> None
+    def export_mod_uint8() -> None:
         node = onnx.helper.make_node(
             'Mod',
             inputs=['x', 'y'],
@@ -130,7 +130,7 @@ class Mod(Base):
                name='test_mod_uint8')
 
     @staticmethod
-    def export_mod_uint16():  # type: () -> None
+    def export_mod_uint16() -> None:
         node = onnx.helper.make_node(
             'Mod',
             inputs=['x', 'y'],
@@ -144,7 +144,7 @@ class Mod(Base):
                name='test_mod_uint16')
 
     @staticmethod
-    def export_mod_uint32():  # type: () -> None
+    def export_mod_uint32() -> None:
         node = onnx.helper.make_node(
             'Mod',
             inputs=['x', 'y'],
@@ -158,7 +158,7 @@ class Mod(Base):
                name='test_mod_uint32')
 
     @staticmethod
-    def export_mod_uint64():  # type: () -> None
+    def export_mod_uint64() -> None:
         node = onnx.helper.make_node(
             'Mod',
             inputs=['x', 'y'],
@@ -172,7 +172,7 @@ class Mod(Base):
                name='test_mod_uint64')
 
     @staticmethod
-    def export_mod_int64_fmod():  # type: () -> None
+    def export_mod_int64_fmod() -> None:
         node = onnx.helper.make_node(
             'Mod',
             inputs=['x', 'y'],
@@ -187,7 +187,7 @@ class Mod(Base):
                name='test_mod_int64_fmod')
 
     @staticmethod
-    def export_mod_broadcast():  # type: () -> None
+    def export_mod_broadcast() -> None:
         node = onnx.helper.make_node(
             'Mod',
             inputs=['x', 'y'],

--- a/onnx/backend/test/case/node/momentum.py
+++ b/onnx/backend/test/case/node/momentum.py
@@ -40,7 +40,7 @@ def apply_nesterov(r, t, x, g, v, norm_coefficient, alpha, beta):  # type: ignor
 class Momentum(Base):
 
     @staticmethod
-    def export_momentum():  # type: () -> None
+    def export_momentum() -> None:
         # Define operator attributes.
         norm_coefficient = 0.001
         alpha = 0.95
@@ -74,7 +74,7 @@ class Momentum(Base):
                opset_imports=[onnx.helper.make_opsetid(AI_ONNX_PREVIEW_TRAINING_DOMAIN, 1)])
 
     @staticmethod
-    def export_nesterov_momentum():  # type: () -> None
+    def export_nesterov_momentum() -> None:
         # Define operator attributes.
         norm_coefficient = 0.01
         alpha = 0.95
@@ -108,7 +108,7 @@ class Momentum(Base):
                opset_imports=[onnx.helper.make_opsetid(AI_ONNX_PREVIEW_TRAINING_DOMAIN, 1)])
 
     @staticmethod
-    def export_momentum_multiple():  # type: () -> None
+    def export_momentum_multiple() -> None:
         # Define operator attributes.
         norm_coefficient = 0.001
         alpha = 0.95

--- a/onnx/backend/test/case/node/mul.py
+++ b/onnx/backend/test/case/node/mul.py
@@ -15,7 +15,7 @@ from . import expect
 class Mul(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Mul',
             inputs=['x', 'y'],
@@ -41,7 +41,7 @@ class Mul(Base):
                name='test_mul_uint8')
 
     @staticmethod
-    def export_mul_broadcast():  # type: () -> None
+    def export_mul_broadcast() -> None:
         node = onnx.helper.make_node(
             'Mul',
             inputs=['x', 'y'],

--- a/onnx/backend/test/case/node/neg.py
+++ b/onnx/backend/test/case/node/neg.py
@@ -15,7 +15,7 @@ from . import expect
 class Neg(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Neg',
             inputs=['x'],

--- a/onnx/backend/test/case/node/negativeloglikelihoodloss.py
+++ b/onnx/backend/test/case/node/negativeloglikelihoodloss.py
@@ -76,7 +76,7 @@ def compute_negative_log_likelihood_loss(input, target, weight=None, reduction='
 class NegativeLogLikelihoodLoss(Base):
 
     @staticmethod
-    def export_input_shape_is_NC():  # type: () -> None
+    def export_input_shape_is_NC() -> None:
         reduction = 'none'
         node = onnx.helper.make_node(
             'NegativeLogLikelihoodLoss',
@@ -96,7 +96,7 @@ class NegativeLogLikelihoodLoss(Base):
             name='test_nllloss_NC')
 
     @staticmethod
-    def export_input_shape_is_NCd1d2():  # type: () -> None
+    def export_input_shape_is_NCd1d2() -> None:
         reduction = 'none'
         node = onnx.helper.make_node(
             'NegativeLogLikelihoodLoss',
@@ -116,7 +116,7 @@ class NegativeLogLikelihoodLoss(Base):
             name='test_nllloss_NCd1d2')
 
     @staticmethod
-    def export_input_shape_is_NCd1d2_reduction_mean():  # type: () -> None
+    def export_input_shape_is_NCd1d2_reduction_mean() -> None:
         reduction = 'mean'
         node = onnx.helper.make_node(
             'NegativeLogLikelihoodLoss',
@@ -136,7 +136,7 @@ class NegativeLogLikelihoodLoss(Base):
             name='test_nllloss_NCd1d2_reduction_mean')
 
     @staticmethod
-    def export_input_shape_is_NCd1d2_reduction_sum():  # type: () -> None
+    def export_input_shape_is_NCd1d2_reduction_sum() -> None:
         reduction = 'sum'
         node = onnx.helper.make_node(
             'NegativeLogLikelihoodLoss',
@@ -156,7 +156,7 @@ class NegativeLogLikelihoodLoss(Base):
             name='test_nllloss_NCd1d2_reduction_sum')
 
     @staticmethod
-    def export_input_shape_is_NCd1d2_with_weight():  # type: () -> None
+    def export_input_shape_is_NCd1d2_with_weight() -> None:
         reduction = 'none'
         node = onnx.helper.make_node(
             'NegativeLogLikelihoodLoss',
@@ -177,7 +177,7 @@ class NegativeLogLikelihoodLoss(Base):
             name='test_nllloss_NCd1d2_with_weight')
 
     @staticmethod
-    def export_input_shape_is_NCd1d2_with_weight_reduction_mean():  # type: () -> None
+    def export_input_shape_is_NCd1d2_with_weight_reduction_mean() -> None:
         reduction = 'mean'
         node = onnx.helper.make_node(
             'NegativeLogLikelihoodLoss',
@@ -198,7 +198,7 @@ class NegativeLogLikelihoodLoss(Base):
             name='test_nllloss_NCd1d2_with_weight_reduction_mean')
 
     @staticmethod
-    def export_input_shape_is_NCd1d2_with_weight_reduction_sum():  # type: () -> None
+    def export_input_shape_is_NCd1d2_with_weight_reduction_sum() -> None:
         reduction = 'sum'
         node = onnx.helper.make_node(
             'NegativeLogLikelihoodLoss',
@@ -219,7 +219,7 @@ class NegativeLogLikelihoodLoss(Base):
             name='test_nllloss_NCd1d2_with_weight_reduction_sum')
 
     @staticmethod
-    def export_input_shape_is_NCd1d2_with_weight_reduction_sum_ii():  # type: () -> None
+    def export_input_shape_is_NCd1d2_with_weight_reduction_sum_ii() -> None:
         reduction = 'sum'
         ignore_index = np.int64(0)
         node = onnx.helper.make_node(
@@ -243,7 +243,7 @@ class NegativeLogLikelihoodLoss(Base):
             name='test_nllloss_NCd1d2_with_weight_reduction_sum_ii')
 
     @staticmethod
-    def export_input_shape_is_NCd1d2_no_weight_reduction_mean_ii():  # type: () -> None
+    def export_input_shape_is_NCd1d2_no_weight_reduction_mean_ii() -> None:
         reduction = 'mean'
         ignore_index = np.int64(1)
         node = onnx.helper.make_node(
@@ -266,7 +266,7 @@ class NegativeLogLikelihoodLoss(Base):
             name='test_nllloss_NCd1d2_no_weight_reduction_mean_ii')
 
     @staticmethod
-    def export_input_shape_is_NCd1():  # type: () -> None
+    def export_input_shape_is_NCd1() -> None:
         reduction = 'mean'
         node = onnx.helper.make_node(
             'NegativeLogLikelihoodLoss',
@@ -286,7 +286,7 @@ class NegativeLogLikelihoodLoss(Base):
             name='test_nllloss_NCd1')
 
     @staticmethod
-    def export_input_shape_is_NCd1_weight():  # type: () -> None
+    def export_input_shape_is_NCd1_weight() -> None:
         reduction = 'mean'
         node = onnx.helper.make_node(
             'NegativeLogLikelihoodLoss',
@@ -307,7 +307,7 @@ class NegativeLogLikelihoodLoss(Base):
             name='test_nllloss_NCd1_weight')
 
     @staticmethod
-    def export_input_shape_is_NCd1_ii():  # type: () -> None
+    def export_input_shape_is_NCd1_ii() -> None:
         reduction = 'mean'
         ignore_index = np.int64(1)
         node = onnx.helper.make_node(
@@ -330,7 +330,7 @@ class NegativeLogLikelihoodLoss(Base):
             name='test_nllloss_NCd1_ii')
 
     @staticmethod
-    def export_input_shape_is_NCd1_weight_ii():  # type: () -> None
+    def export_input_shape_is_NCd1_weight_ii() -> None:
         reduction = 'mean'
         ignore_index = np.int64(1)
         node = onnx.helper.make_node(
@@ -354,7 +354,7 @@ class NegativeLogLikelihoodLoss(Base):
             name='test_nllloss_NCd1_weight_ii')
 
     @staticmethod
-    def export_input_shape_is_NCd1d2d3d4d5_mean_weight():  # type: () -> None
+    def export_input_shape_is_NCd1d2d3d4d5_mean_weight() -> None:
         reduction = 'mean'
 
         node = onnx.helper.make_node(
@@ -378,7 +378,7 @@ class NegativeLogLikelihoodLoss(Base):
             name='test_nllloss_NCd1d2d3d4d5_mean_weight')
 
     @staticmethod
-    def export_input_shape_is_NCd1d2d3d4d5_none_no_weight():  # type: () -> None
+    def export_input_shape_is_NCd1d2d3d4d5_none_no_weight() -> None:
         reduction = 'none'
 
         node = onnx.helper.make_node(
@@ -400,7 +400,7 @@ class NegativeLogLikelihoodLoss(Base):
             name='test_nllloss_NCd1d2d3d4d5_none_no_weight')
 
     @staticmethod
-    def export_input_shape_is_NCd1_mean_weight_negative_ii():  # type: () -> None
+    def export_input_shape_is_NCd1_mean_weight_negative_ii() -> None:
         reduction = 'mean'
         ignore_index = np.int64(-1)
 
@@ -428,7 +428,7 @@ class NegativeLogLikelihoodLoss(Base):
             name='test_nllloss_NCd1_mean_weight_negative_ii')
 
     @staticmethod
-    def export_input_shape_is_NCd1d2d3_none_no_weight_negative_ii():  # type: () -> None
+    def export_input_shape_is_NCd1d2d3_none_no_weight_negative_ii() -> None:
         reduction = 'none'
         ignore_index = np.int64(-5)
 
@@ -454,7 +454,7 @@ class NegativeLogLikelihoodLoss(Base):
             name='test_nllloss_NCd1d2d3_none_no_weight_negative_ii')
 
     @staticmethod
-    def export_input_shape_is_NCd1d2d3_sum_weight_high_ii():  # type: () -> None
+    def export_input_shape_is_NCd1d2d3_sum_weight_high_ii() -> None:
         reduction = 'sum'
         ignore_index = np.int64(10)
 

--- a/onnx/backend/test/case/node/nonmaxsuppression.py
+++ b/onnx/backend/test/case/node/nonmaxsuppression.py
@@ -15,7 +15,7 @@ from . import expect
 class NonMaxSuppression(Base):
 
     @staticmethod
-    def export_nonmaxsuppression_suppress_by_IOU():  # type: () -> None
+    def export_nonmaxsuppression_suppress_by_IOU() -> None:
         node = onnx.helper.make_node(
             'NonMaxSuppression',
             inputs=['boxes', 'scores', 'max_output_boxes_per_class', 'iou_threshold', 'score_threshold'],
@@ -38,7 +38,7 @@ class NonMaxSuppression(Base):
         expect(node, inputs=[boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold], outputs=[selected_indices], name='test_nonmaxsuppression_suppress_by_IOU')
 
     @staticmethod
-    def export_nonmaxsuppression_suppress_by_IOU_and_scores():  # type: () -> None
+    def export_nonmaxsuppression_suppress_by_IOU_and_scores() -> None:
         node = onnx.helper.make_node(
             'NonMaxSuppression',
             inputs=['boxes', 'scores', 'max_output_boxes_per_class', 'iou_threshold', 'score_threshold'],
@@ -61,7 +61,7 @@ class NonMaxSuppression(Base):
         expect(node, inputs=[boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold], outputs=[selected_indices], name='test_nonmaxsuppression_suppress_by_IOU_and_scores')
 
     @staticmethod
-    def export_nonmaxsuppression_flipped_coordinates():  # type: () -> None
+    def export_nonmaxsuppression_flipped_coordinates() -> None:
         node = onnx.helper.make_node(
             'NonMaxSuppression',
             inputs=['boxes', 'scores', 'max_output_boxes_per_class', 'iou_threshold', 'score_threshold'],
@@ -84,7 +84,7 @@ class NonMaxSuppression(Base):
         expect(node, inputs=[boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold], outputs=[selected_indices], name='test_nonmaxsuppression_flipped_coordinates')
 
     @staticmethod
-    def export_nonmaxsuppression_limit_output_size():  # type: () -> None
+    def export_nonmaxsuppression_limit_output_size() -> None:
         node = onnx.helper.make_node(
             'NonMaxSuppression',
             inputs=['boxes', 'scores', 'max_output_boxes_per_class', 'iou_threshold', 'score_threshold'],
@@ -107,7 +107,7 @@ class NonMaxSuppression(Base):
         expect(node, inputs=[boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold], outputs=[selected_indices], name='test_nonmaxsuppression_limit_output_size')
 
     @staticmethod
-    def export_nonmaxsuppression_single_box():  # type: () -> None
+    def export_nonmaxsuppression_single_box() -> None:
         node = onnx.helper.make_node(
             'NonMaxSuppression',
             inputs=['boxes', 'scores', 'max_output_boxes_per_class', 'iou_threshold', 'score_threshold'],
@@ -125,7 +125,7 @@ class NonMaxSuppression(Base):
         expect(node, inputs=[boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold], outputs=[selected_indices], name='test_nonmaxsuppression_single_box')
 
     @staticmethod
-    def export_nonmaxsuppression_identical_boxes():  # type: () -> None
+    def export_nonmaxsuppression_identical_boxes() -> None:
         node = onnx.helper.make_node(
             'NonMaxSuppression',
             inputs=['boxes', 'scores', 'max_output_boxes_per_class', 'iou_threshold', 'score_threshold'],
@@ -153,7 +153,7 @@ class NonMaxSuppression(Base):
         expect(node, inputs=[boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold], outputs=[selected_indices], name='test_nonmaxsuppression_identical_boxes')
 
     @staticmethod
-    def export_nonmaxsuppression_center_point_box_format():  # type: () -> None
+    def export_nonmaxsuppression_center_point_box_format() -> None:
         node = onnx.helper.make_node(
             'NonMaxSuppression',
             inputs=['boxes', 'scores', 'max_output_boxes_per_class', 'iou_threshold', 'score_threshold'],
@@ -177,7 +177,7 @@ class NonMaxSuppression(Base):
         expect(node, inputs=[boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold], outputs=[selected_indices], name='test_nonmaxsuppression_center_point_box_format')
 
     @staticmethod
-    def export_nonmaxsuppression_two_classes():  # type: () -> None
+    def export_nonmaxsuppression_two_classes() -> None:
         node = onnx.helper.make_node(
             'NonMaxSuppression',
             inputs=['boxes', 'scores', 'max_output_boxes_per_class', 'iou_threshold', 'score_threshold'],
@@ -201,7 +201,7 @@ class NonMaxSuppression(Base):
         expect(node, inputs=[boxes, scores, max_output_boxes_per_class, iou_threshold, score_threshold], outputs=[selected_indices], name='test_nonmaxsuppression_two_classes')
 
     @staticmethod
-    def export_nonmaxsuppression_two_batches():  # type: () -> None
+    def export_nonmaxsuppression_two_batches() -> None:
         node = onnx.helper.make_node(
             'NonMaxSuppression',
             inputs=['boxes', 'scores', 'max_output_boxes_per_class', 'iou_threshold', 'score_threshold'],

--- a/onnx/backend/test/case/node/nonzero.py
+++ b/onnx/backend/test/case/node/nonzero.py
@@ -15,7 +15,7 @@ from . import expect
 class NonZero(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'NonZero',
             inputs=['condition'],

--- a/onnx/backend/test/case/node/not.py
+++ b/onnx/backend/test/case/node/not.py
@@ -15,7 +15,7 @@ from . import expect
 class Not(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Not',
             inputs=['x'],

--- a/onnx/backend/test/case/node/onehot.py
+++ b/onnx/backend/test/case/node/onehot.py
@@ -29,7 +29,7 @@ def one_hot(indices, depth, axis=-1, dtype=np.float32):  # type: ignore
 class OneHot(Base):
 
     @staticmethod
-    def export_without_axis():  # type: () -> None
+    def export_without_axis() -> None:
         on_value = 5
         off_value = 2
         output_type = np.int32
@@ -46,7 +46,7 @@ class OneHot(Base):
         expect(node, inputs=[indices, depth, values], outputs=[y], name='test_onehot_without_axis')
 
     @staticmethod
-    def export_with_axis():  # type: () -> None
+    def export_with_axis() -> None:
         axisValue = 1
         on_value = 3
         off_value = 1
@@ -66,7 +66,7 @@ class OneHot(Base):
         expect(node, inputs=[indices, depth, values], outputs=[y], name='test_onehot_with_axis')
 
     @staticmethod
-    def export_with_negative_indices():  # type: () -> None
+    def export_with_negative_indices() -> None:
         axisValue = 1
         on_value = 3
         off_value = 1
@@ -91,7 +91,7 @@ class OneHot(Base):
         expect(node, inputs=[indices, depth, values], outputs=[y], name='test_onehot_negative_indices')
 
     @staticmethod
-    def export_with_negative_axis():  # type: () -> None
+    def export_with_negative_axis() -> None:
         axisValue = -2
         on_value = 3
         off_value = 1

--- a/onnx/backend/test/case/node/optionalgetelement.py
+++ b/onnx/backend/test/case/node/optionalgetelement.py
@@ -13,8 +13,7 @@ from ..base import Base
 from . import expect
 
 
-def optional_get_element_reference_implementation(optional):
-    # type: (Optional[Any]) -> Any
+def optional_get_element_reference_implementation(optional: Optional[Any]) -> Any:
     assert optional is not None
     return optional
 
@@ -22,7 +21,7 @@ def optional_get_element_reference_implementation(optional):
 class OptionalHasElement(Base):
 
     @staticmethod
-    def export_get_element_tensor():  # type: () -> None
+    def export_get_element_tensor() -> None:
         optional = np.array([1, 2, 3, 4]).astype(np.float32)
         tensor_type_proto = onnx.helper.make_tensor_type_proto(elem_type=onnx.TensorProto.FLOAT, shape=[4, ])
         input_type_proto = onnx.helper.make_optional_type_proto(tensor_type_proto)
@@ -38,7 +37,7 @@ class OptionalHasElement(Base):
                name='test_optional_get_element')
 
     @staticmethod
-    def export_get_element_sequence():  # type: () -> None
+    def export_get_element_sequence() -> None:
         optional = [np.array([1, 2, 3, 4]).astype(np.int32)]
         tensor_type_proto = onnx.helper.make_tensor_type_proto(elem_type=onnx.TensorProto.INT32, shape=[4, ])
         seq_type_proto = onnx.helper.make_sequence_type_proto(tensor_type_proto)

--- a/onnx/backend/test/case/node/optionalhaselement.py
+++ b/onnx/backend/test/case/node/optionalhaselement.py
@@ -13,7 +13,7 @@ from ..base import Base
 from . import expect
 
 
-def optional_has_element_reference_implementation(optional):  # type: (Optional[np.ndarray]) -> np.ndarray
+def optional_has_element_reference_implementation(optional: Optional[np.ndarray]) -> np.ndarray:
     if optional is None:
         return np.array(False)
     else:
@@ -23,7 +23,7 @@ def optional_has_element_reference_implementation(optional):  # type: (Optional[
 class OptionalHasElement(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         optional = np.array([1, 2, 3, 4]).astype(np.float32)
         tensor_type_proto = onnx.helper.make_tensor_type_proto(elem_type=onnx.TensorProto.FLOAT, shape=[4, ])
         input_type_proto = onnx.helper.make_optional_type_proto(tensor_type_proto)
@@ -38,7 +38,7 @@ class OptionalHasElement(Base):
                name='test_optional_has_element')
 
     @staticmethod
-    def export_empty():  # type: () -> None
+    def export_empty() -> None:
         optional = None
         tensor_type_proto = onnx.helper.make_tensor_type_proto(elem_type=onnx.TensorProto.INT32, shape=[])
         input_type_proto = onnx.helper.make_optional_type_proto(tensor_type_proto)

--- a/onnx/backend/test/case/node/or.py
+++ b/onnx/backend/test/case/node/or.py
@@ -15,7 +15,7 @@ from . import expect
 class Or(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Or',
             inputs=['x', 'y'],
@@ -44,7 +44,7 @@ class Or(Base):
                name='test_or4d')
 
     @staticmethod
-    def export_or_broadcast():  # type: () -> None
+    def export_or_broadcast() -> None:
         node = onnx.helper.make_node(
             'Or',
             inputs=['x', 'y'],

--- a/onnx/backend/test/case/node/pad.py
+++ b/onnx/backend/test/case/node/pad.py
@@ -44,7 +44,7 @@ def pad_impl(data, raw_pads, mode, constant_values=0.0):  # type: ignore
 class Pad(Base):
 
     @staticmethod
-    def export_constant_pad():  # type: () -> None
+    def export_constant_pad() -> None:
         node = onnx.helper.make_node(
             'Pad',
             inputs=['x', 'pads', 'value'],
@@ -65,7 +65,7 @@ class Pad(Base):
                name='test_constant_pad')
 
     @staticmethod
-    def export_reflection_and_edge_pad():  # type: () -> None
+    def export_reflection_and_edge_pad() -> None:
         for mode in ['edge', 'reflect']:
             node = onnx.helper.make_node(
                 'Pad',

--- a/onnx/backend/test/case/node/pool_op_common.py
+++ b/onnx/backend/test/case/node/pool_op_common.py
@@ -5,12 +5,12 @@ import itertools
 from typing import Text, Sequence
 
 
-def get_pad_shape(auto_pad,  # type: Text
-                  input_spatial_shape,  # type: Sequence[int]
-                  kernel_spatial_shape,  # type: Sequence[int]
-                  strides_spatial,  # type: Sequence[int]
-                  output_spatial_shape  # type: Sequence[int]
-                  ):  # type: (...) -> Sequence[int]
+def get_pad_shape(auto_pad: Text,
+                  input_spatial_shape: Sequence[int],
+                  kernel_spatial_shape: Sequence[int],
+                  strides_spatial: Sequence[int],
+                  output_spatial_shape: Sequence[int]
+                  ) -> Sequence[int]:
     pad_shape = [0] * len(input_spatial_shape)
     if auto_pad in ('SAME_UPPER', 'SAME_LOWER'):
         for i in range(len(input_spatial_shape)):
@@ -21,11 +21,11 @@ def get_pad_shape(auto_pad,  # type: Text
     return pad_shape
 
 
-def get_output_shape(auto_pad,  # type: Text
-                     input_spatial_shape,  # type: Sequence[int]
-                     kernel_spatial_shape,  # type: Sequence[int]
-                     strides_spatial  # type: Sequence[int]
-                     ):  # type: (...) -> Sequence[int]
+def get_output_shape(auto_pad: Text,
+                     input_spatial_shape: Sequence[int],
+                     kernel_spatial_shape: Sequence[int],
+                     strides_spatial: Sequence[int]
+                     ) -> Sequence[int]:
     out_shape = [0] * len(input_spatial_shape)
     if auto_pad in ('SAME_UPPER', 'SAME_LOWER'):
         for i in range(len(input_spatial_shape)):
@@ -41,15 +41,15 @@ def get_output_shape(auto_pad,  # type: Text
     return out_shape
 
 
-def pool(padded,  # type: np.ndarray
-         x_shape,  # type: Sequence[int]
-         kernel_shape,  # type: Sequence[int]
-         strides_shape,  # type: Sequence[int]
-         out_shape,  # type: Sequence[int]
-         pad_shape,  # type: Sequence[int]
-         pooling_type,  # type: Text
-         count_include_pad=0  # type: int
-         ):  # type: (...) -> np.ndarray
+def pool(padded: np.ndarray,
+         x_shape: Sequence[int],
+         kernel_shape: Sequence[int],
+         strides_shape: Sequence[int],
+         out_shape: Sequence[int],
+         pad_shape: Sequence[int],
+         pooling_type: Text,
+         count_include_pad: int = 0
+         ) -> np.ndarray:
     spatial_size = len(x_shape) - 2
     y = np.zeros([x_shape[0], x_shape[1]] + list(out_shape))
 

--- a/onnx/backend/test/case/node/pow.py
+++ b/onnx/backend/test/case/node/pow.py
@@ -20,7 +20,7 @@ def pow(x, y):  # type: ignore
 class Pow(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Pow',
             inputs=['x', 'y'],
@@ -40,7 +40,7 @@ class Pow(Base):
                name='test_pow')
 
     @staticmethod
-    def export_pow_broadcast():  # type: () -> None
+    def export_pow_broadcast() -> None:
         node = onnx.helper.make_node(
             'Pow',
             inputs=['x', 'y'],
@@ -66,7 +66,7 @@ class Pow(Base):
                name='test_pow_bcast_array')
 
     @staticmethod
-    def export_types():  # type: () -> None
+    def export_types() -> None:
         node = onnx.helper.make_node(
             'Pow',
             inputs=['x', 'y'],

--- a/onnx/backend/test/case/node/prelu.py
+++ b/onnx/backend/test/case/node/prelu.py
@@ -15,7 +15,7 @@ from . import expect
 class PRelu(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'PRelu',
             inputs=['x', 'slope'],
@@ -30,7 +30,7 @@ class PRelu(Base):
                name='test_prelu_example')
 
     @staticmethod
-    def export_prelu_broadcast():  # type: () -> None
+    def export_prelu_broadcast() -> None:
         node = onnx.helper.make_node(
             'PRelu',
             inputs=['x', 'slope'],

--- a/onnx/backend/test/case/node/qlinearconv.py
+++ b/onnx/backend/test/case/node/qlinearconv.py
@@ -14,7 +14,7 @@ from . import expect
 class QLinearConv(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node('QLinearConv',
             inputs=['x', 'x_scale', 'x_zero_point', 'w', 'w_scale', 'w_zero_point', 'y_scale', 'y_zero_point'],
             outputs=['y'],)

--- a/onnx/backend/test/case/node/qlinearmatmul.py
+++ b/onnx/backend/test/case/node/qlinearmatmul.py
@@ -14,7 +14,7 @@ from . import expect
 class QLinearMatMul(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node('QLinearMatMul',
             inputs=['a', 'a_scale', 'a_zero_point', 'b', 'b_scale', 'b_zero_point', 'y_scale', 'y_zero_point'],
             outputs=['y'],)

--- a/onnx/backend/test/case/node/quantizelinear.py
+++ b/onnx/backend/test/case/node/quantizelinear.py
@@ -14,7 +14,7 @@ from . import expect
 class QuantizeLinear(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node('QuantizeLinear',
                                      inputs=['x', 'y_scale', 'y_zero_point'],
                                      outputs=['y'],)
@@ -28,7 +28,7 @@ class QuantizeLinear(Base):
                name='test_quantizelinear')
 
     @staticmethod
-    def export_axis():  # type: () -> None
+    def export_axis() -> None:
         node = onnx.helper.make_node('QuantizeLinear',
                                      inputs=['x', 'y_scale', 'y_zero_point'],
                                      outputs=['y'],)

--- a/onnx/backend/test/case/node/rangeop.py
+++ b/onnx/backend/test/case/node/rangeop.py
@@ -15,7 +15,7 @@ from . import expect
 class Range(Base):
 
     @staticmethod
-    def export_range_float_type_positive_delta():  # type: () -> None
+    def export_range_float_type_positive_delta() -> None:
         node = onnx.helper.make_node(
             'Range',
             inputs=['start', 'limit', 'delta'],
@@ -31,7 +31,7 @@ class Range(Base):
                name='test_range_float_type_positive_delta')
 
     @staticmethod
-    def export_range_int32_type_negative_delta():  # type: () -> None
+    def export_range_int32_type_negative_delta() -> None:
         node = onnx.helper.make_node(
             'Range',
             inputs=['start', 'limit', 'delta'],

--- a/onnx/backend/test/case/node/reciprocal.py
+++ b/onnx/backend/test/case/node/reciprocal.py
@@ -15,7 +15,7 @@ from . import expect
 class Reciprocal(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Reciprocal',
             inputs=['x'],

--- a/onnx/backend/test/case/node/reduce_log_sum.py
+++ b/onnx/backend/test/case/node/reduce_log_sum.py
@@ -15,7 +15,7 @@ from . import expect
 class ReduceLogSum(Base):
 
     @staticmethod
-    def export_nokeepdims():  # type: () -> None
+    def export_nokeepdims() -> None:
         node = onnx.helper.make_node(
             'ReduceLogSum',
             inputs=['data'],
@@ -41,7 +41,7 @@ class ReduceLogSum(Base):
                name='test_reduce_log_sum_asc_axes')
 
     @staticmethod
-    def export_keepdims():  # type: () -> None
+    def export_keepdims() -> None:
         node = onnx.helper.make_node(
             'ReduceLogSum',
             inputs=['data'],
@@ -53,7 +53,7 @@ class ReduceLogSum(Base):
                name='test_reduce_log_sum_default')
 
     @staticmethod
-    def export_negative_axes_keepdims():  # type: () -> None
+    def export_negative_axes_keepdims() -> None:
         node = onnx.helper.make_node(
             'ReduceLogSum',
             inputs=['data'],

--- a/onnx/backend/test/case/node/reduce_log_sum_exp.py
+++ b/onnx/backend/test/case/node/reduce_log_sum_exp.py
@@ -15,7 +15,7 @@ from . import expect
 class ReduceLogSumExp(Base):
 
     @staticmethod
-    def export_do_not_keepdims():  # type: () -> None
+    def export_do_not_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 0
@@ -49,7 +49,7 @@ class ReduceLogSumExp(Base):
             name='test_reduce_log_sum_exp_do_not_keepdims_random')
 
     @staticmethod
-    def export_keepdims():  # type: () -> None
+    def export_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 1
@@ -85,7 +85,7 @@ class ReduceLogSumExp(Base):
               name='test_reduce_log_sum_exp_keepdims_random')
 
     @staticmethod
-    def export_default_axes_keepdims():  # type: () -> None
+    def export_default_axes_keepdims() -> None:
         shape = [3, 2, 2]
         axes = None
         keepdims = 1
@@ -118,7 +118,7 @@ class ReduceLogSumExp(Base):
               name='test_reduce_log_sum_exp_default_axes_keepdims_random')
 
     @staticmethod
-    def export_negative_axes_keepdims():  # type: () -> None
+    def export_negative_axes_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [-2]
         keepdims = 1

--- a/onnx/backend/test/case/node/reducel1.py
+++ b/onnx/backend/test/case/node/reducel1.py
@@ -15,7 +15,7 @@ from . import expect
 class ReduceL1(Base):
 
     @staticmethod
-    def export_do_not_keepdims():  # type: () -> None
+    def export_do_not_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [2]
         keepdims = 0
@@ -47,7 +47,7 @@ class ReduceL1(Base):
             name='test_reduce_l1_do_not_keepdims_random')
 
     @staticmethod
-    def export_keepdims():  # type: () -> None
+    def export_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [2]
         keepdims = 1
@@ -79,7 +79,7 @@ class ReduceL1(Base):
             name='test_reduce_l1_keep_dims_random')
 
     @staticmethod
-    def export_default_axes_keepdims():  # type: () -> None
+    def export_default_axes_keepdims() -> None:
         shape = [3, 2, 2]
         axes = None
         keepdims = 1
@@ -110,7 +110,7 @@ class ReduceL1(Base):
             name='test_reduce_l1_default_axes_keepdims_random')
 
     @staticmethod
-    def export_negative_axes_keepdims():  # type: () -> None
+    def export_negative_axes_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [-1]
         keepdims = 1

--- a/onnx/backend/test/case/node/reducel2.py
+++ b/onnx/backend/test/case/node/reducel2.py
@@ -15,7 +15,7 @@ from . import expect
 class ReduceL2(Base):
 
     @staticmethod
-    def export_do_not_keepdims():  # type: () -> None
+    def export_do_not_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [2]
         keepdims = 0
@@ -51,7 +51,7 @@ class ReduceL2(Base):
             name='test_reduce_l2_do_not_keepdims_random')
 
     @staticmethod
-    def export_keepdims():  # type: () -> None
+    def export_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [2]
         keepdims = 1
@@ -86,7 +86,7 @@ class ReduceL2(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_l2_keep_dims_random')
 
     @staticmethod
-    def export_default_axes_keepdims():  # type: () -> None
+    def export_default_axes_keepdims() -> None:
         shape = [3, 2, 2]
         axes = None
         keepdims = 1
@@ -119,7 +119,7 @@ class ReduceL2(Base):
             name='test_reduce_l2_default_axes_keepdims_random')
 
     @staticmethod
-    def export_negative_axes_keepdims():  # type: () -> None
+    def export_negative_axes_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [-1]
         keepdims = 1

--- a/onnx/backend/test/case/node/reducemax.py
+++ b/onnx/backend/test/case/node/reducemax.py
@@ -15,7 +15,7 @@ from . import expect
 class ReduceMax(Base):
 
     @staticmethod
-    def export_do_not_keepdims():  # type: () -> None
+    def export_do_not_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 0
@@ -43,7 +43,7 @@ class ReduceMax(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_max_do_not_keepdims_random')
 
     @staticmethod
-    def export_keepdims():  # type: () -> None
+    def export_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 1
@@ -71,7 +71,7 @@ class ReduceMax(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_max_keepdims_random')
 
     @staticmethod
-    def export_default_axes_keepdims():  # type: () -> None
+    def export_default_axes_keepdims() -> None:
         shape = [3, 2, 2]
         axes = None
         keepdims = 1
@@ -95,7 +95,7 @@ class ReduceMax(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_max_default_axes_keepdims_random')
 
     @staticmethod
-    def export_negative_axes_keepdims():  # type: () -> None
+    def export_negative_axes_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [-2]
         keepdims = 1

--- a/onnx/backend/test/case/node/reducemean.py
+++ b/onnx/backend/test/case/node/reducemean.py
@@ -15,7 +15,7 @@ from . import expect
 class ReduceMean(Base):
 
     @staticmethod
-    def export_do_not_keepdims():  # type: () -> None
+    def export_do_not_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 0
@@ -43,7 +43,7 @@ class ReduceMean(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_mean_do_not_keepdims_random')
 
     @staticmethod
-    def export_keepdims():  # type: () -> None
+    def export_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 1
@@ -71,7 +71,7 @@ class ReduceMean(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_mean_keepdims_random')
 
     @staticmethod
-    def export_default_axes_keepdims():  # type: () -> None
+    def export_default_axes_keepdims() -> None:
         shape = [3, 2, 2]
         axes = None
         keepdims = 1
@@ -96,7 +96,7 @@ class ReduceMean(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_mean_default_axes_keepdims_random')
 
     @staticmethod
-    def export_negative_axes_keepdims():  # type: () -> None
+    def export_negative_axes_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [-2]
         keepdims = 1

--- a/onnx/backend/test/case/node/reducemin.py
+++ b/onnx/backend/test/case/node/reducemin.py
@@ -15,7 +15,7 @@ from . import expect
 class ReduceMin(Base):
 
     @staticmethod
-    def export_do_not_keepdims():  # type: () -> None
+    def export_do_not_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 0
@@ -43,7 +43,7 @@ class ReduceMin(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_min_do_not_keepdims_random')
 
     @staticmethod
-    def export_keepdims():  # type: () -> None
+    def export_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 1
@@ -70,7 +70,7 @@ class ReduceMin(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_min_keepdims_random')
 
     @staticmethod
-    def export_default_axes_keepdims():  # type: () -> None
+    def export_default_axes_keepdims() -> None:
         shape = [3, 2, 2]
         axes = None
         keepdims = 1
@@ -95,7 +95,7 @@ class ReduceMin(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_min_default_axes_keepdims_random')
 
     @staticmethod
-    def export_negative_axes_keepdims():  # type: () -> None
+    def export_negative_axes_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [-2]
         keepdims = 1

--- a/onnx/backend/test/case/node/reduceprod.py
+++ b/onnx/backend/test/case/node/reduceprod.py
@@ -15,7 +15,7 @@ from . import expect
 class ReduceProd(Base):
 
     @staticmethod
-    def export_do_not_keepdims():  # type: () -> None
+    def export_do_not_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 0
@@ -42,7 +42,7 @@ class ReduceProd(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_prod_do_not_keepdims_random')
 
     @staticmethod
-    def export_keepdims():  # type: () -> None
+    def export_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 1
@@ -69,7 +69,7 @@ class ReduceProd(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_prod_keepdims_random')
 
     @staticmethod
-    def export_default_axes_keepdims():  # type: () -> None
+    def export_default_axes_keepdims() -> None:
         shape = [3, 2, 2]
         axes = None
         keepdims = 1
@@ -93,7 +93,7 @@ class ReduceProd(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_prod_default_axes_keepdims_random')
 
     @staticmethod
-    def export_negative_axes_keepdims():  # type: () -> None
+    def export_negative_axes_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [-2]
         keepdims = 1

--- a/onnx/backend/test/case/node/reducesum.py
+++ b/onnx/backend/test/case/node/reducesum.py
@@ -15,7 +15,7 @@ from . import expect
 class ReduceSum(Base):
 
     @staticmethod
-    def export_do_not_keepdims():  # type: () -> None
+    def export_do_not_keepdims() -> None:
         shape = [3, 2, 2]
         axes = np.array([1], dtype=np.int64)
         keepdims = 0
@@ -42,7 +42,7 @@ class ReduceSum(Base):
         expect(node, inputs=[data, axes], outputs=[reduced], name='test_reduce_sum_do_not_keepdims_random')
 
     @staticmethod
-    def export_keepdims():  # type: () -> None
+    def export_keepdims() -> None:
         shape = [3, 2, 2]
         axes = np.array([1], dtype=np.int64)
         keepdims = 1
@@ -69,7 +69,7 @@ class ReduceSum(Base):
         expect(node, inputs=[data, axes], outputs=[reduced], name='test_reduce_sum_keepdims_random')
 
     @staticmethod
-    def export_default_axes_keepdims():  # type: () -> None
+    def export_default_axes_keepdims() -> None:
         shape = [3, 2, 2]
         axes = np.array([], dtype=np.int64)
         keepdims = 1
@@ -94,7 +94,7 @@ class ReduceSum(Base):
         expect(node, inputs=[data, axes], outputs=[reduced], name='test_reduce_sum_default_axes_keepdims_random')
 
     @staticmethod
-    def export_negative_axes_keepdims():  # type: () -> None
+    def export_negative_axes_keepdims() -> None:
         shape = [3, 2, 2]
         axes = np.array([-2], dtype=np.int64)
         keepdims = 1
@@ -124,7 +124,7 @@ class ReduceSum(Base):
                name='test_reduce_sum_negative_axes_keepdims_random')
 
     @staticmethod
-    def export_empty_axes_input_noop():  # type: () -> None
+    def export_empty_axes_input_noop() -> None:
         shape = [3, 2, 2]
         keepdims = 1
 

--- a/onnx/backend/test/case/node/reducesumsquare.py
+++ b/onnx/backend/test/case/node/reducesumsquare.py
@@ -15,7 +15,7 @@ from . import expect
 class ReduceSumSquare(Base):
 
     @staticmethod
-    def export_do_not_keepdims():  # type: () -> None
+    def export_do_not_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 0
@@ -43,7 +43,7 @@ class ReduceSumSquare(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_sum_square_do_not_keepdims_random')
 
     @staticmethod
-    def export_keepdims():  # type: () -> None
+    def export_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [1]
         keepdims = 1
@@ -71,7 +71,7 @@ class ReduceSumSquare(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_sum_square_keepdims_random')
 
     @staticmethod
-    def export_default_axes_keepdims():  # type: () -> None
+    def export_default_axes_keepdims() -> None:
         shape = [3, 2, 2]
         axes = None
         keepdims = 1
@@ -96,7 +96,7 @@ class ReduceSumSquare(Base):
         expect(node, inputs=[data], outputs=[reduced], name='test_reduce_sum_square_default_axes_keepdims_random')
 
     @staticmethod
-    def export_negative_axes_keepdims():  # type: () -> None
+    def export_negative_axes_keepdims() -> None:
         shape = [3, 2, 2]
         axes = [-2]
         keepdims = 1

--- a/onnx/backend/test/case/node/relu.py
+++ b/onnx/backend/test/case/node/relu.py
@@ -15,7 +15,7 @@ from . import expect
 class Relu(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Relu',
             inputs=['x'],

--- a/onnx/backend/test/case/node/reshape.py
+++ b/onnx/backend/test/case/node/reshape.py
@@ -12,7 +12,7 @@ from ..base import Base
 from . import expect
 
 
-def reshape_reference_implementation(data, shape, allowzero=0):  # type: (np.ndarray, np.ndarray, int) -> np.ndarray
+def reshape_reference_implementation(data: np.ndarray, shape: np.ndarray, allowzero: int = 0) -> np.ndarray:
     # replace zeros with corresponding dim size
     # we need to do this because np.reshape doesn't support 0 by default unless 'allowzero' is set
     new_shape = np.copy(shape)
@@ -26,7 +26,7 @@ def reshape_reference_implementation(data, shape, allowzero=0):  # type: (np.nda
 class Reshape(Base):
 
     @staticmethod
-    def export_reshape():  # type: () -> None
+    def export_reshape() -> None:
         original_shape = [2, 3, 4]
         test_cases = {
             'reordered_all_dims': np.array([4, 2, 3], dtype=np.int64),
@@ -54,7 +54,7 @@ class Reshape(Base):
                    name='test_reshape_' + test_name)
 
     @staticmethod
-    def export_allowzero():  # type: () -> None
+    def export_allowzero() -> None:
         original_shape = [0, 3, 4]
         test_cases = {
             'allowzero_reordered': np.array([3, 4, 0], dtype=np.int64),

--- a/onnx/backend/test/case/node/resize.py
+++ b/onnx/backend/test/case/node/resize.py
@@ -13,8 +13,7 @@ from . import expect
 from typing import Any, List, Callable, Union, Optional, Text
 
 
-def cartesian(arrays, out=None):
-    # type: (List[np.ndarray], np.ndarray) -> np.ndarray
+def cartesian(arrays: List[np.ndarray], out: np.ndarray = None) -> np.ndarray:
     """
     From https://stackoverflow.com/a/1235363
     Generate a cartesian product of input arrays.
@@ -62,16 +61,16 @@ def cartesian(arrays, out=None):
     return out
 
 
-def interpolate_1d_with_x(data,                                             # type: np.ndarray
-                          scale_factor,                                     # type: float
-                          x,                                                # type: float
-                          get_coeffs,                                       # type: Callable[[float], np.ndarray]
-                          roi=None,                                         # type: np.ndarray
-                          extrapolation_value=0.0,                          # type: float
-                          coordinate_transformation_mode='half_pixel',      # type: Text
-                          exclude_outside=False,                            # type: bool
-                          ):                                                # type: (...) -> np.ndarray
-    def get_neighbor_idxes(x, n, limit):  # type: (float, int, int) -> np.ndarray
+def interpolate_1d_with_x(data: np.ndarray,
+                          scale_factor: float,
+                          x: float,
+                          get_coeffs: Callable[[float], np.ndarray],
+                          roi: np.ndarray = None,
+                          extrapolation_value: float = 0.0,
+                          coordinate_transformation_mode: Text = 'half_pixel',
+                          exclude_outside: bool = False,
+                          ) -> np.ndarray:
+    def get_neighbor_idxes(x: float, n: int, limit: int) -> np.ndarray:
         """
         Return the n nearest indexes to x among [0, limit), prefer the indexes smaller than x.
         As a result, the ratio must be in (0, 1]
@@ -92,7 +91,7 @@ def interpolate_1d_with_x(data,                                             # ty
         idxes = sorted(idxes)
         return np.array(idxes)
 
-    def get_neighbor(x, n, data):  # type: (float, int, np.ndarray) -> np.ndarray
+    def get_neighbor(x: float, n: int, data: np.ndarray) -> np.ndarray:
         """
         Pad `data` in 'edge' mode, and get n nearest elements in the padded array and their indexes in the original
         array
@@ -158,14 +157,14 @@ def interpolate_1d_with_x(data,                                             # ty
     return np.dot(coeffs, points).item()
 
 
-def interpolate_nd_with_x(data,                      # type: np.ndarray
-                          n,                         # type: int
-                          scale_factors,             # type: List[float]
-                          x,                         # type: List[float]
-                          get_coeffs,                # type: Callable[[float], np.ndarray]
-                          roi=None,                  # type: np.ndarray
-                          **kwargs                   # type: Any
-                          ):                         # type: (...) -> np.ndarray
+def interpolate_nd_with_x(data: np.ndarray,
+                          n: int,
+                          scale_factors: List[float],
+                          x: List[float],
+                          get_coeffs: Callable[[float], np.ndarray],
+                          roi: np.ndarray = None,
+                          **kwargs: Any
+                          ) -> np.ndarray:
     if n == 1:
         return interpolate_1d_with_x(data, scale_factors[0], x[0], get_coeffs, roi=roi,
                                      **kwargs)
@@ -178,14 +177,14 @@ def interpolate_nd_with_x(data,                      # type: np.ndarray
         roi=None if roi is None else [roi[0], roi[n]], **kwargs)
 
 
-def interpolate_nd(data,                      # type: np.ndarray
-                   get_coeffs,                # type: Callable[[float], np.ndarray]
-                   output_size=None,          # type: Optional[List[int]]
-                   scale_factors=None,        # type: Optional[List[float]]
-                   roi=None,                  # type: np.ndarray
-                   **kwargs                   # type: Any
-                   ):                         # type: (...) -> np.ndarray
-    def get_all_coords(data):   # type: (np.ndarray) -> np.ndarray
+def interpolate_nd(data: np.ndarray,
+                   get_coeffs: Callable[[float], np.ndarray],
+                   output_size: Optional[List[int]] = None,
+                   scale_factors: Optional[List[float]] = None,
+                   roi: np.ndarray = None,
+                   **kwargs: Any
+                   ) -> np.ndarray:
+    def get_all_coords(data: np.ndarray) -> np.ndarray:
         return cartesian([list(range(data.shape[i])) for i in range(len(data.shape))])
 
     assert output_size is not None or scale_factors is not None
@@ -202,7 +201,7 @@ def interpolate_nd(data,                      # type: np.ndarray
     return ret
 
 
-def cubic_coeffs(ratio, A=-0.75):   # type: (float, float) -> np.ndarray
+def cubic_coeffs(ratio: float, A: float = -0.75) -> np.ndarray:
     coeffs = [((A * (ratio + 1) - 5 * A) * (ratio + 1) + 8 * A) * (ratio + 1) - 4 * A,
               ((A + 2) * ratio - (A + 3)) * ratio * ratio + 1,
               ((A + 2) * (1 - ratio) - (A + 3)) * (1 - ratio) * (1 - ratio) + 1,
@@ -211,11 +210,11 @@ def cubic_coeffs(ratio, A=-0.75):   # type: (float, float) -> np.ndarray
     return np.array(coeffs)
 
 
-def linear_coeffs(ratio):           # type: (float) -> np.ndarray
+def linear_coeffs(ratio: float) -> np.ndarray:
     return np.array([1 - ratio, ratio])
 
 
-def nearest_coeffs(ratio, mode='round_prefer_floor'):          # type: (float, Text) -> np.ndarray
+def nearest_coeffs(ratio: float, mode: Text = 'round_prefer_floor') -> np.ndarray:
     if type(ratio) == int or ratio.is_integer():
         return np.array([0, 1])
     elif mode == 'round_prefer_floor':
@@ -231,7 +230,7 @@ def nearest_coeffs(ratio, mode='round_prefer_floor'):          # type: (float, T
 class Resize(Base):
 
     @staticmethod
-    def export_resize_upsample_scales_nearest():  # type: () -> None
+    def export_resize_upsample_scales_nearest() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', '', 'scales'],
@@ -257,7 +256,7 @@ class Resize(Base):
                name='test_resize_upsample_scales_nearest')
 
     @staticmethod
-    def export_resize_downsample_scales_nearest():  # type: () -> None
+    def export_resize_downsample_scales_nearest() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', '', 'scales'],
@@ -280,7 +279,7 @@ class Resize(Base):
                name='test_resize_downsample_scales_nearest')
 
     @staticmethod
-    def export_resize_upsample_sizes_nearest():  # type: () -> None
+    def export_resize_upsample_sizes_nearest() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', '', '', 'sizes'],
@@ -309,7 +308,7 @@ class Resize(Base):
                name='test_resize_upsample_sizes_nearest')
 
     @staticmethod
-    def export_resize_downsample_sizes_nearest():  # type: () -> None
+    def export_resize_downsample_sizes_nearest() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', '', '', 'sizes'],
@@ -332,7 +331,7 @@ class Resize(Base):
                name='test_resize_downsample_sizes_nearest')
 
     @staticmethod
-    def export_resize_upsample_scales_linear():  # type: () -> None
+    def export_resize_upsample_scales_linear() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', '', 'scales'],
@@ -358,7 +357,7 @@ class Resize(Base):
                name='test_resize_upsample_scales_linear')
 
     @staticmethod
-    def export_resize_upsample_scales_linear_align_corners():  # type: () -> None
+    def export_resize_upsample_scales_linear_align_corners() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', '', 'scales'],
@@ -385,7 +384,7 @@ class Resize(Base):
                name='test_resize_upsample_scales_linear_align_corners')
 
     @staticmethod
-    def export_resize_downsample_scales_linear():  # type: () -> None
+    def export_resize_downsample_scales_linear() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', '', 'scales'],
@@ -408,7 +407,7 @@ class Resize(Base):
                name='test_resize_downsample_scales_linear')
 
     @staticmethod
-    def export_resize_downsample_scales_linear_align_corners():  # type: () -> None
+    def export_resize_downsample_scales_linear_align_corners() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', '', 'scales'],
@@ -432,7 +431,7 @@ class Resize(Base):
                name='test_resize_downsample_scales_linear_align_corners')
 
     @staticmethod
-    def export_resize_upsample_scales_cubic():  # type: () -> None
+    def export_resize_upsample_scales_cubic() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', '', 'scales'],
@@ -472,7 +471,7 @@ class Resize(Base):
                name='test_resize_upsample_scales_cubic')
 
     @staticmethod
-    def export_resize_upsample_scales_cubic_align_corners():  # type: () -> None
+    def export_resize_upsample_scales_cubic_align_corners() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', '', 'scales'],
@@ -513,7 +512,7 @@ class Resize(Base):
                name='test_resize_upsample_scales_cubic_align_corners')
 
     @staticmethod
-    def export_resize_downsample_scales_cubic():  # type: () -> None
+    def export_resize_downsample_scales_cubic() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', '', 'scales'],
@@ -540,7 +539,7 @@ class Resize(Base):
                name='test_resize_downsample_scales_cubic')
 
     @staticmethod
-    def export_resize_downsample_scales_cubic_align_corners():  # type: () -> None
+    def export_resize_downsample_scales_cubic_align_corners() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', '', 'scales'],
@@ -568,7 +567,7 @@ class Resize(Base):
                name='test_resize_downsample_scales_cubic_align_corners')
 
     @staticmethod
-    def export_resize_upsample_sizes_cubic():  # type: () -> None
+    def export_resize_upsample_sizes_cubic() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', '', '', 'sizes'],
@@ -610,7 +609,7 @@ class Resize(Base):
                name='test_resize_upsample_sizes_cubic')
 
     @staticmethod
-    def export_resize_downsample_sizes_cubic():  # type: () -> None
+    def export_resize_downsample_sizes_cubic() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', '', '', 'sizes'],
@@ -638,7 +637,7 @@ class Resize(Base):
 
     # TensorFlow v1 bicubic with half_pixel_centers=True
     @staticmethod
-    def export_resize_upsample_scales_cubic_A_n0p5_exclude_outside():  # type: () -> None
+    def export_resize_upsample_scales_cubic_A_n0p5_exclude_outside() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', '', 'scales'],
@@ -680,7 +679,7 @@ class Resize(Base):
                name='test_resize_upsample_scales_cubic_A_n0p5_exclude_outside')
 
     @staticmethod
-    def export_resize_downsample_scales_cubic_A_n0p5_exclude_outside():  # type: () -> None
+    def export_resize_downsample_scales_cubic_A_n0p5_exclude_outside() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', '', 'scales'],
@@ -710,7 +709,7 @@ class Resize(Base):
 
     # TensorFlow v1 bicubic with half_pixel_centers=False
     @staticmethod
-    def export_resize_upsample_scales_cubic_asymmetric():  # type: () -> None
+    def export_resize_upsample_scales_cubic_asymmetric() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', '', 'scales'],
@@ -751,7 +750,7 @@ class Resize(Base):
                name='test_resize_upsample_scales_cubic_asymmetric')
 
     @staticmethod
-    def export_resize_tf_crop_and_resize():  # type: () -> None
+    def export_resize_tf_crop_and_resize() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', 'roi', '', 'sizes'],
@@ -781,7 +780,7 @@ class Resize(Base):
                name='test_resize_tf_crop_and_resize')
 
     @staticmethod
-    def export_resize_tf_crop_and_resize_extrapolation_value():  # type: () -> None
+    def export_resize_tf_crop_and_resize_extrapolation_value() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', 'roi', '', 'sizes'],
@@ -812,7 +811,7 @@ class Resize(Base):
                name='test_resize_tf_crop_and_resize')
 
     @staticmethod
-    def export_resize_downsample_sizes_linear_pytorch_half_pixel():  # type: () -> None
+    def export_resize_downsample_sizes_linear_pytorch_half_pixel() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', '', '', 'sizes'],
@@ -840,7 +839,7 @@ class Resize(Base):
                name='test_resize_downsample_sizes_linear_pytorch_half_pixel')
 
     @staticmethod
-    def export_resize_upsample_sizes_nearest_floor_align_corners():  # type: () -> None
+    def export_resize_upsample_sizes_nearest_floor_align_corners() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', '', '', 'sizes'],
@@ -874,7 +873,7 @@ class Resize(Base):
                name='test_resize_upsample_sizes_nearest_floor_align_corners')
 
     @staticmethod
-    def export_resize_upsample_sizes_nearest_round_prefer_ceil_asymmetric():  # type: () -> None
+    def export_resize_upsample_sizes_nearest_round_prefer_ceil_asymmetric() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', '', '', 'sizes'],
@@ -909,7 +908,7 @@ class Resize(Base):
                name='test_resize_upsample_sizes_nearest_round_prefer_ceil_asymmetric')
 
     @staticmethod
-    def export_resize_upsample_sizes_nearest_ceil_half_pixel():  # type: () -> None
+    def export_resize_upsample_sizes_nearest_ceil_half_pixel() -> None:
         node = onnx.helper.make_node(
             'Resize',
             inputs=['X', '', '', 'sizes'],

--- a/onnx/backend/test/case/node/reversesequence.py
+++ b/onnx/backend/test/case/node/reversesequence.py
@@ -15,7 +15,7 @@ from . import expect
 class ReverseSequence(Base):
 
     @staticmethod
-    def export_reversesequence_time():  # type: () -> None
+    def export_reversesequence_time() -> None:
         node = onnx.helper.make_node(
             'ReverseSequence',
             inputs=['x', 'sequence_lens'],
@@ -38,7 +38,7 @@ class ReverseSequence(Base):
                name='test_reversesequence_time')
 
     @staticmethod
-    def export_reversesequence_batch():  # type: () -> None
+    def export_reversesequence_batch() -> None:
         node = onnx.helper.make_node(
             'ReverseSequence',
             inputs=['x', 'sequence_lens'],

--- a/onnx/backend/test/case/node/rnn.py
+++ b/onnx/backend/test/case/node/rnn.py
@@ -14,7 +14,7 @@ from . import expect
 
 
 class RNN_Helper():
-    def __init__(self, **params):  # type: (**Any) -> None
+    def __init__(self, **params: Any) -> None:
         # RNN Input Names
         X = str('X')
         W = str('W')
@@ -53,10 +53,10 @@ class RNN_Helper():
         else:
             raise NotImplementedError()
 
-    def f(self, x):  # type: (np.ndarray) -> np.ndarray
+    def f(self, x: np.ndarray) -> np.ndarray:
         return np.tanh(x)
 
-    def step(self):  # type: () -> Tuple[np.ndarray, np.ndarray]
+    def step(self) -> Tuple[np.ndarray, np.ndarray]:
         seq_length = self.X.shape[0]
         hidden_size = self.H_0.shape[-1]
         batch_size = self.X.shape[1]
@@ -87,7 +87,7 @@ class RNN_Helper():
 class RNN(Base):
 
     @staticmethod
-    def export_defaults():  # type: () -> None
+    def export_defaults() -> None:
         input = np.array([[[1., 2.], [3., 4.], [5., 6.]]]).astype(np.float32)
 
         input_size = 2
@@ -109,7 +109,7 @@ class RNN(Base):
         expect(node, inputs=[input, W, R], outputs=[Y_h.astype(np.float32)], name='test_simple_rnn_defaults')
 
     @staticmethod
-    def export_initial_bias():  # type: () -> None
+    def export_initial_bias() -> None:
         input = np.array([[[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]]).astype(np.float32)
 
         input_size = 3
@@ -138,7 +138,7 @@ class RNN(Base):
                name='test_simple_rnn_with_initial_bias')
 
     @staticmethod
-    def export_seq_length():  # type: () -> None
+    def export_seq_length() -> None:
         input = np.array([[[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]],
                           [[10., 11., 12.], [13., 14., 15.], [16., 17., 18.]]]).astype(np.float32)
 
@@ -165,7 +165,7 @@ class RNN(Base):
         expect(node, inputs=[input, W, R, B], outputs=[Y_h.astype(np.float32)], name='test_rnn_seq_length')
 
     @staticmethod
-    def export_batchwise():  # type: () -> None
+    def export_batchwise() -> None:
         input = np.array([[[1., 2.]], [[3., 4.]], [[5., 6.]]]).astype(np.float32)
 
         input_size = 2

--- a/onnx/backend/test/case/node/roialign.py
+++ b/onnx/backend/test/case/node/roialign.py
@@ -149,7 +149,7 @@ def get_roi_align_input_values():  # type: ignore
 
 class RoiAlign(Base):
     @staticmethod
-    def export_roialign_aligned_false():  # type: () -> None
+    def export_roialign_aligned_false() -> None:
         node = onnx.helper.make_node(
             "RoiAlign",
             inputs=["X", "rois", "batch_indices"],
@@ -199,7 +199,7 @@ class RoiAlign(Base):
         expect(node, inputs=[X, rois, batch_indices], outputs=[Y], name="test_roialign_aligned_false")
 
     @staticmethod
-    def export_roialign_aligned_true():  # type: () -> None
+    def export_roialign_aligned_true() -> None:
         node = onnx.helper.make_node(
             "RoiAlign",
             inputs=["X", "rois", "batch_indices"],

--- a/onnx/backend/test/case/node/round.py
+++ b/onnx/backend/test/case/node/round.py
@@ -15,7 +15,7 @@ from . import expect
 class Round(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Round',
             inputs=['x'],

--- a/onnx/backend/test/case/node/scan.py
+++ b/onnx/backend/test/case/node/scan.py
@@ -15,7 +15,7 @@ from . import expect
 class Scan(Base):
 
     @staticmethod
-    def export_scan_8():  # type: () -> None
+    def export_scan_8() -> None:
         # Given an input sequence [x1, ..., xN], sum up its elements using a scan
         # returning the final state (x1+x2+...+xN) as well the scan_output
         # [x1, x1+x2, ..., x1+x2+...+xN]
@@ -62,7 +62,7 @@ class Scan(Base):
                name='test_scan_sum', opset_imports=[onnx.helper.make_opsetid("", 8)])
 
     @staticmethod
-    def export_scan_9():  # type: () -> None
+    def export_scan_9() -> None:
         # Given an input sequence [x1, ..., xN], sum up its elements using a scan
         # returning the final state (x1+x2+...+xN) as well the scan_output
         # [x1, x1+x2, ..., x1+x2+...+xN]

--- a/onnx/backend/test/case/node/scatter.py
+++ b/onnx/backend/test/case/node/scatter.py
@@ -51,7 +51,7 @@ def scatter(data, indices, updates, axis=0):  # type: ignore
 class Scatter(Base):
 
     @staticmethod
-    def export_scatter_without_axis():  # type: () -> None
+    def export_scatter_without_axis() -> None:
         node = onnx.helper.make_node(
             'Scatter',
             inputs=['data', 'indices', 'updates'],
@@ -71,7 +71,7 @@ class Scatter(Base):
                name='test_scatter_without_axis', opset_imports=[helper.make_opsetid("", 10)])
 
     @staticmethod
-    def export_scatter_with_axis():  # type: () -> None
+    def export_scatter_with_axis() -> None:
         axis = 1
         node = onnx.helper.make_node(
             'Scatter',

--- a/onnx/backend/test/case/node/scatterelements.py
+++ b/onnx/backend/test/case/node/scatterelements.py
@@ -64,7 +64,7 @@ def scatter_elements(data, indices, updates, axis=0, reduction='none'):  # type:
 class ScatterElements(Base):
 
     @staticmethod
-    def export_scatter_elements_without_axis():  # type: () -> None
+    def export_scatter_elements_without_axis() -> None:
         node = onnx.helper.make_node(
             'ScatterElements',
             inputs=['data', 'indices', 'updates'],
@@ -84,7 +84,7 @@ class ScatterElements(Base):
                name='test_scatter_elements_without_axis')
 
     @staticmethod
-    def export_scatter_elements_with_axis():  # type: () -> None
+    def export_scatter_elements_with_axis() -> None:
         axis = 1
         node = onnx.helper.make_node(
             'ScatterElements',
@@ -104,7 +104,7 @@ class ScatterElements(Base):
                name='test_scatter_elements_with_axis')
 
     @staticmethod
-    def export_scatter_elements_with_negative_indices():  # type: () -> None
+    def export_scatter_elements_with_negative_indices() -> None:
         axis = 1
         node = onnx.helper.make_node(
             'ScatterElements',
@@ -124,7 +124,7 @@ class ScatterElements(Base):
                name='test_scatter_elements_with_negative_indices')
 
     @staticmethod
-    def export_scatter_elements_with_duplicate_indices():  # type: () -> None
+    def export_scatter_elements_with_duplicate_indices() -> None:
         axis = 1
         node = onnx.helper.make_node(
             'ScatterElements',

--- a/onnx/backend/test/case/node/scatternd.py
+++ b/onnx/backend/test/case/node/scatternd.py
@@ -34,7 +34,7 @@ def scatter_nd_impl(data, indices, updates, reduction='none'):  # type: ignore
 class ScatterND(Base):
 
     @staticmethod
-    def export_scatternd():  # type: () -> None
+    def export_scatternd() -> None:
         node = onnx.helper.make_node(
             'ScatterND',
             inputs=['data', 'indices', 'updates'],
@@ -59,7 +59,7 @@ class ScatterND(Base):
                name='test_scatternd')
 
     @staticmethod
-    def export_scatternd_add():  # type: () -> None
+    def export_scatternd_add() -> None:
         node = onnx.helper.make_node(
             'ScatterND',
             inputs=['data', 'indices', 'updates'],
@@ -85,7 +85,7 @@ class ScatterND(Base):
                name='test_scatternd_add')
 
     @staticmethod
-    def export_scatternd_multiply():  # type: () -> None
+    def export_scatternd_multiply() -> None:
         node = onnx.helper.make_node(
             'ScatterND',
             inputs=['data', 'indices', 'updates'],

--- a/onnx/backend/test/case/node/selu.py
+++ b/onnx/backend/test/case/node/selu.py
@@ -15,7 +15,7 @@ from . import expect
 class Selu(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Selu',
             inputs=['x'],
@@ -36,7 +36,7 @@ class Selu(Base):
                name='test_selu')
 
     @staticmethod
-    def export_selu_default():  # type: () -> None
+    def export_selu_default() -> None:
         default_alpha = 1.67326319217681884765625
         default_gamma = 1.05070102214813232421875
         node = onnx.helper.make_node(

--- a/onnx/backend/test/case/node/sequenceinsert.py
+++ b/onnx/backend/test/case/node/sequenceinsert.py
@@ -13,7 +13,7 @@ from ..base import Base
 from . import expect
 
 
-def sequence_insert_reference_implementation(sequence, tensor, position=None):  # type: (List[Any], np.ndarray, np.ndarray) -> List[Any]
+def sequence_insert_reference_implementation(sequence: List[Any], tensor: np.ndarray, position: np.ndarray = None) -> List[Any]:
     # make a copy of input sequence
     seq = list(sequence)
     if position is not None:
@@ -30,7 +30,7 @@ def sequence_insert_reference_implementation(sequence, tensor, position=None):  
 class SequenceInsert(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         test_cases = {
             'at_back': [np.array([10, 11, 12]).astype(np.int64)],
             'at_front': [np.array([-2, -1, 0]), np.array([0]).astype(np.int64)]

--- a/onnx/backend/test/case/node/shape.py
+++ b/onnx/backend/test/case/node/shape.py
@@ -35,7 +35,7 @@ def test_shape(testname, xval, start=None, end=None):  # type: ignore
 class Shape(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         x = np.array([
             [1, 2, 3],
             [4, 5, 6],

--- a/onnx/backend/test/case/node/shrink.py
+++ b/onnx/backend/test/case/node/shrink.py
@@ -15,7 +15,7 @@ from . import expect
 class Shrink(Base):
 
     @staticmethod
-    def export_hard_shrink():  # type: () -> None
+    def export_hard_shrink() -> None:
         node = onnx.helper.make_node(
             'Shrink',
             inputs=['x'],
@@ -28,7 +28,7 @@ class Shrink(Base):
                name='test_shrink_hard')
 
     @staticmethod
-    def export_soft_shrink():  # type: () -> None
+    def export_soft_shrink() -> None:
         node = onnx.helper.make_node(
             'Shrink',
             inputs=['x'],

--- a/onnx/backend/test/case/node/sigmoid.py
+++ b/onnx/backend/test/case/node/sigmoid.py
@@ -15,7 +15,7 @@ from . import expect
 class Sigmoid(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Sigmoid',
             inputs=['x'],

--- a/onnx/backend/test/case/node/sign.py
+++ b/onnx/backend/test/case/node/sign.py
@@ -15,7 +15,7 @@ from . import expect
 class Sign(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Sign',
             inputs=['x'],

--- a/onnx/backend/test/case/node/sin.py
+++ b/onnx/backend/test/case/node/sin.py
@@ -15,7 +15,7 @@ from . import expect
 class Sin(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Sin',
             inputs=['x'],

--- a/onnx/backend/test/case/node/sinh.py
+++ b/onnx/backend/test/case/node/sinh.py
@@ -15,7 +15,7 @@ from . import expect
 class Sinh(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Sinh',
             inputs=['x'],

--- a/onnx/backend/test/case/node/size.py
+++ b/onnx/backend/test/case/node/size.py
@@ -15,7 +15,7 @@ from . import expect
 class Size(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Size',
             inputs=['x'],

--- a/onnx/backend/test/case/node/slice.py
+++ b/onnx/backend/test/case/node/slice.py
@@ -15,7 +15,7 @@ from . import expect
 class Slice(Base):
 
     @staticmethod
-    def export_slice():  # type: () -> None
+    def export_slice() -> None:
         node = onnx.helper.make_node(
             'Slice',
             inputs=['x', 'starts', 'ends', 'axes', 'steps'],
@@ -33,7 +33,7 @@ class Slice(Base):
                name='test_slice')
 
     @staticmethod
-    def export_slice_neg():  # type: () -> None
+    def export_slice_neg() -> None:
         node = onnx.helper.make_node(
             'Slice',
             inputs=['x', 'starts', 'ends', 'axes', 'steps'],
@@ -51,7 +51,7 @@ class Slice(Base):
                name='test_slice_neg')
 
     @staticmethod
-    def export_slice_start_out_of_bounds():  # type: () -> None
+    def export_slice_start_out_of_bounds() -> None:
         node = onnx.helper.make_node(
             'Slice',
             inputs=['x', 'starts', 'ends', 'axes', 'steps'],
@@ -69,7 +69,7 @@ class Slice(Base):
                name='test_slice_start_out_of_bounds')
 
     @staticmethod
-    def export_slice_end_out_of_bounds():  # type: () -> None
+    def export_slice_end_out_of_bounds() -> None:
         node = onnx.helper.make_node(
             'Slice',
             inputs=['x', 'starts', 'ends', 'axes', 'steps'],
@@ -87,7 +87,7 @@ class Slice(Base):
                name='test_slice_end_out_of_bounds')
 
     @staticmethod
-    def export_slice_default_axes():  # type: () -> None
+    def export_slice_default_axes() -> None:
         node = onnx.helper.make_node(
             'Slice',
             inputs=['x', 'starts', 'ends'],
@@ -103,7 +103,7 @@ class Slice(Base):
                name='test_slice_default_axes')
 
     @staticmethod
-    def export_slice_default_steps():  # type: () -> None
+    def export_slice_default_steps() -> None:
         node = onnx.helper.make_node(
             'Slice',
             inputs=['x', 'starts', 'ends', 'axes'],
@@ -120,7 +120,7 @@ class Slice(Base):
                name='test_slice_default_steps')
 
     @staticmethod
-    def export_slice_neg_steps():  # type: () -> None
+    def export_slice_neg_steps() -> None:
         node = onnx.helper.make_node(
             'Slice',
             inputs=['x', 'starts', 'ends', 'axes', 'steps'],
@@ -138,7 +138,7 @@ class Slice(Base):
                name='test_slice_neg_steps')
 
     @staticmethod
-    def export_slice_negative_axes():  # type: () -> None
+    def export_slice_negative_axes() -> None:
         node = onnx.helper.make_node(
             'Slice',
             inputs=['x', 'starts', 'ends', 'axes'],

--- a/onnx/backend/test/case/node/softmax.py
+++ b/onnx/backend/test/case/node/softmax.py
@@ -12,7 +12,7 @@ from ..base import Base
 from . import expect
 
 
-def softmax(x, axis=-1):  # type: (np.ndarray, int) -> np.ndarray
+def softmax(x: np.ndarray, axis: int = -1) -> np.ndarray:
     x_max = np.max(x, axis=axis, keepdims=True)
     tmp = np.exp(x - x_max)
     s = np.sum(tmp, axis=axis, keepdims=True)
@@ -21,7 +21,7 @@ def softmax(x, axis=-1):  # type: (np.ndarray, int) -> np.ndarray
 
 class Softmax(Base):
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Softmax',
             inputs=['x'],
@@ -34,7 +34,7 @@ class Softmax(Base):
                name='test_softmax_example')
 
     @staticmethod
-    def export_softmax_axis():  # type: () -> None
+    def export_softmax_axis() -> None:
         x = np.array([[0, 1, 2, 3], [10000, 10001, 10002, 10003]]
                      ).astype(np.float32)
         # expected output

--- a/onnx/backend/test/case/node/softmaxcrossentropy.py
+++ b/onnx/backend/test/case/node/softmaxcrossentropy.py
@@ -92,7 +92,7 @@ def softmaxcrossentropy(x, target, weight=None, reduction='mean', ignore_index=N
 class SoftmaxCrossEntropyLoss(Base):
 
     @staticmethod
-    def export_softmaxcrossentropy_none():  # type: () -> None
+    def export_softmaxcrossentropy_none() -> None:
         # Define operator attributes.
         reduction = 'none'
 
@@ -114,7 +114,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels], outputs=[sce], name='test_sce_none')
 
     @staticmethod
-    def export_softmaxcrossentropy_none_log_prob():  # type: () -> None
+    def export_softmaxcrossentropy_none_log_prob() -> None:
         # Define operator attributes.
         reduction = 'none'
 
@@ -136,7 +136,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels], outputs=[loss, log_prob], name='test_sce_none_log_prob')
 
     @staticmethod
-    def export_softmaxcrossentropy_none_weights():  # type: () -> None
+    def export_softmaxcrossentropy_none_weights() -> None:
         # Define operator attributes.
         reduction = 'none'
 
@@ -159,7 +159,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels, weights], outputs=[sce], name='test_sce_none_weights')
 
     @staticmethod
-    def export_softmaxcrossentropy_none_weights_log_prob():  # type: () -> None
+    def export_softmaxcrossentropy_none_weights_log_prob() -> None:
         # Define operator attributes.
         reduction = 'none'
 
@@ -182,7 +182,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels, weights], outputs=[loss, log_prob], name='test_sce_none_weights_log_prob')
 
     @staticmethod
-    def export_softmaxcrossentropy_sum():  # type: () -> None
+    def export_softmaxcrossentropy_sum() -> None:
         # Define operator attributes.
         reduction = 'sum'
 
@@ -204,7 +204,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels], outputs=[sce], name='test_sce_sum')
 
     @staticmethod
-    def export_softmaxcrossentropy_sum_log_prob():  # type: () -> None
+    def export_softmaxcrossentropy_sum_log_prob() -> None:
         # Define operator attributes.
         reduction = 'sum'
 
@@ -226,7 +226,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels], outputs=[loss, log_prob], name='test_sce_sum_log_prob')
 
     @staticmethod
-    def export_softmaxcrossentropy_mean():  # type: () -> None
+    def export_softmaxcrossentropy_mean() -> None:
         # Define operator attributes.
         reduction = 'mean'
 
@@ -248,7 +248,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels], outputs=[sce], name='test_sce_mean')
 
     @staticmethod
-    def export_softmaxcrossentropy_mean_log_prob():  # type: () -> None
+    def export_softmaxcrossentropy_mean_log_prob() -> None:
         # Define operator attributes.
         reduction = 'mean'
 
@@ -270,7 +270,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels], outputs=[loss, log_prob], name='test_sce_mean_log_prob')
 
     @staticmethod
-    def export_softmaxcrossentropy_mean_3d():  # type: () -> None
+    def export_softmaxcrossentropy_mean_3d() -> None:
         # Define operator attributes.
         reduction = 'mean'
 
@@ -292,7 +292,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, y], outputs=[sce], name='test_sce_mean_3d')
 
     @staticmethod
-    def export_softmaxcrossentropy_mean_3d_log_prob():  # type: () -> None
+    def export_softmaxcrossentropy_mean_3d_log_prob() -> None:
         # Define operator attributes.
         reduction = 'mean'
 
@@ -314,7 +314,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, y], outputs=[loss, log_prob], name='test_sce_mean_3d_log_prob')
 
     @staticmethod
-    def export_softmaxcrossentropy_mean_weights():  # type: () -> None
+    def export_softmaxcrossentropy_mean_weights() -> None:
         # Define operator attributes.
         reduction = 'mean'
 
@@ -337,7 +337,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels, weights], outputs=[sce], name='test_sce_mean_weight')
 
     @staticmethod
-    def export_softmaxcrossentropy_mean_weights_log_prob():  # type: () -> None
+    def export_softmaxcrossentropy_mean_weights_log_prob() -> None:
         # Define operator attributes.
         reduction = 'mean'
 
@@ -360,7 +360,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels, weights], outputs=[loss, log_prob], name='test_sce_mean_weight_log_prob')
 
     @staticmethod
-    def export_softmaxcrossentropy_mean_weights_ii():  # type: () -> None
+    def export_softmaxcrossentropy_mean_weights_ii() -> None:
         # Define operator attributes.
         reduction = 'mean'
         ignore_index = np.int64(0)
@@ -386,7 +386,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels, weights], outputs=[sce], name='test_sce_mean_weight_ii')
 
     @staticmethod
-    def export_softmaxcrossentropy_mean_weights_ii_log_prob():  # type: () -> None
+    def export_softmaxcrossentropy_mean_weights_ii_log_prob() -> None:
         # Define operator attributes.
         reduction = 'mean'
         ignore_index = np.int64(0)
@@ -412,7 +412,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels, weights], outputs=[loss, log_prob], name='test_sce_mean_weight_ii_log_prob')
 
     @staticmethod
-    def export_softmaxcrossentropy_mean_no_weights_ii():  # type: () -> None
+    def export_softmaxcrossentropy_mean_no_weights_ii() -> None:
         # Define operator attributes.
         reduction = 'mean'
         ignore_index = np.int64(2)
@@ -437,7 +437,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels], outputs=[sce], name='test_sce_mean_no_weight_ii')
 
     @staticmethod
-    def export_softmaxcrossentropy_mean_no_weights_ii_log_prob():  # type: () -> None
+    def export_softmaxcrossentropy_mean_no_weights_ii_log_prob() -> None:
         # Define operator attributes.
         reduction = 'mean'
         ignore_index = np.int64(2)
@@ -462,7 +462,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels], outputs=[loss, log_prob], name='test_sce_mean_no_weight_ii_log_prob')
 
     @staticmethod
-    def export_softmaxcrossentropy_mean_weights_ii_3d():  # type: () -> None
+    def export_softmaxcrossentropy_mean_weights_ii_3d() -> None:
         # Define operator attributes.
         reduction = 'mean'
         ignore_index = np.int64(1)
@@ -488,7 +488,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels, weights], outputs=[sce], name='test_sce_mean_weight_ii_3d')
 
     @staticmethod
-    def export_softmaxcrossentropy_mean_weights_ii_3d_log_prob():  # type: () -> None
+    def export_softmaxcrossentropy_mean_weights_ii_3d_log_prob() -> None:
         # Define operator attributes.
         reduction = 'mean'
         ignore_index = np.int64(1)
@@ -514,7 +514,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels, weights], outputs=[loss, log_prob], name='test_sce_mean_weight_ii_3d_log_prob')
 
     @staticmethod
-    def export_softmaxcrossentropy_mean_no_weights_ii_3d():  # type: () -> None
+    def export_softmaxcrossentropy_mean_no_weights_ii_3d() -> None:
         # Define operator attributes.
         reduction = 'mean'
         ignore_index = np.int64(2)
@@ -539,7 +539,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels], outputs=[sce], name='test_sce_mean_no_weight_ii_3d')
 
     @staticmethod
-    def export_softmaxcrossentropy_mean_no_weights_ii_3d_log_prob():  # type: () -> None
+    def export_softmaxcrossentropy_mean_no_weights_ii_3d_log_prob() -> None:
         # Define operator attributes.
         reduction = 'mean'
         ignore_index = np.int64(2)
@@ -564,7 +564,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels], outputs=[loss, log_prob], name='test_sce_mean_no_weight_ii_3d_log_prob')
 
     @staticmethod
-    def export_softmaxcrossentropy_mean_weights_ii_4d():  # type: () -> None
+    def export_softmaxcrossentropy_mean_weights_ii_4d() -> None:
         # Define operator attributes.
         reduction = 'mean'
         ignore_index = np.int64(2)
@@ -590,7 +590,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels, weights], outputs=[sce], name='test_sce_mean_weight_ii_4d')
 
     @staticmethod
-    def export_softmaxcrossentropy_mean_weights_ii_4d_log_prob():  # type: () -> None
+    def export_softmaxcrossentropy_mean_weights_ii_4d_log_prob() -> None:
         # Define operator attributes.
         reduction = 'mean'
         ignore_index = np.int64(2)
@@ -616,7 +616,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels, weights], outputs=[loss, log_prob], name='test_sce_mean_weight_ii_4d_log_prob')
 
     @staticmethod
-    def export_softmaxcrossentropy_mean_no_weights_ii_4d():  # type: () -> None
+    def export_softmaxcrossentropy_mean_no_weights_ii_4d() -> None:
         # Define operator attributes.
         reduction = 'mean'
         ignore_index = np.int64(2)
@@ -641,7 +641,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels], outputs=[sce], name='test_sce_mean_no_weight_ii_4d')
 
     @staticmethod
-    def export_softmaxcrossentropy_mean_no_weights_ii_4d_log_prob():  # type: () -> None
+    def export_softmaxcrossentropy_mean_no_weights_ii_4d_log_prob() -> None:
         # Define operator attributes.
         reduction = 'mean'
         ignore_index = np.int64(2)
@@ -666,7 +666,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels], outputs=[loss, log_prob], name='test_sce_mean_no_weight_ii_4d_log_prob')
 
     @staticmethod
-    def export_input_shape_is_NCd1d2d3d4d5_mean_weight():  # type: () -> None
+    def export_input_shape_is_NCd1d2d3d4d5_mean_weight() -> None:
         reduction = 'mean'
 
         node = onnx.helper.make_node('SoftmaxCrossEntropyLoss',
@@ -688,7 +688,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels, weight], outputs=[sce], name='test_sce_NCd1d2d3d4d5_mean_weight')
 
     @staticmethod
-    def export_input_shape_is_NCd1d2d3d4d5_mean_weight_log_prob():  # type: () -> None
+    def export_input_shape_is_NCd1d2d3d4d5_mean_weight_log_prob() -> None:
         reduction = 'mean'
 
         node = onnx.helper.make_node('SoftmaxCrossEntropyLoss',
@@ -711,7 +711,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels, weight], outputs=[loss, log_prob], name='test_sce_NCd1d2d3d4d5_mean_weight_log_prob')
 
     @staticmethod
-    def export_input_shape_is_NCd1d2d3d4d5_none_no_weight():  # type: () -> None
+    def export_input_shape_is_NCd1d2d3d4d5_none_no_weight() -> None:
         reduction = 'none'
 
         node = onnx.helper.make_node('SoftmaxCrossEntropyLoss',
@@ -731,7 +731,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels], outputs=[sce], name='test_sce_NCd1d2d3d4d5_none_no_weight')
 
     @staticmethod
-    def export_input_shape_is_NCd1d2d3d4d5_none_no_weight_log_prob():  # type: () -> None
+    def export_input_shape_is_NCd1d2d3d4d5_none_no_weight_log_prob() -> None:
         reduction = 'none'
 
         node = onnx.helper.make_node('SoftmaxCrossEntropyLoss',
@@ -752,7 +752,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels], outputs=[loss, log_prob], name='test_sce_NCd1d2d3d4d5_none_no_weight_log_prob')
 
     @staticmethod
-    def export_input_shape_is_NCd1_mean_weight_negative_ii():  # type: () -> None
+    def export_input_shape_is_NCd1_mean_weight_negative_ii() -> None:
         reduction = 'mean'
         ignore_index = np.int64(-1)
 
@@ -778,7 +778,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels, weight], outputs=[sce], name='test_sce_NCd1_mean_weight_negative_ii')
 
     @staticmethod
-    def export_input_shape_is_NCd1_mean_weight_negative_ii_log_prob():  # type: () -> None
+    def export_input_shape_is_NCd1_mean_weight_negative_ii_log_prob() -> None:
         reduction = 'mean'
         ignore_index = np.int64(-1)
 
@@ -805,7 +805,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels, weight], outputs=[loss, log_prob], name='test_sce_NCd1_mean_weight_negative_ii_log_prob')
 
     @staticmethod
-    def export_input_shape_is_NCd1d2d3_none_no_weight_negative_ii():  # type: () -> None
+    def export_input_shape_is_NCd1d2d3_none_no_weight_negative_ii() -> None:
         reduction = 'none'
         ignore_index = np.int64(-5)
 
@@ -829,7 +829,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels], outputs=[sce], name='test_sce_NCd1d2d3_none_no_weight_negative_ii')
 
     @staticmethod
-    def export_input_shape_is_NCd1d2d3_none_no_weight_negative_ii_log_prob():  # type: () -> None
+    def export_input_shape_is_NCd1d2d3_none_no_weight_negative_ii_log_prob() -> None:
         reduction = 'none'
         ignore_index = np.int64(-5)
 
@@ -854,7 +854,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels], outputs=[loss, log_prob], name='test_sce_NCd1d2d3_none_no_weight_negative_ii_log_prob')
 
     @staticmethod
-    def export_input_shape_is_NCd1d2d3_sum_weight_high_ii():  # type: () -> None
+    def export_input_shape_is_NCd1d2d3_sum_weight_high_ii() -> None:
         reduction = 'sum'
         ignore_index = np.int64(10)
 
@@ -880,7 +880,7 @@ class SoftmaxCrossEntropyLoss(Base):
         expect(node, inputs=[x, labels, weight], outputs=[sce], name='test_sce_NCd1d2d3_sum_weight_high_ii')
 
     @staticmethod
-    def export_input_shape_is_NCd1d2d3_sum_weight_high_ii_log_prob():  # type: () -> None
+    def export_input_shape_is_NCd1d2d3_sum_weight_high_ii_log_prob() -> None:
         reduction = 'sum'
         ignore_index = np.int64(10)
 

--- a/onnx/backend/test/case/node/softplus.py
+++ b/onnx/backend/test/case/node/softplus.py
@@ -15,7 +15,7 @@ from . import expect
 class Softplus(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Softplus',
             inputs=['x'],

--- a/onnx/backend/test/case/node/softsign.py
+++ b/onnx/backend/test/case/node/softsign.py
@@ -15,7 +15,7 @@ from . import expect
 class Softsign(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Softsign',
             inputs=['x'],

--- a/onnx/backend/test/case/node/spacetodepth.py
+++ b/onnx/backend/test/case/node/spacetodepth.py
@@ -13,7 +13,7 @@ from . import expect
 class SpaceToDepth(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         b, c, h, w = shape = (2, 2, 6, 6)
         blocksize = 2
         node = onnx.helper.make_node(
@@ -34,7 +34,7 @@ class SpaceToDepth(Base):
                name='test_spacetodepth')
 
     @staticmethod
-    def export_example():  # type: () -> None
+    def export_example() -> None:
         node = onnx.helper.make_node(
             'SpaceToDepth',
             inputs=['x'],

--- a/onnx/backend/test/case/node/split.py
+++ b/onnx/backend/test/case/node/split.py
@@ -15,7 +15,7 @@ from . import expect
 class Split(Base):
 
     @staticmethod
-    def export_1d():  # type: () -> None
+    def export_1d() -> None:
         input = np.array([1., 2., 3., 4., 5., 6.]).astype(np.float32)
 
         node = onnx.helper.make_node(
@@ -40,7 +40,7 @@ class Split(Base):
         expect(node, inputs=[input, split], outputs=[y for y in expected_outputs], name='test_split_variable_parts_1d')
 
     @staticmethod
-    def export_2d():  # type: () -> None
+    def export_2d() -> None:
         input = np.array([[1., 2., 3., 4., 5., 6.],
                           [7., 8., 9., 10., 11., 12.]]).astype(np.float32)
 
@@ -70,7 +70,7 @@ class Split(Base):
         expect(node, inputs=[input, split], outputs=[y for y in expected_outputs], name='test_split_variable_parts_2d')
 
     @staticmethod
-    def export_default_values():  # type: () -> None
+    def export_default_values() -> None:
         input = np.array([1., 2., 3., 4., 5., 6.]).astype(np.float32)
 
         # If axis is not specified, split is applied on default axis 0
@@ -94,7 +94,7 @@ class Split(Base):
         expect(node, inputs=[input, split], outputs=[y for y in expected_outputs], name='test_split_variable_parts_default_axis')
 
     @staticmethod
-    def export_zero_size_splits():  # type: () -> None
+    def export_zero_size_splits() -> None:
         input = np.array([]).astype(np.float32)
 
         # Split emtpy tensor to tensors of size zero

--- a/onnx/backend/test/case/node/sqrt.py
+++ b/onnx/backend/test/case/node/sqrt.py
@@ -15,7 +15,7 @@ from . import expect
 class Sqrt(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Sqrt',
             inputs=['x'],

--- a/onnx/backend/test/case/node/squeeze.py
+++ b/onnx/backend/test/case/node/squeeze.py
@@ -15,7 +15,7 @@ from onnx.backend.test.case.node import expect
 class Squeeze(Base):
 
     @staticmethod
-    def export_squeeze():  # type: () -> None
+    def export_squeeze() -> None:
         node = onnx.helper.make_node(
             'Squeeze',
             inputs=['x', 'axes'],
@@ -29,7 +29,7 @@ class Squeeze(Base):
                name='test_squeeze')
 
     @staticmethod
-    def export_squeeze_negative_axes():  # type: () -> None
+    def export_squeeze_negative_axes() -> None:
         node = onnx.helper.make_node(
             'Squeeze',
             inputs=['x', 'axes'],

--- a/onnx/backend/test/case/node/stringnormalizer.py
+++ b/onnx/backend/test/case/node/stringnormalizer.py
@@ -17,7 +17,7 @@ from . import expect
 class StringNormalizer(Base):
 
     @staticmethod
-    def export_nostopwords_nochangecase():    # type: () -> None
+    def export_nostopwords_nochangecase() -> None:
         input = np.array([u'monday', u'tuesday']).astype(object)
         output = input
 
@@ -31,7 +31,7 @@ class StringNormalizer(Base):
         expect(node, inputs=[input], outputs=[output], name='test_strnormalizer_nostopwords_nochangecase')
 
     @staticmethod
-    def export_monday_casesensintive_nochangecase():    # type: () -> None
+    def export_monday_casesensintive_nochangecase() -> None:
         input = np.array([u'monday', u'tuesday', u'wednesday', u'thursday']).astype(object)
         output = np.array([u'tuesday', u'wednesday', u'thursday']).astype(object)
         stopwords = [u'monday']
@@ -46,7 +46,7 @@ class StringNormalizer(Base):
         expect(node, inputs=[input], outputs=[output], name='test_strnormalizer_export_monday_casesensintive_nochangecase')
 
     @staticmethod
-    def export_monday_casesensintive_lower():    # type: () -> None
+    def export_monday_casesensintive_lower() -> None:
         input = np.array([u'monday', u'tuesday', u'wednesday', u'thursday']).astype(object)
         output = np.array([u'tuesday', u'wednesday', u'thursday']).astype(object)
         stopwords = [u'monday']
@@ -62,7 +62,7 @@ class StringNormalizer(Base):
         expect(node, inputs=[input], outputs=[output], name='test_strnormalizer_export_monday_casesensintive_lower')
 
     @staticmethod
-    def export_monday_casesensintive_upper():    # type: () -> None
+    def export_monday_casesensintive_upper() -> None:
         input = np.array([u'monday', u'tuesday', u'wednesday', u'thursday']).astype(object)
         output = np.array([u'TUESDAY', u'WEDNESDAY', u'THURSDAY']).astype(object)
         stopwords = [u'monday']
@@ -78,7 +78,7 @@ class StringNormalizer(Base):
         expect(node, inputs=[input], outputs=[output], name='test_strnormalizer_export_monday_casesensintive_upper')
 
     @staticmethod
-    def export_monday_empty_output():    # type: () -> None
+    def export_monday_empty_output() -> None:
         input = np.array([u'monday', u'monday']).astype(object)
         output = np.array([u'']).astype(object)
         stopwords = [u'monday']
@@ -94,7 +94,7 @@ class StringNormalizer(Base):
         expect(node, inputs=[input], outputs=[output], name='test_strnormalizer_export_monday_empty_output')
 
     @staticmethod
-    def export_monday_insensintive_upper_twodim():    # type: () -> None
+    def export_monday_insensintive_upper_twodim() -> None:
         input = np.array([u'Monday', u'tuesday', u'wednesday', u'Monday', u'tuesday', u'wednesday']).astype(object).reshape([1, 6])
 
         # It does upper case cecedille, accented E

--- a/onnx/backend/test/case/node/sub.py
+++ b/onnx/backend/test/case/node/sub.py
@@ -15,7 +15,7 @@ from . import expect
 class Sub(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Sub',
             inputs=['x', 'y'],
@@ -41,7 +41,7 @@ class Sub(Base):
                name='test_sub_uint8')
 
     @staticmethod
-    def export_sub_broadcast():  # type: () -> None
+    def export_sub_broadcast() -> None:
         node = onnx.helper.make_node(
             'Sub',
             inputs=['x', 'y'],

--- a/onnx/backend/test/case/node/sum.py
+++ b/onnx/backend/test/case/node/sum.py
@@ -15,7 +15,7 @@ from . import expect
 class Sum(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         data_0 = np.array([3, 0, 2]).astype(np.float32)
         data_1 = np.array([1, 3, 4]).astype(np.float32)
         data_2 = np.array([2, 6, 6]).astype(np.float32)

--- a/onnx/backend/test/case/node/tan.py
+++ b/onnx/backend/test/case/node/tan.py
@@ -15,7 +15,7 @@ from . import expect
 class Tan(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Tan',
             inputs=['x'],

--- a/onnx/backend/test/case/node/tanh.py
+++ b/onnx/backend/test/case/node/tanh.py
@@ -15,7 +15,7 @@ from . import expect
 class Tanh(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Tanh',
             inputs=['x'],

--- a/onnx/backend/test/case/node/tfidfvectorizer.py
+++ b/onnx/backend/test/case/node/tfidfvectorizer.py
@@ -15,7 +15,7 @@ from . import expect
 
 
 class TfIdfVectorizerHelper():
-    def __init__(self, **params):    # type: (*Any) -> None
+    def __init__(self, **params: Any) -> None:
         # Attr names
         mode = str('mode')
         min_gram_length = str('min_gram_length')
@@ -39,7 +39,7 @@ class TfIdfVectorizerHelper():
         self.ngram_indexes = params[ngram_indexes]
         self.pool_int64s = params[pool_int64s]
 
-    def make_node_noweights(self):    # type: () -> NodeProto
+    def make_node_noweights(self) -> NodeProto:
         return onnx.helper.make_node(
             'TfIdfVectorizer',
             inputs=['X'],
@@ -57,7 +57,7 @@ class TfIdfVectorizerHelper():
 class TfIdfVectorizer(Base):
 
     @staticmethod
-    def export_tf_only_bigrams_skip0():    # type: () -> None
+    def export_tf_only_bigrams_skip0() -> None:
         input = np.array([1, 1, 3, 3, 3, 7, 8, 6, 7, 5, 6, 8]).astype(np.int32)
         output = np.array([0., 0., 0., 0., 1., 1., 1.]).astype(np.float32)
 
@@ -79,7 +79,7 @@ class TfIdfVectorizer(Base):
         expect(node, inputs=[input], outputs=[output], name='test_tfidfvectorizer_tf_only_bigrams_skip0')
 
     @staticmethod
-    def export_tf_batch_onlybigrams_skip0():    # type: () -> None
+    def export_tf_batch_onlybigrams_skip0() -> None:
         input = np.array([[1, 1, 3, 3, 3, 7], [8, 6, 7, 5, 6, 8]]).astype(np.int32)
         output = np.array([[0., 0., 0., 0., 0., 0., 0.], [0., 0., 0., 0., 1., 0., 1.]]).astype(np.float32)
 
@@ -101,7 +101,7 @@ class TfIdfVectorizer(Base):
         expect(node, inputs=[input], outputs=[output], name='test_tfidfvectorizer_tf_batch_onlybigrams_skip0')
 
     @staticmethod
-    def export_tf_onlybigrams_levelempty():    # type: () -> None
+    def export_tf_onlybigrams_levelempty() -> None:
         input = np.array([1, 1, 3, 3, 3, 7, 8, 6, 7, 5, 6, 8]).astype(np.int32)
         output = np.array([1., 1., 1.]).astype(np.float32)
 
@@ -123,7 +123,7 @@ class TfIdfVectorizer(Base):
         expect(node, inputs=[input], outputs=[output], name='test_tfidfvectorizer_tf_onlybigrams_levelempty')
 
     @staticmethod
-    def export_tf_onlybigrams_skip5():    # type: () -> None
+    def export_tf_onlybigrams_skip5() -> None:
         input = np.array([1, 1, 3, 3, 3, 7, 8, 6, 7, 5, 6, 8]).astype(np.int32)
         output = np.array([0., 0., 0., 0., 1., 3., 1.]).astype(np.float32)
 
@@ -145,7 +145,7 @@ class TfIdfVectorizer(Base):
         expect(node, inputs=[input], outputs=[output], name='test_tfidfvectorizer_tf_onlybigrams_skip5')
 
     @staticmethod
-    def export_tf_batch_onlybigrams_skip5():    # type: () -> None
+    def export_tf_batch_onlybigrams_skip5() -> None:
         input = np.array([[1, 1, 3, 3, 3, 7], [8, 6, 7, 5, 6, 8]]).astype(np.int32)
         output = np.array([[0., 0., 0., 0., 0., 0., 0.], [0., 0., 0., 0., 1., 1., 1.]]).astype(np.float32)
 
@@ -167,7 +167,7 @@ class TfIdfVectorizer(Base):
         expect(node, inputs=[input], outputs=[output], name='test_tfidfvectorizer_tf_batch_onlybigrams_skip5')
 
     @staticmethod
-    def export_tf_uniandbigrams_skip5():    # type: () -> None
+    def export_tf_uniandbigrams_skip5() -> None:
         input = np.array([1, 1, 3, 3, 3, 7, 8, 6, 7, 5, 6, 8]).astype(np.int32)
         output = np.array([0., 3., 1., 0., 1., 3., 1.]).astype(np.float32)
 
@@ -189,7 +189,7 @@ class TfIdfVectorizer(Base):
         expect(node, inputs=[input], outputs=[output], name='test_tfidfvectorizer_tf_uniandbigrams_skip5')
 
     @staticmethod
-    def export_tf_batch_uniandbigrams_skip5():    # type: () -> None
+    def export_tf_batch_uniandbigrams_skip5() -> None:
         input = np.array([[1, 1, 3, 3, 3, 7], [8, 6, 7, 5, 6, 8]]).astype(np.int32)
         output = np.array([[0., 3., 0., 0., 0., 0., 0.], [0., 0., 1., 0., 1., 1., 1.]]).astype(np.float32)
 

--- a/onnx/backend/test/case/node/thresholdedrelu.py
+++ b/onnx/backend/test/case/node/thresholdedrelu.py
@@ -15,7 +15,7 @@ from . import expect
 class ThresholdedRelu(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         alpha = 2.0
         node = onnx.helper.make_node(
             'ThresholdedRelu',
@@ -39,7 +39,7 @@ class ThresholdedRelu(Base):
                name='test_thresholdedrelu')
 
     @staticmethod
-    def export_default():  # type: () -> None
+    def export_default() -> None:
         default_alpha = 1.0
         node = onnx.helper.make_node(
             'ThresholdedRelu',

--- a/onnx/backend/test/case/node/tile.py
+++ b/onnx/backend/test/case/node/tile.py
@@ -15,7 +15,7 @@ from . import expect
 class Tile(Base):
 
     @staticmethod
-    def export_tile():  # type: () -> None
+    def export_tile() -> None:
         node = onnx.helper.make_node(
             'Tile',
             inputs=['x', 'y'],
@@ -34,7 +34,7 @@ class Tile(Base):
                name='test_tile')
 
     @staticmethod
-    def export_tile_precomputed():  # type: () -> None
+    def export_tile_precomputed() -> None:
         node = onnx.helper.make_node(
             'Tile',
             inputs=['x', 'y'],

--- a/onnx/backend/test/case/node/topk.py
+++ b/onnx/backend/test/case/node/topk.py
@@ -26,7 +26,7 @@ def topk_sorted_implementation(X, k, axis, largest):  # type: ignore
 class TopK(Base):
 
     @staticmethod
-    def export_top_k():  # type: () -> None
+    def export_top_k() -> None:
         axis = 1
         largest = 1
 
@@ -58,7 +58,7 @@ class TopK(Base):
                name='test_top_k')
 
     @staticmethod
-    def export_top_k_smallest():  # type: () -> None
+    def export_top_k_smallest() -> None:
         axis = 1
         largest = 0
         sorted = 1
@@ -94,7 +94,7 @@ class TopK(Base):
                name='test_top_k_smallest')
 
     @staticmethod
-    def export_top_k_negative_axis():  # type: () -> None
+    def export_top_k_negative_axis() -> None:
         axis = -1
         largest = 1
 

--- a/onnx/backend/test/case/node/transpose.py
+++ b/onnx/backend/test/case/node/transpose.py
@@ -16,7 +16,7 @@ from . import expect
 class Transpose(Base):
 
     @staticmethod
-    def export_default():  # type: () -> None
+    def export_default() -> None:
         shape = (2, 3, 4)
         data = np.random.random_sample(shape).astype(np.float32)
 
@@ -31,7 +31,7 @@ class Transpose(Base):
                name='test_transpose_default')
 
     @staticmethod
-    def export_all_permutations():  # type: () -> None
+    def export_all_permutations() -> None:
         shape = (2, 3, 4)
         data = np.random.random_sample(shape).astype(np.float32)
         permutations = list(itertools.permutations(np.arange(len(shape))))

--- a/onnx/backend/test/case/node/trilu.py
+++ b/onnx/backend/test/case/node/trilu.py
@@ -22,7 +22,7 @@ def tril_reference_implementation(x, k=0):  # type: ignore
 
 class Trilu(Base):
     @staticmethod
-    def export_triu():  # type: () -> None
+    def export_triu() -> None:
         node = onnx.helper.make_node(
             'Trilu',
             inputs=['x'],
@@ -44,7 +44,7 @@ class Trilu(Base):
         expect(node, inputs=[x], outputs=[y], name='test_triu')
 
     @staticmethod
-    def export_triu_neg():  # type: () -> None
+    def export_triu_neg() -> None:
         node = onnx.helper.make_node(
             'Trilu',
             inputs=['x', 'k'],
@@ -67,7 +67,7 @@ class Trilu(Base):
         expect(node, inputs=[x, k], outputs=[y], name='test_triu_neg')
 
     @staticmethod
-    def export_triu_out_neg_out():  # type: () -> None
+    def export_triu_out_neg_out() -> None:
         node = onnx.helper.make_node(
             'Trilu',
             inputs=['x', 'k'],
@@ -90,7 +90,7 @@ class Trilu(Base):
         expect(node, inputs=[x, k], outputs=[y], name='test_triu_out_neg_out')
 
     @staticmethod
-    def export_triu_pos():  # type: () -> None
+    def export_triu_pos() -> None:
         node = onnx.helper.make_node(
             'Trilu',
             inputs=['x', 'k'],
@@ -113,7 +113,7 @@ class Trilu(Base):
         expect(node, inputs=[x, k], outputs=[y], name='test_triu_pos')
 
     @staticmethod
-    def export_triu_out_pos():  # type: () -> None
+    def export_triu_out_pos() -> None:
         node = onnx.helper.make_node(
             'Trilu',
             inputs=['x', 'k'],
@@ -136,7 +136,7 @@ class Trilu(Base):
         expect(node, inputs=[x, k], outputs=[y], name='test_triu_out_pos')
 
     @staticmethod
-    def export_triu_square():  # type: () -> None
+    def export_triu_square() -> None:
         node = onnx.helper.make_node(
             'Trilu',
             inputs=['x'],
@@ -164,7 +164,7 @@ class Trilu(Base):
         expect(node, inputs=[x], outputs=[y], name='test_triu_square')
 
     @staticmethod
-    def export_triu_square_neg():  # type: () -> None
+    def export_triu_square_neg() -> None:
         node = onnx.helper.make_node(
             'Trilu',
             inputs=['x', 'k'],
@@ -193,7 +193,7 @@ class Trilu(Base):
         expect(node, inputs=[x, k], outputs=[y], name='test_triu_square_neg')
 
     @staticmethod
-    def export_triu_one_row():  # type: () -> None
+    def export_triu_one_row() -> None:
         node = onnx.helper.make_node(
             'Trilu',
             inputs=['x', 'k'],
@@ -218,7 +218,7 @@ class Trilu(Base):
         expect(node, inputs=[x, k], outputs=[y], name='test_triu_one_row')
 
     @staticmethod
-    def export_triu_zero():  # type: () -> None
+    def export_triu_zero() -> None:
         node = onnx.helper.make_node(
             'Trilu',
             inputs=['x', 'k'],
@@ -235,7 +235,7 @@ class Trilu(Base):
         expect(node, inputs=[x, k], outputs=[y], name='test_triu_zero')
 
     @staticmethod
-    def export_tril():  # type: () -> None
+    def export_tril() -> None:
         node = onnx.helper.make_node(
             'Trilu',
             inputs=['x'],
@@ -258,7 +258,7 @@ class Trilu(Base):
         expect(node, inputs=[x], outputs=[y], name='test_tril')
 
     @staticmethod
-    def export_tril_neg():  # type: () -> None
+    def export_tril_neg() -> None:
         node = onnx.helper.make_node(
             'Trilu',
             inputs=['x', 'k'],
@@ -282,7 +282,7 @@ class Trilu(Base):
         expect(node, inputs=[x, k], outputs=[y], name='test_tril_neg')
 
     @staticmethod
-    def export_tril_out_neg():  # type: () -> None
+    def export_tril_out_neg() -> None:
         node = onnx.helper.make_node(
             'Trilu',
             inputs=['x', 'k'],
@@ -306,7 +306,7 @@ class Trilu(Base):
         expect(node, inputs=[x, k], outputs=[y], name='test_tril_out_neg')
 
     @staticmethod
-    def export_tril_pos():  # type: () -> None
+    def export_tril_pos() -> None:
         node = onnx.helper.make_node(
             'Trilu',
             inputs=['x', 'k'],
@@ -330,7 +330,7 @@ class Trilu(Base):
         expect(node, inputs=[x, k], outputs=[y], name='test_tril_pos')
 
     @staticmethod
-    def export_tril_out_pos():  # type: () -> None
+    def export_tril_out_pos() -> None:
         node = onnx.helper.make_node(
             'Trilu',
             inputs=['x', 'k'],
@@ -353,7 +353,7 @@ class Trilu(Base):
         expect(node, inputs=[x, k], outputs=[y], name='test_tril_out_pos')
 
     @staticmethod
-    def export_tril_square():  # type: () -> None
+    def export_tril_square() -> None:
         node = onnx.helper.make_node(
             'Trilu',
             inputs=['x'],
@@ -382,7 +382,7 @@ class Trilu(Base):
         expect(node, inputs=[x], outputs=[y], name='test_tril_square')
 
     @staticmethod
-    def export_tril_square_neg():  # type: () -> None
+    def export_tril_square_neg() -> None:
         node = onnx.helper.make_node(
             'Trilu',
             inputs=['x', 'k'],
@@ -412,7 +412,7 @@ class Trilu(Base):
         expect(node, inputs=[x, k], outputs=[y], name='test_tril_square_neg')
 
     @staticmethod
-    def export_tril_one_row():  # type: () -> None
+    def export_tril_one_row() -> None:
         node = onnx.helper.make_node(
             'Trilu',
             inputs=['x'],
@@ -437,7 +437,7 @@ class Trilu(Base):
         expect(node, inputs=[x], outputs=[y], name='test_tril_one_row_neg')
 
     @staticmethod
-    def export_tril_zero():  # type: () -> None
+    def export_tril_zero() -> None:
         node = onnx.helper.make_node(
             'Trilu',
             inputs=['x', 'k'],

--- a/onnx/backend/test/case/node/unique.py
+++ b/onnx/backend/test/case/node/unique.py
@@ -19,7 +19,7 @@ def specify_int64(indices, inverse_indices, counts):  # type: ignore
 class Unique(Base):
 
     @staticmethod
-    def export_sorted_without_axis():  # type: () -> None
+    def export_sorted_without_axis() -> None:
         node_sorted = onnx.helper.make_node(
             'Unique',
             inputs=['X'],
@@ -32,7 +32,7 @@ class Unique(Base):
         expect(node_sorted, inputs=[x], outputs=[y, indices, inverse_indices, counts], name='test_unique_sorted_without_axis')
 
     @staticmethod
-    def export_not_sorted_without_axis():  # type: () -> None
+    def export_not_sorted_without_axis() -> None:
         node_not_sorted = onnx.helper.make_node(
             'Unique',
             inputs=['X'],
@@ -66,7 +66,7 @@ class Unique(Base):
         expect(node_not_sorted, inputs=[x], outputs=[y, indices, inverse_indices, counts], name='test_unique_not_sorted_without_axis')
 
     @staticmethod
-    def export_sorted_with_axis():  # type: () -> None
+    def export_sorted_with_axis() -> None:
         node_sorted = onnx.helper.make_node(
             'Unique',
             inputs=['X'],
@@ -91,7 +91,7 @@ class Unique(Base):
         expect(node_sorted, inputs=[x], outputs=[y, indices, inverse_indices, counts], name='test_unique_sorted_with_axis')
 
     @staticmethod
-    def export_sorted_with_axis_3d():  # type: () -> None
+    def export_sorted_with_axis_3d() -> None:
         node_sorted = onnx.helper.make_node(
             'Unique',
             inputs=['X'],
@@ -120,7 +120,7 @@ class Unique(Base):
         expect(node_sorted, inputs=[x], outputs=[y, indices, inverse_indices, counts], name='test_unique_sorted_with_axis_3d')
 
     @staticmethod
-    def export_sorted_with_negative_axis():  # type: () -> None
+    def export_sorted_with_negative_axis() -> None:
         node_sorted = onnx.helper.make_node(
             'Unique',
             inputs=['X'],

--- a/onnx/backend/test/case/node/unsqueeze.py
+++ b/onnx/backend/test/case/node/unsqueeze.py
@@ -15,7 +15,7 @@ from . import expect
 class Unsqueeze(Base):
 
     @staticmethod
-    def export_unsqueeze_one_axis():  # type: () -> None
+    def export_unsqueeze_one_axis() -> None:
         x = np.random.randn(3, 4, 5).astype(np.float32)
 
         for i in range(x.ndim):
@@ -31,7 +31,7 @@ class Unsqueeze(Base):
                    name='test_unsqueeze_axis_' + str(i))
 
     @staticmethod
-    def export_unsqueeze_two_axes():  # type: () -> None
+    def export_unsqueeze_two_axes() -> None:
         x = np.random.randn(3, 4, 5).astype(np.float32)
         axes = np.array([1, 4]).astype(np.int64)
 
@@ -47,7 +47,7 @@ class Unsqueeze(Base):
                name='test_unsqueeze_two_axes')
 
     @staticmethod
-    def export_unsqueeze_three_axes():  # type: () -> None
+    def export_unsqueeze_three_axes() -> None:
         x = np.random.randn(3, 4, 5).astype(np.float32)
         axes = np.array([2, 4, 5]).astype(np.int64)
 
@@ -64,7 +64,7 @@ class Unsqueeze(Base):
                name='test_unsqueeze_three_axes')
 
     @staticmethod
-    def export_unsqueeze_unsorted_axes():  # type: () -> None
+    def export_unsqueeze_unsorted_axes() -> None:
         x = np.random.randn(3, 4, 5).astype(np.float32)
         axes = np.array([5, 4, 2]).astype(np.int64)
 
@@ -81,7 +81,7 @@ class Unsqueeze(Base):
                name='test_unsqueeze_unsorted_axes')
 
     @staticmethod
-    def export_unsqueeze_negative_axes():  # type: () -> None
+    def export_unsqueeze_negative_axes() -> None:
         node = onnx.helper.make_node(
             'Unsqueeze',
             inputs=['x', 'axes'],

--- a/onnx/backend/test/case/node/upsample.py
+++ b/onnx/backend/test/case/node/upsample.py
@@ -16,7 +16,7 @@ from onnx import helper
 class Upsample(Base):
 
     @staticmethod
-    def export_nearest():  # type: () -> None
+    def export_nearest() -> None:
         node = onnx.helper.make_node(
             'Upsample',
             inputs=['X', 'scales'],

--- a/onnx/backend/test/case/node/where.py
+++ b/onnx/backend/test/case/node/where.py
@@ -15,7 +15,7 @@ from . import expect
 class Where(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Where',
             inputs=['condition', 'x', 'y'],
@@ -30,7 +30,7 @@ class Where(Base):
                name='test_where_example')
 
     @staticmethod
-    def export_long():  # type: () -> None
+    def export_long() -> None:
         node = onnx.helper.make_node(
             'Where',
             inputs=['condition', 'x', 'y'],

--- a/onnx/backend/test/case/node/xor.py
+++ b/onnx/backend/test/case/node/xor.py
@@ -15,7 +15,7 @@ from . import expect
 class Xor(Base):
 
     @staticmethod
-    def export():  # type: () -> None
+    def export() -> None:
         node = onnx.helper.make_node(
             'Xor',
             inputs=['x', 'y'],
@@ -44,7 +44,7 @@ class Xor(Base):
                name='test_xor4d')
 
     @staticmethod
-    def export_xor_broadcast():  # type: () -> None
+    def export_xor_broadcast() -> None:
         node = onnx.helper.make_node(
             'Xor',
             inputs=['x', 'y'],

--- a/onnx/backend/test/case/utils.py
+++ b/onnx/backend/test/case/utils.py
@@ -19,11 +19,11 @@ all_numeric_dtypes = [
 ]
 
 
-def import_recursive(package):  # type: (ModuleType) -> None
+def import_recursive(package: ModuleType) -> None:
     """
     Takes a package and imports all modules underneath it
     """
-    pkg_dir = None  # type: Optional[List[str]]
+    pkg_dir: Optional[List[str]] = None
     pkg_dir = package.__path__  # type: ignore
     module_location = package.__name__
     for (_module_loader, name, ispkg) in pkgutil.iter_modules(pkg_dir):

--- a/onnx/backend/test/cmd_tools.py
+++ b/onnx/backend/test/cmd_tools.py
@@ -20,9 +20,9 @@ TOP_DIR = os.path.realpath(os.path.dirname(__file__))
 DATA_DIR = os.path.join(TOP_DIR, 'data')
 
 
-def generate_data(args):  # type: (argparse.Namespace) -> None
+def generate_data(args: argparse.Namespace) -> None:
 
-    def prepare_dir(path):  # type: (Text) -> None
+    def prepare_dir(path: Text) -> None:
         if os.path.exists(path):
             shutil.rmtree(path)
         os.makedirs(path)
@@ -87,7 +87,7 @@ def generate_data(args):  # type: (argparse.Namespace) -> None
                                 output, case.model.graph.output[j].name).SerializeToString())
 
 
-def parse_args():  # type: () -> argparse.Namespace
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser('backend-test-tools')
     subparsers = parser.add_subparsers()
 
@@ -101,7 +101,7 @@ def parse_args():  # type: () -> argparse.Namespace
     return parser.parse_args()
 
 
-def main():  # type: () -> None
+def main() -> None:
     args = parse_args()
     args.func(args)
 

--- a/onnx/backend/test/loader/__init__.py
+++ b/onnx/backend/test/loader/__init__.py
@@ -17,9 +17,9 @@ DATA_DIR = os.path.join(
 
 
 def load_model_tests(
-    data_dir=DATA_DIR,  # type: Text
-    kind=None,  # type: Optional[Text]
-):  # type: (...) -> List[TestCase]
+    data_dir: Text = DATA_DIR,
+    kind: Optional[Text] = None,
+) -> List[TestCase]:
     '''Load model test cases from on-disk data files.
     '''
 
@@ -40,7 +40,7 @@ def load_model_tests(
         if os.path.exists(os.path.join(case_dir, 'model.onnx')):
             url = None
             model_name = test_name[len('test_')]
-            model_dir = case_dir  # type: Optional[Text]
+            model_dir: Optional[Text] = case_dir
         else:
             with open(os.path.join(case_dir, 'data.json')) as f:
                 data = json.load(f)

--- a/onnx/backend/test/report/__init__.py
+++ b/onnx/backend/test/report/__init__.py
@@ -11,10 +11,10 @@ from .coverage import Coverage
 from typing import Dict, Text, Sequence, Any, List
 
 _coverage = Coverage()
-_marks = {}  # type: Dict[Text, Sequence[Any]]
+_marks: Dict[Text, Sequence[Any]] = {}
 
 
-def _add_mark(mark, bucket):  # type: (Any, Text) -> None
+def _add_mark(mark: Any, bucket: Text) -> None:
     proto = mark.args[0]
     if isinstance(proto, list):
         assert len(proto) == 1
@@ -23,14 +23,14 @@ def _add_mark(mark, bucket):  # type: (Any, Text) -> None
         _coverage.add_proto(proto, bucket, mark.args[1] == 'RealModel')
 
 
-def pytest_runtest_call(item):  # type: (pytest.nodes.Item) -> None
+def pytest_runtest_call(item: pytest.nodes.Item) -> None:
     mark = item.get_closest_marker('onnx_coverage')
     if mark:
         assert item.nodeid not in _marks
         _marks[item.nodeid] = mark
 
 
-def pytest_runtest_logreport(report):  # type: (Any) -> None
+def pytest_runtest_logreport(report: Any) -> None:
     if (report.when == 'call'
         and report.outcome == 'passed'
             and report.nodeid in _marks):
@@ -39,7 +39,7 @@ def pytest_runtest_logreport(report):  # type: (Any) -> None
 
 
 @pytest.hookimpl(trylast=True)  # type: ignore
-def pytest_terminal_summary(terminalreporter, exitstatus):  # type: (pytest.terminal.TerminalReporter, int) -> None
+def pytest_terminal_summary(terminalreporter: pytest.terminal.TerminalReporter, exitstatus: int) -> None:
     for mark in _marks.values():
         _add_mark(mark, 'loaded')
     _coverage.report_text(terminalreporter)

--- a/onnx/backend/test/report/coverage.py
+++ b/onnx/backend/test/report/coverage.py
@@ -20,11 +20,11 @@ _all_schemas = defs.get_all_schemas()
 
 
 class AttrCoverage(object):
-    def __init__(self):  # type: () -> None
-        self.name = None  # type: Optional[Text]
-        self.values = set()  # type: Set[Text]
+    def __init__(self) -> None:
+        self.name: Optional[Text] = None
+        self.values: Set[Text] = set()
 
-    def add(self, attr):  # type: (onnx.AttributeProto) -> None
+    def add(self, attr: onnx.AttributeProto) -> None:
         assert self.name in [None, attr.name]
         self.name = attr.name
         value = helper.get_attribute_value(attr)
@@ -37,11 +37,11 @@ class AttrCoverage(object):
 
 
 class NodeCoverage(object):
-    def __init__(self):  # type: () -> None
-        self.op_type = None  # type: Optional[Text]
-        self.attr_coverages = defaultdict(AttrCoverage)  # type: Dict[Text, AttrCoverage]
+    def __init__(self) -> None:
+        self.op_type: Optional[Text] = None
+        self.attr_coverages: Dict[Text, AttrCoverage] = defaultdict(AttrCoverage)
 
-    def add(self, node):  # type: (onnx.NodeProto) -> None
+    def add(self, node: onnx.NodeProto) -> None:
         assert self.op_type in [None, node.op_type]
 
         if self.op_type is None:
@@ -54,12 +54,12 @@ class NodeCoverage(object):
 
 
 class ModelCoverage(object):
-    def __init__(self):  # type: () -> None
-        self.name = None  # type: Optional[Text]
-        self.graph = None  # type: Optional[GraphProto]
-        self.node_coverages = defaultdict(NodeCoverage)  # type: Dict[Text, NodeCoverage]
+    def __init__(self) -> None:
+        self.name: Optional[Text] = None
+        self.graph: Optional[GraphProto] = None
+        self.node_coverages: Dict[Text, NodeCoverage] = defaultdict(NodeCoverage)
 
-    def add(self, model):  # type: (onnx.ModelProto) -> None
+    def add(self, model: onnx.ModelProto) -> None:
         assert self.name in [None, model.graph.name]
 
         if self.name is None:
@@ -72,34 +72,34 @@ class ModelCoverage(object):
 
 
 class Coverage(object):
-    def __init__(self):  # type: () -> None
-        self.buckets = {
+    def __init__(self) -> None:
+        self.buckets: Dict[Text, Dict[Text, NodeCoverage]] = {
             'loaded': defaultdict(NodeCoverage),
             'passed': defaultdict(NodeCoverage),
-        }  # type: Dict[Text, Dict[Text, NodeCoverage]]
-        self.models = {
+        }
+        self.models: Dict[Text, Dict[Text, ModelCoverage]] = {
             'loaded': defaultdict(ModelCoverage),
             'passed': defaultdict(ModelCoverage),
-        }  # type: Dict[Text, Dict[Text, ModelCoverage]]
+        }
 
-    def add_node(self, node, bucket):  # type: (onnx.NodeProto, Text) -> None
+    def add_node(self, node: onnx.NodeProto, bucket: Text) -> None:
         self.buckets[bucket][node.op_type].add(node)
 
-    def add_graph(self, graph, bucket):  # type: (onnx.GraphProto, Text) -> None
+    def add_graph(self, graph: onnx.GraphProto, bucket: Text) -> None:
         for node in graph.node:
             self.add_node(node, bucket)
 
-    def add_model(self, model, bucket, is_model):  # type: (onnx.ModelProto, Text, bool) -> None
+    def add_model(self, model: onnx.ModelProto, bucket: Text, is_model: bool) -> None:
         self.add_graph(model.graph, bucket)
         # Only add model if name does not start with test
         if is_model:
             self.models[bucket][model.graph.name].add(model)
 
-    def add_proto(self, proto, bucket, is_model):  # type: (onnx.ModelProto, Text, bool) -> None
+    def add_proto(self, proto: onnx.ModelProto, bucket: Text, is_model: bool) -> None:
         assert isinstance(proto, onnx.ModelProto)
         self.add_model(proto, bucket, is_model)
 
-    def report_text(self, writer):  # type: (IO[Text]) -> None
+    def report_text(self, writer: IO[Text]) -> None:
         writer.write('---------- onnx coverage: ----------\n')
         writer.write('Operators (passed/loaded/total): {}/{}/{}\n'.format(
             len(self.buckets['passed']),
@@ -109,8 +109,8 @@ class Coverage(object):
 
         rows = []
         passed = []
-        all_ops = []  # type: List[Text]
-        experimental = []  # type: List[Text]
+        all_ops: List[Text] = []
+        experimental: List[Text] = []
         for op_cov in self.buckets['passed'].values():
             covered_attrs = [
                 '{}: {}'.format(attr_cov.name, len(attr_cov.values))
@@ -142,7 +142,7 @@ class Coverage(object):
     # files is a column naming each op or model and columns for each
     # backend with indications of whether the tests passed or failed for
     # each row.
-    def report_csv(self, all_ops, passed, experimental):  # type: (List[Text], List[Optional[Text]], List[Text]) -> None
+    def report_csv(self, all_ops: List[Text], passed: List[Optional[Text]], experimental: List[Text]) -> None:
         for schema in _all_schemas:
             if schema.domain == '' or schema.domain == 'ai.onnx':
                 all_ops.append(schema.name)
@@ -153,9 +153,9 @@ class Coverage(object):
                 'nodes.csv')  # type: ignore
         models_path = os.path.join(str(os.environ.get('CSVDIR')),  # type: ignore
                 'models.csv')  # type: ignore
-        existing_nodes = OrderedDict()  # type: OrderedDict[Text, Dict[str, str]]
-        existing_models = OrderedDict()  # type: OrderedDict[Text, Dict[str, str]]
-        frameworks = []  # type: List[str]
+        existing_nodes: OrderedDict[Text, Dict[str, str]] = OrderedDict()
+        existing_models: OrderedDict[Text, Dict[str, str]] = OrderedDict()
+        frameworks: List[str] = []
         if os.path.isfile(nodes_path):
             with open(nodes_path, 'r') as nodes_file:
                 reader = csv.DictReader(nodes_file)
@@ -195,7 +195,7 @@ class Coverage(object):
                     existing_nodes[node_name][str(backend)] = str("Passed!")
                 else:
                     existing_nodes[node_name][str(backend)] = str("Failed!")
-            summaries = dict()  # type: Dict[Any, Any]
+            summaries: Dict[Any, Any] = dict()
             if "Summary" in existing_nodes:
                 summaries = existing_nodes["Summary"]
                 del existing_nodes["Summary"]

--- a/onnx/backend/test/runner/__init__.py
+++ b/onnx/backend/test/runner/__init__.py
@@ -33,12 +33,12 @@ class BackendIsNotSupposedToImplementIt(unittest.SkipTest):
     pass
 
 
-def retry_excute(times):  # type: (int) -> Callable[[Callable[..., Any]], Callable[..., Any]]
+def retry_excute(times: int) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     assert times >= 1
 
-    def wrapper(func):  # type: (Callable[..., Any]) -> Callable[..., Any]
+    def wrapper(func: Callable[..., Any]) -> Callable[..., Any]:
         @functools.wraps(func)
-        def wrapped(*args, **kwargs):  # type: (*Any, **Any) -> Any
+        def wrapped(*args: Any, **kwargs: Any) -> Any:
             for i in range(1, times + 1):
                 try:
                     return func(*args, **kwargs)
@@ -53,18 +53,18 @@ def retry_excute(times):  # type: (int) -> Callable[[Callable[..., Any]], Callab
 
 class Runner(object):
 
-    def __init__(self, backend, parent_module=None):  # type: (Type[Backend], Optional[str]) -> None
+    def __init__(self, backend: Type[Backend], parent_module: Optional[str] = None) -> None:
         self.backend = backend
         self._parent_module = parent_module
-        self._include_patterns = set()  # type: Set[Pattern[Text]]
-        self._exclude_patterns = set()  # type: Set[Pattern[Text]]
-        self._xfail_patterns = set()    # type: Set[Pattern[Text]]
+        self._include_patterns: Set[Pattern[Text]] = set()
+        self._exclude_patterns: Set[Pattern[Text]] = set()
+        self._xfail_patterns: Set[Pattern[Text]] = set()
 
         # This is the source of the truth of all test functions.
         # Properties `test_cases`, `test_suite` and `tests` will be
         # derived from it.
         # {category: {name: func}}
-        self._test_items = defaultdict(dict)  # type: Dict[Text, Dict[Text, TestItem]]
+        self._test_items: Dict[Text, Dict[Text, TestItem]] = defaultdict(dict)
 
         for rt in load_model_tests(kind='node'):
             self._add_model_test(rt, 'Node')
@@ -81,25 +81,25 @@ class Runner(object):
         for ot in load_model_tests(kind='pytorch-operator'):
             self._add_model_test(ot, 'PyTorchOperator')
 
-    def _get_test_case(self, name):  # type: (Text) -> Type[unittest.TestCase]
+    def _get_test_case(self, name: Text) -> Type[unittest.TestCase]:
         test_case = type(str(name), (unittest.TestCase,), {})
         if self._parent_module:
             test_case.__module__ = self._parent_module
         return test_case
 
-    def include(self, pattern):  # type: (Text) -> Runner
+    def include(self, pattern: Text) -> Runner:
         self._include_patterns.add(re.compile(pattern))
         return self
 
-    def exclude(self, pattern):  # type: (Text) -> Runner
+    def exclude(self, pattern: Text) -> Runner:
         self._exclude_patterns.add(re.compile(pattern))
         return self
 
-    def xfail(self, pattern):  # type: (Text) -> Runner
+    def xfail(self, pattern: Text) -> Runner:
         self._xfail_patterns.add(re.compile(pattern))
         return self
 
-    def enable_report(self):  # type: () -> Runner
+    def enable_report(self) -> Runner:
         import pytest  # type: ignore
 
         for category, items_map in self._test_items.items():
@@ -108,8 +108,8 @@ class Runner(object):
         return self
 
     @property
-    def _filtered_test_items(self):  # type: () -> Dict[Text, Dict[Text, TestItem]]
-        filtered = {}  # type: Dict[Text, Dict[Text, TestItem]]
+    def _filtered_test_items(self) -> Dict[Text, Dict[Text, TestItem]]:
+        filtered: Dict[Text, Dict[Text, TestItem]] = {}
         for category, items_map in self._test_items.items():
             filtered[category] = {}
             for name, item in items_map.items():
@@ -132,7 +132,7 @@ class Runner(object):
         return filtered
 
     @property
-    def test_cases(self):  # type: () -> Dict[str, Type[unittest.TestCase]]
+    def test_cases(self) -> Dict[str, Type[unittest.TestCase]]:
         '''
         List of test cases to be applied on the parent scope
         Example usage:
@@ -148,7 +148,7 @@ class Runner(object):
         return test_cases
 
     @property
-    def test_suite(self):  # type: () -> unittest.TestSuite
+    def test_suite(self) -> unittest.TestSuite:
         '''
         TestSuite that can be run by TestRunner
         Example usage:
@@ -161,7 +161,7 @@ class Runner(object):
 
     # For backward compatibility (we used to expose `.tests`)
     @property
-    def tests(self):  # type: () -> Type[unittest.TestCase]
+    def tests(self) -> Type[unittest.TestCase]:
         '''
         One single unittest.TestCase that hosts all the test functions
         Example usage:
@@ -174,7 +174,7 @@ class Runner(object):
         return tests
 
     @classmethod
-    def assert_similar_outputs(cls, ref_outputs, outputs, rtol, atol):  # type: (Sequence[Any], Sequence[Any], float, float) -> None
+    def assert_similar_outputs(cls, ref_outputs: Sequence[Any], outputs: Sequence[Any], rtol: float, atol: float) -> None:
         np.testing.assert_equal(len(outputs), len(ref_outputs))
         for i in range(len(outputs)):
             if isinstance(outputs[i], (list, tuple)):
@@ -193,7 +193,7 @@ class Runner(object):
 
     @classmethod
     @retry_excute(3)
-    def download_model(cls, model_test, model_dir, models_dir):  # type: (TestCase, Text, Text) -> None
+    def download_model(cls, model_test: TestCase, model_dir: Text, models_dir: Text) -> None:
         # On Windows, NamedTemporaryFile can not be opened for a
         # second time
         download_file = tempfile.NamedTemporaryFile(delete=False)
@@ -214,11 +214,11 @@ class Runner(object):
             os.remove(download_file.name)
 
     @classmethod
-    def prepare_model_data(cls, model_test):  # type: (TestCase) -> Text
+    def prepare_model_data(cls, model_test: TestCase) -> Text:
         onnx_home = os.path.expanduser(os.getenv('ONNX_HOME', os.path.join('~', '.onnx')))
         models_dir = os.getenv('ONNX_MODELS',
                                os.path.join(onnx_home, 'models'))
-        model_dir = os.path.join(models_dir, model_test.model_name)  # type: Text
+        model_dir: Text = os.path.join(models_dir, model_test.model_name)
         if not os.path.exists(os.path.join(model_dir, 'model.onnx')):
             if os.path.exists(model_dir):
                 bi = 0
@@ -235,18 +235,18 @@ class Runner(object):
         return model_dir
 
     def _add_test(self,
-                  category,  # type: Text
-                  test_name,  # type: Text
-                  test_func,  # type: Callable[..., Any]
-                  report_item,  # type: List[Optional[Union[ModelProto, NodeProto]]]
-                  devices=('CPU', 'CUDA'),  # type: Iterable[Text]
-                  ):  # type: (...) -> None
+                  category: Text,
+                  test_name: Text,
+                  test_func: Callable[..., Any],
+                  report_item: List[Optional[Union[ModelProto, NodeProto]]],
+                  devices: Iterable[Text] = ('CPU', 'CUDA'),
+                  ) -> None:
         # We don't prepend the 'test_' prefix to improve greppability
         if not test_name.startswith('test_'):
             raise ValueError(
                 'Test name must start with test_: {}'.format(test_name))
 
-        def add_device_test(device):  # type: (Text) -> None
+        def add_device_test(device: Text) -> None:
             device_test_name = '{}_{}'.format(test_name, device.lower())
             if device_test_name in self._test_items[category]:
                 raise ValueError(
@@ -257,7 +257,7 @@ class Runner(object):
                 not self.backend.supports_device(device),
                 "Backend doesn't support device {}".format(device))
             @functools.wraps(test_func)
-            def device_test_func(*args, **kwargs):  # type: (*Any, **Any) -> Any
+            def device_test_func(*args: Any, **kwargs: Any) -> Any:
                 try:
                     return test_func(*args, device=device, **kwargs)
                 except BackendIsNotSupposedToImplementIt as e:
@@ -272,12 +272,12 @@ class Runner(object):
         for device in devices:
             add_device_test(device)
 
-    def _add_model_test(self, model_test, kind):  # type: (TestCase, Text) -> None
+    def _add_model_test(self, model_test: TestCase, kind: Text) -> None:
         # model is loaded at runtime, note sometimes it could even
         # never loaded if the test skipped
-        model_marker = [None]  # type: List[Optional[Union[ModelProto, NodeProto]]]
+        model_marker: List[Optional[Union[ModelProto, NodeProto]]] = [None]
 
-        def run(test_self, device):  # type: (Any, Text) -> None
+        def run(test_self: Any, device: Text) -> None:
             if model_test.model_dir is None:
                 model_dir = self.prepare_model_data(model_test)
             else:
@@ -321,7 +321,7 @@ class Runner(object):
 
         self._add_test(kind + 'Model', model_test.name, run, model_marker)
 
-    def _load_proto(self, proto_filename, target_list, model_type_proto):  # type: (Text, List[Union[np.ndarray[Any], List[Any]]], TypeProto) -> None
+    def _load_proto(self, proto_filename: Text, target_list: List[Union[np.ndarray[Any], List[Any]]], model_type_proto: TypeProto) -> None:
         with open(proto_filename, 'rb') as f:
             protobuf_content = f.read()
             if model_type_proto.HasField('sequence_type'):

--- a/onnx/backend/test/runner/item.py
+++ b/onnx/backend/test/runner/item.py
@@ -14,6 +14,6 @@ from onnx import NodeProto, ModelProto
 
 
 class TestItem(object):
-    def __init__(self, func, proto):  # type: (Callable[..., Any], List[Optional[Union[ModelProto, NodeProto]]]) -> None
+    def __init__(self, func: Callable[..., Any], proto: List[Optional[Union[ModelProto, NodeProto]]]) -> None:
         self.func = func
         self.proto = proto

--- a/onnx/backend/test/stat_coverage.py
+++ b/onnx/backend/test/stat_coverage.py
@@ -17,14 +17,14 @@ from onnx.backend.test.loader import load_model_tests
 from typing import Any, IO, Sequence, Text, Dict, List
 
 
-def is_ml(schemas):  # type: (Sequence[defs.OpSchema]) -> bool
+def is_ml(schemas: Sequence[defs.OpSchema]) -> bool:
     for s in schemas:
         if s.domain == 'ai.onnx.ml':
             return True
     return False
 
 
-def gen_outlines(f, ml):  # type: (IO[Any], bool) -> None
+def gen_outlines(f: IO[Any], ml: bool) -> None:
     f.write('# Test Coverage Report')
     if ml:
         f.write(' (ONNX-ML Operators)\n')
@@ -36,12 +36,11 @@ def gen_outlines(f, ml):  # type: (IO[Any], bool) -> None
     f.write('* [Overall Test Coverage](#overall-test-coverage)\n')
 
 
-common_covered = []  # type: Sequence[Text]
-experimental_covered = []  # type: Sequence[Text]
+common_covered: Sequence[Text] = []
+experimental_covered: Sequence[Text] = []
 
 
-def gen_node_test_coverage(schemas, f, ml):
-    # type: (Sequence[defs.OpSchema], IO[Any], bool) -> None
+def gen_node_test_coverage(schemas: Sequence[defs.OpSchema], f: IO[Any], ml: bool) -> None:
     global common_covered
     global experimental_covered
     generators = set({
@@ -125,8 +124,7 @@ def gen_node_test_coverage(schemas, f, ml):
         f.write('<br/>\n\n')
 
 
-def gen_model_test_coverage(schemas, f, ml):
-    # type: (Sequence[defs.OpSchema], IO[Any], bool) -> None
+def gen_model_test_coverage(schemas: Sequence[defs.OpSchema], f: IO[Any], ml: bool) -> None:
     f.write('# Model Test Coverage\n')
     # Process schemas
     schema_dict = dict()
@@ -134,8 +132,8 @@ def gen_model_test_coverage(schemas, f, ml):
         schema_dict[schema.name] = schema
     # Load models from each model test using Runner.prepare_model_data
     # Need to grab associated nodes
-    attrs = dict()  # type: Dict[Text, Dict[Text, List[Any]]]
-    model_paths = []  # type: List[Any]
+    attrs: Dict[Text, Dict[Text, List[Any]]] = dict()
+    model_paths: List[Any] = []
     for rt in load_model_tests(kind='real'):
         model_dir = Runner.prepare_model_data(rt)
         model_paths.append(os.path.join(model_dir, 'model.onnx'))
@@ -218,19 +216,16 @@ def gen_model_test_coverage(schemas, f, ml):
         f.write('No model tests present for selected domain\n')
 
 
-def gen_overall_test_coverage(schemas, f, ml):
-    # type: (Sequence[defs.OpSchema], IO[Any], bool) -> None
+def gen_overall_test_coverage(schemas: Sequence[defs.OpSchema], f: IO[Any], ml: bool) -> None:
     f.write('# Overall Test Coverage\n')
     f.write('## To be filled.\n')
 
 
-def gen_spdx(f):
-    # type: (IO[Any]) -> None
+def gen_spdx(f: IO[Any]) -> None:
     f.write('<!--- SPDX-License-Identifier: Apache-2.0 -->\n')
 
 
-def main():
-    # type: () -> None
+def main() -> None:
     base_dir = os.path.dirname(os.path.dirname(os.path.dirname(
         os.path.dirname(os.path.realpath(__file__)))))
     docs_dir = os.path.join(base_dir, 'docs')

--- a/onnx/bin/checker.py
+++ b/onnx/bin/checker.py
@@ -10,7 +10,7 @@ import argparse
 from onnx import load, checker, NodeProto
 
 
-def check_model():  # type: () -> None
+def check_model() -> None:
     parser = argparse.ArgumentParser('check-model')
     parser.add_argument('model_pb', type=argparse.FileType('rb'))
     args = parser.parse_args()
@@ -19,7 +19,7 @@ def check_model():  # type: () -> None
     checker.check_model(model)
 
 
-def check_node():  # type: () -> None
+def check_node() -> None:
     parser = argparse.ArgumentParser('check-node')
     parser.add_argument('node_pb', type=argparse.FileType('rb'))
     args = parser.parse_args()

--- a/onnx/checker.py
+++ b/onnx/checker.py
@@ -47,10 +47,10 @@ FuncType = TypeVar('FuncType', bound=Callable[..., Any])
 
 
 # TODO: This really doesn't seem worth the metaprogramming...
-def _create_checker(proto_type):  # type: (Type[Message]) -> Callable[[FuncType], FuncType]
-    def decorator(py_func):  # type: (FuncType) -> FuncType
+def _create_checker(proto_type: Type[Message]) -> Callable[[FuncType], FuncType]:
+    def decorator(py_func: FuncType) -> FuncType:
         @functools.wraps(py_func)
-        def checker(proto, ctx=DEFAULT_CONTEXT):  # type: (Message, C.CheckerContext) -> Any
+        def checker(proto: Message, ctx: C.CheckerContext = DEFAULT_CONTEXT) -> Any:
             if not isinstance(proto, proto_type):
                 raise RuntimeError(
                     'You cannot pass an object that is not of type {}'.format(
@@ -62,35 +62,35 @@ def _create_checker(proto_type):  # type: (Type[Message]) -> Callable[[FuncType]
 
 
 @_create_checker(ValueInfoProto)
-def check_value_info(value_info, ctx=DEFAULT_CONTEXT):  # type: (ValueInfoProto, C.CheckerContext) -> None
+def check_value_info(value_info: ValueInfoProto, ctx: C.CheckerContext = DEFAULT_CONTEXT) -> None:
     pass
 
 
 @_create_checker(TensorProto)
-def check_tensor(tensor, ctx=DEFAULT_CONTEXT):  # type: (TensorProto, C.CheckerContext) -> None
+def check_tensor(tensor: TensorProto, ctx: C.CheckerContext = DEFAULT_CONTEXT) -> None:
     pass
 
 
 @_create_checker(AttributeProto)
-def check_attribute(attr, ctx=DEFAULT_CONTEXT):  # type: (AttributeProto, C.CheckerContext) -> None
+def check_attribute(attr: AttributeProto, ctx: C.CheckerContext = DEFAULT_CONTEXT) -> None:
     pass
 
 
 @_create_checker(NodeProto)
-def check_node(node, ctx=DEFAULT_CONTEXT):  # type: (NodeProto, C.CheckerContext) -> None
+def check_node(node: NodeProto, ctx: C.CheckerContext = DEFAULT_CONTEXT) -> None:
     pass
 
 
 @_create_checker(GraphProto)
-def check_graph(graph, ctx=DEFAULT_CONTEXT):  # type: (GraphProto, C.CheckerContext) -> None
+def check_graph(graph: GraphProto, ctx: C.CheckerContext = DEFAULT_CONTEXT) -> None:
     pass
 
 
-def check_sparse_tensor(sparse, ctx=DEFAULT_CONTEXT):  # type: (SparseTensorProto, C.CheckerContext) -> None
+def check_sparse_tensor(sparse: SparseTensorProto, ctx: C.CheckerContext = DEFAULT_CONTEXT) -> None:
     C.check_sparse_tensor(sparse.SerializeToString(), ctx)
 
 
-def check_model(model, full_check=False):  # type: (Union[ModelProto, Text, bytes], bool) -> None
+def check_model(model: Union[ModelProto, Text, bytes], full_check: bool = False) -> None:
     # If model is a path instead of ModelProto
     if isinstance(model, str):
         C.check_model_path(model)

--- a/onnx/compose.py
+++ b/onnx/compose.py
@@ -12,10 +12,10 @@ from onnx import utils
 
 
 def check_overlapping_names(
-    g1,  # type: GraphProto
-    g2,  # type: GraphProto
-    io_map=None  # type: Optional[List[Tuple[Text, Text]]]
-):  # type: (...) -> List[Tuple[Text, List[Text]]]
+    g1: GraphProto,
+    g2: GraphProto,
+    io_map: Optional[List[Tuple[Text, Text]]] = None
+) -> List[Tuple[Text, List[Text]]]:
     """Checks whether there are name collisions between two graphs
 
     Returns a list of tuples where the first element represents the member containing overlapping names
@@ -30,10 +30,10 @@ def check_overlapping_names(
     if type(g2) is not GraphProto:
         raise ValueError("g2 argument is not an ONNX graph")
 
-    def _overlapping(c1, c2):  # type: (List[Text], List[Text]) -> List[Text]
+    def _overlapping(c1: List[Text], c2: List[Text]) -> List[Text]:
         return list(set(c1) & set(c2))
 
-    def _edge_names(graph, exclude=set()):  # type: (GraphProto, Set[Text]) -> List[Text]
+    def _edge_names(graph: GraphProto, exclude: Set[Text] = set()) -> List[Text]:
         edges = []
         for n in graph.node:
             for i in n.input:
@@ -76,16 +76,16 @@ def check_overlapping_names(
 
 
 def merge_graphs(
-        g1,  # type: GraphProto
-        g2,  # type: GraphProto
-        io_map,  # type: List[Tuple[Text, Text]]
-        inputs=None,  # type: Optional[List[Text]]
-        outputs=None,  # type: Optional[List[Text]]
-        prefix1=None,  # type: Optional[Text]
-        prefix2=None,  # type: Optional[Text]
-        name=None,  # type: Optional[Text]
-        doc_string=None,  # type: Optional[Text]
-):  # type: (...) -> GraphProto
+        g1: GraphProto,
+        g2: GraphProto,
+        io_map: List[Tuple[Text, Text]],
+        inputs: Optional[List[Text]] = None,
+        outputs: Optional[List[Text]] = None,
+        prefix1: Optional[Text] = None,
+        prefix2: Optional[Text] = None,
+        name: Optional[Text] = None,
+        doc_string: Optional[Text] = None,
+) -> GraphProto:
     """Combines two ONNX graphs into a single one.
 
     The combined graph is defined by connecting the specified set of outputs/inputs. Those inputs/outputs
@@ -233,20 +233,20 @@ def merge_graphs(
 
 
 def merge_models(
-        m1,  # type: ModelProto
-        m2,  # type: ModelProto
-        io_map,  # type: List[Tuple[Text, Text]]
-        inputs=None,  # type: Optional[List[Text]]
-        outputs=None,  # type: Optional[List[Text]]
-        prefix1=None,  # type: Optional[Text]
-        prefix2=None,  # type: Optional[Text]
-        name=None,  # type: Optional[Text]
-        doc_string=None,  # type: Optional[Text]
-        producer_name='onnx.compose.merge_models',  # type: Optional[Text]
-        producer_version="1.0",  # type: Optional[Text]
-        domain="",  # type: Optional[Text]
-        model_version=1  # type: Optional[int]
-):  # type: (...) -> ModelProto
+        m1: ModelProto,
+        m2: ModelProto,
+        io_map: List[Tuple[Text, Text]],
+        inputs: Optional[List[Text]] = None,
+        outputs: Optional[List[Text]] = None,
+        prefix1: Optional[Text] = None,
+        prefix2: Optional[Text] = None,
+        name: Optional[Text] = None,
+        doc_string: Optional[Text] = None,
+        producer_name: Optional[Text] = 'onnx.compose.merge_models',
+        producer_version: Optional[Text] = "1.0",
+        domain: Optional[Text] = "",
+        model_version: Optional[int] = 1
+) -> ModelProto:
     """Combines two ONNX models into a single one.
 
     The combined model is defined by connecting the specified set of outputs/inputs.
@@ -289,7 +289,7 @@ def merge_models(
             " Both models should have have the same IR version")
     ir_version = m1.ir_version
 
-    opset_import_map = {}  # type: MutableMapping[Text, int]
+    opset_import_map: MutableMapping[Text, int] = {}
     opset_imports = \
         [entry for entry in m1.opset_import] + \
         [entry for entry in m2.opset_import]
@@ -363,16 +363,16 @@ def merge_models(
 
 
 def add_prefix_graph(
-        graph,  # type: GraphProto
-        prefix,  # type: Text
-        rename_nodes=True,  # type: Optional[bool]
-        rename_edges=True,  # type: Optional[bool]
-        rename_inputs=True,  # type: Optional[bool]
-        rename_outputs=True,  # type: Optional[bool]
-        rename_initializers=True,  # type: Optional[bool]
-        rename_value_infos=True,  # type: Optional[bool]
-        inplace=False,  # type: Optional[bool]
-):  # type: (...) -> GraphProto
+        graph: GraphProto,
+        prefix: Text,
+        rename_nodes: Optional[bool] = True,
+        rename_edges: Optional[bool] = True,
+        rename_inputs: Optional[bool] = True,
+        rename_outputs: Optional[bool] = True,
+        rename_initializers: Optional[bool] = True,
+        rename_value_infos: Optional[bool] = True,
+        inplace: Optional[bool] = False,
+) -> GraphProto:
     """Adds a prefix to names of elements in a graph: nodes, edges, inputs, outputs,
     initializers, sparse initializer, value infos.
 
@@ -400,7 +400,7 @@ def add_prefix_graph(
     else:
         g = graph
 
-    def _prefixed(prefix, name):  # type: (Text, Text) -> Text
+    def _prefixed(prefix: Text, name: Text) -> Text:
         return prefix + name if len(name) > 0 else name
 
     name_map = {}
@@ -465,17 +465,17 @@ def add_prefix_graph(
 
 
 def add_prefix(
-        model,  # type: ModelProto
-        prefix,  # type: Text
-        rename_nodes=True,  # type: Optional[bool]
-        rename_edges=True,  # type: Optional[bool]
-        rename_inputs=True,  # type: Optional[bool]
-        rename_outputs=True,  # type: Optional[bool]
-        rename_initializers=True,  # type: Optional[bool]
-        rename_value_infos=True,  # type: Optional[bool]
-        rename_functions=True,  # type: Optional[bool]
-        inplace=False,  # type: Optional[bool]
-):  # type: (...) -> ModelProto
+        model: ModelProto,
+        prefix: Text,
+        rename_nodes: Optional[bool] = True,
+        rename_edges: Optional[bool] = True,
+        rename_inputs: Optional[bool] = True,
+        rename_outputs: Optional[bool] = True,
+        rename_initializers: Optional[bool] = True,
+        rename_value_infos: Optional[bool] = True,
+        rename_functions: Optional[bool] = True,
+        inplace: Optional[bool] = False,
+) -> ModelProto:
     """Adds a prefix to names of elements in a graph: nodes, edges, inputs, outputs,
     initializers, sparse initializer, value infos, and local functions.
 
@@ -535,10 +535,10 @@ def add_prefix(
 
 
 def expand_out_dim_graph(
-        graph,  # type: GraphProto
-        dim_idx,  # type: int
-        inplace=False,  # type: Optional[bool]
-):  # type: (...) -> GraphProto
+        graph: GraphProto,
+        dim_idx: int,
+        inplace: Optional[bool] = False,
+) -> GraphProto:
     """Inserts an extra dimension with extent 1 to each output in the graph.
 
     Inserts an Unsqueeze node for each output. It can be used as a utility before merging graphs,
@@ -593,10 +593,10 @@ def expand_out_dim_graph(
 
 
 def expand_out_dim(
-        model,  # type: ModelProto
-        dim_idx,  # type: int
-        inplace=False,  # type: Optional[bool]
-):  # type: (...) -> ModelProto
+        model: ModelProto,
+        dim_idx: int,
+        inplace: Optional[bool] = False,
+) -> ModelProto:
     """Inserts an extra dimension with extent 1 to each output in the graph.
 
     Inserts an Unsqueeze node for each output. It can be used as a utility before merging graphs,

--- a/onnx/defs/__init__.py
+++ b/onnx/defs/__init__.py
@@ -22,7 +22,7 @@ get_all_schemas = C.get_all_schemas
 get_all_schemas_with_history = C.get_all_schemas_with_history
 
 
-def onnx_opset_version():  # type: () -> int
+def onnx_opset_version() -> int:
     return C.schema_version_map()[ONNX_DOMAIN][1]
 
 
@@ -47,7 +47,7 @@ def _Attribute_default_value(self):  # type: ignore
 OpSchema.Attribute.default_value = _Attribute_default_value  # type: ignore
 
 
-def get_function_ops():  # type: () -> List[OpSchema]
+def get_function_ops() -> List[OpSchema]:
     schemas = C.get_all_schemas()
     return [schema for schema in schemas if schema.has_function or schema.has_context_dependent_function]  # type: ignore
 

--- a/onnx/defs/gen_doc.py
+++ b/onnx/defs/gen_doc.py
@@ -28,13 +28,13 @@ ONNX_ML = not bool(os.getenv('ONNX_ML') == '0')
 ext = '-ml.md' if ONNX_ML else '.md'
 
 
-def display_number(v):  # type: (int) -> Text
+def display_number(v: int) -> Text:
     if defs.OpSchema.is_infinite(v):
         return '&#8734;'
     return Text(v)
 
 
-def should_render_domain(domain):  # type: (Text) -> bool
+def should_render_domain(domain: Text) -> bool:
     if domain == ONNX_ML_DOMAIN and not ONNX_ML:
         return False
     if ONNX_ML and domain != ONNX_ML_DOMAIN:
@@ -42,18 +42,18 @@ def should_render_domain(domain):  # type: (Text) -> bool
     return True
 
 
-def format_name_with_domain(domain, schema_name):  # type: (Text, Text) -> Text
+def format_name_with_domain(domain: Text, schema_name: Text) -> Text:
     if domain:
         return '{}.{}'.format(domain, schema_name)
     return schema_name
 
 
-def format_versions(versions):  # type: (Sequence[OpSchema]) -> Text
+def format_versions(versions: Sequence[OpSchema]) -> Text:
     return '{}'.format(', '.join(display_version_link(format_name_with_domain(v.domain, v.name),
                                                v.since_version) for v in versions[::-1]))
 
 
-def display_attr_type(v):  # type: (OpSchema.AttrType) -> Text
+def display_attr_type(v: OpSchema.AttrType) -> Text:
     assert isinstance(v, OpSchema.AttrType)
     s = Text(v)
     s = s[s.rfind('.') + 1:].lower()
@@ -62,26 +62,26 @@ def display_attr_type(v):  # type: (OpSchema.AttrType) -> Text
     return s
 
 
-def display_domain(domain):  # type: (Text) -> Text
+def display_domain(domain: Text) -> Text:
     if domain:
         return "the '{}' operator set".format(domain)
     return "the default ONNX operator set"
 
 
-def display_domain_short(domain):  # type: (Text) -> Text
+def display_domain_short(domain: Text) -> Text:
     if domain:
         return domain
     return 'ai.onnx (default)'
 
 
-def display_version_link(name, version):  # type: (Text, int) -> Text
+def display_version_link(name: Text, version: int) -> Text:
     changelog_md = 'Changelog' + ext
     name_with_ver = '{}-{}'.format(name, version)
     return '<a href="{}#{}">{}</a>'.format(changelog_md, name_with_ver, version)
 
 
-def generate_formal_parameter_tags(formal_parameter):  # type: (OpSchema.FormalParameter) -> Text
-    tags = []  # type: List[Text]
+def generate_formal_parameter_tags(formal_parameter: OpSchema.FormalParameter) -> Text:
+    tags: List[Text] = []
     if OpSchema.FormalParameterOption.Optional == formal_parameter.option:
         tags = ["optional"]
     elif OpSchema.FormalParameterOption.Variadic == formal_parameter.option:
@@ -89,8 +89,8 @@ def generate_formal_parameter_tags(formal_parameter):  # type: (OpSchema.FormalP
             tags = ["variadic"]
         else:
             tags = ["variadic", "heterogeneous"]
-    differentiable = OpSchema.DifferentiationCategory.Differentiable  # type: OpSchema.DifferentiationCategory
-    non_differentiable = OpSchema.DifferentiationCategory.NonDifferentiable  # type: OpSchema.DifferentiationCategory
+    differentiable: OpSchema.DifferentiationCategory = OpSchema.DifferentiationCategory.Differentiable
+    non_differentiable: OpSchema.DifferentiationCategory = OpSchema.DifferentiationCategory.NonDifferentiable
     if differentiable == formal_parameter.differentiationCategory:
         tags.append('differentiable')
     elif non_differentiable == formal_parameter.differentiationCategory:
@@ -99,7 +99,7 @@ def generate_formal_parameter_tags(formal_parameter):  # type: (OpSchema.FormalP
     return '' if len(tags) == 0 else ' (' + ', '.join(tags) + ')'
 
 
-def display_schema(schema, versions):  # type: (OpSchema, Sequence[OpSchema]) -> Text
+def display_schema(schema: OpSchema, versions: Sequence[OpSchema]) -> Text:
     s = ''
 
     # doc
@@ -138,7 +138,7 @@ def display_schema(schema, versions):  # type: (OpSchema, Sequence[OpSchema]) ->
             elif attr.default_value.name:
                 default_value = helper.get_attribute_value(attr.default_value)
 
-                def format_value(value):  # type: (Any) -> Text
+                def format_value(value: Any) -> Text:
                     if isinstance(value, float):
                         formatted = str(np.round(value, 5))
                         # use default formatting, unless too long.
@@ -216,12 +216,12 @@ def display_schema(schema, versions):  # type: (OpSchema, Sequence[OpSchema]) ->
     return s
 
 
-def support_level_str(level):  # type: (OpSchema.SupportType) -> Text
+def support_level_str(level: OpSchema.SupportType) -> Text:
     return \
         "<sub>experimental</sub> " if level == OpSchema.SupportType.EXPERIMENTAL else ""
 
 
-def main(args):  # type: (Type[Args]) -> None
+def main(args: Type[Args]) -> None:
     with io.open(args.changelog, 'w', newline='') as fout:
         fout.write('<!--- SPDX-License-Identifier: Apache-2.0 -->\n')
         fout.write('## Operator Changelog\n')
@@ -235,7 +235,7 @@ def main(args):  # type: (Type[Args]) -> None
             "            is not specified, that variable has undefined differentiability.\n")
 
         # domain -> version -> [schema]
-        dv_index = defaultdict(lambda: defaultdict(list))  # type: Dict[Text, Dict[int, List[OpSchema]]]
+        dv_index: Dict[Text, Dict[int, List[OpSchema]]] = defaultdict(lambda: defaultdict(list))
         for schema in defs.get_all_schemas_with_history():
             dv_index[schema.domain][schema.since_version].append(schema)
 
@@ -271,7 +271,7 @@ def main(args):  # type: (Type[Args]) -> None
             "            is not specified, that variable has undefined differentiability.\n")
 
         # domain -> support level -> name -> [schema]
-        index = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))  # type: Dict[Text, Dict[int, Dict[Text, List[OpSchema]]]]
+        index: Dict[Text, Dict[int, Dict[Text, List[OpSchema]]]] = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
         for schema in defs.get_all_schemas_with_history():
             index[schema.domain][int(schema.support_level)][schema.name].append(schema)
 
@@ -279,8 +279,8 @@ def main(args):  # type: (Type[Args]) -> None
 
         # Preprocess the Operator Schemas
         # [(domain, [(support_level, [(schema name, current schema, all versions schemas)])])]
-        operator_schemas = list()  # type: List[Tuple[Text, List[Tuple[int, List[Tuple[Text, OpSchema, List[OpSchema]]]]]]]
-        existing_ops = set()  # type: Set[Text]
+        operator_schemas: List[Tuple[Text, List[Tuple[int, List[Tuple[Text, OpSchema, List[OpSchema]]]]]]] = list()
+        existing_ops: Set[Text] = set()
         for domain, _supportmap in sorted(index.items()):
             if not should_render_domain(domain):
                 continue

--- a/onnx/defs/gen_shape_inference_information.py
+++ b/onnx/defs/gen_shape_inference_information.py
@@ -8,7 +8,7 @@ from __future__ import unicode_literals
 from onnx import defs
 
 
-def main():  # type: () -> None
+def main() -> None:
     # domain -> support level -> name -> [schema]
     with_inference = []
     without_inference = []

--- a/onnx/external_data_helper.py
+++ b/onnx/external_data_helper.py
@@ -16,7 +16,7 @@ from .onnx_pb import TensorProto, ModelProto
 
 class ExternalDataInfo(object):
 
-    def __init__(self, tensor):  # type: (TensorProto) -> None
+    def __init__(self, tensor: TensorProto) -> None:
         self.location = ''
         self.offset = None
         self.length = None
@@ -33,7 +33,7 @@ class ExternalDataInfo(object):
             self.length = int(self.length)
 
 
-def load_external_data_for_tensor(tensor, base_dir):  # type: (TensorProto, Text) -> None
+def load_external_data_for_tensor(tensor: TensorProto, base_dir: Text) -> None:
     """
     Load data from an external file for tensor.
     Ideally TensorProto should not hold any raw data but if it does it will be ignored.
@@ -56,7 +56,7 @@ def load_external_data_for_tensor(tensor, base_dir):  # type: (TensorProto, Text
             tensor.raw_data = data_file.read()
 
 
-def load_external_data_for_model(model, base_dir):  # type: (ModelProto, Text) -> None
+def load_external_data_for_model(model: ModelProto, base_dir: Text) -> None:
     """
     Loads external tensors into model
 
@@ -73,13 +73,13 @@ def load_external_data_for_model(model, base_dir):  # type: (ModelProto, Text) -
             del tensor.external_data[:]
 
 
-def set_external_data(tensor,  # type: TensorProto
-                      location,  # type: Text
-                      offset=None,  # type: Optional[int]
-                      length=None,  # type: Optional[int]
-                      checksum=None,  # type: Optional[Text]
-                      basepath=None  # type: Optional[Text]
-                      ):  # type: (...) -> None
+def set_external_data(tensor: TensorProto,
+                      location: Text,
+                      offset: Optional[int] = None,
+                      length: Optional[int] = None,
+                      checksum: Optional[Text] = None,
+                      basepath: Optional[Text] = None
+                      ) -> None:
     if not tensor.HasField("raw_data"):
         raise ValueError("Tensor " + tensor.name + "does not have raw_data field. Cannot set external data for this tensor.")
 
@@ -98,8 +98,7 @@ def set_external_data(tensor,  # type: TensorProto
             entry.value = str(v)
 
 
-def convert_model_to_external_data(model, all_tensors_to_one_file=True, location=None, size_threshold=1024, convert_attribute=False):
-    # type: (ModelProto, bool, Optional[Text], int, bool) -> None
+def convert_model_to_external_data(model: ModelProto, all_tensors_to_one_file: bool = True, location: Optional[Text] = None, size_threshold: int = 1024, convert_attribute: bool = False) -> None:
     """
     Call to set all tensors with raw data as external data. This call should preceed 'save_model'.
     'save_model' saves all the tensors data as external data after calling this function.
@@ -134,7 +133,7 @@ def convert_model_to_external_data(model, all_tensors_to_one_file=True, location
                 set_external_data(tensor, tensor_location)
 
 
-def convert_model_from_external_data(model):  # type: (ModelProto) -> None
+def convert_model_from_external_data(model: ModelProto) -> None:
     """
     Call to set all tensors which use external data as embedded data. save_model saves all the tensors data as embedded data after calling this function.
     @params
@@ -148,7 +147,7 @@ def convert_model_from_external_data(model):  # type: (ModelProto) -> None
             tensor.data_location = TensorProto.DEFAULT
 
 
-def save_external_data(tensor, base_path):  # type: (TensorProto, Text) -> None
+def save_external_data(tensor: TensorProto, base_path: Text) -> None:
     """
     Write tensor data to an external file according to information in the `external_data` field.
 
@@ -182,19 +181,19 @@ def save_external_data(tensor, base_path):  # type: (TensorProto, Text) -> None
         set_external_data(tensor, info.location, offset, data_file.tell() - offset)
 
 
-def _get_all_tensors(onnx_model_proto):  # type: (ModelProto) -> Iterable[TensorProto]
+def _get_all_tensors(onnx_model_proto: ModelProto) -> Iterable[TensorProto]:
     """Scan an ONNX model for all tensors and return as an iterator."""
     return chain(_get_initializer_tensors(onnx_model_proto),
                  _get_attribute_tensors(onnx_model_proto))
 
 
-def _get_initializer_tensors(onnx_model_proto):  # type: (ModelProto) -> Iterable[TensorProto]
+def _get_initializer_tensors(onnx_model_proto: ModelProto) -> Iterable[TensorProto]:
     """Create an iterator of initializer tensors from ONNX model."""
     for initializer in onnx_model_proto.graph.initializer:
         yield initializer
 
 
-def _get_attribute_tensors(onnx_model_proto):  # type: (ModelProto) -> Iterable[TensorProto]
+def _get_attribute_tensors(onnx_model_proto: ModelProto) -> Iterable[TensorProto]:
     """Create an iterator of tensors from node attributes of an ONNX model."""
     for node in onnx_model_proto.graph.node:
         for attribute in node.attribute:
@@ -204,7 +203,7 @@ def _get_attribute_tensors(onnx_model_proto):  # type: (ModelProto) -> Iterable[
                 yield tensor
 
 
-def _sanitize_path(path):  # type: (Text) -> Text
+def _sanitize_path(path: Text) -> Text:
     """Remove path components which would allow traversing up a directory tree from a base path.
 
     Note: This method is currently very basic and should be expanded.
@@ -212,7 +211,7 @@ def _sanitize_path(path):  # type: (Text) -> Text
     return path.lstrip('/.')
 
 
-def _is_valid_filename(filename):  # type: (Text) -> bool
+def _is_valid_filename(filename: Text) -> bool:
     """Utility to check whether the provided filename is valid."""
     exp = re.compile("^[^<>:;,?\"*|/]+$")
     match = exp.match(filename)
@@ -222,12 +221,12 @@ def _is_valid_filename(filename):  # type: (Text) -> bool
         return False
 
 
-def uses_external_data(tensor):  # type: (TensorProto) -> bool
+def uses_external_data(tensor: TensorProto) -> bool:
     """Return true if the tensor stores data in an external location."""
     return tensor.HasField("data_location") and tensor.data_location == TensorProto.EXTERNAL
 
 
-def remove_external_data_field(tensor, field_key):  # type: (TensorProto, Text) -> None
+def remove_external_data_field(tensor: TensorProto, field_key: Text) -> None:
     """
     Remove a field from a Tensor's external_data key-value store.
 
@@ -242,7 +241,7 @@ def remove_external_data_field(tensor, field_key):  # type: (TensorProto, Text) 
             del tensor.external_data[i]
 
 
-def write_external_data_tensors(model, filepath):  # type: (ModelProto, Text) -> ModelProto
+def write_external_data_tensors(model: ModelProto, filepath: Text) -> ModelProto:
     """
     Serializes data for all the tensors which have data location set to TensorProto.External.
 

--- a/onnx/gen_proto.py
+++ b/onnx/gen_proto.py
@@ -42,7 +42,7 @@ if MYPY:
     from typing import Iterable, Text
 
 
-def process_ifs(lines, onnx_ml):  # type: (Iterable[Text], bool) -> Iterable[Text]
+def process_ifs(lines: Iterable[Text], onnx_ml: bool) -> Iterable[Text]:
     in_if = 0
     for line in lines:
         if IF_ONNX_ML_REGEX.match(line):
@@ -68,7 +68,7 @@ PACKAGE_NAME_REGEX = re.compile(r'\{PACKAGE_NAME\}')
 ML_REGEX = re.compile(r'(.*)\-ml')
 
 
-def process_package_name(lines, package_name):  # type: (Iterable[Text], Text) -> Iterable[Text]
+def process_package_name(lines: Iterable[Text], package_name: Text) -> Iterable[Text]:
     need_rename = (package_name != DEFAULT_PACKAGE_NAME)
     for line in lines:
         m = IMPORT_REGEX.match(line) if need_rename else None
@@ -88,7 +88,7 @@ PROTO_SYNTAX_REGEX = re.compile(r'(\s*)syntax\s*=\s*"proto2"\s*;\s*$')
 OPTIONAL_REGEX = re.compile(r'(\s*)optional\s(.*)$')
 
 
-def convert_to_proto3(lines):  # type: (Iterable[Text]) -> Iterable[Text]
+def convert_to_proto3(lines: Iterable[Text]) -> Iterable[Text]:
     for line in lines:
         # Set the syntax specifier
         m = PROTO_SYNTAX_REGEX.match(line)
@@ -111,15 +111,15 @@ def convert_to_proto3(lines):  # type: (Iterable[Text]) -> Iterable[Text]
         yield line
 
 
-def gen_proto3_code(protoc_path, proto3_path, include_path, cpp_out, python_out):  # type: (Text, Text, Text, Text, Text) -> None
+def gen_proto3_code(protoc_path: Text, proto3_path: Text, include_path: Text, cpp_out: Text, python_out: Text) -> None:
     print("Generate pb3 code using {}".format(protoc_path))
     build_args = [protoc_path, proto3_path, '-I', include_path]
     build_args.extend(['--cpp_out', cpp_out, '--python_out', python_out])
     subprocess.check_call(build_args)
 
 
-def translate(source, proto, onnx_ml, package_name):  # type: (Text, int, bool, Text) -> Text
-    lines = source.splitlines()  # type: Iterable[Text]
+def translate(source: Text, proto: int, onnx_ml: bool, package_name: Text) -> Text:
+    lines: Iterable[Text] = source.splitlines()
     lines = process_ifs(lines, onnx_ml=onnx_ml)
     lines = process_package_name(lines, package_name=package_name)
     if proto == 3:
@@ -129,11 +129,11 @@ def translate(source, proto, onnx_ml, package_name):  # type: (Text, int, bool, 
     return "\n".join(lines)  # TODO: not Windows friendly
 
 
-def qualify(f, pardir=os.path.realpath(os.path.dirname(__file__))):  # type: (Text, Text) -> Text
+def qualify(f: Text, pardir: Text = os.path.realpath(os.path.dirname(__file__))) -> Text:
     return os.path.join(pardir, f)
 
 
-def convert(stem, package_name, output, do_onnx_ml=False, lite=False, protoc_path=''):  # type: (Text, Text, Text, bool, bool, Text) -> None
+def convert(stem: Text, package_name: Text, output: Text, do_onnx_ml: bool = False, lite: bool = False, protoc_path: Text = '') -> None:
     proto_in = qualify("{}.in.proto".format(stem))
     need_rename = (package_name != DEFAULT_PACKAGE_NAME)
     # Having a separate variable for import_ml ensures that the import statements for the generated
@@ -209,7 +209,7 @@ def convert(stem, package_name, output, do_onnx_ml=False, lite=False, protoc_pat
         '''.format(os.path.splitext(os.path.basename(pb2_py))[0]))))
 
 
-def main():  # type: () -> None
+def main() -> None:
     parser = argparse.ArgumentParser(
         description='Generates .proto file variations from .in.proto')
     parser.add_argument('-p', '--package', default='onnx',

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -26,7 +26,7 @@ AssignmentBindingType = List[Tuple[Text, Text]]
 
 # This is a copy of the documented version in https://github.com/onnx/onnx/blob/main/docs/Versioning.md#released-versions
 # Both must be updated whenever a new version of ONNX is released.
-VERSION_TABLE = [
+VERSION_TABLE: VersionTableType = [
     # Release-version, IR version, ai.onnx version, ai.onnx.ml version, (optional) ai.onnx.training version
     ('1.0', 3, 1, 1),
     ('1.1', 3, 5, 1),
@@ -43,16 +43,16 @@ VERSION_TABLE = [
     ('1.10.0', 8, 15, 2, 1),
     ('1.10.1', 8, 15, 2, 1),
     ('1.10.2', 8, 15, 2, 1)
-]  # type: VersionTableType
+]
 
 VersionMapType = Dict[Tuple[Text, int], int]
 
 
 # create a map from (opset-domain, opset-version) to ir-version from above table
-def create_op_set_id_version_map(table):  # type: (VersionTableType) -> VersionMapType
-    result = dict()  # type: VersionMapType
+def create_op_set_id_version_map(table: VersionTableType) -> VersionMapType:
+    result: VersionMapType = dict()
 
-    def process(release_version, ir_version, *args):  # type: (Text, int, Any) -> None
+    def process(release_version: Text, ir_version: int, *args: Any) -> None:
         for pair in zip(['ai.onnx', 'ai.onnx.ml', 'ai.onnx.training'], args):
             if (pair not in result):
                 result[pair] = ir_version
@@ -65,10 +65,10 @@ OP_SET_ID_VERSION_MAP = create_op_set_id_version_map(VERSION_TABLE)
 
 
 # Given list of opset ids, determine minimum IR version required
-def find_min_ir_version_for(opsetidlist):  # type: (List[OperatorSetIdProto]) -> int
+def find_min_ir_version_for(opsetidlist: List[OperatorSetIdProto]) -> int:
     default_min_version = 3
 
-    def find_min(domain, version):  # type: (Union[Text, None], int) -> int
+    def find_min(domain: Union[Text, None], version: int) -> int:
         key = (domain if domain else 'ai.onnx', version)
         if (key in OP_SET_ID_VERSION_MAP):
             return OP_SET_ID_VERSION_MAP[key]
@@ -80,14 +80,14 @@ def find_min_ir_version_for(opsetidlist):  # type: (List[OperatorSetIdProto]) ->
 
 
 def make_node(
-        op_type,  # type: Text
-        inputs,  # type: Sequence[Text]
-        outputs,  # type: Sequence[Text]
-        name=None,  # type: Optional[Text]
-        doc_string=None,  # type: Optional[Text]
-        domain=None,  # type: Optional[Text]
-        **kwargs  # type: Any
-):  # type: (...) -> NodeProto
+        op_type: Text,
+        inputs: Sequence[Text],
+        outputs: Sequence[Text],
+        name: Optional[Text] = None,
+        doc_string: Optional[Text] = None,
+        domain: Optional[Text] = None,
+        **kwargs: Any
+) -> NodeProto:
     """Construct a NodeProto.
 
     Arguments:
@@ -121,9 +121,9 @@ def make_node(
 
 
 def make_operatorsetid(
-        domain,  # type: Text
-        version,  # type: int
-):  # type: (...) -> OperatorSetIdProto
+        domain: Text,
+        version: int,
+) -> OperatorSetIdProto:
     """Construct an OperatorSetIdProto.
 
     Arguments:
@@ -137,15 +137,15 @@ def make_operatorsetid(
 
 
 def make_graph(
-    nodes,  # type: Sequence[NodeProto]
-    name,  # type: Text
-    inputs,  # type: Sequence[ValueInfoProto]
-    outputs,  # type: Sequence[ValueInfoProto]
-    initializer=None,  # type: Optional[Sequence[TensorProto]]
-    doc_string=None,  # type: Optional[Text]
-    value_info=[],  # type: Sequence[ValueInfoProto]
-    sparse_initializer=None,  # type: Optional[Sequence[SparseTensorProto]]
-):  # type: (...) -> GraphProto
+    nodes: Sequence[NodeProto],
+    name: Text,
+    inputs: Sequence[ValueInfoProto],
+    outputs: Sequence[ValueInfoProto],
+    initializer: Optional[Sequence[TensorProto]] = None,
+    doc_string: Optional[Text] = None,
+    value_info: Sequence[ValueInfoProto] = [],
+    sparse_initializer: Optional[Sequence[SparseTensorProto]] = None,
+) -> GraphProto:
     if initializer is None:
         initializer = []
     if sparse_initializer is None:
@@ -165,7 +165,7 @@ def make_graph(
     return graph
 
 
-def make_opsetid(domain, version):  # type: (Text, int) -> OperatorSetIdProto
+def make_opsetid(domain: Text, version: int) -> OperatorSetIdProto:
     opsetid = OperatorSetIdProto()
     opsetid.domain = domain
     opsetid.version = version
@@ -173,15 +173,15 @@ def make_opsetid(domain, version):  # type: (Text, int) -> OperatorSetIdProto
 
 
 def make_function(
-    domain,  # type: Text
-    fname,  # type: Text
-    inputs,  # type: Sequence[Text]
-    outputs,  # type: Sequence[Text]
-    nodes,  # type: Sequence[NodeProto]
-    opset_imports,  # type: Sequence[OperatorSetIdProto]
-    attributes=[],  # type: Optional[Sequence[Text]]
-    doc_string=None  # type: Optional[Text]
-):  # type: (...) -> FunctionProto
+    domain: Text,
+    fname: Text,
+    inputs: Sequence[Text],
+    outputs: Sequence[Text],
+    nodes: Sequence[NodeProto],
+    opset_imports: Sequence[OperatorSetIdProto],
+    attributes: Optional[Sequence[Text]] = [],
+    doc_string: Optional[Text] = None
+) -> FunctionProto:
     f = FunctionProto()
     f.domain = domain
     f.name = fname
@@ -195,14 +195,14 @@ def make_function(
     return f
 
 
-def make_model(graph, **kwargs):  # type: (GraphProto, **Any) -> ModelProto
+def make_model(graph: GraphProto, **kwargs: Any) -> ModelProto:
     model = ModelProto()
     # Touch model.ir_version so it is stored as the version from which it is
     # generated.
     model.ir_version = IR_VERSION
     model.graph.CopyFrom(graph)
 
-    opset_imports = None  # type: Optional[Sequence[OperatorSetIdProto]]
+    opset_imports: Optional[Sequence[OperatorSetIdProto]] = None
     opset_imports = kwargs.pop('opset_imports', None)  # type: ignore
     if opset_imports is not None:
         model.opset_import.extend(opset_imports)
@@ -211,7 +211,7 @@ def make_model(graph, **kwargs):  # type: (GraphProto, **Any) -> ModelProto
         imp = model.opset_import.add()
         imp.version = defs.onnx_opset_version()
 
-    functions = None  # type: Optional[Sequence[FunctionProto]]
+    functions: Optional[Sequence[FunctionProto]] = None
     functions = kwargs.pop('functions', None)  # type: ignore
     if functions is not None:
         model.functions.extend(functions)
@@ -224,7 +224,7 @@ def make_model(graph, **kwargs):  # type: (GraphProto, **Any) -> ModelProto
 
 # An extension of make_model that infers an IR_VERSION for the model,
 # if not specified, using a best-effort-basis.
-def make_model_gen_version(graph, **kwargs):  # type: (GraphProto, **Any) -> ModelProto
+def make_model_gen_version(graph: GraphProto, **kwargs: Any) -> ModelProto:
     ir_version_field = str('ir_version')
     if (ir_version_field not in kwargs):
         opset_imports_field = str('opset_imports')
@@ -233,7 +233,7 @@ def make_model_gen_version(graph, **kwargs):  # type: (GraphProto, **Any) -> Mod
     return make_model(graph, **kwargs)
 
 
-def set_model_props(model, dict_value):  # type: (ModelProto, Dict[Text, Text]) -> None
+def set_model_props(model: ModelProto, dict_value: Dict[Text, Text]) -> None:
     del model.metadata_props[:]
     for (k, v) in dict_value.items():
         entry = model.metadata_props.add()
@@ -242,18 +242,18 @@ def set_model_props(model, dict_value):  # type: (ModelProto, Dict[Text, Text]) 
         # model.metadata_properties.append(entry)
 
 
-def split_complex_to_pairs(ca):  # type: (Sequence[np.complex64]) -> Sequence[int]
+def split_complex_to_pairs(ca: Sequence[np.complex64]) -> Sequence[int]:
     return [(ca[i // 2].real if (i % 2 == 0) else ca[i // 2].imag)
             for i in range(len(ca) * 2)]
 
 
 def make_tensor(
-        name,  # type: Text
-        data_type,  # type: int
-        dims,  # type: Sequence[int]
-        vals,  # type: Any
-        raw=False  # type: bool
-):  # type: (...) -> TensorProto
+        name: Text,
+        data_type: int,
+        dims: Sequence[int],
+        vals: Any,
+        raw: bool = False
+) -> TensorProto:
     '''
     Make a TensorProto with specified arguments.  If raw is False, this
     function will choose the corresponding proto field to store the
@@ -298,10 +298,10 @@ def make_tensor(
 
 
 def make_sparse_tensor(
-    values,   # type: TensorProto
-    indices,   # type: TensorProto
-    dims   # type: Sequence[int]
-):  # type: (...) -> SparseTensorProto
+    values: TensorProto,
+    indices: TensorProto,
+    dims: Sequence[int]
+) -> SparseTensorProto:
     sparse = SparseTensorProto()
     sparse.values.CopyFrom(values)
     sparse.indices.CopyFrom(indices)
@@ -310,10 +310,10 @@ def make_sparse_tensor(
 
 
 def make_sequence(
-        name,   # type: Text
-        elem_type,   # type: SequenceProto.DataType
-        values,   # type: Sequence[Any]
-):  # type: (...) -> SequenceProto
+        name: Text,
+        elem_type: SequenceProto.DataType,
+        values: Sequence[Any],
+) -> SequenceProto:
     '''
     Make a Sequence with specified value arguments.
     '''
@@ -326,11 +326,11 @@ def make_sequence(
 
 
 def make_map(
-        name,   # type: Text
-        key_type,   # type: int
-        keys,   # type: List[Any]
-        values   # type: SequenceProto
-):  # type: (...) -> MapProto
+        name: Text,
+        key_type: int,
+        keys: List[Any],
+        values: SequenceProto
+) -> MapProto:
     '''
     Make a Map with specified key-value pair arguments.
 
@@ -354,10 +354,10 @@ def make_map(
 
 
 def make_optional(
-        name,   # type: Text
-        elem_type,   # type: OptionalProto.DataType
-        value,   # type: Optional[Any]
-):  # type: (...) -> OptionalProto
+        name: Text,
+        elem_type: OptionalProto.DataType,
+        value: Optional[Any],
+) -> OptionalProto:
     '''
     Make an Optional with specified value arguments.
     '''
@@ -370,7 +370,7 @@ def make_optional(
     return optional
 
 
-def _to_bytes_or_false(val):  # type: (Union[Text, bytes]) -> Union[bytes, bool]
+def _to_bytes_or_false(val: Union[Text, bytes]) -> Union[bytes, bool]:
     """An internal graph to convert the input to a bytes or to False.
 
     The criteria for conversion is as follows and should be python 2 and 3
@@ -388,10 +388,10 @@ def _to_bytes_or_false(val):  # type: (Union[Text, bytes]) -> Union[bytes, bool]
 
 
 def make_attribute(
-        key,  # type: Text
-        value,  # type: Any
-        doc_string=None  # type: Optional[Text]
-):  # type: (...) -> AttributeProto
+        key: Text,
+        value: Any,
+        doc_string: Optional[Text] = None
+) -> AttributeProto:
     """Makes an AttributeProto based on the value type."""
     attr = AttributeProto()
     attr.name = key
@@ -463,7 +463,7 @@ def make_attribute(
     return attr
 
 
-def get_attribute_value(attr):  # type: (AttributeProto) -> Any
+def get_attribute_value(attr: AttributeProto) -> Any:
     if attr.type == AttributeProto.FLOAT:
         return attr.f
     if attr.type == AttributeProto.INT:
@@ -495,17 +495,17 @@ def get_attribute_value(attr):  # type: (AttributeProto) -> Any
     raise ValueError("Unsupported ONNX attribute: {}".format(attr))
 
 
-def make_empty_tensor_value_info(name):  # type: (Text) -> ValueInfoProto
+def make_empty_tensor_value_info(name: Text) -> ValueInfoProto:
     value_info_proto = ValueInfoProto()
     value_info_proto.name = name
     return value_info_proto
 
 
 def make_tensor_type_proto(
-        elem_type,  # type: int
-        shape,  # type: Optional[Sequence[Union[Text, int, None]]]
-        shape_denotation=None,  # type: Optional[List[Text]]
-):  # type: (...) -> TypeProto
+        elem_type: int,
+        shape: Optional[Sequence[Union[Text, int, None]]],
+        shape_denotation: Optional[List[Text]] = None,
+) -> TypeProto:
     """Makes a Tensor TypeProto based on the data type and shape."""
 
     type_proto = TypeProto()
@@ -549,12 +549,12 @@ def make_tensor_type_proto(
 
 
 def make_tensor_value_info(
-        name,  # type: Text
-        elem_type,  # type: int
-        shape,  # type: Optional[Sequence[Union[Text, int, None]]]
-        doc_string="",  # type: Text
-        shape_denotation=None,  # type: Optional[List[Text]]
-):  # type: (...) -> ValueInfoProto
+        name: Text,
+        elem_type: int,
+        shape: Optional[Sequence[Union[Text, int, None]]],
+        doc_string: Text = "",
+        shape_denotation: Optional[List[Text]] = None,
+) -> ValueInfoProto:
     """Makes a ValueInfoProto based on the data type and shape."""
     value_info_proto = ValueInfoProto()
     value_info_proto.name = name
@@ -567,10 +567,10 @@ def make_tensor_value_info(
 
 
 def make_sparse_tensor_type_proto(
-        elem_type,  # type: int
-        shape,  # type: Optional[Sequence[Union[Text, int, None]]]
-        shape_denotation=None,  # type: Optional[List[Text]]
-):  # type: (...) -> TypeProto
+        elem_type: int,
+        shape: Optional[Sequence[Union[Text, int, None]]],
+        shape_denotation: Optional[List[Text]] = None,
+) -> TypeProto:
     """Makes a SparseTensor TypeProto based on the data type and shape."""
 
     type_proto = TypeProto()
@@ -614,12 +614,12 @@ def make_sparse_tensor_type_proto(
 
 
 def make_sparse_tensor_value_info(
-        name,  # type: Text
-        elem_type,  # type: int
-        shape,  # type: Optional[Sequence[Union[Text, int, None]]]
-        doc_string="",  # type: Text
-        shape_denotation=None,  # type: Optional[List[Text]]
-):  # type: (...) -> ValueInfoProto
+        name: Text,
+        elem_type: int,
+        shape: Optional[Sequence[Union[Text, int, None]]],
+        doc_string: Text = "",
+        shape_denotation: Optional[List[Text]] = None,
+) -> ValueInfoProto:
     """Makes a SparseTensor ValueInfoProto based on the data type and shape."""
     value_info_proto = ValueInfoProto()
     value_info_proto.name = name
@@ -632,8 +632,8 @@ def make_sparse_tensor_value_info(
 
 
 def make_sequence_type_proto(
-        inner_type_proto,  # type: TypeProto
-):  # type: (...) -> TypeProto
+        inner_type_proto: TypeProto,
+) -> TypeProto:
     """Makes a sequence TypeProto."""
     type_proto = TypeProto()
     type_proto.sequence_type.elem_type.CopyFrom(inner_type_proto)
@@ -641,8 +641,8 @@ def make_sequence_type_proto(
 
 
 def make_optional_type_proto(
-        inner_type_proto,  # type: TypeProto
-):  # type: (...) -> TypeProto
+        inner_type_proto: TypeProto,
+) -> TypeProto:
     """Makes an optional TypeProto."""
     type_proto = TypeProto()
     type_proto.optional_type.elem_type.CopyFrom(inner_type_proto)
@@ -650,10 +650,10 @@ def make_optional_type_proto(
 
 
 def make_value_info(
-        name,  # type: Text
-        type_proto,  # type: TypeProto
-        doc_string="",  # type: Text
-):  # type: (...) -> ValueInfoProto
+        name: Text,
+        type_proto: TypeProto,
+        doc_string: Text = "",
+) -> ValueInfoProto:
     """Makes a ValueInfoProto with the given type_proto."""
     value_info_proto = ValueInfoProto()
     value_info_proto.name = name
@@ -664,7 +664,7 @@ def make_value_info(
     return value_info_proto
 
 
-def _sanitize_str(s):  # type: (Union[Text, bytes]) -> Text
+def _sanitize_str(s: Union[Text, bytes]) -> Text:
     if isinstance(s, str):
         sanitized = s
     elif isinstance(s, bytes):
@@ -677,12 +677,12 @@ def _sanitize_str(s):  # type: (Union[Text, bytes]) -> Text
 
 
 def make_tensor_sequence_value_info(
-        name,  # type: Text
-        elem_type,  # type: int
-        shape,  # type: Optional[Sequence[Union[Text, int, None]]]
-        doc_string="",  # type: Text
-        elem_shape_denotation=None,  # type: Optional[List[Text]]
-):  # type: (...) -> ValueInfoProto
+        name: Text,
+        elem_type: int,
+        shape: Optional[Sequence[Union[Text, int, None]]],
+        doc_string: Text = "",
+        elem_shape_denotation: Optional[List[Text]] = None,
+) -> ValueInfoProto:
     """Makes a Sequence[Tensors] ValueInfoProto based on the data type and shape."""
     value_info_proto = ValueInfoProto()
     value_info_proto.name = name
@@ -696,28 +696,28 @@ def make_tensor_sequence_value_info(
     return value_info_proto
 
 
-def printable_attribute(attr, subgraphs=False):  # type: (AttributeProto, bool) -> Union[Text, Tuple[Text, List[GraphProto]]]
+def printable_attribute(attr: AttributeProto, subgraphs: bool = False) -> Union[Text, Tuple[Text, List[GraphProto]]]:
     content = []
     content.append(attr.name)
     content.append("=")
 
-    def str_float(f):  # type: (float) -> Text
+    def str_float(f: float) -> Text:
         # NB: Different Python versions print different numbers of trailing
         # decimals, specifying this explicitly keeps it consistent for all
         # versions
         return '{:.15g}'.format(f)
 
-    def str_int(i):  # type: (int) -> Text
+    def str_int(i: int) -> Text:
         # NB: In Python 2, longs will repr() as '2L', which is ugly and
         # unnecessary.  Explicitly format it to keep it consistent.
         return '{:d}'.format(i)
 
-    def str_str(s):  # type: (Text) -> Text
+    def str_str(s: Text) -> Text:
         return repr(s)
 
     _T = TypeVar('_T')  # noqa
 
-    def str_list(str_elem, xs):  # type: (Callable[[_T], Text], Sequence[_T]) -> Text
+    def str_list(str_elem: Callable[[_T], Text], xs: Sequence[_T]) -> Text:
         return '[' + ', '.join(map(str_elem, xs)) + ']'
 
     # for now, this logic should continue to work as long as we are running on a proto3
@@ -776,13 +776,13 @@ def printable_attribute(attr, subgraphs=False):  # type: (AttributeProto, bool) 
         return ' '.join(content)
 
 
-def printable_dim(dim):  # type: (TensorShapeProto.Dimension) -> Text
+def printable_dim(dim: TensorShapeProto.Dimension) -> Text:
     which = dim.WhichOneof('value')
     assert which is not None
     return str(getattr(dim, which))
 
 
-def printable_type(t):  # type: (TypeProto) -> Text
+def printable_type(t: TypeProto) -> Text:
     if t.WhichOneof('value') == "tensor_type":
         s = TensorProto.DataType.Name(t.tensor_type.elem_type)
         if t.tensor_type.HasField('shape'):
@@ -796,14 +796,14 @@ def printable_type(t):  # type: (TypeProto) -> Text
     return 'Unknown type {}'.format(t.WhichOneof('value'))
 
 
-def printable_value_info(v):  # type: (ValueInfoProto) -> Text
+def printable_value_info(v: ValueInfoProto) -> Text:
     s = '%{}'.format(v.name)
     if v.type:
         s = '{}[{}]'.format(s, printable_type(v.type))
     return s
 
 
-def printable_tensor_proto(t):  # type: (TensorProto) -> Text
+def printable_tensor_proto(t: TensorProto) -> Text:
     s = '%{}['.format(t.name)
     s += TensorProto.DataType.Name(t.data_type)
     if t.dims is not None:
@@ -815,14 +815,14 @@ def printable_tensor_proto(t):  # type: (TensorProto) -> Text
     return s
 
 
-def printable_node(node, prefix='', subgraphs=False):  # type: (NodeProto, Text, bool) -> Union[Text, Tuple[Text, List[GraphProto]]]
+def printable_node(node: NodeProto, prefix: Text = '', subgraphs: bool = False) -> Union[Text, Tuple[Text, List[GraphProto]]]:
     content = []
     if len(node.output):
         content.append(
             ', '.join(['%{}'.format(name) for name in node.output]))
         content.append('=')
     # To deal with nested graphs
-    graphs = []  # type: List[GraphProto]
+    graphs: List[GraphProto] = []
     printed_attrs = []
     for attr in node.attribute:
         if subgraphs:
@@ -846,7 +846,7 @@ def printable_node(node, prefix='', subgraphs=False):  # type: (NodeProto, Text,
         return prefix + ' '.join(content)
 
 
-def printable_graph(graph, prefix=''):  # type: (GraphProto, Text) -> Text
+def printable_graph(graph: GraphProto, prefix: Text = '') -> Text:
     content = []
     indent = prefix + '  '
     # header
@@ -891,7 +891,7 @@ def printable_graph(graph, prefix=''):  # type: (GraphProto, Text) -> Text
 
     header.append('{')
     content.append(prefix + ' '.join(header))
-    graphs = []  # type: List[GraphProto]
+    graphs: List[GraphProto] = []
     # body
     for node in graph.node:
         pn, gs = printable_node(node, indent, subgraphs=True)
@@ -911,7 +911,7 @@ def printable_graph(graph, prefix=''):  # type: (GraphProto, Text) -> Text
     return '\n'.join(content)
 
 
-def strip_doc_string(proto):  # type: (google.protobuf.message.Message) -> None
+def strip_doc_string(proto: google.protobuf.message.Message) -> None:
     """
     Empties `doc_string` field on any nested protobuf messages
     """
@@ -927,7 +927,7 @@ def strip_doc_string(proto):  # type: (google.protobuf.message.Message) -> None
                 strip_doc_string(getattr(proto, descriptor.name))
 
 
-def make_training_info(algorithm, algorithm_bindings, initialization, initialization_bindings):  # type: (GraphProto, AssignmentBindingType,  Optional[GraphProto], Optional[AssignmentBindingType]) -> TrainingInfoProto
+def make_training_info(algorithm: GraphProto, algorithm_bindings: AssignmentBindingType, initialization: Optional[GraphProto], initialization_bindings: Optional[AssignmentBindingType]) -> TrainingInfoProto:
     training_info = TrainingInfoProto()
     training_info.algorithm.CopyFrom(algorithm)
     for k, v in algorithm_bindings:
@@ -948,12 +948,12 @@ def make_training_info(algorithm, algorithm_bindings, initialization, initializa
 
 # For backwards compatibility
 def make_sequence_value_info(
-        name,  # type: Text
-        elem_type,  # type: int
-        shape,  # type: Optional[Sequence[Union[Text, int, None]]]
-        doc_string="",  # type: Text
-        elem_shape_denotation=None,  # type: Optional[List[Text]]
-):  # type: (...) -> ValueInfoProto
+        name: Text,
+        elem_type: int,
+        shape: Optional[Sequence[Union[Text, int, None]]],
+        doc_string: Text = "",
+        elem_shape_denotation: Optional[List[Text]] = None,
+) -> ValueInfoProto:
     """Makes a Sequence[Tensors] ValueInfoProto based on the data type and shape."""
     warnings.warn(str("`onnx.helper.make_sequence_value_info` is a deprecated alias for `onnx.helper.make_tensor_sequence_value_info`. To silence this warning, please use `make_tensor_sequence_value_info` for `TensorProto` sequences. Deprecated in ONNX v1.10.0, `onnx.helper.make_sequence_value_info alias` will be removed in an upcoming release."), DeprecationWarning, stacklevel=2)
     return make_tensor_sequence_value_info(name, elem_type, shape, doc_string, elem_shape_denotation)

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -14,11 +14,11 @@ from onnx.external_data_helper import load_external_data_for_tensor, uses_extern
 from typing import Sequence, Any, Optional, Text, List, Dict
 
 
-def combine_pairs_to_complex(fa):  # type: (Sequence[int]) -> Sequence[np.complex64]
+def combine_pairs_to_complex(fa: Sequence[int]) -> Sequence[np.complex64]:
     return [complex(fa[i * 2], fa[i * 2 + 1]) for i in range(len(fa) // 2)]
 
 
-def to_array(tensor, base_dir=""):  # type: (TensorProto, Text) -> np.ndarray[Any]
+def to_array(tensor: TensorProto, base_dir: Text = "") -> np.ndarray[Any]:
     """Converts a tensor def object to a numpy array.
 
     Inputs:
@@ -81,7 +81,7 @@ def to_array(tensor, base_dir=""):  # type: (TensorProto, Text) -> np.ndarray[An
         )
 
 
-def from_array(arr, name=None):  # type: (np.ndarray[Any], Optional[Text]) -> TensorProto
+def from_array(arr: np.ndarray[Any], name: Optional[Text] = None) -> TensorProto:
     """Converts a numpy array to a tensor def.
 
     Inputs:
@@ -139,7 +139,7 @@ def from_array(arr, name=None):  # type: (np.ndarray[Any], Optional[Text]) -> Te
     return tensor
 
 
-def to_list(sequence):  # type: (SequenceProto) -> List[Any]
+def to_list(sequence: SequenceProto) -> List[Any]:
     """Converts a sequence def to a Python list.
 
     Inputs:
@@ -147,7 +147,7 @@ def to_list(sequence):  # type: (SequenceProto) -> List[Any]
     Returns:
         lst: the converted list.
     """
-    lst = []  # type: List[Any]
+    lst: List[Any] = []
     elem_type = sequence.elem_type
     value_field = mapping.STORAGE_ELEMENT_TYPE_TO_FIELD[elem_type]
     values = getattr(sequence, value_field)
@@ -163,7 +163,7 @@ def to_list(sequence):  # type: (SequenceProto) -> List[Any]
     return lst
 
 
-def from_list(lst, name=None, dtype=None):  # type: (List[Any], Optional[Text], Optional[int]) -> SequenceProto
+def from_list(lst: List[Any], name: Optional[Text] = None, dtype: Optional[int] = None) -> SequenceProto:
     """Converts a list into a sequence def.
 
     Inputs:
@@ -213,7 +213,7 @@ def from_list(lst, name=None, dtype=None):  # type: (List[Any], Optional[Text], 
     return sequence
 
 
-def to_dict(map):  # type: (MapProto) -> np.ndarray[Any]
+def to_dict(map: MapProto) -> np.ndarray[Any]:
     """Converts a map def to a Python dictionary.
 
     Inputs:
@@ -221,7 +221,7 @@ def to_dict(map):  # type: (MapProto) -> np.ndarray[Any]
     Returns:
         dict: the converted dictionary.
     """
-    key_list = []  # type: List[Any]
+    key_list: List[Any] = []
     if map.key_type == TensorProto.STRING:
         key_list = list(map.string_keys)
     else:
@@ -236,7 +236,7 @@ def to_dict(map):  # type: (MapProto) -> np.ndarray[Any]
     return dictionary
 
 
-def from_dict(dict, name=None):  # type: (Dict[Any, Any], Optional[Text]) -> MapProto
+def from_dict(dict: Dict[Any, Any], name: Optional[Text] = None) -> MapProto:
     """Converts a Python dictionary into a map def.
 
     Inputs:
@@ -277,7 +277,7 @@ def from_dict(dict, name=None):  # type: (Dict[Any, Any], Optional[Text]) -> Map
     return map
 
 
-def to_optional(optional):  # type: (OptionalProto) -> Optional[Any]
+def to_optional(optional: OptionalProto) -> Optional[Any]:
     """Converts an optional def to a Python optional.
 
     Inputs:
@@ -285,7 +285,7 @@ def to_optional(optional):  # type: (OptionalProto) -> Optional[Any]
     Returns:
         opt: the converted optional.
     """
-    opt = None  # type: Optional[Any]
+    opt: Optional[Any] = None
     elem_type = optional.elem_type
     if elem_type == OptionalProto.UNDEFINED:
         return opt
@@ -306,10 +306,10 @@ def to_optional(optional):  # type: (OptionalProto) -> Optional[Any]
 
 
 def from_optional(
-        opt,  # type: Optional[Any]
-        name=None,  # type: Optional[Text]
-        dtype=None  # type: Optional[int]
-):  # type: (...) -> OptionalProto
+        opt: Optional[Any],
+        name: Optional[Text] = None,
+        dtype: Optional[int] = None
+) -> OptionalProto:
     """Converts an optional value into a Optional def.
 
     Inputs:
@@ -355,7 +355,7 @@ def from_optional(
     return optional
 
 
-def convert_endian(tensor):  # type: (TensorProto) -> None
+def convert_endian(tensor: TensorProto) -> None:
     """
     call to convert endianess of raw data in tensor.
     @params

--- a/onnx/parser.py
+++ b/onnx/parser.py
@@ -9,7 +9,7 @@ class ParseError(Exception):
     pass
 
 
-def parse_model(model_text):  # type: (Text) -> onnx.ModelProto
+def parse_model(model_text: Text) -> onnx.ModelProto:
     (success, msg, model_proto_str) = C.parse_model(model_text)
     if success:
         return onnx.load_from_string(model_proto_str)
@@ -17,7 +17,7 @@ def parse_model(model_text):  # type: (Text) -> onnx.ModelProto
         raise ParseError(msg)
 
 
-def parse_graph(graph_text):  # type: (Text) -> onnx.GraphProto
+def parse_graph(graph_text: Text) -> onnx.GraphProto:
     (success, msg, graph_proto_str) = C.parse_graph(graph_text)
     if success:
         G = onnx.GraphProto()

--- a/onnx/shape_inference.py
+++ b/onnx/shape_inference.py
@@ -35,7 +35,7 @@ Return:
 """
 
 
-def infer_shapes(model, check_type=False, strict_mode=False, data_prop=False):  # type: (Union[ModelProto, bytes], bool, bool, bool) -> ModelProto
+def infer_shapes(model: Union[ModelProto, bytes], check_type: bool = False, strict_mode: bool = False, data_prop: bool = False) -> ModelProto:
     if isinstance(model, (ModelProto, bytes)):
         model_str = model if isinstance(model, bytes) else model.SerializeToString()
         inferred_model_str = C.infer_shapes(model_str, check_type, strict_mode, data_prop)
@@ -48,7 +48,7 @@ def infer_shapes(model, check_type=False, strict_mode=False, data_prop=False):  
                          'incorrect type: {}'.format(type(model)))
 
 
-def infer_shapes_path(model_path, output_path='', check_type=False, strict_mode=False, data_prop=False):  # type: (Text, Text, bool, bool, bool) -> None
+def infer_shapes_path(model_path: Text, output_path: Text = '', check_type: bool = False, strict_mode: bool = False, data_prop: bool = False) -> None:
     """
     Take model path for shape_inference same as infer_shape; it support >2GB models
     Directly output the inferred model to the output_path; Default is the original model path

--- a/onnx/test/automatic_upgrade_test.py
+++ b/onnx/test/automatic_upgrade_test.py
@@ -21,19 +21,19 @@ class TestAutomaticUpgrade(unittest.TestCase):
 
     def _test_op_upgrade(
         self,
-        op,  # type: Text
-        from_opset,  # type: int
-        input_shapes=[[3, 4, 5]],  # type: List[Union[List[Optional[int]], Text]]
-        output_shapes=[[3, 4, 5]],  # type: List[List[Optional[int]]]
-        input_types=None,  # type: Union[List[Any], None]
-        output_types=None,  # type: Union[List[Any], None]
-        initializer=[],  # type: List[Any]
-        attrs={},  # type: Dict[Text, Any]
-        seq_inputs=[],  # type: List[int]
-        seq_outputs=[],  # type: List[int]
-        optional_inputs=[],  # type: List[int]
-        optional_outputs=[]  # type: List[int]
-    ):  # type: (...) -> None
+        op: Text,
+        from_opset: int,
+        input_shapes: List[Union[List[Optional[int]], Text]] = [[3, 4, 5]],
+        output_shapes: List[List[Optional[int]]] = [[3, 4, 5]],
+        input_types: Union[List[Any], None] = None,
+        output_types: Union[List[Any], None] = None,
+        initializer: List[Any] = [],
+        attrs: Dict[Text, Any] = {},
+        seq_inputs: List[int] = [],
+        seq_outputs: List[int] = [],
+        optional_inputs: List[int] = [],
+        optional_outputs: List[int] = []
+    ) -> None:
         global tested_ops
         tested_ops.append(op)
 
@@ -51,7 +51,7 @@ class TestAutomaticUpgrade(unittest.TestCase):
         input_shapes_cast = cast(List[List[int]],
                 [[0] if isinstance(shape, str) else shape for shape in input_shapes]
         )
-        inputs = []  # type: List[ValueInfoProto]
+        inputs: List[ValueInfoProto] = []
         for (name, ttype, shape, is_seq, is_opt) in \
                 zip(input_names, input_types, input_shapes_cast, is_sequence, is_optional):
             if name != '':
@@ -73,7 +73,7 @@ class TestAutomaticUpgrade(unittest.TestCase):
         output_shapes_cast = cast(List[List[int]],
                 [[0] if isinstance(shape, str) else shape for shape in output_shapes]
         )
-        outputs = []  # type: List[ValueInfoProto]
+        outputs: List[ValueInfoProto] = []
         for (name, ttype, shape, is_seq, is_opt) in \
                 zip(output_names, output_types, output_shapes_cast, is_sequence, is_optional):
             if is_seq:
@@ -99,127 +99,127 @@ class TestAutomaticUpgrade(unittest.TestCase):
         onnx.checker.check_model(converted)
         shape_inference.infer_shapes(converted, strict_mode=True)
 
-    def test_Abs(self):  # type: () -> None
+    def test_Abs(self) -> None:
         self._test_op_upgrade('Abs', 1, attrs={'consumed_inputs': [0]})
 
-    def test_Acosh(self):  # type: () -> None
+    def test_Acosh(self) -> None:
         self._test_op_upgrade('Acosh', 9)
 
-    def test_Acos(self):  # type: () -> None
+    def test_Acos(self) -> None:
         self._test_op_upgrade('Acos', 7)
 
-    def test_And(self):  # type: () -> None
+    def test_And(self) -> None:
         # 6->7 adapter is missing
         self._test_op_upgrade('And', 7, [[2, 3], [2, 3]], [[2, 3]],
             [TensorProto.BOOL, TensorProto.BOOL], [TensorProto.BOOL]
         )
 
-    def test_Asinh(self):  # type: () -> None
+    def test_Asinh(self) -> None:
         self._test_op_upgrade('Asinh', 9)
 
-    def test_Atanh(self):  # type: () -> None
+    def test_Atanh(self) -> None:
         self._test_op_upgrade('Atanh', 9)
 
-    def test_Add_1(self):  # type: () -> None
+    def test_Add_1(self) -> None:
         self._test_op_upgrade('Add', 1,
             [[3, 4, 5], [3, 4, 5]],
             attrs={'consumed_inputs': [0]}
         )
 
-    def test_Add_2(self):  # type: () -> None
+    def test_Add_2(self) -> None:
         self._test_op_upgrade('Add', 1, [[3, 4, 5], [5]],
             attrs={'consumed_inputs': [0], 'broadcast': 1}
         )
 
-    def test_Add_3(self):  # type: () -> None
+    def test_Add_3(self) -> None:
         self._test_op_upgrade('Add', 1, [[3, 4, 5], [3]],
             attrs={'consumed_inputs': [0], 'broadcast': 1, 'axis': 0}
         )
 
-    def test_ArgMax_1(self):  # type: () -> None
+    def test_ArgMax_1(self) -> None:
         self._test_op_upgrade('ArgMax', 7, [[2, 3, 4]], [[1, 3, 4]],
             output_types=[TensorProto.INT64]
         )
 
-    def test_ArgMax_2(self):  # type: () -> None
+    def test_ArgMax_2(self) -> None:
         self._test_op_upgrade('ArgMax', 7, [[2, 3, 4]], [[2, 1, 4]],
             output_types=[TensorProto.INT64],
             attrs={'axis': 1}
         )
 
-    def test_ArgMin_1(self):  # type: () -> None
+    def test_ArgMin_1(self) -> None:
         self._test_op_upgrade('ArgMin', 7, [[2, 3, 4]], [[1, 3, 4]],
             output_types=[TensorProto.INT64]
         )
 
-    def test_ArgMin_2(self):  # type: () -> None
+    def test_ArgMin_2(self) -> None:
         self._test_op_upgrade('ArgMin', 7, [[2, 3, 4]], [[2, 1, 4]],
             output_types=[TensorProto.INT64],
             attrs={'axis': 1}
         )
 
-    def test_Asin(self):  # type: () -> None
+    def test_Asin(self) -> None:
         self._test_op_upgrade('Asin', 7)
 
-    def test_Atan(self):  # type: () -> None
+    def test_Atan(self) -> None:
         self._test_op_upgrade('Atan', 7)
 
-    def test_AveragePool(self):  # type: () -> None
+    def test_AveragePool(self) -> None:
         self._test_op_upgrade('AveragePool', 1, [[1, 1, 5, 5]], [[1, 1, 4, 4]],
             attrs={'kernel_shape': [2, 2]}
         )
 
-    def test_Bernoulli(self):  # type: () -> None
+    def test_Bernoulli(self) -> None:
         self._test_op_upgrade('Bernoulli', 15)
 
-    def test_BitShift(self):  # type: () -> None
+    def test_BitShift(self) -> None:
         self._test_op_upgrade('BitShift', 11, [[2, 3], [2, 3]], [[2, 3]],
             [TensorProto.UINT8, TensorProto.UINT8], [TensorProto.UINT8],
             attrs={'direction': 'RIGHT'}
         )
 
-    def test_BatchNormalization_1(self):  # type: () -> None
+    def test_BatchNormalization_1(self) -> None:
         self._test_op_upgrade('BatchNormalization', 1, [[1, 3], [3], [3], [3], [3]], [[1, 3]],
             attrs={'consumed_inputs': [1, 1], 'is_test': 1, 'spatial': 1}
         )
 
-    def test_BatchNormalization_2(self):  # type: () -> None
+    def test_BatchNormalization_2(self) -> None:
         self._test_op_upgrade('BatchNormalization', 14,
             [[1, 3], [3], [3], [3], [3]], [[1, 3], [3], [3]],
             attrs={'training_mode': 1}
         )
 
-    def test_Cast(self):  # type: () -> None
+    def test_Cast(self) -> None:
         # 5->6 adapter is missing
         self._test_op_upgrade('Cast', 6, [[2, 3]], [[2, 3]], [TensorProto.INT64], attrs={'to': 1})
 
-    def test_Ceil(self):  # type: () -> None
+    def test_Ceil(self) -> None:
         self._test_op_upgrade('Ceil', 1, attrs={'consumed_inputs': [0]})
 
-    def test_Celu(self):  # type: () -> None
+    def test_Celu(self) -> None:
         self._test_op_upgrade('Celu', 12)
 
-    def test_Clip_1(self):  # type: () -> None
+    def test_Clip_1(self) -> None:
         self._test_op_upgrade('Clip', 1, attrs={'consumed_inputs': [0]})
 
-    def test_Clip_2(self):  # type: () -> None
+    def test_Clip_2(self) -> None:
         self._test_op_upgrade('Clip', 1, attrs={'consumed_inputs': [0], 'min': -1.4})
 
-    def test_Clip_3(self):  # type: () -> None
+    def test_Clip_3(self) -> None:
         self._test_op_upgrade('Clip', 1, attrs={'consumed_inputs': [0], 'max': 2.6})
 
-    def test_Clip_4(self):  # type: () -> None
+    def test_Clip_4(self) -> None:
         self._test_op_upgrade('Clip', 1, attrs={'consumed_inputs': [0], 'min': -1.4, 'max': 2.6})
 
-    def test_Compress(self):  # type: () -> None
+    def test_Compress(self) -> None:
         self._test_op_upgrade('Compress', 9, [[6, 7], [3]], [[3]],
             [TensorProto.FLOAT, TensorProto.BOOL], [TensorProto.FLOAT]
         )
 
-    def test_Concat(self):  # type: () -> None
+    def test_Concat(self) -> None:
         self._test_op_upgrade('Concat', 1, [[2, 3], [2, 4]], [[2, 7]])
 
-    def test_constant(self):  # type: () -> None
+    def test_constant(self) -> None:
         value = helper.make_tensor(
             'Value',
             TensorProto.FLOAT,
@@ -229,89 +229,89 @@ class TestAutomaticUpgrade(unittest.TestCase):
         )
         self._test_op_upgrade('Constant', 1, [], attrs={'value': value})
 
-    def test_ConstantOfShape(self):  # type: () -> None
+    def test_ConstantOfShape(self) -> None:
         self._test_op_upgrade('ConstantOfShape', 9, [[3]])
 
-    def test_Conv_1(self):  # type: () -> None
+    def test_Conv_1(self) -> None:
         self._test_op_upgrade('Conv', 1, [[1, 3, 5, 5], [4, 3, 2, 2], [4]], [[1, 4, 4, 4]])
 
-    def test_Conv_2(self):  # type: () -> None
+    def test_Conv_2(self) -> None:
         self._test_op_upgrade('Conv', 1, [[1, 3, 5, 5], [4, 3, 2, 2], [4]], [[1, 4, 4, 4]])
 
-    def test_Conv_3(self):  # type: () -> None
+    def test_Conv_3(self) -> None:
         self._test_op_upgrade('Conv', 1, [[1, 3, 5, 5], [4, 1, 2, 2], [4]], [[1, 4, 3, 7]],
             attrs={'dilations': [1, 2], 'group': 3, 'pads': [0, 1, 2, 3], 'strides': [2, 1]})
 
-    def test_Convinteger(self):  # type: () -> None
+    def test_Convinteger(self) -> None:
         self._test_op_upgrade('ConvInteger', 10, [[1, 3, 5, 5], [4, 3, 2, 2], [4]], [[1, 4, 4, 4]],
             [TensorProto.UINT8, TensorProto.UINT8, TensorProto.UINT8], [TensorProto.INT32]
         )
 
-    def test_ConvTranspose(self):  # type: () -> None
+    def test_ConvTranspose(self) -> None:
         self._test_op_upgrade('ConvTranspose', 1, [[1, 1, 5, 5], [1, 1, 3, 3]], [[1, 1, 7, 7]])
 
-    def test_Cosh(self):  # type: () -> None
+    def test_Cosh(self) -> None:
         self._test_op_upgrade('Cosh', 9)
 
-    def test_Cos(self):  # type: () -> None
+    def test_Cos(self) -> None:
         self._test_op_upgrade('Cos', 7)
 
-    def test_Cumsum(self):  # type: () -> None
+    def test_Cumsum(self) -> None:
         self._test_op_upgrade('CumSum', 11, [[3, 4, 5], []], [[3, 4, 5]],
             [TensorProto.FLOAT, TensorProto.INT64]
         )
 
-    def test_DepthToSpace(self):  # type: () -> None
+    def test_DepthToSpace(self) -> None:
         self._test_op_upgrade('DepthToSpace', 1, [[1, 8, 3, 3]], [[1, 2, 6, 6]],
             attrs={'blocksize': 2}
         )
 
-    def test_DequantizeLinear(self):  # type: () -> None
+    def test_DequantizeLinear(self) -> None:
         self._test_op_upgrade('DequantizeLinear', 10, [[2, 3], [], []], [[2, 3]],
             [TensorProto.INT8, TensorProto.FLOAT, TensorProto.INT8]
         )
 
-    def test_Det_1(self):  # type: () -> None
+    def test_Det_1(self) -> None:
         self._test_op_upgrade('Det', 11, [[3, 5, 5]], [[3]])
 
-    def test_Det_2(self):  # type: () -> None
+    def test_Det_2(self) -> None:
         self._test_op_upgrade('Det', 11, [[5, 5]], [[]])
 
-    def test_DynamicQuantizeLinear(self):  # type: () -> None
+    def test_DynamicQuantizeLinear(self) -> None:
         self._test_op_upgrade('DynamicQuantizeLinear', 11, [[3, 4, 5]], [[3, 4, 5], [], []],
             output_types=[TensorProto.UINT8, TensorProto.FLOAT, TensorProto.UINT8]
         )
 
-    def test_Div(self):  # type: () -> None
+    def test_Div(self) -> None:
         self._test_op_upgrade('Div', 1, [[3, 4, 5], [3, 1, 5]], attrs={'consumed_inputs': [0]})
 
-    def test_Dropout(self):  # type: () -> None
+    def test_Dropout(self) -> None:
         self._test_op_upgrade('Dropout', 1, attrs={'consumed_inputs': [0], 'is_test': 1})
 
-    def test_Einsum_1(self):  # type: () -> None
+    def test_Einsum_1(self) -> None:
         self._test_op_upgrade('Einsum', 12, [[3, 4, 5], [3, 5, 6]], [[3, 4, 6]],
             attrs={'equation': 'bij, bjk -> bik'}
         )
 
-    def test_Einsum_2(self):  # type: () -> None
+    def test_Einsum_2(self) -> None:
         self._test_op_upgrade('Einsum', 12, [[4, 5]], [[5, 4]],
             attrs={'equation': 'ij->ji'}
         )
 
-    def test_Elu(self):  # type: () -> None
+    def test_Elu(self) -> None:
         self._test_op_upgrade('Elu', 1, attrs={'consumed_inputs': [0]})
 
-    def test_Equal(self):  # type: () -> None
+    def test_Equal(self) -> None:
         # 6->7 adapter is missing
         self._test_op_upgrade('Equal', 7, [[2, 3], [2, 3]], [[2, 3]], output_types=[TensorProto.BOOL])
 
-    def test_Erf(self):  # type: () -> None
+    def test_Erf(self) -> None:
         self._test_op_upgrade('Erf', 9)
 
-    def test_Exp(self):  # type: () -> None
+    def test_Exp(self) -> None:
         self._test_op_upgrade('Exp', 1, attrs={'consumed_inputs': [0]})
 
-    def test_Expand(self):  # type: () -> None
+    def test_Expand(self) -> None:
         shape = helper.make_tensor(
             'b',
             TensorProto.INT64,
@@ -323,74 +323,74 @@ class TestAutomaticUpgrade(unittest.TestCase):
             initializer=[shape]
         )
 
-    def test_EyeLike(self):  # type: () -> None
+    def test_EyeLike(self) -> None:
         self._test_op_upgrade('EyeLike', 9, [[4, 5]], [[4, 5]])
 
-    def test_Flatten(self):  # type: () -> None
+    def test_Flatten(self) -> None:
         self._test_op_upgrade('Flatten', 1, [[3, 4, 5]], [[3, 20]], attrs={'axis': 1})
 
-    def test_Floor(self):  # type: () -> None
+    def test_Floor(self) -> None:
         self._test_op_upgrade('Floor', 1, attrs={'consumed_inputs': [0]})
 
-    def test_Gather(self):  # type: () -> None
+    def test_Gather(self) -> None:
         self._test_op_upgrade('Gather', 1, [[3, 4, 5], [6, 7]], [[6, 7, 4, 5]],
             [TensorProto.FLOAT, TensorProto.INT64]
         )
 
-    def test_GatherElements(self):  # type: () -> None
+    def test_GatherElements(self) -> None:
         self._test_op_upgrade('GatherElements', 11, [[3, 4, 5], [6, 7]], [[6, 7]],
             [TensorProto.FLOAT, TensorProto.INT64]
         )
 
-    def test_GatherND(self):  # type: () -> None
+    def test_GatherND(self) -> None:
         self._test_op_upgrade('GatherND', 11, [[1, 2, 3], [1, 2, 3]], [[1, 2]])
 
-    def test_Gemm(self):  # type: () -> None
+    def test_Gemm(self) -> None:
         self._test_op_upgrade('Gemm', 1, [[5, 4], [4, 3], [3]], [[5, 3]])
 
-    def test_GlobalAveragePool(self):  # type: () -> None
+    def test_GlobalAveragePool(self) -> None:
         self._test_op_upgrade('GlobalAveragePool', 1, [[1, 3, 10, 10]], [[1, 3, 1, 1]])
 
-    def test_GlobalMaxPool(self):  # type: () -> None
+    def test_GlobalMaxPool(self) -> None:
         self._test_op_upgrade('GlobalMaxPool', 1, [[1, 3, 10, 10]], [[1, 3, 1, 1]])
 
-    def test_GlobalLpPool(self):  # type: () -> None
+    def test_GlobalLpPool(self) -> None:
         # 1->2 adapter is missing
         self._test_op_upgrade('GlobalLpPool', 2, [[1, 3, 10, 10]], [[1, 3, 1, 1]])
 
-    def test_Greater(self):  # type: () -> None
+    def test_Greater(self) -> None:
         # 6->7 adapter is missing
         self._test_op_upgrade('Greater', 7, [[2, 3], [2, 3]], [[2, 3]],
             output_types=[TensorProto.BOOL]
         )
 
-    def test_GreaterOrEqual(self):  # type: () -> None
+    def test_GreaterOrEqual(self) -> None:
         self._test_op_upgrade('GreaterOrEqual', 12, [[2, 3], [2, 3]], [[2, 3]],
             output_types=[TensorProto.BOOL]
         )
 
-    def test_GridSample(self):  # type: () -> None
+    def test_GridSample(self) -> None:
         self._test_op_upgrade('GridSample', 16, [[1, 1, 3, 3], [1, 3, 3, 2]], [[1, 1, 3, 3]],
             input_types=[TensorProto.FLOAT, TensorProto.FLOAT],
             output_types=[TensorProto.FLOAT],
             attrs={'mode': 'nearest', 'padding_mode': 'border', 'align_corners': 1},
         )
 
-    def test_GRU_1(self):  # type: () -> None
+    def test_GRU_1(self) -> None:
         # 2->3, 6->7 adapters are missing
         self._test_op_upgrade('GRU', 7,
             [[5, 3, 4], [1, 18, 4], [1, 18, 4]], [[5, 1, 3, 6], [1, 3, 6]],
             attrs={'hidden_size': 6}
         )
 
-    def test_GRU_2(self):  # type: () -> None
+    def test_GRU_2(self) -> None:
         # 2->3, 6->7 adapters are missing
         self._test_op_upgrade('GRU', 7,
             [[5, 3, 4], [2, 18, 4], [2, 18, 4]], [[5, 2, 3, 6], [2, 3, 6]],
             attrs={'hidden_size': 6, 'direction': 'bidirectional'}
         )
 
-    def test_GRU_3(self):  # type: () -> None
+    def test_GRU_3(self) -> None:
         # 2->3, 6->7 adapters are missing
         self._test_op_upgrade('GRU', 7,
             [[5, 3, 4], [1, 18, 4], [1, 18, 4], [1, 24], [5], [1, 5, 6]],
@@ -399,19 +399,19 @@ class TestAutomaticUpgrade(unittest.TestCase):
             attrs={'hidden_size': 6}
         )
 
-    def test_HardSigmoid(self):  # type: () -> None
+    def test_HardSigmoid(self) -> None:
         self._test_op_upgrade('HardSigmoid', 1, attrs={'consumed_inputs': [0]})
 
-    def test_HardSwish(self):  # type: () -> None
+    def test_HardSwish(self) -> None:
         self._test_op_upgrade('HardSwish', 14)
 
-    def test_Hardmax(self):  # type: () -> None
+    def test_Hardmax(self) -> None:
         self._test_op_upgrade('Hardmax', 1)
 
-    def test_Identity(self):  # type: () -> None
+    def test_Identity(self) -> None:
         self._test_op_upgrade('Identity', 1)
 
-    def test_If(self):  # type: () -> None
+    def test_If(self) -> None:
         sub_output = [helper.make_tensor_value_info('out', TensorProto.FLOAT, [3, 4, 5])]
         then_tensor = helper.make_tensor(
             'Value',
@@ -433,36 +433,36 @@ class TestAutomaticUpgrade(unittest.TestCase):
             attrs={'then_branch': then_graph, 'else_branch': else_graph}
         )
 
-    def test_InstanceNormalization(self):  # type: () -> None
+    def test_InstanceNormalization(self) -> None:
         self._test_op_upgrade('InstanceNormalization', 1, [[1, 3], [3], [3]], [[1, 3]],
             attrs={'consumed_inputs': [0]}
         )
 
-    def test_IsInf(self):  # type: () -> None
+    def test_IsInf(self) -> None:
         self._test_op_upgrade('IsInf', 10, [[2, 3]], [[2, 3]], output_types=[TensorProto.BOOL])
 
-    def test_IsNaN(self):  # type: () -> None
+    def test_IsNaN(self) -> None:
         self._test_op_upgrade('IsNaN', 9, [[2, 3]], [[2, 3]], output_types=[TensorProto.BOOL])
 
-    def test_LeakyRelu(self):  # type: () -> None
+    def test_LeakyRelu(self) -> None:
         self._test_op_upgrade('LeakyRelu', 1, attrs={'consumed_inputs': [0]})
 
-    def test_Less(self):  # type: () -> None
+    def test_Less(self) -> None:
         # 6->7 adapter is missing
         self._test_op_upgrade('Less', 7, [[2, 3], [2, 3]], [[2, 3]], output_types=[TensorProto.BOOL])
 
-    def test_LessOrEqual(self):  # type: () -> None
+    def test_LessOrEqual(self) -> None:
         self._test_op_upgrade('LessOrEqual', 12, [[2, 3], [2, 3]], [[2, 3]],
             output_types=[TensorProto.BOOL]
         )
 
-    def test_Log(self):  # type: () -> None
+    def test_Log(self) -> None:
         self._test_op_upgrade('Log', 1, attrs={'consumed_inputs': [0]})
 
-    def test_LogSoftmax(self):  # type: () -> None
+    def test_LogSoftmax(self) -> None:
         self._test_op_upgrade('LogSoftmax', 1)
 
-    def test_Loop_1(self):  # type: () -> None
+    def test_Loop_1(self) -> None:
         iter_count = onnx.helper.make_tensor_value_info('iter_count', onnx.TensorProto.INT64, [])
         cond_in = onnx.helper.make_tensor_value_info('cond_in', onnx.TensorProto.BOOL, [])
         x_in = onnx.helper.make_tensor_value_info('x_in', onnx.TensorProto.FLOAT, [1])
@@ -506,7 +506,7 @@ class TestAutomaticUpgrade(unittest.TestCase):
             attrs={'body': loop_body}
         )
 
-    def test_Loop_2(self):  # type: () -> None
+    def test_Loop_2(self) -> None:
         iter_count = onnx.helper.make_tensor_value_info('iter_count', onnx.TensorProto.INT64, [])
         cond_in = onnx.helper.make_tensor_value_info('cond_in', onnx.TensorProto.BOOL, [])
         x_in = onnx.helper.make_tensor_value_info('x_in', onnx.TensorProto.FLOAT, [2, 1])
@@ -540,24 +540,24 @@ class TestAutomaticUpgrade(unittest.TestCase):
             attrs={'body': loop_body}
         )
 
-    def test_LpNormalization(self):  # type: () -> None
+    def test_LpNormalization(self) -> None:
         self._test_op_upgrade('LpNormalization', 1)
 
-    def test_LpPool(self):  # type: () -> None
+    def test_LpPool(self) -> None:
         # 1->2 adapter is missing
         self._test_op_upgrade('LpPool', 2, [[1, 1, 5, 5]], [[1, 1, 4, 4]],
             attrs={'kernel_shape': [2, 2]}
         )
 
-    def test_LRN_1(self):  # type: () -> None
+    def test_LRN_1(self) -> None:
         self._test_op_upgrade('LRN', 1, attrs={'size': 3})
 
-    def test_LRN_2(self):  # type: () -> None
+    def test_LRN_2(self) -> None:
         self._test_op_upgrade('LRN', 1, [[2, 3, 4, 5]], [[2, 3, 4, 5]],
             attrs={'size': 3}
         )
 
-    def test_LSTM_1(self):  # type: () -> None
+    def test_LSTM_1(self) -> None:
         # 6->7 adapter is missing
         self._test_op_upgrade('LSTM', 7,
             [[5, 3, 4], [1, 24, 4], [1, 24, 4]],
@@ -565,7 +565,7 @@ class TestAutomaticUpgrade(unittest.TestCase):
             attrs={'hidden_size': 6}
         )
 
-    def test_LSTM_2(self):  # type: () -> None
+    def test_LSTM_2(self) -> None:
         # 6->7 adapter is missing
         self._test_op_upgrade('LSTM', 7,
             [[5, 3, 4], [2, 24, 4], [2, 24, 4]],
@@ -573,7 +573,7 @@ class TestAutomaticUpgrade(unittest.TestCase):
             attrs={'hidden_size': 6, 'direction': 'bidirectional'}
         )
 
-    def test_LSTM_3(self):  # type: () -> None
+    def test_LSTM_3(self) -> None:
         # 6->7 adapter is missing
         self._test_op_upgrade('LSTM', 7,
             [[5, 3, 4], [1, 24, 4], [1, 24, 4], [1, 48], [5], [1, 5, 6], [1, 5, 6], [1, 18]],
@@ -582,150 +582,150 @@ class TestAutomaticUpgrade(unittest.TestCase):
             attrs={'hidden_size': 6}
         )
 
-    def test_MatMul_1(self):  # type: () -> None
+    def test_MatMul_1(self) -> None:
         self._test_op_upgrade('MatMul', 1, [[2, 3], [3, 4]], [[2, 4]])
 
-    def test_MatMul_2(self):  # type: () -> None
+    def test_MatMul_2(self) -> None:
         self._test_op_upgrade('MatMul', 1, [[5, 2, 3], [5, 3, 4]], [[5, 2, 4]])
 
-    def test_MatMulInteger_1(self):  # type: () -> None
+    def test_MatMulInteger_1(self) -> None:
         self._test_op_upgrade('MatMulInteger', 10, [[2, 3], [3, 4]], [[2, 4]],
             [TensorProto.INT8, TensorProto.INT8], [TensorProto.INT32]
         )
 
-    def test_MatMulInteger_2(self):  # type: () -> None
+    def test_MatMulInteger_2(self) -> None:
         self._test_op_upgrade('MatMulInteger', 10, [[2, 3], [3, 4], [], []], [[2, 4]],
             [TensorProto.INT8, TensorProto.INT8, TensorProto.INT8, TensorProto.INT8],
             [TensorProto.INT32]
         )
 
-    def test_MatMulInteger_3(self):  # type: () -> None
+    def test_MatMulInteger_3(self) -> None:
         self._test_op_upgrade('MatMulInteger', 10, [[2, 3], [3, 4], [2], [4]], [[2, 4]],
             [TensorProto.INT8, TensorProto.INT8, TensorProto.INT8, TensorProto.INT8],
             [TensorProto.INT32]
         )
 
-    def test_Max(self):  # type: () -> None
+    def test_Max(self) -> None:
         self._test_op_upgrade('Max', 1, [[2, 3, 4], [2, 3, 4]], [[2, 3, 4]],
             attrs={'consumed_inputs': [0]}
         )
 
-    def test_MaxPool_1(self):  # type: () -> None
+    def test_MaxPool_1(self) -> None:
         self._test_op_upgrade('MaxPool', 1, [[1, 1, 5, 5]], [[1, 1, 4, 4]],
             attrs={'kernel_shape': [2, 2]}
         )
 
-    def test_MaxPool_2(self):  # type: () -> None
+    def test_MaxPool_2(self) -> None:
         self._test_op_upgrade('MaxPool', 8, [[1, 1, 5, 5]], [[1, 1, 4, 4], [1, 1, 4, 4]],
             output_types=[TensorProto.FLOAT, TensorProto.INT64],
             attrs={'kernel_shape': [2, 2]}
         )
 
-    def test_MaxRoiPool(self):  # type: () -> None
+    def test_MaxRoiPool(self) -> None:
         self._test_op_upgrade('MaxRoiPool', 1, [[2, 3, 20, 20], [4, 5]], [[4, 3, 3, 3]],
             attrs={'pooled_shape': [3, 3]}
         )
 
-    def test_MaxUnpool(self):  # type: () -> None
+    def test_MaxUnpool(self) -> None:
         self._test_op_upgrade('MaxUnpool', 9, [[1, 1, 5, 5], [1, 1, 5, 5]], [[1, 1, 6, 6]],
             [TensorProto.FLOAT, TensorProto.INT64],
             attrs={'kernel_shape': [2, 2]}
         )
 
-    def test_Mean(self):  # type: () -> None
+    def test_Mean(self) -> None:
         self._test_op_upgrade('Mean', 1, [[2, 3, 4], [2, 3, 4]], [[2, 3, 4]],
             attrs={'consumed_inputs': [0]}
         )
 
-    def test_MeanVarianceNormalization(self):  # type: () -> None
+    def test_MeanVarianceNormalization(self) -> None:
         self._test_op_upgrade('MeanVarianceNormalization', 9, attrs={'axes': [1, 2]})
 
-    def test_Min(self):  # type: () -> None
+    def test_Min(self) -> None:
         self._test_op_upgrade('Min', 1, [[2, 3, 4], [2, 3, 4]], [[2, 3, 4]],
             attrs={'consumed_inputs': [0]}
         )
 
-    def test_Mod_1(self):  # type: () -> None
+    def test_Mod_1(self) -> None:
         self._test_op_upgrade('Mod', 10, [[2, 3], [2, 3]], [[2, 3]])
 
-    def test_Mod_2(self):  # type: () -> None
+    def test_Mod_2(self) -> None:
         self._test_op_upgrade('Mod', 10, [[2, 3], [2, 3]], [[2, 3]], attrs={'fmod': 1})
 
-    def test_Mul(self):  # type: () -> None
+    def test_Mul(self) -> None:
         self._test_op_upgrade('Mul', 1, [[2, 3, 4], [2, 1, 4]], [[2, 3, 4]],
             attrs={'consumed_inputs': [0]}
         )
 
-    def test_Multinomial(self):  # type: () -> None
+    def test_Multinomial(self) -> None:
         self._test_op_upgrade('Multinomial', 7, [[3, 5]], [[3, 7]],
             output_types=[TensorProto.INT32],
             attrs={'sample_size': 7}
         )
 
-    def test_Neg(self):  # type: () -> None
+    def test_Neg(self) -> None:
         self._test_op_upgrade('Neg', 1, attrs={'consumed_inputs': [0]})
 
-    def test_NegativeLogLikelihoodLoss_1(self):  # type: () -> None
+    def test_NegativeLogLikelihoodLoss_1(self) -> None:
         self._test_op_upgrade('NegativeLogLikelihoodLoss', 12, [[3, 4, 5], [3, 5]], [[]],
             [TensorProto.FLOAT, TensorProto.INT64]
         )
 
-    def test_NegativeLogLikelihoodLoss_2(self):  # type: () -> None
+    def test_NegativeLogLikelihoodLoss_2(self) -> None:
         self._test_op_upgrade('NegativeLogLikelihoodLoss', 12, [[3, 4, 5], [3, 5], [4]], [[]],
             [TensorProto.FLOAT, TensorProto.INT64, TensorProto.FLOAT]
         )
 
-    def test_NonMaxSuppression(self):  # type: () -> None
+    def test_NonMaxSuppression(self) -> None:
         self._test_op_upgrade('NonMaxSuppression', 10, [[2, 3, 4], [3, 5, 6]], [[2, 3]],
             output_types=[TensorProto.INT64]
         )
 
-    def test_NonZero(self):  # type: () -> None
+    def test_NonZero(self) -> None:
         self._test_op_upgrade('NonZero', 9, [[3, 3]], [[2, 4]], output_types=[TensorProto.INT64])
 
-    def test_Not(self):  # type: () -> None
+    def test_Not(self) -> None:
         self._test_op_upgrade('Not', 1, [[2, 3]], [[2, 3]], [TensorProto.BOOL], [TensorProto.BOOL])
 
-    def test_OneHot(self):  # type: () -> None
+    def test_OneHot(self) -> None:
         self._test_op_upgrade('OneHot', 9, [[3, 4, 5], [], [2]], [[3, 4, 5, 6]])
 
-    def test_Or(self):  # type: () -> None
+    def test_Or(self) -> None:
         # 6->7 adapter is missing
         self._test_op_upgrade('Or', 7, [[2, 3], [2, 3]], [[2, 3]],
             [TensorProto.BOOL, TensorProto.BOOL], [TensorProto.BOOL]
         )
 
-    def test_Pad(self):  # type: () -> None
+    def test_Pad(self) -> None:
         # 1->2 adapter is missing
         self._test_op_upgrade('Pad', 2, [[3, 4]], [[5, 8]],
             attrs={'pads': [1, 2, 1, 2], 'value': 1.5}
         )
 
-    def test_Pow(self):  # type: () -> None
+    def test_Pow(self) -> None:
         self._test_op_upgrade('Pow', 1, [[2, 3, 4], [2, 3, 4]], [[2, 3, 4]])
 
-    def test_PRelu(self):  # type: () -> None
+    def test_PRelu(self) -> None:
         self._test_op_upgrade('PRelu', 1, [[2, 3, 4], [2, 3, 4]], [[2, 3, 4]],
             attrs={'consumed_inputs': [0]}
         )
 
-    def test_QLinearConv(self):  # type: () -> None
+    def test_QLinearConv(self) -> None:
         self._test_op_upgrade('QLinearConv', 10,
             [[1, 3, 5, 5], [], [], [4, 3, 2, 2], [], [], [], []], [[1, 4, 4, 4]]
         )
 
-    def test_QLinearMatMul(self):  # type: () -> None
+    def test_QLinearMatMul(self) -> None:
         self._test_op_upgrade('QLinearMatMul', 10, [[2, 3], [], [], [3, 4], [], [], [], []], [[2, 4]])
 
-    def test_QuantizeLinear(self):  # type: () -> None
+    def test_QuantizeLinear(self) -> None:
         self._test_op_upgrade('QuantizeLinear', 10, [[3, 4, 5], [], []], [[3, 4, 5]],
             [TensorProto.FLOAT, TensorProto.FLOAT, TensorProto.UINT8], [TensorProto.UINT8]
         )
 
-    def test_RandomNormal(self):  # type: () -> None
+    def test_RandomNormal(self) -> None:
         self._test_op_upgrade('RandomNormal', 1, [], [[3, 4, 5]], attrs={'shape': [3, 4, 5]})
 
-    def test_RandomNormalLike(self):  # type: () -> None
+    def test_RandomNormalLike(self) -> None:
         like = helper.make_tensor(
             'a',
             TensorProto.FLOAT,
@@ -736,10 +736,10 @@ class TestAutomaticUpgrade(unittest.TestCase):
             initializer=[like]
         )
 
-    def test_RandomUniform(self):  # type: () -> None
+    def test_RandomUniform(self) -> None:
         self._test_op_upgrade('RandomUniform', 1, [], [[3, 4, 5]], attrs={'shape': [3, 4, 5]})
 
-    def test_RandomUniformLike(self):  # type: () -> None
+    def test_RandomUniformLike(self) -> None:
         like = helper.make_tensor(
             'a',
             TensorProto.FLOAT,
@@ -750,7 +750,7 @@ class TestAutomaticUpgrade(unittest.TestCase):
             initializer=[like]
         )
 
-    def test_Range(self):  # type: () -> None
+    def test_Range(self) -> None:
         start = helper.make_tensor('a', TensorProto.FLOAT, dims=[], vals=np.array([0]))
         end = helper.make_tensor('b', TensorProto.FLOAT, dims=[], vals=np.array([12]))
         step = helper.make_tensor('c', TensorProto.FLOAT, dims=[], vals=np.array([2]))
@@ -758,68 +758,68 @@ class TestAutomaticUpgrade(unittest.TestCase):
             initializer=[start, end, step]
         )
 
-    def test_Reciprocal(self):  # type: () -> None
+    def test_Reciprocal(self) -> None:
         self._test_op_upgrade('Reciprocal', 1, attrs={'consumed_inputs': [0]})
 
-    def test_ReduceL1(self):  # type: () -> None
+    def test_ReduceL1(self) -> None:
         self._test_op_upgrade('ReduceL1', 1, [[3, 4, 5]], [[1, 1, 1]])
 
-    def test_ReduceL2(self):  # type: () -> None
+    def test_ReduceL2(self) -> None:
         self._test_op_upgrade('ReduceL2', 1, [[3, 4, 5]], [[1, 1, 1]])
 
-    def test_ReduceLogSum(self):  # type: () -> None
+    def test_ReduceLogSum(self) -> None:
         self._test_op_upgrade('ReduceLogSum', 1, [[3, 4, 5]], [[1, 1, 1]])
 
-    def test_ReduceLogSumExp(self):  # type: () -> None
+    def test_ReduceLogSumExp(self) -> None:
         self._test_op_upgrade('ReduceLogSumExp', 1, [[3, 4, 5]], [[1, 1, 1]])
 
-    def test_ReduceMean(self):  # type: () -> None
+    def test_ReduceMean(self) -> None:
         self._test_op_upgrade('ReduceMean', 1, [[3, 4, 5]], [[1, 1, 1]])
 
-    def test_ReduceMax(self):  # type: () -> None
+    def test_ReduceMax(self) -> None:
         self._test_op_upgrade('ReduceMax', 1, [[3, 4, 5]], [[1, 1, 1]])
 
-    def test_ReduceMin(self):  # type: () -> None
+    def test_ReduceMin(self) -> None:
         self._test_op_upgrade('ReduceMin', 1, [[3, 4, 5]], [[1, 1, 1]])
 
-    def test_ReduceProd(self):  # type: () -> None
+    def test_ReduceProd(self) -> None:
         self._test_op_upgrade('ReduceProd', 1, [[3, 4, 5]], [[1, 1, 1]])
 
-    def test_ReduceSum(self):  # type: () -> None
+    def test_ReduceSum(self) -> None:
         self._test_op_upgrade('ReduceSum', 1, [[3, 4, 5]], [[1, 1, 1]])
 
-    def test_ReduceSumSquare(self):  # type: () -> None
+    def test_ReduceSumSquare(self) -> None:
         self._test_op_upgrade('ReduceSumSquare', 1, [[3, 4, 5]], [[1, 1, 1]])
 
-    def test_Relu(self):  # type: () -> None
+    def test_Relu(self) -> None:
         self._test_op_upgrade('Relu', 1, attrs={'consumed_inputs': [0]})
 
-    def test_Reshape(self):  # type: () -> None
+    def test_Reshape(self) -> None:
         self._test_op_upgrade('Reshape', 1, [[3, 4, 5]], [[3, 10, 2]],
             attrs={'consumed_inputs': [0], 'shape': [3, 10, 2]}
         )
 
-    def test_Resize(self):  # type: () -> None
+    def test_Resize(self) -> None:
         self._test_op_upgrade('Resize', 10, [[3, 4, 5], [3]], [[3, 8, 15]])
 
-    def test_ReverseSequence(self):  # type: () -> None
+    def test_ReverseSequence(self) -> None:
         self._test_op_upgrade('ReverseSequence', 10, [[3, 4, 5], [4]], [[3, 4, 5]],
             [TensorProto.FLOAT, TensorProto.INT64]
         )
 
-    def test_RNN_1(self):  # type: () -> None
+    def test_RNN_1(self) -> None:
         # 6->7 adapter is missing
         self._test_op_upgrade('RNN', 7, [[5, 3, 4], [1, 6, 4], [1, 6, 4]], [[5, 1, 3, 6], [1, 3, 6]],
             attrs={'hidden_size': 6}
         )
 
-    def test_RNN_2(self):  # type: () -> None
+    def test_RNN_2(self) -> None:
         # 6->7 adapter is missing
         self._test_op_upgrade('RNN', 7, [[5, 3, 4], [2, 6, 4], [2, 6, 4]], [[5, 2, 3, 6], [2, 3, 6]],
             attrs={'hidden_size': 6, 'direction': 'bidirectional'}
         )
 
-    def test_RNN_3(self):  # type: () -> None
+    def test_RNN_3(self) -> None:
         # 6->7 adapter is missing
         self._test_op_upgrade('RNN', 7,
             [[5, 3, 4], [1, 6, 4], [1, 6, 4], [1, 12], [5], [1, 5, 6]],
@@ -828,53 +828,53 @@ class TestAutomaticUpgrade(unittest.TestCase):
             attrs={'hidden_size': 6}
         )
 
-    def test_RoiAlign_1(self):  # type: () -> None
+    def test_RoiAlign_1(self) -> None:
         self._test_op_upgrade('RoiAlign', 10, [[2, 3, 20, 20], [10, 4], [10]], [[10, 3, 1, 1]],
             [TensorProto.FLOAT, TensorProto.FLOAT, TensorProto.INT64]
         )
 
-    def test_RoiAlign_2(self):  # type: () -> None
+    def test_RoiAlign_2(self) -> None:
         self._test_op_upgrade('RoiAlign', 16, [[2, 3, 20, 20], [10, 4], [10]], [[10, 3, 1, 1]],
             [TensorProto.FLOAT, TensorProto.FLOAT, TensorProto.INT64],
             attrs={'coordinate_transformation_mode': 'half_pixel'}
         )
 
-    def test_Round(self):  # type: () -> None
+    def test_Round(self) -> None:
         self._test_op_upgrade('Round', 11)
 
-    def test_Scatter(self):  # type: () -> None
+    def test_Scatter(self) -> None:
         self._test_op_upgrade('Scatter', 9, [[2, 3], [1, 2], [1, 2]], [[2, 3]],
             [TensorProto.FLOAT, TensorProto.INT64, TensorProto.FLOAT],
             [TensorProto.FLOAT]
         )
 
-    def test_ScatterElements_1(self):  # type: () -> None
+    def test_ScatterElements_1(self) -> None:
         self._test_op_upgrade('ScatterElements', 11, [[2, 3], [1, 2], [1, 2]], [[2, 3]],
             [TensorProto.FLOAT, TensorProto.INT64, TensorProto.FLOAT],
             [TensorProto.FLOAT]
         )
 
-    def test_ScatterElements_2(self):  # type: () -> None
+    def test_ScatterElements_2(self) -> None:
         self._test_op_upgrade('ScatterElements', 16, [[2, 3], [1, 2], [1, 2]], [[2, 3]],
             [TensorProto.FLOAT, TensorProto.INT64, TensorProto.FLOAT],
             [TensorProto.FLOAT],
             attrs={'reduction': 'add'}
         )
 
-    def test_ScatterND_1(self):  # type: () -> None
+    def test_ScatterND_1(self) -> None:
         self._test_op_upgrade('ScatterND', 11, [[2, 3], [1, 2], [1, 2]], [[2, 3]],
             [TensorProto.FLOAT, TensorProto.INT64, TensorProto.FLOAT],
             [TensorProto.FLOAT]
         )
 
-    def test_ScatterND_2(self):  # type: () -> None
+    def test_ScatterND_2(self) -> None:
         self._test_op_upgrade('ScatterND', 16, [[2, 3], [1, 2], [1, 2]], [[2, 3]],
             [TensorProto.FLOAT, TensorProto.INT64, TensorProto.FLOAT],
             [TensorProto.FLOAT],
             attrs={'reduction': 'mul'}
         )
 
-    def test_Scan(self):  # type: () -> None
+    def test_Scan(self) -> None:
         sum_in = onnx.helper.make_tensor_value_info('sum_in', onnx.TensorProto.FLOAT, [2])
         next_in = onnx.helper.make_tensor_value_info('next_in', onnx.TensorProto.FLOAT, [2])
         sum_out = onnx.helper.make_tensor_value_info('sum_out', onnx.TensorProto.FLOAT, [2])
@@ -899,112 +899,112 @@ class TestAutomaticUpgrade(unittest.TestCase):
             attrs={'body': body, 'num_scan_inputs': 1}
         )
 
-    def test_Selu(self):  # type: () -> None
+    def test_Selu(self) -> None:
         self._test_op_upgrade('Selu', 1, attrs={'consumed_inputs': [0]})
 
-    def test_Shape(self):  # type: () -> None
+    def test_Shape(self) -> None:
         self._test_op_upgrade('Shape', 1, [[3, 4, 5]], [[3]], output_types=[TensorProto.INT64])
 
-    def test_Shrink(self):  # type: () -> None
+    def test_Shrink(self) -> None:
         self._test_op_upgrade('Shrink', 9)
 
-    def test_Sigmoid(self):  # type: () -> None
+    def test_Sigmoid(self) -> None:
         self._test_op_upgrade('Sigmoid', 1, attrs={'consumed_inputs': [0]})
 
-    def test_Sign(self):  # type: () -> None
+    def test_Sign(self) -> None:
         self._test_op_upgrade('Sign', 9)
 
-    def test_Sinh(self):  # type: () -> None
+    def test_Sinh(self) -> None:
         self._test_op_upgrade('Sinh', 9)
 
-    def test_Sin(self):  # type: () -> None
+    def test_Sin(self) -> None:
         self._test_op_upgrade('Sin', 7)
 
-    def test_Size(self):  # type: () -> None
+    def test_Size(self) -> None:
         self._test_op_upgrade('Size', 1, [[3, 4, 5]], [[]], output_types=[TensorProto.INT64])
 
-    def test_Slice(self):  # type: () -> None
+    def test_Slice(self) -> None:
         self._test_op_upgrade('Slice', 1, [[3, 4, 5]], [[3, 2, 2]],
             attrs={'axes': [1, 2], 'starts': [0, 1], 'ends': [2, 3]}
         )
 
-    def test_Softmax_0(self):  # type: () -> None
+    def test_Softmax_0(self) -> None:
         self._test_op_upgrade('Softmax', 1, attrs={'axis': 0})
 
-    def test_Softmax_1(self):  # type: () -> None
+    def test_Softmax_1(self) -> None:
         self._test_op_upgrade('Softmax', 1, attrs={'axis': 1})
 
-    def test_Softmax_2(self):  # type: () -> None
+    def test_Softmax_2(self) -> None:
         self._test_op_upgrade('Softmax', 1, attrs={'axis': 2})
 
-    def test_Softmax_3(self):  # type: () -> None
+    def test_Softmax_3(self) -> None:
         self._test_op_upgrade('Softmax', 1, attrs={'axis': -1})
 
-    def test_Softmax_4(self):  # type: () -> None
+    def test_Softmax_4(self) -> None:
         self._test_op_upgrade('Softmax', 1, attrs={'axis': -2})
 
-    def test_Softmax_5(self):  # type: () -> None
+    def test_Softmax_5(self) -> None:
         self._test_op_upgrade('Softmax', 1, attrs={'axis': -3})
 
-    def test_Softplus(self):  # type: () -> None
+    def test_Softplus(self) -> None:
         self._test_op_upgrade('Softplus', 1)
 
-    def test_Softsign(self):  # type: () -> None
+    def test_Softsign(self) -> None:
         self._test_op_upgrade('Softsign', 1)
 
-    def test_SoftmaxCrossEntropyLoss(self):  # type: () -> None
+    def test_SoftmaxCrossEntropyLoss(self) -> None:
         self._test_op_upgrade('SoftmaxCrossEntropyLoss', 12, [[3, 4, 5, 6], [3, 6]], [[]],
             [TensorProto.FLOAT, TensorProto.INT64]
         )
 
-    def test_SpaceToDepth(self):  # type: () -> None
+    def test_SpaceToDepth(self) -> None:
         self._test_op_upgrade('SpaceToDepth', 1, [[1, 3, 8, 8]], [[1, 12, 4, 4]],
             attrs={'blocksize': 2}
         )
 
-    def test_Split(self):  # type: () -> None
+    def test_Split(self) -> None:
         # 1->2 adapter is missing
         self._test_op_upgrade('Split', 2, [[3, 4, 7]], [[3, 4, 2], [3, 4, 1], [3, 4, 4]],
             attrs={'axis': 2, 'split': [2, 1, 4]}
         )
 
-    def test_Sqrt(self):  # type: () -> None
+    def test_Sqrt(self) -> None:
         self._test_op_upgrade('Sqrt', 1, attrs={'consumed_inputs': [0]})
 
-    def test_Squeeze(self):  # type: () -> None
+    def test_Squeeze(self) -> None:
         self._test_op_upgrade('Squeeze', 1, [[2, 1, 3, 4, 1]], [[2, 3, 4]])
 
-    def test_StringNormalizer(self):  # type: () -> None
+    def test_StringNormalizer(self) -> None:
         self._test_op_upgrade('StringNormalizer', 10, [[1, 3]], [[1, 3]],
             [TensorProto.STRING], [TensorProto.STRING],
             attrs={'case_change_action': 'LOWER'}
         )
 
-    def test_Sub(self):  # type: () -> None
+    def test_Sub(self) -> None:
         self._test_op_upgrade('Sub', 1, [[2, 3, 4], [2, 3, 4]], [[2, 3, 4]],
             attrs={'consumed_inputs': [0]}
         )
 
-    def test_Sum(self):  # type: () -> None
+    def test_Sum(self) -> None:
         self._test_op_upgrade('Sum', 1, [[2, 3, 4], [2, 3, 4]], [[2, 3, 4]],
             attrs={'consumed_inputs': [0]}
         )
 
-    def test_Tanh(self):  # type: () -> None
+    def test_Tanh(self) -> None:
         self._test_op_upgrade('Tanh', 1, attrs={'consumed_inputs': [0]})
 
-    def test_Tan(self):  # type: () -> None
+    def test_Tan(self) -> None:
         self._test_op_upgrade('Tan', 7)
 
-    def test_TfIdfVectorizer(self):  # type: () -> None
+    def test_TfIdfVectorizer(self) -> None:
         self._test_op_upgrade('TfIdfVectorizer', 9, [[3]], [[5]],
             attrs={'max_gram_length': 3, 'max_skip_count': 1, 'min_gram_length': 2, 'mode': 'TFIDF', 'ngram_counts': [0, 20], 'ngram_indexes': [3, 4]}
         )
 
-    def test_ThresholdedRelu(self):  # type: () -> None
+    def test_ThresholdedRelu(self) -> None:
         self._test_op_upgrade('ThresholdedRelu', 10)
 
-    def test_Tile(self):  # type: () -> None
+    def test_Tile(self) -> None:
         # 5->6 adapter is missing
         repeats = helper.make_tensor('b', TensorProto.INT64, dims=[3], vals=np.array([1, 2, 3]))
         self._test_op_upgrade('Tile', 6, [[3, 4, 5], [3]], [[3, 8, 15]],
@@ -1012,55 +1012,55 @@ class TestAutomaticUpgrade(unittest.TestCase):
             initializer=[repeats]
         )
 
-    def test_TopK(self):  # type: () -> None
+    def test_TopK(self) -> None:
         self._test_op_upgrade('TopK', 1, [[3, 4, 5]], [[3, 4, 2], [3, 4, 2]],
             output_types=[TensorProto.FLOAT, TensorProto.INT64],
             attrs={'k': 2}
         )
 
-    def test_Transpose(self):  # type: () -> None
+    def test_Transpose(self) -> None:
         self._test_op_upgrade('Transpose', 1, [[1, 2, 5, 3, 7]], [[1, 7, 5, 2, 3]],
             attrs={'perm': [0, 4, 2, 1, 3]}
         )
 
-    def test_Trilu(self):  # type: () -> None
+    def test_Trilu(self) -> None:
         self._test_op_upgrade('Trilu', 14)
 
-    def test_Unique_1(self):  # type: () -> None
+    def test_Unique_1(self) -> None:
         self._test_op_upgrade('Unique', 11, [[3, 4, 5]], [[None]])
 
-    def test_Unique_2(self):  # type: () -> None
+    def test_Unique_2(self) -> None:
         self._test_op_upgrade('Unique', 11, [[3, 4, 5]], [[3, None, 5]],
             attrs={'axis': 1}
         )
 
-    def test_Unsqueeze(self):  # type: () -> None
+    def test_Unsqueeze(self) -> None:
         self._test_op_upgrade('Unsqueeze', 1, [[3, 4, 5]], [[3, 4, 1, 5]], attrs={'axes': [2]})
 
-    def test_Upsample(self):  # type: () -> None
+    def test_Upsample(self) -> None:
         self._test_op_upgrade('Upsample', 1, [[1, 3, 4, 5]], [[1, 3, 6, 10]],
             attrs={'width_scale': 2., 'height_scale': 1.5}
         )
 
-    def test_Where(self):  # type: () -> None
+    def test_Where(self) -> None:
         self._test_op_upgrade('Where', 9, [[2, 3], [2, 3], [2, 3]], [[2, 3]],
             [TensorProto.BOOL, TensorProto.FLOAT, TensorProto.FLOAT]
         )
 
-    def test_Xor(self):  # type: () -> None
+    def test_Xor(self) -> None:
         # 6->7 adapter is missing
         self._test_op_upgrade('Xor', 7, [[2, 3], [2, 3]], [[2, 3]],
             [TensorProto.BOOL, TensorProto.BOOL], [TensorProto.BOOL]
         )
 
-    def test_CastLike(self):  # type: () -> None
+    def test_CastLike(self) -> None:
         self._test_op_upgrade('CastLike', 15,
             [[2, 3, 4], [2, 1, 4]],
             [[2, 3, 4]],
             input_types=[TensorProto.FLOAT, TensorProto.FLOAT16],
             output_types=[TensorProto.FLOAT16])
 
-    def test_ops_tested(self):  # type: () -> None
+    def test_ops_tested(self) -> None:
         all_schemas = onnx.defs.get_all_schemas()
         all_op_names = [schema.name for schema in all_schemas if schema.domain == '']
         excluded_ops = [

--- a/onnx/test/basic_test.py
+++ b/onnx/test/basic_test.py
@@ -18,13 +18,13 @@ from onnx import helper
 
 class TestBasicFunctions(unittest.TestCase):
 
-    def _simple_model(self):  # type: () -> ModelProto
+    def _simple_model(self) -> ModelProto:
         # Create a ModelProto.
         model = ModelProto()
         model.ir_version = IR_VERSION
         return model
 
-    def _simple_tensor(self):  # type: () -> TensorProto
+    def _simple_tensor(self) -> TensorProto:
         # Create a TensorProto.
         tensor = helper.make_tensor(
             name='test-tensor',
@@ -34,7 +34,7 @@ class TestBasicFunctions(unittest.TestCase):
         )
         return tensor
 
-    def test_save_and_load_model(self):  # type: () -> None
+    def test_save_and_load_model(self) -> None:
         proto = self._simple_model()
         cls = ModelProto
         proto_string = onnx._serialize(proto)
@@ -61,7 +61,7 @@ class TestBasicFunctions(unittest.TestCase):
         finally:
             os.remove(fi.name)
 
-    def test_save_and_load_tensor(self):  # type: () -> None
+    def test_save_and_load_tensor(self) -> None:
         proto = self._simple_tensor()
         cls = TensorProto
         proto_string = onnx._serialize(proto)
@@ -88,7 +88,7 @@ class TestBasicFunctions(unittest.TestCase):
         finally:
             os.remove(tfile.name)
 
-    def test_existence(self):  # type: () -> None
+    def test_existence(self) -> None:
         try:
             AttributeProto
             NodeProto
@@ -99,7 +99,7 @@ class TestBasicFunctions(unittest.TestCase):
                 'Did not find proper onnx protobufs. Error is: {}'
                 .format(e))
 
-    def test_version_exists(self):  # type: () -> None
+    def test_version_exists(self) -> None:
         model = ModelProto()
         # When we create it, graph should not have a version string.
         self.assertFalse(model.HasField('ir_version'))

--- a/onnx/test/checker_test.py
+++ b/onnx/test/checker_test.py
@@ -17,7 +17,7 @@ import onnx.defs
 
 class TestChecker(unittest.TestCase):
     @property
-    def _sample_float_tensor(self):  # type: () -> TensorProto
+    def _sample_float_tensor(self) -> TensorProto:
         np_array = np.random.randn(2, 3).astype(np.float32)
         return helper.make_tensor(
             name='test',
@@ -27,12 +27,12 @@ class TestChecker(unittest.TestCase):
         )
 
     def make_sparse(self,
-                    shape,  # type: Sequence[int]
-                    values,  # type: Sequence[int]
-                    indices_shape,  # type: Sequence[int]
-                    indices,  # type: Sequence[int]
-                    name='spval'  # type: Text
-                    ):  # type: (...) -> SparseTensorProto
+                    shape: Sequence[int],
+                    values: Sequence[int],
+                    indices_shape: Sequence[int],
+                    indices: Sequence[int],
+                    name: Text = 'spval'
+                    ) -> SparseTensorProto:
         sparse = SparseTensorProto()
         sparse.dims.extend(shape)
         nnz = len(values)
@@ -41,13 +41,13 @@ class TestChecker(unittest.TestCase):
         sparse.indices.CopyFrom(helper.make_tensor('spind', TensorProto.INT64, indices_shape, indices))
         return sparse
 
-    def test_check_node(self):  # type: () -> None
+    def test_check_node(self) -> None:
         node = helper.make_node(
             "Relu", ["X"], ["Y"], name="test")
 
         checker.check_node(node)
 
-    def test_check_node_input_marked_optional(self):  # type: () -> None
+    def test_check_node_input_marked_optional(self) -> None:
         # GivenTensorFill's input is marked optional, hence it is used in this test.
         node = helper.make_node(
             "GivenTensorFill", [], ["Y"], name="test")
@@ -62,12 +62,12 @@ class TestChecker(unittest.TestCase):
             "Relu", [""], ["Y"], name="test")
         self.assertRaises(checker.ValidationError, checker.check_node, node)
 
-    def test_check_graph_ir_version_3(self):  # type: () -> None
+    def test_check_graph_ir_version_3(self) -> None:
         ctx = C.CheckerContext()
         ctx.ir_version = 3
         ctx.opset_imports = {'': onnx.defs.onnx_opset_version()}
 
-        def check_ir_version_3(g):   # type: (GraphProto) -> None
+        def check_ir_version_3(g: GraphProto) -> None:
             checker.check_graph(g, ctx)
 
         node = helper.make_node(
@@ -88,7 +88,7 @@ class TestChecker(unittest.TestCase):
         graph.initializer[0].name = 'X'
         check_ir_version_3(graph)
 
-    def test_check_graph(self):  # type: () -> None
+    def test_check_graph(self) -> None:
         node = helper.make_node(
             "Relu", ["X"], ["Y"], name="test")
         graph = helper.make_graph(
@@ -106,7 +106,7 @@ class TestChecker(unittest.TestCase):
         graph.initializer[0].name = 'X'
         checker.check_graph(graph)
 
-    def test_check_graph_types(self):  # type: () -> None
+    def test_check_graph_types(self) -> None:
         # This is for https://github.com/onnx/onnx/issues/3849.
         # It confirms that type checking is performed
         # when checker.check_model is called with full_check=True
@@ -146,7 +146,7 @@ class TestChecker(unittest.TestCase):
 
         checker.check_graph(graph)
 
-    def test_check_graph_empty_initializer_name(self):  # type: () -> None
+    def test_check_graph_empty_initializer_name(self) -> None:
         node = helper.make_node(
             "Relu", ["X"], ["Y"], name="test")
         graph = helper.make_graph(
@@ -161,7 +161,7 @@ class TestChecker(unittest.TestCase):
         graph.initializer[0].name = ''
         self.assertRaises(checker.ValidationError, checker.check_graph, graph)
 
-    def test_check_graph_empty_sparse_initializer_name(self):  # type: () -> None
+    def test_check_graph_empty_sparse_initializer_name(self) -> None:
         node = helper.make_node(
             "Relu", ["X"], ["Y"], name="test")
         graph = helper.make_graph(
@@ -176,7 +176,7 @@ class TestChecker(unittest.TestCase):
         graph.sparse_initializer.extend([sparse])
         self.assertRaises(checker.ValidationError, checker.check_graph, graph)
 
-    def test_check_graph_duplicate_init_names(self):  # type: () -> None
+    def test_check_graph_duplicate_init_names(self) -> None:
         node = helper.make_node(
             "Relu", ["X"], ["Y"], name="test")
         graph = helper.make_graph(
@@ -194,7 +194,7 @@ class TestChecker(unittest.TestCase):
         graph.sparse_initializer.extend([sparse])
         self.assertRaises(checker.ValidationError, checker.check_graph, graph)
 
-    def test_check_graph_optional_input(self):  # type: () -> None
+    def test_check_graph_optional_input(self) -> None:
         # GivenTensorFill's input is marked optional, hence it is used in this test.
         node = helper.make_node(
             "GivenTensorFill", [""], ["Y"], name="test")
@@ -205,7 +205,7 @@ class TestChecker(unittest.TestCase):
             [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 2])])
         checker.check_graph(graph)
 
-    def test_check_graph_ssa(self):  # type: () -> None
+    def test_check_graph_ssa(self) -> None:
         relu1 = helper.make_node(
             "Relu", ["X"], ["Z"], name="relu1")
         relu2 = helper.make_node(
@@ -224,7 +224,7 @@ class TestChecker(unittest.TestCase):
         )
         self.assertRaises(checker.ValidationError, checker.check_graph, graph)
 
-    def test_check_graph_topologically_sorted(self):  # type: () -> None
+    def test_check_graph_topologically_sorted(self) -> None:
         n1 = helper.make_node(
             "Scale", ["X"], ["Y"], scale=2., name="n1")
         n2 = helper.make_node(
@@ -242,7 +242,7 @@ class TestChecker(unittest.TestCase):
         )
         self.assertRaises(checker.ValidationError, checker.check_graph, graph)
 
-    def test_check_model(self):  # type: () -> None
+    def test_check_model(self) -> None:
         node = helper.make_node(
             "Relu", ["X"], ["Y"], name="test")
         graph = helper.make_graph(
@@ -254,7 +254,7 @@ class TestChecker(unittest.TestCase):
 
         checker.check_model(model)
 
-    def test_check_serialized_model(self):  # type: () -> None
+    def test_check_serialized_model(self) -> None:
         node = helper.make_node(
             "Relu", ["X"], ["Y"], name="test")
         graph = helper.make_graph(
@@ -266,7 +266,7 @@ class TestChecker(unittest.TestCase):
 
         checker.check_model(model.SerializeToString())
 
-    def test_check_old_model(self):  # type: () -> None
+    def test_check_old_model(self) -> None:
         node = helper.make_node(
             "Pad", ["X"], ["Y"], paddings=(0, 0, 0, 0))
         graph = helper.make_graph(
@@ -279,14 +279,14 @@ class TestChecker(unittest.TestCase):
 
         checker.check_model(model)
 
-    def test_check_tensor(self):  # type: () -> None
+    def test_check_tensor(self) -> None:
         tensor = self._sample_float_tensor
         checker.check_tensor(tensor)
 
         tensor.raw_data = np.random.randn(2, 3).astype(np.float32).tobytes()
         self.assertRaises(checker.ValidationError, checker.check_tensor, tensor)
 
-    def test_check_string_tensor(self):  # type: () -> None
+    def test_check_string_tensor(self) -> None:
         tensor = TensorProto()
         tensor.data_type = TensorProto.STRING
         tensor.dims.append(1)
@@ -298,12 +298,12 @@ class TestChecker(unittest.TestCase):
         # string data should not be stored in raw_data field
         self.assertRaises(checker.ValidationError, checker.check_tensor, tensor)
 
-    def test_check_tensor_mismatched_field(self):  # type: () -> None
+    def test_check_tensor_mismatched_field(self) -> None:
         tensor = self._sample_float_tensor
         tensor.data_type = TensorProto.INT32
         self.assertRaises(checker.ValidationError, checker.check_tensor, tensor)
 
-    def test_nested_graph(self):  # type: () -> None
+    def test_nested_graph(self) -> None:
         n1 = helper.make_node(
             "Scale", ["X"], ["Y"], scale=2., name="n1")
         n2 = helper.make_node(
@@ -333,7 +333,7 @@ class TestChecker(unittest.TestCase):
 
         checker.check_graph(graph)
 
-    def test_nested_graph_without_subgraph_input_shape(self):  # type: () -> None
+    def test_nested_graph_without_subgraph_input_shape(self) -> None:
         n1 = helper.make_node(
             "Scale", ["X"], ["Y"], scale=2., name="n1")
         n2 = helper.make_node(
@@ -366,7 +366,7 @@ class TestChecker(unittest.TestCase):
         checker.check_graph(graph)
 
     @property
-    def _sample_0_elem_tensor(self):  # type: () -> TensorProto
+    def _sample_0_elem_tensor(self) -> TensorProto:
         np_array = np.random.randn(0, 3).astype(np.float32)
         return helper.make_tensor(
             name='test',
@@ -375,16 +375,16 @@ class TestChecker(unittest.TestCase):
             vals=np_array.reshape(0).tolist()
         )
 
-    def test_check_tensor_zero_elem(self):  # type: () -> None
+    def test_check_tensor_zero_elem(self) -> None:
         tensor = self._sample_0_elem_tensor
         checker.check_tensor(tensor)
 
-    def test_check_removed_experimental_op(self):  # type: () -> None
+    def test_check_removed_experimental_op(self) -> None:
         node = helper.make_node(
             "ConstantFill", [], ["Y"], name="test", shape=[1, 2])
         checker.check_node(node)
 
-    def test_skip_schema_check_on_non_standard_domain(self):  # type: () -> None
+    def test_skip_schema_check_on_non_standard_domain(self) -> None:
         node = helper.make_node(
             "NonExistOp", ["X"], ["Y"], name="test", domain="test.domain")
         graph = helper.make_graph(
@@ -397,37 +397,37 @@ class TestChecker(unittest.TestCase):
                                   opset_imports=[onnx_id])
         checker.check_model(model)
 
-    def test_check_sparse_tensor(self):  # type: () -> None
+    def test_check_sparse_tensor(self) -> None:
         sparse = self.make_sparse([100], [13, 17, 19], [3], [9, 27, 81])
         checker.check_sparse_tensor(sparse)
 
-    def test_check_sparse_tensor_invalid_index(self):  # type: () -> None
+    def test_check_sparse_tensor_invalid_index(self) -> None:
         # index value 181 is out-of-range
         sparse = self.make_sparse([100], [13, 17, 19], [3], [9, 27, 181])
         self.assertRaises(checker.ValidationError, checker.check_sparse_tensor, sparse)
 
-    def test_check_sparse_tensor_unordered(self):  # type: () -> None
+    def test_check_sparse_tensor_unordered(self) -> None:
         # index values are not in sorted order
         sparse = self.make_sparse([100], [13, 17, 19], [3], [27, 9, 81])
         self.assertRaises(checker.ValidationError, checker.check_sparse_tensor, sparse)
 
-    def test_check_sparse_tensor_coo_format(self):  # type: () -> None
+    def test_check_sparse_tensor_coo_format(self) -> None:
         sparse = self.make_sparse([10, 10], [13, 17, 19], [3, 2], [0, 9, 2, 7, 8, 1])
         checker.check_sparse_tensor(sparse)
 
-    def test_check_sparse_tensor_coo_format_invalid_index(self):  # type: () -> None
+    def test_check_sparse_tensor_coo_format_invalid_index(self) -> None:
         sparse = self.make_sparse([10, 10], [13, 17, 19], [3, 2], [0, 9, 0, 27, 8, 1])
         self.assertRaises(checker.ValidationError, checker.check_sparse_tensor, sparse)
 
-    def test_check_sparse_tensor_coo_format_invalid_shape(self):  # type: () -> None
+    def test_check_sparse_tensor_coo_format_invalid_shape(self) -> None:
         sparse = self.make_sparse([10, 10], [13, 17, 19], [2, 3], [0, 9, 2, 7, 8, 1])
         self.assertRaises(checker.ValidationError, checker.check_sparse_tensor, sparse)
 
-    def test_check_sparse_tensor_coo_format_invalid_dim2(self):  # type: () -> None
+    def test_check_sparse_tensor_coo_format_invalid_dim2(self) -> None:
         sparse = self.make_sparse([10, 10], [13, 17, 19], [3, 1], [0, 1, 2])
         self.assertRaises(checker.ValidationError, checker.check_sparse_tensor, sparse)
 
-    def test_check_sparse_matmul(self):  # type: () -> None
+    def test_check_sparse_matmul(self) -> None:
         M = 5
         N = 10
         # Create ValueInfoProto for input X of shape [N]
@@ -444,7 +444,7 @@ class TestChecker(unittest.TestCase):
         # check graph
         checker.check_graph(graph)
 
-    def test_check_model_unsupported_input_type(self):  # type: () -> None
+    def test_check_model_unsupported_input_type(self) -> None:
         N = 10
         X = helper.make_tensor_value_info('X', TensorProto.BOOL, [N])
         Y = helper.make_tensor_value_info('Y', TensorProto.FLOAT, [N])
@@ -455,7 +455,7 @@ class TestChecker(unittest.TestCase):
         model = helper.make_model(graph, producer_name='test', opset_imports=[onnx_id])
         self.assertRaises(shape_inference.InferenceError, checker.check_model, model, True)
 
-    def test_check_model_inconsistent_type(self):  # type: () -> None
+    def test_check_model_inconsistent_type(self) -> None:
         N = 10
         X = helper.make_tensor_value_info('X', TensorProto.FLOAT, [N])
         Y = helper.make_tensor_value_info('Y', TensorProto.INT32, [N])
@@ -466,7 +466,7 @@ class TestChecker(unittest.TestCase):
         model = helper.make_model(graph, producer_name='test', opset_imports=[onnx_id])
         self.assertRaises(shape_inference.InferenceError, checker.check_model, model, True)
 
-    def test_check_model_unsupported_output_type(self):  # type: () -> None
+    def test_check_model_unsupported_output_type(self) -> None:
         N = 10
         X = helper.make_tensor_value_info('X', TensorProto.FLOAT, [N])
         Y = helper.make_tensor_value_info('Y', TensorProto.FLOAT, [N])
@@ -477,7 +477,7 @@ class TestChecker(unittest.TestCase):
         model = helper.make_model(graph, producer_name='test', opset_imports=[onnx_id])
         self.assertRaises(shape_inference.InferenceError, checker.check_model, model, True)
 
-    def test_loop_with_same_initializer_input_below_ir4(self):  # type: () -> None
+    def test_loop_with_same_initializer_input_below_ir4(self) -> None:
         # This is for testing IR<4: tensors must exist both in initializer and input
         # shape_inference should allow different number of graph input and node input for Loop
         # Comes from a tf2onnx model
@@ -541,7 +541,7 @@ class TestChecker(unittest.TestCase):
         # Should not throw an error
         checker.check_model(model, full_check=True)
 
-    def test_loop_with_different_initializer_input_below_ir4(self):  # type: () -> None
+    def test_loop_with_different_initializer_input_below_ir4(self) -> None:
         # This is for testing IR<4: tensors must exist both in initializer and input
         # Testing an optional input which does not exist in initializers
         # Checker should throw an error said the missing input is not in initializers
@@ -603,7 +603,7 @@ class TestChecker(unittest.TestCase):
         )
         self.assertRaises(shape_inference.InferenceError, checker.check_model, model, True)
 
-    def test_loop_with_same_initializer_input_above_ir4(self):  # type: () -> None
+    def test_loop_with_same_initializer_input_above_ir4(self) -> None:
         # This is for testing IR>=4:
         # Cannot use the same name as both a subgraph initializer and subgraph input
 

--- a/onnx/test/compose_test.py
+++ b/onnx/test/compose_test.py
@@ -15,7 +15,7 @@ from onnx import helper, parser, checker, compose, version_converter, \
     FunctionProto, NodeProto
 
 
-def _load_model(m_def):  # type: (Text) -> ModelProto
+def _load_model(m_def: Text) -> ModelProto:
     '''
     Parses a model from a string representation, including checking the model for correctness
     '''
@@ -24,14 +24,14 @@ def _load_model(m_def):  # type: (Text) -> ModelProto
     return m
 
 
-def _prefixed(prefix, s):  # type: (Text, Text) -> Text
+def _prefixed(prefix: Text, s: Text) -> Text:
     '''
     Prefixes a string (if not empty)
     '''
     return prefix + s if len(s) > 0 else s
 
 
-def _get_shape(value_info):  # type: (ValueInfoProto) -> List[int]
+def _get_shape(value_info: ValueInfoProto) -> List[int]:
     '''
     Returns a list of integers representing the shape of the provided ValueInfoProto
     '''
@@ -39,7 +39,7 @@ def _get_shape(value_info):  # type: (ValueInfoProto) -> List[int]
             for d in range(len(value_info.type.tensor_type.shape.dim))]
 
 
-def _make_sparse_tensor(name):  # type: (Text) -> SparseTensorProto
+def _make_sparse_tensor(name: Text) -> SparseTensorProto:
     dense_shape = [3, 3]
     linear_indices = [2, 3, 5]
     sparse_values = [1.7, 0.4, 0.9]
@@ -85,15 +85,15 @@ m2_def = '''
 class TestComposeFunctions(unittest.TestCase):
     def _test_merge_models(
         self,
-        m1def,  # type: Text
-        m2def,  # type: Text
-        io_map,  # type: List[Tuple[Text, Text]]
-        check_expectations,  # type: Callable[[GraphProto, GraphProto, GraphProto], None]
-        inputs=None,  # type: Optional[List[Text]]
-        outputs=None,  # type: Optional[List[Text]]
-        prefix1=None,  # type: Optional[Text]
-        prefix2=None  # type: Optional[Text]
-    ):  # type: (...) -> None
+        m1def: Text,
+        m2def: Text,
+        io_map: List[Tuple[Text, Text]],
+        check_expectations: Callable[[GraphProto, GraphProto, GraphProto], None],
+        inputs: Optional[List[Text]] = None,
+        outputs: Optional[List[Text]] = None,
+        prefix1: Optional[Text] = None,
+        prefix2: Optional[Text] = None
+    ) -> None:
         m1, m2 = _load_model(m1def), _load_model(m2def)
         g3 = compose.merge_graphs(
             m1.graph, m2.graph, io_map=io_map,
@@ -110,12 +110,12 @@ class TestComposeFunctions(unittest.TestCase):
         checker.check_model(m3)
         check_expectations(m1.graph, m2.graph, m3.graph)
 
-    def test_case_connect_all_no_name_collision(self):  # type: () -> None
+    def test_case_connect_all_no_name_collision(self) -> None:
         '''
         Tests a simple scenario where two models without overlapping names are merged by
         connecting all the outputs in the first models to all the inputs in the second model
         '''
-        def check_expectations(g1, g2, g3):  # type: (GraphProto, GraphProto, GraphProto) -> None
+        def check_expectations(g1: GraphProto, g2: GraphProto, g3: GraphProto) -> None:
             self.assertEqual(g3.input, g1.input)
             self.assertEqual(g3.output, g2.output)
             self.assertEqual(['Add', 'Sub', 'Mul', 'Add', 'Sub', 'Mul'],
@@ -123,12 +123,12 @@ class TestComposeFunctions(unittest.TestCase):
         io_map = [("B00", "B01"), ("B10", "B11"), ("B20", "B21")]
         self._test_merge_models(m1_def, m2_def, io_map, check_expectations)
 
-    def test_case_connect_same_output_twice(self):  # type: () -> None
+    def test_case_connect_same_output_twice(self) -> None:
         '''
         Tests a scenario where we merge two models by connecting a single output in the first model
         to all the inputs in the second
         '''
-        def check_expectations(g1, g2, g3):  # type: (GraphProto, GraphProto, GraphProto) -> None
+        def check_expectations(g1: GraphProto, g2: GraphProto, g3: GraphProto) -> None:
             self.assertEqual(g3.input, g1.input)
             self.assertEqual(['B10', 'B20', 'D0'], [elem.name for elem in g3.output])
             self.assertEqual(['Add', 'Sub', 'Mul', 'Add', 'Sub', 'Mul'],
@@ -136,12 +136,12 @@ class TestComposeFunctions(unittest.TestCase):
         io_map = [("B00", "B01"), ("B00", "B11"), ("B00", "B21")]
         self._test_merge_models(m1_def, m2_def, io_map, check_expectations)
 
-    def test_case_connect_same_output_drop_outputs(self):  # type: () -> None
+    def test_case_connect_same_output_drop_outputs(self) -> None:
         '''
         Tests a scenario where we merge two models by connecting a single output in the first model
         to all the inputs in the second, while dropping the rest of the outputs in the first model
         '''
-        def check_expectations(g1, g2, g3):  # type: (GraphProto, GraphProto, GraphProto) -> None
+        def check_expectations(g1: GraphProto, g2: GraphProto, g3: GraphProto) -> None:
             self.assertEqual(g3.input, g1.input)
             self.assertEqual(['D0'], [elem.name for elem in g3.output])
             self.assertEqual(['Add', 'Add', 'Sub', 'Mul'], [item.op_type for item in g3.node])
@@ -149,7 +149,7 @@ class TestComposeFunctions(unittest.TestCase):
         outputs = ['D0']
         self._test_merge_models(m1_def, m2_def, io_map, check_expectations, outputs=outputs)
 
-    def test_case_connect_same_input_output_name(self):  # type: () -> None
+    def test_case_connect_same_input_output_name(self) -> None:
         '''
         Tests a scenario where we merge two models, where the inputs/outputs connected
         are named exactly the same
@@ -177,12 +177,12 @@ class TestComposeFunctions(unittest.TestCase):
             '''
         io_map = [("B", "B")]
 
-        def check_expectations(g1, g2, g3):  # type: (GraphProto, GraphProto, GraphProto) -> None
+        def check_expectations(g1: GraphProto, g2: GraphProto, g3: GraphProto) -> None:
             self.assertEqual(['A'], [elem.name for elem in g3.input])
             self.assertEqual(['C'], [elem.name for elem in g3.output])
         self._test_merge_models(m1_def, m2_def, io_map, check_expectations)
 
-    def test_case_drop_inputs_outputs(self):  # type: () -> None
+    def test_case_drop_inputs_outputs(self) -> None:
         '''
         Tests a scenario where we merge two models, not including some of the inputs/outputs
         '''
@@ -211,7 +211,7 @@ class TestComposeFunctions(unittest.TestCase):
             '''
         io_map = [("A1", "B2")]
 
-        def check_expectations(g1, g2, g3):  # type: (GraphProto, GraphProto, GraphProto) -> None
+        def check_expectations(g1: GraphProto, g2: GraphProto, g3: GraphProto) -> None:
             self.assertEqual(['A0'], [elem.name for elem in g3.input])
             self.assertEqual(['B3'], [elem.name for elem in g3.output])
             self.assertEqual(['Add', 'Sub'], [elem.op_type for elem in g3.node])
@@ -221,7 +221,7 @@ class TestComposeFunctions(unittest.TestCase):
         self._test_merge_models(
             m1_def, m2_def, io_map, check_expectations, inputs=inputs, outputs=outputs)
 
-    def test_case_name_collision_prefix(self):  # type: () -> None
+    def test_case_name_collision_prefix(self) -> None:
         '''
         Tests a scenario where we merge two models that have name collisions, but they
         are avoided by prefixing the models model.
@@ -239,7 +239,7 @@ class TestComposeFunctions(unittest.TestCase):
             '''
         io_map = [("C", "A")]
 
-        def check_expectations(g1, g2, g3):  # type: (GraphProto, GraphProto, GraphProto) -> None
+        def check_expectations(g1: GraphProto, g2: GraphProto, g3: GraphProto) -> None:
             self.assertEqual(['m1/A', 'm1/B', 'm2/B'], [elem.name for elem in g3.input])
             self.assertEqual(['m2/C'], [elem.name for elem in g3.output])
             self.assertEqual(['Add', 'Add'], [elem.op_type for elem in g3.node])
@@ -247,13 +247,13 @@ class TestComposeFunctions(unittest.TestCase):
         self._test_merge_models(
             m1_def, m1_def, io_map, check_expectations, prefix1='m1/', prefix2='m2/')
 
-    def test_case_connect_partially_no_name_collision(self):  # type: () -> None
+    def test_case_connect_partially_no_name_collision(self) -> None:
         '''
         Tests a scenario where two models without overlapping names are merged by
         connecting some outputs from the first model to some inputs in the second.
         The remaining inputs/outputs should be present in the combined model
         '''
-        def check_expectations(g1, g2, g4):  # type: (GraphProto, GraphProto, GraphProto) -> None
+        def check_expectations(g1: GraphProto, g2: GraphProto, g4: GraphProto) -> None:
             # B20 <-> B21 not connected. They should still be present
             # in the inputs and outputs of the combined graph
             self.assertEqual(['A0', 'A1', 'B21'], [elem.name for elem in g4.input])
@@ -261,7 +261,7 @@ class TestComposeFunctions(unittest.TestCase):
         io_map = [("B00", "B01"), ("B10", "B11")]
         self._test_merge_models(m1_def, m2_def, io_map, check_expectations)
 
-    def test_merge_models_with_metadata_props(self):  # type: () -> None
+    def test_merge_models_with_metadata_props(self) -> None:
         m1 = _load_model(m1_def)
         helper.set_model_props(m1, {'p1': 'v1', 'p2': 'v2'})
 
@@ -282,7 +282,7 @@ class TestComposeFunctions(unittest.TestCase):
         self.assertRaises(ValueError,
                           compose.merge_models, m1, m2, io_map=io_map)
 
-    def test_error_wrong_input_output_name(self):  # type: () -> None
+    def test_error_wrong_input_output_name(self) -> None:
         '''
         Tests that providing a non existing output/input name in the io_map argument produces an error.
         '''
@@ -297,7 +297,7 @@ class TestComposeFunctions(unittest.TestCase):
                           compose.merge_models, m1, m2,
                           io_map=[("B00", "wrong_input"), ("B10", "B11"), ("B20", "B21")])
 
-    def test_error_ir_version_mismatch(self):  # type: () -> None
+    def test_error_ir_version_mismatch(self) -> None:
         m1 = _load_model('''
     <
         ir_version: 7,
@@ -324,7 +324,7 @@ class TestComposeFunctions(unittest.TestCase):
                           compose.merge_models, m1, m2,
                           io_map=[("Y0", "X1")])
 
-    def test_error_opset_import_mismatch(self):  # type: () -> None
+    def test_error_opset_import_mismatch(self) -> None:
         '''
         Tests that providing models with different operator set imported produces an error
         '''
@@ -344,10 +344,10 @@ class TestComposeFunctions(unittest.TestCase):
         checker.check_model(m3)
 
     def _test_add_prefix(self,
-                         rename_nodes=False, rename_edges=False,
-                         rename_inputs=False, rename_outputs=False,
-                         rename_initializers=False, rename_value_infos=False,
-                         inplace=False):  # type: (bool, bool, bool, bool, bool, bool, bool) -> None
+                         rename_nodes: bool = False, rename_edges: bool = False,
+                         rename_inputs: bool = False, rename_outputs: bool = False,
+                         rename_initializers: bool = False, rename_value_infos: bool = False,
+                         inplace: bool = False) -> None:
         m1 = _load_model(m1_def)
 
         prefix = 'pre/'
@@ -432,50 +432,50 @@ class TestComposeFunctions(unittest.TestCase):
                 for n1, n0 in zip(g_out.node, g_in.node):
                     self.assertEqual(_prefixed(prefix, n0.name), n1.name)
 
-    def test_add_prefix_nodes(self):  # type: () -> None
+    def test_add_prefix_nodes(self) -> None:
         '''
         Tests renaming nodes only
         '''
         self._test_add_prefix(rename_nodes=True)
 
-    def test_add_prefix_edges(self):  # type: () -> None
+    def test_add_prefix_edges(self) -> None:
         '''
         Tests prefixing nodes edges. This will also rename inputs/outputs, since the names are shared
         '''
         self._test_add_prefix(rename_edges=True)
 
-    def test_add_prefix_inputs(self):  # type: () -> None
+    def test_add_prefix_inputs(self) -> None:
         '''
         Tests prefixing graph inputs only. Relevant node edges should be renamed as well
         '''
         self._test_add_prefix(rename_inputs=True)
 
-    def test_add_prefix_outputs(self):  # type: () -> None
+    def test_add_prefix_outputs(self) -> None:
         '''
         Tests prefixing graph outputs only. Relevant node edges should be renamed as well
         '''
         self._test_add_prefix(rename_outputs=True)
 
-    def test_add_prefix_all(self):  # type: () -> None
+    def test_add_prefix_all(self) -> None:
         '''
         Tests prefixing all names in the graph
         '''
         self._test_add_prefix(True, True, True, True, True, True)
 
-    def test_add_prefix_inplace(self):  # type: () -> None
+    def test_add_prefix_inplace(self) -> None:
         '''
         Tests prefixing inplace
         '''
         self._test_add_prefix(inplace=True)
 
-    def test_expand_out_dim(self):  # type: () -> None
+    def test_expand_out_dim(self) -> None:
         '''
         Tests expanding output dimensions. The resulting graph should have the same output names,
         but with one more dimension at the specified index.
         '''
         m1 = _load_model(m1_def)
 
-        def _check_model(m1, m2, dim_idx):  # type: (ModelProto, ModelProto, int) -> None
+        def _check_model(m1: ModelProto, m2: ModelProto, dim_idx: int) -> None:
             for out_g2, out_g1 in zip(m2.graph.output, m1.graph.output):
                 self.assertEqual(out_g2.name, out_g1.name)
                 self.assertEqual(out_g2.type.tensor_type.elem_type,
@@ -497,17 +497,17 @@ class TestComposeFunctions(unittest.TestCase):
 
     def _test_overlapping_names(
         self,
-        inputs0=['i0', 'i1'],  # type: List[Text]
-        inputs1=['i2', 'i3'],  # type: List[Text]
-        outputs0=['o0', 'o1'],  # type: List[Text]
-        outputs1=['o2', 'o3'],  # type: List[Text]
-        value_info0=['v0', 'v1'],  # type: List[Text]
-        value_info1=['v2', 'v3'],  # type: List[Text]
-        initializer0=['init0', 'init1'],  # type: List[Text]
-        initializer1=['init2', 'init3'],  # type: List[Text]
-        sparse_initializer0=['sparse_init0', 'sparse_init1'],  # type: List[Text]
-        sparse_initializer1=['sparse_init2', 'sparse_init3'],  # type: List[Text]
-    ):  # type: (...) -> None
+        inputs0: List[Text] = ['i0', 'i1'],
+        inputs1: List[Text] = ['i2', 'i3'],
+        outputs0: List[Text] = ['o0', 'o1'],
+        outputs1: List[Text] = ['o2', 'o3'],
+        value_info0: List[Text] = ['v0', 'v1'],
+        value_info1: List[Text] = ['v2', 'v3'],
+        initializer0: List[Text] = ['init0', 'init1'],
+        initializer1: List[Text] = ['init2', 'init3'],
+        sparse_initializer0: List[Text] = ['sparse_init0', 'sparse_init1'],
+        sparse_initializer1: List[Text] = ['sparse_init2', 'sparse_init3'],
+    ) -> None:
         n0 = [helper.make_node('Identity', inputs=[inputs0[i]], outputs=[outputs0[i]])
               for i in range(len(inputs0))]
         i0 = [helper.make_tensor_value_info(inputs0[i], TensorProto.FLOAT, [])
@@ -582,35 +582,35 @@ class TestComposeFunctions(unittest.TestCase):
         overlap = compose.check_overlapping_names(m0_new.graph, m1.graph)
         self.assertEqual(0, len(overlap))
 
-    def test_overlapping_input_names(self):  # type: () -> None
+    def test_overlapping_input_names(self) -> None:
         '''
         Tests error checking when the name of the inputs overlaps
         '''
         self._test_overlapping_names(
             inputs0=['i0', 'i1'], inputs1=['i1', 'i2'])
 
-    def test_overlapping_output_names(self):  # type: () -> None
+    def test_overlapping_output_names(self) -> None:
         '''
         Tests error checking when the name of the output overlaps
         '''
         self._test_overlapping_names(
             outputs0=['o0', 'o1'], outputs1=['o1', 'o2'])
 
-    def test_overlapping_value_info_names(self):  # type: () -> None
+    def test_overlapping_value_info_names(self) -> None:
         '''
         Tests error checking when the name of value_info entries overlaps
         '''
         self._test_overlapping_names(
             value_info0=['vi0', 'vi1'], value_info1=['vi1', 'vi2'])
 
-    def test_overlapping_initializer_names(self):  # type: () -> None
+    def test_overlapping_initializer_names(self) -> None:
         '''
         Tests error checking when the name of initializer entries overlaps
         '''
         self._test_overlapping_names(
             initializer0=['init0', 'init1'], initializer1=['init1', 'init2'])
 
-    def test_overlapping_sparse_initializer_names(self):  # type: () -> None
+    def test_overlapping_sparse_initializer_names(self) -> None:
         '''
         Tests error checking when the name of sparse_initializer entries overlaps
         '''
@@ -618,7 +618,7 @@ class TestComposeFunctions(unittest.TestCase):
             sparse_initializer0=['sparse_init0', 'sparse_init1'],
             sparse_initializer1=['sparse_init1', 'sparse_init2'])
 
-    def test_overlapping_function_names(self):  # type: () -> None
+    def test_overlapping_function_names(self) -> None:
         '''
         Tests error checking when the name of local function entries overlaps
         '''
@@ -628,12 +628,12 @@ class TestComposeFunctions(unittest.TestCase):
         ]
 
         def _make_function(
-            domain,  # type: Text
-            fname,  # type: Text
-            inputs,  # type: List[Text]
-            outputs,  # type: List[Text]
-            nodes,  # type: List[NodeProto]
-        ):  # type: (...) -> FunctionProto
+            domain: Text,
+            fname: Text,
+            inputs: List[Text],
+            outputs: List[Text],
+            nodes: List[NodeProto],
+        ) -> FunctionProto:
             f = FunctionProto()
             f.domain = domain
             f.name = fname
@@ -743,7 +743,7 @@ class TestComposeFunctions(unittest.TestCase):
         self.assertEqual(
             ['m3/f1', 'Mul', 'Add'], [n.op_type for n in m.functions[2].node])
 
-    def test_merge_drop_unnecessary_initializers_and_value_info(self):  # type: () -> None
+    def test_merge_drop_unnecessary_initializers_and_value_info(self) -> None:
         '''
         Tests automatic removal of initializers when merging graphs
         '''

--- a/onnx/test/elu_test.py
+++ b/onnx/test/elu_test.py
@@ -7,7 +7,7 @@ from onnx import defs, checker, helper
 
 class TestRelu(unittest.TestCase):
 
-    def test_elu(self):  # type: () -> None
+    def test_elu(self) -> None:
         self.assertTrue(defs.has('Elu'))
         node_def = helper.make_node(
             'Elu', ['X'], ['Y'], alpha=1.0)

--- a/onnx/test/function_test.py
+++ b/onnx/test/function_test.py
@@ -17,7 +17,7 @@ class TestFunction(unittest.TestCase):
                 next((f for f in extracted_model.functions
                 if f.name == function and f.domain == func_domain), None))
 
-    def test_extract_model_with_local_function(self):  # type: () -> None
+    def test_extract_model_with_local_function(self) -> None:
         '''
         #   1. build a model with graph below. extract models with output combinations
         #   2. validate extracted models' local functions

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -18,7 +18,7 @@ import unittest
 
 class TestHelperAttributeFunctions(unittest.TestCase):
 
-    def test_attr_float(self):  # type: () -> None
+    def test_attr_float(self) -> None:
         # float
         attr = helper.make_attribute("float", 1.)
         self.assertEqual(attr.name, "float")
@@ -30,7 +30,7 @@ class TestHelperAttributeFunctions(unittest.TestCase):
         self.assertEqual(attr.f, 1e10)
         checker.check_attribute(attr)
 
-    def test_attr_int(self):  # type: () -> None
+    def test_attr_int(self) -> None:
         # integer
         attr = helper.make_attribute("int", 3)
         self.assertEqual(attr.name, "int")
@@ -52,7 +52,7 @@ class TestHelperAttributeFunctions(unittest.TestCase):
         self.assertEqual(attr.i, 0x1701)
         checker.check_attribute(attr)
 
-    def test_attr_doc_string(self):  # type: () -> None
+    def test_attr_doc_string(self) -> None:
         attr = helper.make_attribute("a", "value")
         self.assertEqual(attr.name, "a")
         self.assertEqual(attr.doc_string, "")
@@ -60,7 +60,7 @@ class TestHelperAttributeFunctions(unittest.TestCase):
         self.assertEqual(attr.name, "a")
         self.assertEqual(attr.doc_string, "doc")
 
-    def test_attr_string(self):  # type: () -> None
+    def test_attr_string(self) -> None:
         # bytes
         attr = helper.make_attribute("str", b"test")
         self.assertEqual(attr.name, "str")
@@ -82,31 +82,31 @@ class TestHelperAttributeFunctions(unittest.TestCase):
         self.assertEqual(helper.get_attribute_value(attr), b"")
         checker.check_attribute(attr)
 
-    def test_attr_repeated_float(self):  # type: () -> None
+    def test_attr_repeated_float(self) -> None:
         attr = helper.make_attribute("floats", [1.0, 2.0])
         self.assertEqual(attr.name, "floats")
         self.assertEqual(list(attr.floats), [1.0, 2.0])
         checker.check_attribute(attr)
 
-    def test_attr_repeated_int(self):  # type: () -> None
+    def test_attr_repeated_int(self) -> None:
         attr = helper.make_attribute("ints", [1, 2])
         self.assertEqual(attr.name, "ints")
         self.assertEqual(list(attr.ints), [1, 2])
         checker.check_attribute(attr)
 
-    def test_attr_repeated_mixed_floats_and_ints(self):  # type: () -> None
+    def test_attr_repeated_mixed_floats_and_ints(self) -> None:
         attr = helper.make_attribute("mixed", [1, 2, 3.0, 4.5])
         self.assertEqual(attr.name, "mixed")
         self.assertEqual(list(attr.floats), [1.0, 2.0, 3.0, 4.5])
         checker.check_attribute(attr)
 
-    def test_attr_repeated_str(self):  # type: () -> None
+    def test_attr_repeated_str(self) -> None:
         attr = helper.make_attribute("strings", ["str1", "str2"])
         self.assertEqual(attr.name, "strings")
         self.assertEqual(list(attr.strings), [b"str1", b"str2"])
         checker.check_attribute(attr)
 
-    def test_attr_repeated_tensor_proto(self):  # type: () -> None
+    def test_attr_repeated_tensor_proto(self) -> None:
         tensors = [
             helper.make_tensor(
                 name='a',
@@ -125,7 +125,7 @@ class TestHelperAttributeFunctions(unittest.TestCase):
         self.assertEqual(list(attr.tensors), tensors)
         checker.check_attribute(attr)
 
-    def test_attr_sparse_tensor_proto(self):  # type: () -> None
+    def test_attr_sparse_tensor_proto(self) -> None:
         dense_shape = [3, 3]
         sparse_values = [1.764052391052246, 0.40015721321105957, 0.978738009929657]
         values_tensor = helper.make_tensor(name='sparse_values', data_type=TensorProto.FLOAT,
@@ -143,7 +143,7 @@ class TestHelperAttributeFunctions(unittest.TestCase):
         checker.check_sparse_tensor(helper.get_attribute_value(attr))
         checker.check_attribute(attr)
 
-    def test_attr_sparse_tensor_repeated_protos(self):  # type: () -> None
+    def test_attr_sparse_tensor_repeated_protos(self) -> None:
         dense_shape = [3, 3]
         sparse_values = [1.764052391052246, 0.40015721321105957, 0.978738009929657]
         values_tensor = helper.make_tensor(name='sparse_values', data_type=TensorProto.FLOAT,
@@ -163,7 +163,7 @@ class TestHelperAttributeFunctions(unittest.TestCase):
         for s in helper.get_attribute_value(attr):
             checker.check_sparse_tensor(s)
 
-    def test_attr_repeated_graph_proto(self):  # type: () -> None
+    def test_attr_repeated_graph_proto(self) -> None:
         graphs = [GraphProto(), GraphProto()]
         graphs[0].name = "a"
         graphs[1].name = "b"
@@ -172,7 +172,7 @@ class TestHelperAttributeFunctions(unittest.TestCase):
         self.assertEqual(list(attr.graphs), graphs)
         checker.check_attribute(attr)
 
-    def test_attr_type_proto(self):  # type: () -> None
+    def test_attr_type_proto(self) -> None:
         # type_proto
         type = TypeProto()
         attr = helper.make_attribute("type_proto", type)
@@ -187,7 +187,7 @@ class TestHelperAttributeFunctions(unittest.TestCase):
         self.assertEqual(list(attr.type_protos), types)
         self.assertEqual(attr.type, AttributeProto.TYPE_PROTOS)
 
-    def test_is_attr_legal(self):  # type: () -> None
+    def test_is_attr_legal(self) -> None:
         # no name, no field
         attr = AttributeProto()
         self.assertRaises(checker.ValidationError, checker.check_attribute, attr)
@@ -202,13 +202,13 @@ class TestHelperAttributeFunctions(unittest.TestCase):
         attr.i = 2
         self.assertRaises(checker.ValidationError, checker.check_attribute, attr)
 
-    def test_is_attr_legal_verbose(self):  # type: () -> None
+    def test_is_attr_legal_verbose(self) -> None:
 
-        def _set(attr, type, var, value):  # type: (AttributeProto, AttributeProto.AttributeType, Text, Any) -> None
+        def _set(attr: AttributeProto, type: AttributeProto.AttributeType, var: Text, value: Any) -> None:
             setattr(attr, var, value)
             setattr(attr, 'type', type)
 
-        def _extend(attr, type, var, value):  # type: (AttributeProto, AttributeProto.AttributeType, List[Any], Any) -> None
+        def _extend(attr: AttributeProto, type: AttributeProto.AttributeType, var: List[Any], value: Any) -> None:
             var.extend(value)
             setattr(attr, 'type', type)
 
@@ -239,7 +239,7 @@ class TestHelperAttributeFunctions(unittest.TestCase):
 
 class TestHelperNodeFunctions(unittest.TestCase):
 
-    def test_node_no_arg(self):  # type: () -> None
+    def test_node_no_arg(self) -> None:
         self.assertTrue(defs.has("Relu"))
         node_def = helper.make_node(
             "Relu", ["X"], ["Y"], name="test")
@@ -248,12 +248,12 @@ class TestHelperNodeFunctions(unittest.TestCase):
         self.assertEqual(list(node_def.input), ["X"])
         self.assertEqual(list(node_def.output), ["Y"])
 
-    def test_attr_doc_string(self):  # type: () -> None
+    def test_attr_doc_string(self) -> None:
         node_def = helper.make_node(
             "Relu", ["X"], ["Y"], name="test", doc_string="doc")
         self.assertEqual(node_def.doc_string, "doc")
 
-    def test_node_with_arg(self):  # type: () -> None
+    def test_node_with_arg(self) -> None:
         self.assertTrue(defs.has("Relu"))
         # Note: Relu actually does not need an arg, but let's
         # test it.
@@ -268,12 +268,12 @@ class TestHelperNodeFunctions(unittest.TestCase):
             node_def.attribute[0],
             helper.make_attribute("arg_value", 1))
 
-    def test_node_domain(self):  # type: () -> None
+    def test_node_domain(self) -> None:
         node_def = helper.make_node(
             "Relu", ["X"], ["Y"], name="test", doc_string="doc", domain="test.domain")
         self.assertEqual(node_def.domain, "test.domain")
 
-    def test_graph(self):  # type: () -> None
+    def test_graph(self) -> None:
         node_def1 = helper.make_node(
             "Relu", ["X"], ["Y"])
         node_def2 = helper.make_node(
@@ -294,12 +294,12 @@ class TestHelperNodeFunctions(unittest.TestCase):
         self.assertEqual(graph.doc_string, "")
         self.assertEqual(graph.value_info[0], value_info[0])
 
-    def test_graph_docstring(self):  # type: () -> None
+    def test_graph_docstring(self) -> None:
         graph = helper.make_graph([], "my graph", [], [], None, "my docs")
         self.assertEqual(graph.name, "my graph")
         self.assertEqual(graph.doc_string, "my docs")
 
-    def test_model(self):  # type: () -> None
+    def test_model(self) -> None:
         node_def = helper.make_node(
             "Relu", ["X"], ["Y"])
         graph_def = helper.make_graph(
@@ -311,7 +311,7 @@ class TestHelperNodeFunctions(unittest.TestCase):
         model_def = helper.make_model(graph_def, producer_name='test')
         self.assertEqual(model_def.producer_name, 'test')
 
-    def test_model_docstring(self):  # type: () -> None
+    def test_model_docstring(self) -> None:
         graph = helper.make_graph([], "my graph", [], [])
         model_def = helper.make_model(graph, doc_string='test')
         # models may have their own documentation, but don't have a name
@@ -319,7 +319,7 @@ class TestHelperNodeFunctions(unittest.TestCase):
         self.assertFalse(hasattr(model_def, "name"))
         self.assertEqual(model_def.doc_string, 'test')
 
-    def test_model_metadata_props(self):  # type: () -> None
+    def test_model_metadata_props(self) -> None:
         graph = helper.make_graph([], "my graph", [], [])
         model_def = helper.make_model(graph, doc_string='test')
         helper.set_model_props(model_def, {'Title': 'my graph', 'Keywords': 'test;graph'})
@@ -332,12 +332,12 @@ class TestHelperNodeFunctions(unittest.TestCase):
         dupe.value = 'Other'
         self.assertRaises(checker.ValidationError, checker.check_model, model_def)
 
-    def test_model_irversion(self):  # type: () -> None
-        def mk_model(opset_versions):  # type: (List[Tuple[Text, int]]) -> ModelProto
+    def test_model_irversion(self) -> None:
+        def mk_model(opset_versions: List[Tuple[Text, int]]) -> ModelProto:
             graph = helper.make_graph([], "my graph", [], [])
             return helper.make_model_gen_version(graph, opset_imports=[helper.make_opsetid(*pair) for pair in opset_versions])
 
-        def test(opset_versions, ir_version):  # type: (List[Tuple[Text, int]], int) -> None
+        def test(opset_versions: List[Tuple[Text, int]], ir_version: int) -> None:
             model = mk_model(opset_versions)
             self.assertEqual(model.ir_version, ir_version)
         # opset version 9 requires minimum ir_version 4
@@ -359,7 +359,7 @@ class TestHelperNodeFunctions(unittest.TestCase):
 
 class TestHelperTensorFunctions(unittest.TestCase):
 
-    def test_make_tensor(self):  # type: () -> None
+    def test_make_tensor(self) -> None:
         np_array = np.random.randn(2, 3).astype(np.float32)
 
         tensor = helper.make_tensor(
@@ -391,7 +391,7 @@ class TestHelperTensorFunctions(unittest.TestCase):
         )
         self.assertEqual(string_list, list(tensor.string_data))
 
-    def test_make_float16_tensor(self):  # type: () -> None
+    def test_make_float16_tensor(self) -> None:
         np_array = np.random.randn(2, 3).astype(np.float16)
 
         tensor = helper.make_tensor(
@@ -403,7 +403,7 @@ class TestHelperTensorFunctions(unittest.TestCase):
         self.assertEqual(tensor.name, 'test')
         np.testing.assert_equal(np_array, numpy_helper.to_array(tensor))
 
-    def test_make_float16_tensor_with_raw(self):  # type: () -> None
+    def test_make_float16_tensor_with_raw(self) -> None:
         np_array = np.random.randn(2, 3).astype(np.float16)
 
         tensor = helper.make_tensor(
@@ -416,7 +416,7 @@ class TestHelperTensorFunctions(unittest.TestCase):
         self.assertEqual(tensor.name, 'test')
         np.testing.assert_equal(np_array, numpy_helper.to_array(tensor))
 
-    def test_make_bfloat16_tensor(self):  # type: () -> None
+    def test_make_bfloat16_tensor(self) -> None:
         np_array = np.random.randn(8, 7).astype(np.float16)
 
         tensor = helper.make_tensor(
@@ -428,7 +428,7 @@ class TestHelperTensorFunctions(unittest.TestCase):
         self.assertEqual(tensor.name, 'test')
         np.testing.assert_equal(np_array, numpy_helper.to_array(tensor))
 
-    def test_make_bfloat16_tensor_with_raw(self):  # type: () -> None
+    def test_make_bfloat16_tensor_with_raw(self) -> None:
         np_array = np.random.randn(8, 7).astype(np.float16)
 
         tensor = helper.make_tensor(
@@ -441,7 +441,7 @@ class TestHelperTensorFunctions(unittest.TestCase):
         self.assertEqual(tensor.name, 'test')
         np.testing.assert_equal(np_array, numpy_helper.to_array(tensor))
 
-    def test_make_sparse_tensor(self):  # type: () -> None
+    def test_make_sparse_tensor(self) -> None:
         values = [1.1, 2.2, 3.3, 4.4, 5.5]
         values_tensor = helper.make_tensor(
             name='test',
@@ -462,7 +462,7 @@ class TestHelperTensorFunctions(unittest.TestCase):
         self.assertEqual(sparse.indices, indices_tensor)
         self.assertEqual(sparse.dims, dense_shape)
 
-    def test_make_tensor_value_info(self):  # type: () -> None
+    def test_make_tensor_value_info(self) -> None:
         vi = helper.make_tensor_value_info('X', TensorProto.FLOAT, (2, 4))
         checker.check_value_info(vi)
 
@@ -470,7 +470,7 @@ class TestHelperTensorFunctions(unittest.TestCase):
         vi = helper.make_tensor_value_info('Y', TensorProto.FLOAT, ())
         checker.check_value_info(vi)
 
-    def test_make_sparse_tensor_value_info(self):  # type: () -> None
+    def test_make_sparse_tensor_value_info(self) -> None:
         vi = helper.make_sparse_tensor_value_info('X', TensorProto.FLOAT, (2, 3))
         checker.check_value_info(vi)
 
@@ -480,7 +480,7 @@ class TestHelperTensorFunctions(unittest.TestCase):
 
 
 class TestHelperOptionalAndSequenceFunctions(unittest.TestCase):
-    def test_make_optional(self):  # type: () -> None
+    def test_make_optional(self) -> None:
         values = [1.1, 2.2, 3.3, 4.4, 5.5]
         values_tensor = helper.make_tensor(
             name='test',
@@ -522,7 +522,7 @@ class TestHelperOptionalAndSequenceFunctions(unittest.TestCase):
         self.assertEqual(optional_none.elem_type, OptionalProto.UNDEFINED)
         self.assertFalse(optional_none.HasField('tensor_value'))
 
-    def test_make_optional_value_info(self):  # type: () -> None
+    def test_make_optional_value_info(self) -> None:
         tensor_type_proto = helper.make_tensor_type_proto(elem_type=2, shape=[5])
         tensor_val_into = helper.make_value_info(
             name='test',
@@ -550,7 +550,7 @@ class TestHelperOptionalAndSequenceFunctions(unittest.TestCase):
             type_proto=tensor_type_proto)
         self.assertEqual(optional_val_info.type.optional_type.elem_type.sequence_type.elem_type, sequence_value_info.type)
 
-    def test_make_seuence_value_info(self):  # type: () -> None
+    def test_make_seuence_value_info(self) -> None:
         tensor_type_proto = helper.make_tensor_type_proto(elem_type=2, shape=None)
         sequence_type_proto = helper.make_sequence_type_proto(tensor_type_proto)
         sequence_val_info = helper.make_value_info(
@@ -567,7 +567,7 @@ class TestHelperOptionalAndSequenceFunctions(unittest.TestCase):
 
 class TestPrintableGraph(unittest.TestCase):
 
-    def test_initializer_with_matching_graph_input(self):  # type: () -> None
+    def test_initializer_with_matching_graph_input(self) -> None:
         add = helper.make_node("Add", ["X", "Y_Initializer"], ["Z"])
         value_info = [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1])]
 
@@ -586,7 +586,7 @@ class TestPrintableGraph(unittest.TestCase):
         self.assertTrue(''') optional inputs with matching initializers (
   %Y_Initializer[FLOAT, 1]''' in graph_str, graph_str)
 
-    def test_initializer_no_matching_graph_input(self):  # type: () -> None
+    def test_initializer_no_matching_graph_input(self) -> None:
         add = helper.make_node("Add", ["X", "Y_Initializer"], ["Z"])
         value_info = [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1])]
 

--- a/onnx/test/hub_test.py
+++ b/onnx/test/hub_test.py
@@ -14,19 +14,19 @@ import os
     reason="Conserving Git LFS quota"
 )
 class TestModelHub(unittest.TestCase):
-    def setUp(self):  # type: () -> None
+    def setUp(self) -> None:
         self.name = "MNIST"
         self.repo = "onnx/models:master"
         self.opset = 7
 
-    def test_force_reload(self):  # type: () -> None
+    def test_force_reload(self) -> None:
         model = hub.load(self.name, self.repo, force_reload=True)
         self.assertIsInstance(model, ModelProto)
 
         cached_files = list(glob.glob(join(hub.get_dir(), "**", "*.onnx"), recursive=True))
         self.assertGreaterEqual(len(cached_files), 1)
 
-    def test_listing_models(self):  # type: () -> None
+    def test_listing_models(self) -> None:
         model_info_list_1 = hub.list_models(self.repo, model="mnist", tags=["vision"])
         model_info_list_2 = hub.list_models(self.repo, tags=["vision"])
         model_info_list_3 = hub.list_models(self.repo)
@@ -35,14 +35,14 @@ class TestModelHub(unittest.TestCase):
         self.assertGreater(len(model_info_list_2), len(model_info_list_1))
         self.assertGreater(len(model_info_list_3), len(model_info_list_2))
 
-    def test_basic_usage(self):  # type: () -> None
+    def test_basic_usage(self) -> None:
         model = hub.load(self.name, self.repo)
         self.assertIsInstance(model, ModelProto)
 
         cached_files = list(glob.glob(join(hub.get_dir(), "**", "*.onnx"), recursive=True))
         self.assertGreaterEqual(len(cached_files), 1)
 
-    def test_custom_cache(self):  # type: () -> None
+    def test_custom_cache(self) -> None:
         old_cache = hub.get_dir()
         new_cache = join(old_cache, "custom")
         hub.set_dir(new_cache)
@@ -55,17 +55,17 @@ class TestModelHub(unittest.TestCase):
 
         hub.set_dir(old_cache)
 
-    def test_download_with_opset(self):  # type: () -> None
+    def test_download_with_opset(self) -> None:
         model = hub.load(self.name, self.repo, opset=8)
         self.assertIsInstance(model, ModelProto)
 
-    def test_opset_error(self):  # type: () -> None
+    def test_opset_error(self) -> None:
         self.assertRaises(AssertionError, lambda: hub.load(self.name, self.repo, opset=-1))
 
-    def test_manifest_not_found(self):  # type: () -> None
+    def test_manifest_not_found(self) -> None:
         self.assertRaises(AssertionError, lambda: hub.load(self.name, "onnx/models:unknown", silent=True))
 
-    def test_verify_repo_ref(self):  # type: () -> None
+    def test_verify_repo_ref(self) -> None:
         # Not trusted repo:
         verified = hub._verify_repo_ref("mhamilton723/models")
         self.assertFalse(verified)
@@ -78,7 +78,7 @@ class TestModelHub(unittest.TestCase):
         verified = hub._verify_repo_ref(self.repo)
         self.assertTrue(verified)
 
-    def test_get_model_info(self):  # type: () -> None
+    def test_get_model_info(self) -> None:
         hub.get_model_info("mnist", self.repo, opset=8)
         hub.get_model_info("mnist", self.repo)
         self.assertRaises(AssertionError, lambda: hub.get_model_info("mnist", self.repo, opset=-1))

--- a/onnx/test/numpy_helper_test.py
+++ b/onnx/test/numpy_helper_test.py
@@ -14,14 +14,14 @@ import unittest
 
 class TestNumpyHelper(unittest.TestCase):
 
-    def _test_numpy_helper_float_type(self, dtype):  # type: (np.number) -> None
+    def _test_numpy_helper_float_type(self, dtype: np.number) -> None:
         a = np.random.rand(13, 37).astype(dtype)
         tensor_def = numpy_helper.from_array(a, "test")
         self.assertEqual(tensor_def.name, "test")
         a_recover = numpy_helper.to_array(tensor_def)
         np.testing.assert_equal(a, a_recover)
 
-    def _test_numpy_helper_int_type(self, dtype):  # type: (np.number) -> None
+    def _test_numpy_helper_int_type(self, dtype: np.number) -> None:
         a = np.random.randint(
             np.iinfo(dtype).min,
             np.iinfo(dtype).max,
@@ -32,48 +32,48 @@ class TestNumpyHelper(unittest.TestCase):
         a_recover = numpy_helper.to_array(tensor_def)
         np.testing.assert_equal(a, a_recover)
 
-    def test_float(self):  # type: () -> None
+    def test_float(self) -> None:
         self._test_numpy_helper_float_type(np.float32)
 
-    def test_uint8(self):  # type: () -> None
+    def test_uint8(self) -> None:
         self._test_numpy_helper_int_type(np.uint8)
 
-    def test_int8(self):  # type: () -> None
+    def test_int8(self) -> None:
         self._test_numpy_helper_int_type(np.int8)
 
-    def test_uint16(self):  # type: () -> None
+    def test_uint16(self) -> None:
         self._test_numpy_helper_int_type(np.uint16)
 
-    def test_int16(self):  # type: () -> None
+    def test_int16(self) -> None:
         self._test_numpy_helper_int_type(np.int16)
 
-    def test_int32(self):  # type: () -> None
+    def test_int32(self) -> None:
         self._test_numpy_helper_int_type(np.int32)
 
-    def test_int64(self):  # type: () -> None
+    def test_int64(self) -> None:
         self._test_numpy_helper_int_type(np.int64)
 
-    def test_string(self):  # type: () -> None
+    def test_string(self) -> None:
         a = np.array(['Amy', 'Billy', 'Cindy', 'David']).astype(object)
         tensor_def = numpy_helper.from_array(a, "test")
         self.assertEqual(tensor_def.name, "test")
         a_recover = numpy_helper.to_array(tensor_def)
         np.testing.assert_equal(a, a_recover)
 
-    def test_bool(self):  # type: () -> None
+    def test_bool(self) -> None:
         a = np.random.randint(2, size=(13, 37)).astype(bool)
         tensor_def = numpy_helper.from_array(a, "test")
         self.assertEqual(tensor_def.name, "test")
         a_recover = numpy_helper.to_array(tensor_def)
         np.testing.assert_equal(a, a_recover)
 
-    def test_float16(self):  # type: () -> None
+    def test_float16(self) -> None:
         self._test_numpy_helper_float_type(np.float32)
 
-    def test_complex64(self):  # type: () -> None
+    def test_complex64(self) -> None:
         self._test_numpy_helper_float_type(np.complex64)
 
-    def test_complex128(self):  # type: () -> None
+    def test_complex128(self) -> None:
         self._test_numpy_helper_float_type(np.complex128)
 
 

--- a/onnx/test/parser_test.py
+++ b/onnx/test/parser_test.py
@@ -6,13 +6,13 @@ from onnx import helper, parser, GraphProto
 
 
 class TestBasicFunctions(unittest.TestCase):
-    def check_graph(self, graph):  # type: (GraphProto) -> None
+    def check_graph(self, graph: GraphProto) -> None:
         self.assertTrue(len(graph.node) == 3)
         self.assertTrue(graph.node[0].op_type == "MatMul")
         self.assertTrue(graph.node[1].op_type == "Add")
         self.assertTrue(graph.node[2].op_type == "Softmax")
 
-    def test_parse_graph(self):  # type: () -> None
+    def test_parse_graph(self) -> None:
         input = '''
            agraph (float[N, 128] X, float[128,10] W, float[10] B) => (float[N] C)
            {
@@ -24,7 +24,7 @@ class TestBasicFunctions(unittest.TestCase):
         graph = onnx.parser.parse_graph(input)
         self.check_graph(graph)
 
-    def test_parse_model(self):  # type: () -> None
+    def test_parse_model(self) -> None:
         input = '''
            <
              ir_version: 7,
@@ -42,7 +42,7 @@ class TestBasicFunctions(unittest.TestCase):
         self.assertTrue(len(model.opset_import) == 2)
         self.check_graph(model.graph)
 
-    def test_parse_graph_error(self):  # type: () -> None
+    def test_parse_graph_error(self) -> None:
         input = '''
            agraph (float[N, 128] X, float[128,10] W, float[10] B) => (float[N] C)
            {
@@ -53,7 +53,7 @@ class TestBasicFunctions(unittest.TestCase):
            '''
         self.assertRaises(onnx.parser.ParseError, lambda: onnx.parser.parse_graph(input))
 
-    def test_parse_model_error(self):  # type: () -> None
+    def test_parse_model_error(self) -> None:
         input = '''
            <
              ir_version: 7,

--- a/onnx/test/relu_test.py
+++ b/onnx/test/relu_test.py
@@ -7,7 +7,7 @@ from onnx import defs, helper
 
 class TestRelu(unittest.TestCase):
 
-    def test_relu(self):  # type: () -> None
+    def test_relu(self) -> None:
         self.assertTrue(defs.has('Relu'))
         helper.make_node(
             'Relu', ['X'], ['Y'])

--- a/onnx/test/schema_test.py
+++ b/onnx/test/schema_test.py
@@ -7,13 +7,13 @@ from onnx import defs, AttributeProto
 
 class TestSchema(unittest.TestCase):
 
-    def test_get_schema(self):  # type: () -> None
+    def test_get_schema(self) -> None:
         defs.get_schema("Relu")
 
-    def test_typecheck(self):  # type: () -> None
+    def test_typecheck(self) -> None:
         defs.get_schema("Conv")
 
-    def test_attr_default_value(self):  # type: () -> None
+    def test_attr_default_value(self) -> None:
         v = defs.get_schema(
             "BatchNormalization").attributes['epsilon'].default_value
         self.assertEqual(type(v), AttributeProto)

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -17,11 +17,11 @@ import numpy as np  # type: ignore
 
 class TestShapeInference(unittest.TestCase):
     def _make_graph(self,
-                    seed_values,  # type: Sequence[Union[Text, Tuple[Text, TensorProto.DataType, Any]]]
-                    nodes,  # type: List[NodeProto]
-                    value_info,  # type: List[ValueInfoProto]
-                    initializer=None  # type: Optional[Sequence[TensorProto]]
-                    ):  # type: (...) -> GraphProto
+                    seed_values: Sequence[Union[Text, Tuple[Text, TensorProto.DataType, Any]]],
+                    nodes: List[NodeProto],
+                    value_info: List[ValueInfoProto],
+                    initializer: Optional[Sequence[TensorProto]] = None
+                    ) -> GraphProto:
         if initializer is None:
             initializer = []
         names_in_initializer = set(x.name for x in initializer)
@@ -45,7 +45,7 @@ class TestShapeInference(unittest.TestCase):
                 nodes[:0] = [make_node("Reshape", ['SEED_' + seed_name, 'UNKNOWN_SHAPE_' + seed_name], [seed_name])]
         return helper.make_graph(nodes, "test", input_value_infos, [], initializer=initializer, value_info=value_info)
 
-    def _inferred(self, graph, **kwargs):  # type: (GraphProto, **Any) -> ModelProto
+    def _inferred(self, graph: GraphProto, **kwargs: Any) -> ModelProto:
         kwargs[str('producer_name')] = 'onnx-test'
         data_prop = kwargs.pop('data_prop', False)
         orig_model = helper.make_model(graph, **kwargs)
@@ -53,7 +53,7 @@ class TestShapeInference(unittest.TestCase):
         checker.check_model(inferred_model)
         return inferred_model
 
-    def _assert_inferred(self, graph, vis, **kwargs):  # type: (GraphProto, List[ValueInfoProto], **Any) -> None
+    def _assert_inferred(self, graph: GraphProto, vis: List[ValueInfoProto], **kwargs: Any) -> None:
         names_in_vis = set(x.name for x in vis)
         vis = list(x for x in graph.value_info if x.name not in names_in_vis) + vis
         inferred_model = self._inferred(graph, **kwargs)
@@ -64,7 +64,7 @@ class TestShapeInference(unittest.TestCase):
         for i in range(len(vis)):
             self._compare_value_infos(vis[i].type, inferred_vis[i].type)
 
-    def _compare_value_infos(self, vi_type, inferred_vi_type):  # type: (TypeProto, TypeProto) -> None
+    def _compare_value_infos(self, vi_type: TypeProto, inferred_vi_type: TypeProto) -> None:
         if vi_type.HasField('tensor_type'):
             assert inferred_vi_type.HasField('tensor_type')
             assert vi_type.tensor_type.HasField('elem_type')
@@ -92,62 +92,62 @@ class TestShapeInference(unittest.TestCase):
             raise NotImplementedError(
                 "Unrecognized value info type in _compare_value_infos: ", str(vi_type))
 
-    def test_empty_graph(self):  # type: () -> None
+    def test_empty_graph(self) -> None:
         graph = self._make_graph(
             ['y'],
             [], [])
         self.assertRaises(onnx.shape_inference.InferenceError, self._inferred, graph)
 
-    def _identity_prop(self, op, **kwargs):  # type: (Text, **Any) -> None
+    def _identity_prop(self, op: Text, **kwargs: Any) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (30, 4, 5))],
             [make_node(op, 'x', 'y', **kwargs)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (30, 4, 5))])
 
-    def test_transpose(self):  # type: () -> None
+    def test_transpose(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (2, 3, 4))],
             [make_node("Transpose", ["X"], ["Y"], perm=[1, 0, 2])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (3, 2, 4))])
 
-    def test_transpose_preexisting(self):  # type: () -> None
+    def test_transpose_preexisting(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (2, 3, 4))],
             [make_node("Transpose", ["X"], ["Y"], perm=[1, 0, 2])],
             [make_tensor_value_info("Y", TensorProto.FLOAT, None)])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (3, 2, 4))])
 
-    def test_transpose_partial(self):  # type: () -> None
+    def test_transpose_partial(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (2, 3, 4))],
             [make_node("Transpose", ["X"], ["Y"], perm=[1, 0, 2])],
             [make_tensor_value_info("Y", TensorProto.UNDEFINED, (3, "a", "b"))])  # type: ignore
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (3, 2, 4))])
 
-    def test_transpose_preexisting_incorrect_shape(self):  # type: () -> None
+    def test_transpose_preexisting_incorrect_shape(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (2, 3, 4))],
             [make_node("Transpose", ["X"], ["Y"], perm=[1, 0, 2])],
             [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 5, 5))])
         self.assertRaises(onnx.shape_inference.InferenceError, self._inferred, graph)
 
-    def test_transpose_preexisting_incorrect_type(self):  # type: () -> None
+    def test_transpose_preexisting_incorrect_type(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (2, 3, 4))],
             [make_node("Transpose", ["X"], ["Y"], perm=[1, 0, 2])],
             [make_tensor_value_info("Y", TensorProto.STRING, (3, 2, 4))])
         self.assertRaises(onnx.shape_inference.InferenceError, self._inferred, graph)
 
-    def test_transpose_incorrect_repeated_perm(self):  # type: () -> None
+    def test_transpose_incorrect_repeated_perm(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (2, 3, 4))],
             [make_node("Transpose", ["X"], ["Y"], perm=[1, 0, 1])],
             [])
         self.assertRaises(onnx.shape_inference.InferenceError, self._inferred, graph)
 
-    def _make_matmul_test_all_dims_known(self, shape1, shape2):  # type: (Sequence[int], Sequence[int]) -> None
+    def _make_matmul_test_all_dims_known(self, shape1: Sequence[int], shape2: Sequence[int]) -> None:
         expected_out_shape = np.matmul(np.arange(np.product(shape1)).reshape(shape1),
                                        np.arange(np.product(shape2)).reshape(shape2)).shape
         graph = self._make_graph(
@@ -157,7 +157,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, expected_out_shape)])
 
-    def test_matmul_all_dims_known(self):  # type: () -> None
+    def test_matmul_all_dims_known(self) -> None:
         self._make_matmul_test_all_dims_known((2,), (2,))
 
         self._make_matmul_test_all_dims_known((4, 2), (2, 4))
@@ -171,7 +171,7 @@ class TestShapeInference(unittest.TestCase):
         self._make_matmul_test_all_dims_known((5, 1, 4, 2), (1, 3, 2, 3))
         self._make_matmul_test_all_dims_known((4, 2), (3, 2, 3))
 
-    def _make_matmul_test_allow_unknown(self, shape1, shape2, expected_out_shape):  # type: (Any, Any, Any) -> None
+    def _make_matmul_test_allow_unknown(self, shape1: Any, shape2: Any, expected_out_shape: Any) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, shape1),
              ('y', TensorProto.FLOAT, shape2)],
@@ -179,7 +179,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, expected_out_shape)])
 
-    def test_matmul_allow_unknown(self):  # type: () -> None
+    def test_matmul_allow_unknown(self) -> None:
         self._make_matmul_test_allow_unknown((None,), (None,), ())
         self._make_matmul_test_allow_unknown((3,), (None,), ())
         self._make_matmul_test_allow_unknown((2,), (2, "a"), ("a",))
@@ -191,21 +191,21 @@ class TestShapeInference(unittest.TestCase):
         self._make_matmul_test_allow_unknown((3,), None, None)
         self._make_matmul_test_allow_unknown(None, None, None)
 
-    def test_cast(self):  # type: () -> None
+    def test_cast(self) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 4, 3))],
             [make_node("Cast", ["x"], ["y"], to=TensorProto.UINT8)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("y", TensorProto.UINT8, (2, 4, 3))])
 
-    def test_cast_like(self):  # type: () -> None
+    def test_cast_like(self) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 4, 3)), ("t", TensorProto.FLOAT16, ("N",))],
             [make_node("CastLike", ["x", "t"], ["y"])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("y", TensorProto.FLOAT16, (2, 4, 3))])
 
-    def test_concat(self):  # type: () -> None
+    def test_concat(self) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 4, 3)),
              ("y", TensorProto.FLOAT, (7, 4, 3))],
@@ -213,7 +213,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (9, 4, 3))])
 
-    def test_concat_missing_shape(self):  # type: () -> None
+    def test_concat_missing_shape(self) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 4, 3)),
              "y",
@@ -222,7 +222,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self.assertRaises(onnx.shape_inference.InferenceError, self._inferred, graph)
 
-    def test_concat_3d_axis_2(self):  # type: () -> None
+    def test_concat_3d_axis_2(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 2, 2)),
              ('y', TensorProto.FLOAT, (2, 2, 2))],
@@ -230,7 +230,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (2, 2, 4))])
 
-    def test_concat_param(self):  # type: () -> None
+    def test_concat_param(self) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, ("a", 2)),
              ("y", TensorProto.FLOAT, ("a", 3))],
@@ -238,14 +238,14 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, ("a", 5))])
 
-    def test_concat_param_single_input(self):  # type: () -> None
+    def test_concat_param_single_input(self) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, ("a", 2))],
             [make_node("Concat", ['x'], ['z'], axis=0)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, ("a", 2))])
 
-    def test_reshape_dynamic_shape(self):  # type: () -> None
+    def test_reshape_dynamic_shape(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.UINT8, (2, 4, 3)),
              ('shape', TensorProto.INT64, (2,))],
@@ -253,7 +253,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.UINT8, None)])
 
-    def test_reshape_static_shape(self):  # type: () -> None
+    def test_reshape_static_shape(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.UINT8, (2, 4, 3)),
              ('shape', TensorProto.INT64, (2,))],
@@ -262,7 +262,7 @@ class TestShapeInference(unittest.TestCase):
             initializer=[make_tensor('shape', TensorProto.INT64, (2,), (3, 8))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.UINT8, (3, 8))])
 
-    def test_reshape_static_shape_inferred(self):  # type: () -> None
+    def test_reshape_static_shape_inferred(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.UINT8, (2, 4, 3)),
              ('shape', TensorProto.INT64, (3,))],
@@ -271,7 +271,7 @@ class TestShapeInference(unittest.TestCase):
             initializer=[make_tensor('shape', TensorProto.INT64, (3,), (0, 3, -1))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.UINT8, (2, 3, 4))])
 
-    def test_reshape_static_shape_zero(self):  # type: () -> None
+    def test_reshape_static_shape_zero(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.UINT8, (1, 1, 1)),
              ('shape', TensorProto.INT64, (3,))],
@@ -280,7 +280,7 @@ class TestShapeInference(unittest.TestCase):
             initializer=[make_tensor('shape', TensorProto.INT64, (3,), (0, 1, 1))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.UINT8, (1, 1, 1))])
 
-    def test_reshape_static_shape_allowzero(self):  # type: () -> None
+    def test_reshape_static_shape_allowzero(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.UINT8, (1, 0, 0)),
              ('shape', TensorProto.INT64, (3,))],
@@ -289,7 +289,7 @@ class TestShapeInference(unittest.TestCase):
             initializer=[make_tensor('shape', TensorProto.INT64, (3,), (0, 1, 1))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.UINT8, (0, 1, 1))])
 
-    def test_reshape_static_shape_constant(self):  # type: () -> None
+    def test_reshape_static_shape_constant(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.UINT8, (2, 4, 3))],
             [make_node("Constant", [], ['shape'],
@@ -300,7 +300,7 @@ class TestShapeInference(unittest.TestCase):
             make_tensor_value_info('shape', TensorProto.INT64, (2,)),
             make_tensor_value_info('y', TensorProto.UINT8, (3, 8))])
 
-    def test_upsample(self):  # type: () -> None
+    def test_upsample(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.INT32, (2, 4, 3, 5)),
              ('scales', TensorProto.FLOAT, (4,))],
@@ -312,7 +312,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_value_info('y', TensorProto.INT32, (2, 4, 3, 9))],
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 9)])
 
-    def test_upsample_raw_data(self):  # type: () -> None
+    def test_upsample_raw_data(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.INT32, (2, 4, 3, 5)),
              ('scales', TensorProto.FLOAT, (4,))],
@@ -325,7 +325,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_value_info('y', TensorProto.INT32, (2, 4, 3, 9))],
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 9)])
 
-    def test_upsample_raw_data_v7(self):  # type: () -> None
+    def test_upsample_raw_data_v7(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.INT32, (1, 3, 4, 5))],
             [make_node("Upsample", ['x'], ['y'], scales=[2.0, 1.1, 2.3, 1.9])],
@@ -335,7 +335,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_value_info('y', TensorProto.INT32, (2, 3, 9, 9))],
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 7)])
 
-    def test_expand(self):  # type: () -> None
+    def test_expand(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.INT32, (3, 1)),
              ('shape', TensorProto.INT64, (3,))],
@@ -346,7 +346,7 @@ class TestShapeInference(unittest.TestCase):
             graph,
             [make_tensor_value_info('y', TensorProto.INT32, (2, 3, 6))])
 
-    def test_expand_scalar_input(self):  # type: () -> None
+    def test_expand_scalar_input(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.INT32, ()),
              ('shape', TensorProto.INT64, (2,))],
@@ -357,7 +357,7 @@ class TestShapeInference(unittest.TestCase):
             graph,
             [make_tensor_value_info('y', TensorProto.INT32, (4, 8))])
 
-    def test_expand_raw_data(self):  # type: () -> None
+    def test_expand_raw_data(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.INT32, (3, 1)),
              ('shape', TensorProto.INT64, (2,))],
@@ -369,7 +369,7 @@ class TestShapeInference(unittest.TestCase):
             graph,
             [make_tensor_value_info('y', TensorProto.INT32, (3, 4))])
 
-    def test_expand_dynamic_shape(self):  # type: () -> None
+    def test_expand_dynamic_shape(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.INT32, (1, 2, None)),
              ('shape', TensorProto.INT64, (3,))],
@@ -380,7 +380,7 @@ class TestShapeInference(unittest.TestCase):
             graph,
             [make_tensor_value_info('y', TensorProto.INT32, (None, 2, None))])
 
-    def test_resize_size(self):  # type: () -> None
+    def test_resize_size(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.INT32, (2, 4, 3, 5)),
              ('roi', TensorProto.FLOAT, (8,)),
@@ -393,7 +393,7 @@ class TestShapeInference(unittest.TestCase):
             graph,
             [make_tensor_value_info('y', TensorProto.INT32, (3, 5, 6, 7))])
 
-    def test_resize_scale(self):  # type: () -> None
+    def test_resize_scale(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.INT32, (2, 4, 3, 5)),
              ('roi', TensorProto.FLOAT, (8,)),
@@ -405,7 +405,7 @@ class TestShapeInference(unittest.TestCase):
             graph,
             [make_tensor_value_info('y', TensorProto.INT32, (2, 4, 3, 9))])
 
-    def test_resize_scale_raw_data(self):  # type: () -> None
+    def test_resize_scale_raw_data(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.INT32, (1, 3, 4, 5)),
              ('roi', TensorProto.FLOAT, (8,)),
@@ -418,56 +418,56 @@ class TestShapeInference(unittest.TestCase):
             graph,
             [make_tensor_value_info('y', TensorProto.INT32, (2, 3, 9, 9))])
 
-    def test_shape(self):  # type: () -> None
+    def test_shape(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 4, 3))],
             [make_node("Shape", ['x'], ['y'])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, (3,))])
 
-    def test_shape_start_1(self):  # type: () -> None
+    def test_shape_start_1(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 4, 3))],
             [make_node("Shape", ['x'], ['y'], start=1)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, (2,))])
 
-    def test_shape_end_1(self):  # type: () -> None
+    def test_shape_end_1(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 4, 3))],
             [make_node("Shape", ['x'], ['y'], end=1)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, (1,))])
 
-    def test_shape_negative_start(self):  # type: () -> None
+    def test_shape_negative_start(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 4, 3))],
             [make_node("Shape", ['x'], ['y'], start=-1)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, (1,))])
 
-    def test_shape_clip1(self):  # type: () -> None
+    def test_shape_clip1(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 4, 3))],
             [make_node("Shape", ['x'], ['y'], start=-5)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, (3,))])
 
-    def test_shape_clip2(self):  # type: () -> None
+    def test_shape_clip2(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 4, 3))],
             [make_node("Shape", ['x'], ['y'], end=10)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, (3,))])
 
-    def test_size(self):  # type: () -> None
+    def test_size(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 4, 3))],
             [make_node("Size", ['x'], ['y'])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, ())])
 
-    def test_gather(self):  # type: () -> None
+    def test_gather(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (4, 3)),
              ('i', TensorProto.INT64, (2,))],
@@ -475,7 +475,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (2, 3))])  # type: ignore
 
-    def test_gather_axis1(self):  # type: () -> None
+    def test_gather_axis1(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (4, 3, 5)),
              ('i', TensorProto.INT64, (1, 2))],
@@ -483,7 +483,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (4, 1, 2, 5))])  # type: ignore
 
-    def test_gather_into_scalar(self):  # type: () -> None
+    def test_gather_into_scalar(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3,)),
              ('i', TensorProto.INT64, ())],
@@ -491,7 +491,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, ())])
 
-    def test_gather_elements(self):  # type: () -> None
+    def test_gather_elements(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 2)),
              ('i', TensorProto.INT64, (2, 2))],
@@ -499,7 +499,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (2, 2))])  # type: ignore
 
-    def test_gather_elements_axis0(self):  # type: () -> None
+    def test_gather_elements_axis0(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 3)),
              ('i', TensorProto.INT64, (2, 3))],
@@ -507,7 +507,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (2, 3))])  # type: ignore
 
-    def test_scatter(self):  # type: () -> None
+    def test_scatter(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 3)),
              ('i', TensorProto.INT64, (2, 3)),
@@ -519,7 +519,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_value_info('y', TensorProto.FLOAT, (3, 3))],
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 10)])  # type: ignore
 
-    def test_scatter_axis1(self):  # type: () -> None
+    def test_scatter_axis1(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (1, 5)),
              ('i', TensorProto.INT64, (1, 2)),
@@ -531,7 +531,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_value_info('y', TensorProto.FLOAT, (1, 5))],
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 10)])  # type: ignore
 
-    def test_scatter_elements(self):  # type: () -> None
+    def test_scatter_elements(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 3)),
              ('i', TensorProto.INT64, (2, 3)),
@@ -540,7 +540,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (3, 3))])  # type: ignore
 
-    def test_scatter_elements_axis1(self):  # type: () -> None
+    def test_scatter_elements_axis1(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (1, 5)),
              ('i', TensorProto.INT64, (1, 2)),
@@ -549,7 +549,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (1, 5))])  # type: ignore
 
-    def test_scatternd(self):  # type: () -> None
+    def test_scatternd(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (4, 5, 6)),
              ('indices', TensorProto.INT64, (3, 3, 2)),
@@ -558,7 +558,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (4, 5, 6))])  # type: ignore
 
-    def test_scatternd_noshape(self):  # type: () -> None
+    def test_scatternd_noshape(self) -> None:
         # The shape of 'x_reshaped' cannot be inferred, since it is the output of a dynamic reshape.
         # Thus the shape of 'y' is also None.
         graph = self._make_graph(
@@ -573,7 +573,7 @@ class TestShapeInference(unittest.TestCase):
             make_tensor_value_info('x_reshaped', TensorProto.FLOAT, None),
             make_tensor_value_info('y', TensorProto.FLOAT, None)])  # type: ignore
 
-    def test_squeeze(self):  # type: () -> None
+    def test_squeeze(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (1, 3, 1, 1, 2, 1)),
              ('axes', TensorProto.INT64, (4,))],
@@ -582,7 +582,7 @@ class TestShapeInference(unittest.TestCase):
             initializer=[make_tensor('axes', TensorProto.INT64, (4,), (0, 2, 3, 5))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (3, 2))])
 
-    def test_unsqueeze_regular(self):  # type: () -> None
+    def test_unsqueeze_regular(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 2)),
              ('axes', TensorProto.INT64, (4,))],
@@ -591,7 +591,7 @@ class TestShapeInference(unittest.TestCase):
             initializer=[make_tensor('axes', TensorProto.INT64, (4,), (0, 1, 3, 5))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (1, 1, 3, 1, 2, 1))])
 
-    def test_unsqueeze_unsorted_axes(self):  # type: () -> None
+    def test_unsqueeze_unsorted_axes(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4, 5)),
              ('axes', TensorProto.INT64, (2,))],
@@ -600,7 +600,7 @@ class TestShapeInference(unittest.TestCase):
             initializer=[make_tensor('axes', TensorProto.INT64, (2,), (4, 0))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (1, 3, 4, 5, 1))])
 
-    def test_unsqueeze_negative_axes(self):  # type: () -> None
+    def test_unsqueeze_negative_axes(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4, 5)),
              ('axes', TensorProto.INT64, (2,))],
@@ -609,14 +609,14 @@ class TestShapeInference(unittest.TestCase):
             initializer=[make_tensor('axes', TensorProto.INT64, (2,), (0, -1))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (1, 3, 4, 5, 1))])
 
-    def test_slice_without_input_shape(self):  # type: () -> None
+    def test_slice_without_input_shape(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 2)), ('starts', TensorProto.INT64, (1,)), ('ends', TensorProto.INT64, (1,))],
             [make_node('Slice', ['x', 'starts', 'ends'], ['y'])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, None)])
 
-    def test_slice_with_input_shape(self):  # type: () -> None
+    def test_slice_with_input_shape(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 2)), ('starts', TensorProto.INT64, (2, )), ('ends', TensorProto.INT64, (2, ))],
             [make_node('Slice', ['x', 'starts', 'ends'], ['y'])],
@@ -626,7 +626,7 @@ class TestShapeInference(unittest.TestCase):
                          make_tensor('ends', TensorProto.INT64, (2, ), (2, 2))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (1, 2))])
 
-    def test_slice_with_input_shape_containing_dim_params(self):  # type: () -> None
+    def test_slice_with_input_shape_containing_dim_params(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (1, 'a', 1)),
              ('starts', TensorProto.INT64, (3,)),
@@ -637,7 +637,7 @@ class TestShapeInference(unittest.TestCase):
                             make_tensor('ends', TensorProto.INT64, (3,), (1, 1, 1))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (1, None, 1))])  # type: ignore
 
-    def test_slice_with_input_shape_steps(self):  # type: () -> None
+    def test_slice_with_input_shape_steps(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (5, 6, 7)),
              ('starts', TensorProto.INT64, (3,)),
@@ -651,7 +651,7 @@ class TestShapeInference(unittest.TestCase):
                          make_tensor('steps', TensorProto.INT64, (3,), (1, 4, 3))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (1, 2, 2))])
 
-    def test_slice_with_input_shape_axes(self):  # type: () -> None
+    def test_slice_with_input_shape_axes(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 6, 2)),
              ('starts', TensorProto.INT64, (2,)),
@@ -665,7 +665,7 @@ class TestShapeInference(unittest.TestCase):
                          make_tensor('axes', TensorProto.INT64, (2,), (0, 2))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (1, 6, 2))])
 
-    def test_slice_unsorted_axes(self):  # type: () -> None
+    def test_slice_unsorted_axes(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 2)),
              ('starts', TensorProto.INT64, (2,)),
@@ -678,7 +678,7 @@ class TestShapeInference(unittest.TestCase):
                          make_tensor('axes', TensorProto.INT64, (2,), (1, 0))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (2, 1))])  # can handle unsorted axes
 
-    def test_slice_giant_number(self):  # type: () -> None
+    def test_slice_giant_number(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 2)),
              ('starts', TensorProto.INT64, (2,)),
@@ -691,7 +691,7 @@ class TestShapeInference(unittest.TestCase):
                          make_tensor('axes', TensorProto.INT64, (2,), (0, 1))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (2, 2))])
 
-    def test_slice_giant_step(self):  # type: () -> None
+    def test_slice_giant_step(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 2)),
              ('starts', TensorProto.INT64, (2,)),
@@ -706,7 +706,7 @@ class TestShapeInference(unittest.TestCase):
                          make_tensor('steps', TensorProto.INT64, (2,), (1, 200))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (2, 1))])
 
-    def test_slice_negative_end(self):  # type: () -> None
+    def test_slice_negative_end(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 2)),
              ('starts', TensorProto.INT64, (2,)),
@@ -719,7 +719,7 @@ class TestShapeInference(unittest.TestCase):
                          make_tensor('axes', TensorProto.INT64, (2,), (0, 1))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (2, 1))])  # type: ignore
 
-    def test_slice_negative_start(self):  # type: () -> None
+    def test_slice_negative_start(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 2)),
              ('starts', TensorProto.INT64, (2,)),
@@ -732,7 +732,7 @@ class TestShapeInference(unittest.TestCase):
                          make_tensor('axes', TensorProto.INT64, (2,), (0, 1))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (2, 2))])  # type: ignore
 
-    def test_slice_negative_step(self):  # type: () -> None
+    def test_slice_negative_step(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4)),
              ('starts', TensorProto.INT64, (2,)),
@@ -747,7 +747,7 @@ class TestShapeInference(unittest.TestCase):
                          make_tensor('steps', TensorProto.INT64, (2,), (1, -1))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (2, 3))])  # type: ignore
 
-    def test_slice_variable_copy(self):  # type: () -> None
+    def test_slice_variable_copy(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, ("a", 2)),
              ('starts', TensorProto.INT64, (1,)),
@@ -760,7 +760,7 @@ class TestShapeInference(unittest.TestCase):
                          make_tensor('axes', TensorProto.INT64, (1,), (1,))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, ("a", 1))])  # type: ignore
 
-    def test_slice_variable_input_types(self):  # type: () -> None
+    def test_slice_variable_input_types(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.DOUBLE, (3, 2)),
              ('starts', TensorProto.INT32, (2,)),
@@ -773,7 +773,7 @@ class TestShapeInference(unittest.TestCase):
                          make_tensor('axes', TensorProto.INT32, (2,), (0, 1))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.DOUBLE, (2, 2))])
 
-    def test_conv(self):  # type: () -> None
+    def test_conv(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4, 5, 6, 7)),
              ('y', TensorProto.FLOAT, (5, 4, 2, 4, 3))],
@@ -781,7 +781,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (3, 5, 4, 1, 3))])
 
-    def test_conv_1d_simple(self):  # type: () -> None
+    def test_conv_1d_simple(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (30, 4, 5)),
              ('y', TensorProto.FLOAT, (50, 4, 2))],
@@ -789,7 +789,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (30, 50, 4))])
 
-    def test_conv_dilations(self):  # type: () -> None
+    def test_conv_dilations(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (30, 4, 8, 8, 8)),
              ('y', TensorProto.FLOAT, (50, 4, 3, 3, 3))],
@@ -797,7 +797,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (30, 50, 6, 4, 2))])
 
-    def test_conv_strides(self):  # type: () -> None
+    def test_conv_strides(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (30, 4, 8, 8, 8)),
              ('y', TensorProto.FLOAT, (50, 4, 3, 3, 3))],
@@ -805,7 +805,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (30, 50, 6, 3, 2))])
 
-    def test_conv_pads(self):  # type: () -> None
+    def test_conv_pads(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (30, 4, 7, 6, 4)),
              ('y', TensorProto.FLOAT, (50, 4, 3, 3, 3))],
@@ -813,7 +813,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (30, 50, 6, 6, 6))])
 
-    def test_conv_auto_pad(self):  # type: () -> None
+    def test_conv_auto_pad(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (30, 4, 7, 6, 4)),
              ('y', TensorProto.FLOAT, (50, 4, 4, 3, 2))],
@@ -821,7 +821,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (30, 50, 7, 6, 4))])
 
-    def test_conv_auto_pads(self):  # type: () -> None
+    def test_conv_auto_pads(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (30, 4, 7, 6, 4)),
              ('y', TensorProto.FLOAT, (50, 4, 4, 3, 2))],
@@ -831,7 +831,7 @@ class TestShapeInference(unittest.TestCase):
             graph,
             [make_tensor_value_info('z', TensorProto.FLOAT, (30, 50, 4, 3, 4))])
 
-    def test_conv_auto_pad_dilation(self):  # type: () -> None
+    def test_conv_auto_pad_dilation(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (30, 4, 65, 64, 63)),
              ('y', TensorProto.FLOAT, (50, 4, 4, 3, 2))],
@@ -839,7 +839,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (30, 50, 65, 64, 63))])
 
-    def test_conv_group(self):  # type: () -> None
+    def test_conv_group(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (30, 4, 8, 8, 8)),
              ('y', TensorProto.FLOAT, (4, 1, 8, 8, 8))],
@@ -847,7 +847,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (30, 4, 1, 1, 1))])
 
-    def test_conv_only_one_pos(self):  # type: () -> None
+    def test_conv_only_one_pos(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (30, 4, 5)),
              ('y', TensorProto.FLOAT, (50, 4, 5))],
@@ -855,7 +855,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (30, 50, 1))])
 
-    def test_conv_partial_missing_shape(self):  # type: () -> None
+    def test_conv_partial_missing_shape(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (30, 4, None, 6, 4)),
              ('y', TensorProto.FLOAT, (50, 4, 3, 3, 3))],
@@ -863,7 +863,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (30, 50, None, 6, 6))])  # type: ignore
 
-    def test_conv_partial_missing_weight_shape(self):  # type: () -> None
+    def test_conv_partial_missing_weight_shape(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (30, 4, 7, 6, 4)),
              ('y', TensorProto.FLOAT, (50, 4, None, 3, 3))],
@@ -871,7 +871,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, None)])
 
-    def test_average_pool_auto_pads(self):  # type: () -> None
+    def test_average_pool_auto_pads(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (30, 4, 7, 6, 4))],
             [make_node('AveragePool', ['x'], 'z', auto_pad='SAME_UPPER', kernel_shape=[4, 3, 2], strides=[2, 2, 1])],
@@ -880,13 +880,13 @@ class TestShapeInference(unittest.TestCase):
             graph,
             [make_tensor_value_info('z', TensorProto.FLOAT, (30, 4, 4, 3, 4))])
 
-    def test_relu(self):  # type: () -> None
+    def test_relu(self) -> None:
         self._identity_prop('Relu')
 
-    def test_identity(self):  # type: () -> None
+    def test_identity(self) -> None:
         self._identity_prop('Identity')
 
-    def test_identity_sequence(self):  # type: () -> None
+    def test_identity_sequence(self) -> None:
         graph = self._make_graph(
             [('input1', TensorProto.FLOAT, (2, 3, 4)),
              ('input2', TensorProto.FLOAT, (2, 3, 4)),
@@ -899,7 +899,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_sequence_value_info('in_sequence', TensorProto.FLOAT, (2, None, 4)),  # type: ignore
              make_tensor_sequence_value_info('output_sequence', TensorProto.FLOAT, (2, None, 4))])  # type: ignore
 
-    def test_identity_optional(self):  # type: () -> None
+    def test_identity_optional(self) -> None:
         graph = self._make_graph(
             [('in_tensor', TensorProto.FLOAT, (2, 3, 4))],
             [make_node('Optional', ['in_tensor'], ['in_optional']),
@@ -912,7 +912,7 @@ class TestShapeInference(unittest.TestCase):
             [helper.make_value_info('in_optional', optional_type_proto),  # type: ignore
              helper.make_value_info('output_optional', optional_type_proto)])  # type: ignore
 
-    def test_identity_optional_sequence(self):  # type: () -> None
+    def test_identity_optional_sequence(self) -> None:
         graph = self._make_graph(
             [('input1', TensorProto.FLOAT, (2, 3, 4)),
              ('input2', TensorProto.FLOAT, (2, 3, 4)),
@@ -930,7 +930,7 @@ class TestShapeInference(unittest.TestCase):
              helper.make_value_info('in_optional', optional_type_proto),  # type: ignore
              helper.make_value_info('output_optional', optional_type_proto)])  # type: ignore
 
-    def test_add(self):  # type: () -> None
+    def test_add(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (30, 4, 5)),
              ('y', TensorProto.FLOAT, (30, 4, 5))],
@@ -938,7 +938,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (30, 4, 5))])
 
-    def test_pow(self):  # type: () -> None
+    def test_pow(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (30, 4, 5)),
              ('y', TensorProto.FLOAT, (30, 4, 5))],
@@ -946,7 +946,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (30, 4, 5))])
 
-    def test_bitshift(self):  # type: () -> None
+    def test_bitshift(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.UINT32, (2, 3, 1)),
              ('y', TensorProto.UINT32, (2, 3, 1))],
@@ -954,7 +954,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.UINT32, (2, 3, 1))])
 
-    def test_bitshift_broadcast_to_first(self):  # type: () -> None
+    def test_bitshift_broadcast_to_first(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.UINT32, (16, 4, 1)),
              ('y', TensorProto.UINT32, (1,))],
@@ -962,7 +962,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.UINT32, (16, 4, 1))])
 
-    def test_bitshift_broadcast_to_second(self):  # type: () -> None
+    def test_bitshift_broadcast_to_second(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.UINT32, (1,)),
              ('y', TensorProto.UINT32, (2, 3, 1))],
@@ -970,10 +970,10 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.UINT32, (2, 3, 1))])
 
-    def test_sum_single(self):  # type: () -> None
+    def test_sum_single(self) -> None:
         self._identity_prop('Sum')
 
-    def test_sum_multi(self):  # type: () -> None
+    def test_sum_multi(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (30, 4, 5)),
              ('y', TensorProto.FLOAT, (30, 4, 5)),
@@ -982,7 +982,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.FLOAT, (30, 4, 5))])
 
-    def test_sum_multi_broadcasting(self):  # type: () -> None
+    def test_sum_multi_broadcasting(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (30, 1, 5)),
              ('y', TensorProto.FLOAT, ("a", 4, 1)),
@@ -991,7 +991,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.FLOAT, (30, 4, 5))])
 
-    def test_sum_broadcasting_param(self):  # type: () -> None
+    def test_sum_broadcasting_param(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, ("a", 1, 5)),
              ('y', TensorProto.FLOAT, ("a", 4, 1))],
@@ -999,42 +999,42 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.FLOAT, ("a", 4, 5))])
 
-    def test_random_normal(self):  # type: () -> None
+    def test_random_normal(self) -> None:
         graph = self._make_graph(
             [],
             [make_node('RandomNormal', [], ['out'], dtype=TensorProto.DOUBLE, shape=(3, 4, 5))],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.DOUBLE, (3, 4, 5))])
 
-    def test_random_normal_like(self):  # type: () -> None
+    def test_random_normal_like(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (2, 3, 4))],
             [make_node('RandomNormalLike', ['X'], ['out'])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.FLOAT, (2, 3, 4))])
 
-    def test_random_normal_like_with_dtype(self):  # type: () -> None
+    def test_random_normal_like_with_dtype(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (2, 3, 4))],
             [make_node('RandomNormalLike', ['X'], ['out'], dtype=TensorProto.DOUBLE,)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.DOUBLE, (2, 3, 4))])
 
-    def test_bernoulli(self):  # type: () -> None
+    def test_bernoulli(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4))],
             [make_node('Bernoulli', ['x'], ['out'])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.FLOAT, (3, 4))])  # type: ignore
 
-    def test_bernoulli_with_dtype(self):  # type: () -> None
+    def test_bernoulli_with_dtype(self) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 3, 4))],
             [make_node('Bernoulli', ['x'], ['out'], dtype=TensorProto.DOUBLE,)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.DOUBLE, (2, 3, 4))])  # type: ignore
 
-    def _logical_binary_op(self, op, input_type):  # type: (Text, TensorProto.DataType) -> None
+    def _logical_binary_op(self, op: Text, input_type: TensorProto.DataType) -> None:
         graph = self._make_graph(
             [('x', input_type, (30, 4, 5)),
              ('y', input_type, (30, 4, 5))],
@@ -1042,7 +1042,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.BOOL, (30, 4, 5))])
 
-    def _logical_binary_op_with_broadcasting(self, op, input_type):  # type: (Text, TensorProto.DataType) -> None
+    def _logical_binary_op_with_broadcasting(self, op: Text, input_type: TensorProto.DataType) -> None:
         graph = self._make_graph(
             [('x', input_type, (1, 5)),
              ('y', input_type, (30, 4, 5))],
@@ -1050,74 +1050,74 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.BOOL, (30, 4, 5))])
 
-    def test_logical_and(self):  # type: () -> None
+    def test_logical_and(self) -> None:
         self._logical_binary_op('And', TensorProto.BOOL)
         self._logical_binary_op_with_broadcasting('And', TensorProto.BOOL)
 
-    def test_logical_or(self):  # type: () -> None
+    def test_logical_or(self) -> None:
         self._logical_binary_op('Or', TensorProto.BOOL)
         self._logical_binary_op_with_broadcasting('Or', TensorProto.BOOL)
 
-    def test_logical_xor(self):  # type: () -> None
+    def test_logical_xor(self) -> None:
         self._logical_binary_op('Xor', TensorProto.BOOL)
         self._logical_binary_op_with_broadcasting('Xor', TensorProto.BOOL)
 
-    def test_greater(self):  # type: () -> None
+    def test_greater(self) -> None:
         self._logical_binary_op('Greater', TensorProto.BOOL)
         self._logical_binary_op_with_broadcasting('Greater', TensorProto.BOOL)
 
-    def test_less(self):  # type: () -> None
+    def test_less(self) -> None:
         self._logical_binary_op('Less', TensorProto.BOOL)
         self._logical_binary_op_with_broadcasting('Less', TensorProto.BOOL)
 
-    def test_equal(self):  # type: () -> None
+    def test_equal(self) -> None:
         self._logical_binary_op('Equal', TensorProto.BOOL)
         self._logical_binary_op_with_broadcasting('Equal', TensorProto.BOOL)
 
-    def test_logical_not(self):  # type: () -> None
+    def test_logical_not(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.BOOL, (30, 4, 5))],
             [make_node('Not', ['x'], 'z')],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.BOOL, (30, 4, 5))])
 
-    def test_less_or_equal(self):  # type: () -> None
+    def test_less_or_equal(self) -> None:
         self._logical_binary_op('LessOrEqual', TensorProto.BOOL)
         self._logical_binary_op_with_broadcasting('LessOrEqual', TensorProto.BOOL)
 
-    def test_greater_or_equal(self):  # type: () -> None
+    def test_greater_or_equal(self) -> None:
         self._logical_binary_op('GreaterOrEqual', TensorProto.BOOL)
         self._logical_binary_op_with_broadcasting('GreaterOrEqual', TensorProto.BOOL)
 
-    def test_flatten(self):  # type: () -> None
+    def test_flatten(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 3, 4, 5))],
             [make_node('Flatten', ['x'], ['z'], axis=2)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (6, 20))])
 
-    def test_flatten_default_axis(self):  # type: () -> None
+    def test_flatten_default_axis(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 3, 4, 5))],
             [make_node('Flatten', ['x'], ['z'])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (2, 60))])
 
-    def test_flatten_zero_axis(self):  # type: () -> None
+    def test_flatten_zero_axis(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 3, 4, 5))],
             [make_node('Flatten', ['x'], ['z'], axis=0)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (1, 120))])
 
-    def test_flatten_unknown_dim(self):  # type: () -> None
+    def test_flatten_unknown_dim(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 'N', 4, 5))],
             [make_node('Flatten', ['x'], ['z'], axis=2)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (None, 20))])  # type: ignore
 
-    def test_space_to_depth(self):  # type: () -> None
+    def test_space_to_depth(self) -> None:
         b = 10
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 3, 100, 100))],
@@ -1125,7 +1125,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (2, 300, 10, 10))])
 
-    def test_space_to_depth_unknown_dim(self):  # type: () -> None
+    def test_space_to_depth_unknown_dim(self) -> None:
         b = 10
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 'N', 100, 100))],
@@ -1133,7 +1133,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (2, None, 10, 10))])  # type: ignore
 
-    def test_depth_to_space(self):  # type: () -> None
+    def test_depth_to_space(self) -> None:
         b = 10
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 300, 10, 10))],
@@ -1141,7 +1141,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (2, 3, 100, 100))])
 
-    def _rnn_forward(self, seqlen, batchsize, inpsize, hiddensize):  # type: (int, int, int, int) -> None
+    def _rnn_forward(self, seqlen: int, batchsize: int, inpsize: int, hiddensize: int) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (seqlen, batchsize, inpsize)),
              ('w', TensorProto.FLOAT, (1, hiddensize, inpsize)),
@@ -1152,10 +1152,10 @@ class TestShapeInference(unittest.TestCase):
             make_tensor_value_info('all', TensorProto.FLOAT, (seqlen, 1, batchsize, hiddensize)),
             make_tensor_value_info('last', TensorProto.FLOAT, (1, batchsize, hiddensize))])
 
-    def test_rnn_forward(self):  # type: () -> None
+    def test_rnn_forward(self) -> None:
         self._rnn_forward(64, 32, 10, 4)
 
-    def _rnn_bidirectional(self, seqlen, batchsize, inpsize, hiddensize):  # type: (int, int, int, int) -> None
+    def _rnn_bidirectional(self, seqlen: int, batchsize: int, inpsize: int, hiddensize: int) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (seqlen, batchsize, inpsize)),
              ('w', TensorProto.FLOAT, (2, hiddensize, inpsize)),
@@ -1167,11 +1167,11 @@ class TestShapeInference(unittest.TestCase):
             make_tensor_value_info('all', TensorProto.FLOAT, (seqlen, 2, batchsize, hiddensize)),
             make_tensor_value_info('last', TensorProto.FLOAT, (2, batchsize, hiddensize))])
 
-    def test_rnn_layout(self):  # type: () -> None
+    def test_rnn_layout(self) -> None:
         self._rnn_layout(64, 32, 10, 4)
         self._rnn_layout(64, 32, 10, 4, 'bidirectional')
 
-    def _rnn_layout(self, seqlen, batchsize, inpsize, hiddensize, direction='forward'):  # type: (int, int, int, int, Text) -> None
+    def _rnn_layout(self, seqlen: int, batchsize: int, inpsize: int, hiddensize: int, direction: Text = 'forward') -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (batchsize, seqlen, inpsize)),
              ('w', TensorProto.FLOAT, (1, hiddensize, inpsize)),
@@ -1187,10 +1187,10 @@ class TestShapeInference(unittest.TestCase):
             make_tensor_value_info('all', TensorProto.FLOAT, (batchsize, seqlen, num_directions, hiddensize)),
             make_tensor_value_info('last', TensorProto.FLOAT, (batchsize, num_directions, hiddensize))])
 
-    def test_rnn_bidirectional(self):  # type: () -> None
+    def test_rnn_bidirectional(self) -> None:
         self._rnn_bidirectional(64, 32, 10, 4)
 
-    def _lstm_forward(self, seqlen, batchsize, inpsize, hiddensize):  # type: (int, int, int, int) -> None
+    def _lstm_forward(self, seqlen: int, batchsize: int, inpsize: int, hiddensize: int) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (seqlen, batchsize, inpsize)),
              ('w', TensorProto.FLOAT, (1, 4 * hiddensize, inpsize)),
@@ -1202,10 +1202,10 @@ class TestShapeInference(unittest.TestCase):
             make_tensor_value_info('hidden', TensorProto.FLOAT, (1, batchsize, hiddensize)),
             make_tensor_value_info('last', TensorProto.FLOAT, (1, batchsize, hiddensize))])
 
-    def test_lstm_forward(self):  # type: () -> None
+    def test_lstm_forward(self) -> None:
         self._lstm_forward(64, 32, 10, 4)
 
-    def test_topk_default_axis(self):  # type: () -> None
+    def test_topk_default_axis(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4, 5, 10))],
             [make_node('TopK', ['x', 'k'], ['y', 'z'])],
@@ -1215,7 +1215,7 @@ class TestShapeInference(unittest.TestCase):
                               [make_tensor_value_info('y', TensorProto.FLOAT, (3, 4, 5, 2)),
                                make_tensor_value_info('z', TensorProto.INT64, (3, 4, 5, 2))])
 
-    def test_topk(self):  # type: () -> None
+    def test_topk(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4, 5, 10))],
             [make_node('TopK', ['x', 'k'], ['y', 'z'], axis=2)],
@@ -1225,7 +1225,7 @@ class TestShapeInference(unittest.TestCase):
                               [make_tensor_value_info('y', TensorProto.FLOAT, (3, 4, 2, 10)),
                                make_tensor_value_info('z', TensorProto.INT64, (3, 4, 2, 10))])
 
-    def test_topk_raw_data(self):  # type: () -> None
+    def test_topk_raw_data(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4, 5, 10))],
             [make_node('TopK', ['x', 'k'], ['y', 'z'], axis=2)],
@@ -1236,7 +1236,7 @@ class TestShapeInference(unittest.TestCase):
                               [make_tensor_value_info('y', TensorProto.FLOAT, (3, 4, 3, 10)),
                                make_tensor_value_info('z', TensorProto.INT64, (3, 4, 3, 10))])
 
-    def test_topk_missing_k_value_output_rank_check(self):  # type: () -> None
+    def test_topk_missing_k_value_output_rank_check(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4, 5, 10)),
             ('k', TensorProto.INT64, (1,))],
@@ -1246,7 +1246,7 @@ class TestShapeInference(unittest.TestCase):
                               [make_tensor_value_info('y', TensorProto.FLOAT, (None, None, None, None)),  # type: ignore
                                make_tensor_value_info('z', TensorProto.INT64, (None, None, None, None))])  # type: ignore
 
-    def test_gemm(self):  # type: () -> None
+    def test_gemm(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (7, 5)),
              ('y', TensorProto.FLOAT, (5, 11)),
@@ -1255,7 +1255,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.FLOAT, (7, 11))])
 
-    def test_gemm_transA(self):  # type: () -> None
+    def test_gemm_transA(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (5, 7)),
              ('y', TensorProto.FLOAT, (5, 11)),
@@ -1264,7 +1264,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.FLOAT, (7, 11))])
 
-    def test_gemm_transB(self):  # type: () -> None
+    def test_gemm_transB(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (7, 5)),
              ('y', TensorProto.FLOAT, (11, 5)),
@@ -1273,7 +1273,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.FLOAT, (7, 11))])
 
-    def test_gemm_transA_and_transB(self):  # type: () -> None
+    def test_gemm_transA_and_transB(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (5, 7)),
              ('y', TensorProto.FLOAT, (11, 5)),
@@ -1282,7 +1282,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.FLOAT, (7, 11))])
 
-    def test_gemm_no_bias(self):  # type: () -> None
+    def test_gemm_no_bias(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (13, 7)),
              ('y', TensorProto.FLOAT, (7, 17))],
@@ -1290,70 +1290,70 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.FLOAT, (13, 17))])
 
-    def test_reduce_op_shape_2_axis(self):  # type: () -> None
+    def test_reduce_op_shape_2_axis(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (24, 4, 11))],
             [make_node('ReduceL1', 'x', 'y', axes=(1, 2), keepdims=0)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (24,))])
 
-    def test_reduce_op_shape_keep_dims(self):  # type: () -> None
+    def test_reduce_op_shape_keep_dims(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (24, 4, 11))],
             [make_node('ReduceL1', 'x', 'y', axes=(1, 2), keepdims=1)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (24, 1, 1))])
 
-    def test_reduce_op_shape_default_value(self):  # type: () -> None
+    def test_reduce_op_shape_default_value(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (24, 4, 11))],
             [make_node('ReduceL1', 'x', 'y')],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (1, 1, 1))])
 
-    def test_reduce_op_shape_no_axes_do_not_keep_dims(self):  # type: () -> None
+    def test_reduce_op_shape_no_axes_do_not_keep_dims(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (24, 4, 11))],
             [make_node('ReduceL1', 'x', 'y', keepdims=0)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, tuple())])
 
-    def test_reduce_op_shape_negative_axis(self):  # type: () -> None
+    def test_reduce_op_shape_negative_axis(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (24, 4, 11))],
             [make_node('ReduceL1', 'x', 'y', axes=(-1, -2))],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (24, 1, 1))])
 
-    def test_argmax_shape(self):  # type: () -> None
+    def test_argmax_shape(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (24, 4, 11))],
             [make_node('ArgMax', 'x', 'y', axis=1, keepdims=1)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, (24, 1, 11))])
 
-    def test_argmax_shape_keepdims(self):  # type: () -> None
+    def test_argmax_shape_keepdims(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (24, 4, 11))],
             [make_node('ArgMax', 'x', 'y', axis=0, keepdims=0)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, (4, 11))])
 
-    def test_argmax_shape_default_value(self):  # type: () -> None
+    def test_argmax_shape_default_value(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (24, 4, 11))],
             [make_node('ArgMax', 'x', 'y')],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, (1, 4, 11))])
 
-    def test_argmax_shape_negative_axis(self):  # type: () -> None
+    def test_argmax_shape_negative_axis(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (24, 4, 11))],
             [make_node('ArgMax', 'x', 'y', axis=-2)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, (24, 1, 11))])
 
-    def test_dropout(self):  # type: () -> None
+    def test_dropout(self) -> None:
         graph = self._make_graph(
             [('data', TensorProto.FLOAT, (3, 4, 5,)),
              ('ratio', TensorProto.FLOAT, ())],
@@ -1361,10 +1361,10 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.FLOAT, (3, 4, 5,))])
 
-    def test_LRN(self):  # type: () -> None
+    def test_LRN(self) -> None:
         self._identity_prop('LRN', alpha=0.5, beta=0.5, size=1)
 
-    def test_batch_norm(self):  # type: () -> None
+    def test_batch_norm(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4, 5, 6, 7)),
              ('scale', TensorProto.FLOAT, (4,)),
@@ -1375,7 +1375,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.FLOAT, (3, 4, 5, 6, 7))])
 
-    def test_batch_norm_rank1(self):  # type: () -> None
+    def test_batch_norm_rank1(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (128,)),   # 1-dimensional permitted
              ('scale', TensorProto.FLOAT, (1,)),
@@ -1386,7 +1386,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.FLOAT, (128,))])
 
-    def test_batch_norm_invalid(self):  # type: () -> None
+    def test_batch_norm_invalid(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (128,)),
              ('scale', TensorProto.FLOAT, (1, 2)),   # invalid rank
@@ -1397,7 +1397,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self.assertRaises(onnx.shape_inference.InferenceError, self._inferred, graph)
 
-    def test_split_negative_axis(self):  # type: () -> None
+    def test_split_negative_axis(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 4))],
             [make_node('Split', ['x'], ['y', 'z'], axis=-1)],
@@ -1405,7 +1405,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (2, 2)),
                                       make_tensor_value_info('z', TensorProto.FLOAT, (2, 2))])
 
-    def test_split_with_split_attribute(self):  # type: () -> None
+    def test_split_with_split_attribute(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 4)),
              ('split', TensorProto.INT64, (2,))],
@@ -1415,7 +1415,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (2, 3)),
                                       make_tensor_value_info('z', TensorProto.FLOAT, (2, 1))])
 
-    def test_split_with_split_attribute_unknown_split_dim(self):  # type: () -> None
+    def test_split_with_split_attribute_unknown_split_dim(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 'a', 'b')),
              ('split', TensorProto.INT64, (2,))],
@@ -1425,7 +1425,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (2, None, 'b')),  # type: ignore
                                       make_tensor_value_info('z', TensorProto.FLOAT, (2, None, 'b'))])  # type: ignore
 
-    def test_split_from_GLU(self):  # type: () -> None
+    def test_split_from_GLU(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (5, 6, 7))],
             [make_node('Split', ['x'], ['y', 'z'], axis=1)],
@@ -1433,7 +1433,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (5, 3, 7)),
                                       make_tensor_value_info('z', TensorProto.FLOAT, (5, 3, 7))])
 
-    def test_GLU_partial(self):  # type: () -> None
+    def test_GLU_partial(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (5, 6, 7))],
             [make_node('Split', ['x'], ['y', 'z'], axis=1),
@@ -1443,7 +1443,7 @@ class TestShapeInference(unittest.TestCase):
                                       make_tensor_value_info('z', TensorProto.FLOAT, (5, 3, 7)),
                                       make_tensor_value_info('a', TensorProto.FLOAT, (5, 3, 7))])
 
-    def test_GLU(self):  # type: () -> None
+    def test_GLU(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (5, 6, 7))],
             [make_node('Split', ['x'], ['y', 'z'], axis=1),
@@ -1455,63 +1455,63 @@ class TestShapeInference(unittest.TestCase):
                                       make_tensor_value_info('a', TensorProto.FLOAT, (5, 3, 7)),
                                       make_tensor_value_info('b', TensorProto.FLOAT, (5, 3, 7))])
 
-    def test_softmax_2d(self):  # type: () -> None
+    def test_softmax_2d(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (4, 5))],
             [make_node('Softmax', ['x'], 'z')],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (4, 5))])
 
-    def test_softmax_3d(self):  # type: () -> None
+    def test_softmax_3d(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (4, 5, 6))],
             [make_node('Softmax', ['x'], 'z')],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (4, 5, 6))])
 
-    def test_hardmax_2d(self):  # type: () -> None
+    def test_hardmax_2d(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (4, 5))],
             [make_node('Hardmax', ['x'], 'z')],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (4, 5))])
 
-    def test_hardmax_3d(self):  # type: () -> None
+    def test_hardmax_3d(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (4, 5, 6))],
             [make_node('Hardmax', ['x'], 'z')],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (4, 5, 6))])
 
-    def test_logsoftmax_2d(self):  # type: () -> None
+    def test_logsoftmax_2d(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (4, 5))],
             [make_node('LogSoftmax', ['x'], 'z')],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (4, 5))])
 
-    def test_logsoftmax_3d(self):  # type: () -> None
+    def test_logsoftmax_3d(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (4, 5, 6))],
             [make_node('LogSoftmax', ['x'], 'z')],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (4, 5, 6))])
 
-    def test_logsoftmax_3d_negative_axis(self):  # type: () -> None
+    def test_logsoftmax_3d_negative_axis(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (4, 5, 6))],
             [make_node('LogSoftmax', ['x'], 'z', axis=-1)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (4, 5, 6))])
 
-    def test_maxpool(self):  # type: () -> None
+    def test_maxpool(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
             [make_node("MaxPool", ["X"], ["Y"], kernel_shape=[2, 2])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 3, 3))])
 
-    def test_maxpool_with_indices(self):  # type: () -> None
+    def test_maxpool_with_indices(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
             [make_node("MaxPool", ["X"], ["Y", "Z"], kernel_shape=[2, 2])],
@@ -1519,161 +1519,161 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 3, 3)),
                                       make_tensor_value_info("Z", TensorProto.INT64, (5, 3, 3, 3))])
 
-    def test_maxpool_3D(self):  # type: () -> None
+    def test_maxpool_3D(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4, 4))],
             [make_node("MaxPool", ["X"], ["Y"], kernel_shape=[2, 2, 2])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 3, 3, 3))])
 
-    def test_maxpool_with_padding(self):  # type: () -> None
+    def test_maxpool_with_padding(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
             [make_node("MaxPool", ["X"], ["Y"], kernel_shape=[2, 2], pads=[1, 1, 2, 2])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 6, 6))])
 
-    def test_maxpool_with_padding_and_stride(self):  # type: () -> None
+    def test_maxpool_with_padding_and_stride(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
             [make_node("MaxPool", ["X"], ["Y"], kernel_shape=[2, 2], pads=[1, 1, 2, 2], strides=[2, 2])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 3, 3))])
 
-    def test_maxpool_with_floor_mode(self):  # type: () -> None
+    def test_maxpool_with_floor_mode(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (32, 288, 35, 35))],
             [make_node("MaxPool", ["X"], ["Y"], kernel_shape=[2, 2], strides=[2, 2], ceil_mode=False)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (32, 288, 17, 17))])
 
-    def test_maxpool_with_ceil_mode(self):  # type: () -> None
+    def test_maxpool_with_ceil_mode(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (32, 288, 35, 35))],
             [make_node("MaxPool", ["X"], ["Y"], kernel_shape=[2, 2], strides=[2, 2], ceil_mode=True)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (32, 288, 18, 18))])
 
-    def test_maxpool_ceil(self):  # type: () -> None
+    def test_maxpool_ceil(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (1, 1, 4, 4))],
             [make_node("MaxPool", ["X"], ["Y"], kernel_shape=[3, 3], strides=[2, 2], ceil_mode=True)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (1, 1, 2, 2))])
 
-    def test_maxpool_with_dilations(self):  # type: () -> None
+    def test_maxpool_with_dilations(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
             [make_node("MaxPool", ["X"], ["Y"], kernel_shape=[2, 2], dilations=[2, 2])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 2, 2))])
 
-    def test_maxpool_with_same_upper_padding_and_stride(self):  # type: () -> None
+    def test_maxpool_with_same_upper_padding_and_stride(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
             [make_node("MaxPool", ["X"], ["Y"], auto_pad="SAME_UPPER", kernel_shape=[2, 2], strides=[2, 2])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 2, 2))])
 
-    def test_maxpool_with_same_upper_padding_and_stride_and_dilation(self):  # type: () -> None
+    def test_maxpool_with_same_upper_padding_and_stride_and_dilation(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
             [make_node("MaxPool", ["X"], ["Y"], auto_pad="SAME_UPPER", kernel_shape=[2, 2], strides=[2, 2], dilations=[2, 3])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 2, 2))])
 
-    def test_maxpool_with_same_upper_padding_and_stride_one(self):  # type: () -> None
+    def test_maxpool_with_same_upper_padding_and_stride_one(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
             [make_node("MaxPool", ["X"], ["Y"], auto_pad="SAME_UPPER", kernel_shape=[2, 2], strides=[1, 1])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 4, 4))])
 
-    def test_maxpool_with_same_lower_padding_and_stride(self):  # type: () -> None
+    def test_maxpool_with_same_lower_padding_and_stride(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 9, 9))],
             [make_node("MaxPool", ["X"], ["Y"], auto_pad="SAME_LOWER", kernel_shape=[2, 2], strides=[2, 2])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 5, 5))])
 
-    def test_maxpool_with_same_lower_padding_and_stride_and_dilation(self):  # type: () -> None
+    def test_maxpool_with_same_lower_padding_and_stride_and_dilation(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 9, 9))],
             [make_node("MaxPool", ["X"], ["Y"], auto_pad="SAME_LOWER", kernel_shape=[2, 2], strides=[2, 2], dilations=[2, 3])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 5, 5))])
 
-    def test_maxpool_with_same_lower_padding_and_big_stride(self):  # type: () -> None
+    def test_maxpool_with_same_lower_padding_and_big_stride(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
             [make_node("MaxPool", ["X"], ["Y"], auto_pad="SAME_LOWER", kernel_shape=[2, 2], strides=[4, 4])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 1, 1))])
 
-    def test_averagepool(self):  # type: () -> None
+    def test_averagepool(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
             [make_node("AveragePool", ["X"], ["Y"], kernel_shape=[2, 2])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 3, 3))])
 
-    def test_averagepool_3D(self):  # type: () -> None
+    def test_averagepool_3D(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4, 4))],
             [make_node("AveragePool", ["X"], ["Y"], kernel_shape=[2, 2, 2])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 3, 3, 3))])
 
-    def test_averagepool_with_padding(self):  # type: () -> None
+    def test_averagepool_with_padding(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
             [make_node("AveragePool", ["X"], ["Y"], kernel_shape=[2, 2], pads=[1, 1, 2, 2])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 6, 6))])
 
-    def test_averagepool_with_padding_and_stride(self):  # type: () -> None
+    def test_averagepool_with_padding_and_stride(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
             [make_node("AveragePool", ["X"], ["Y"], kernel_shape=[2, 2], pads=[1, 1, 2, 2], strides=[2, 2])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 3, 3))])
 
-    def test_averagepool_ceil(self):  # type: () -> None
+    def test_averagepool_ceil(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (1, 1, 4, 4))],
             [make_node("AveragePool", ["X"], ["Y"], kernel_shape=[3, 3], strides=[2, 2], ceil_mode=True)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (1, 1, 2, 2))])
 
-    def test_lppool(self):  # type: () -> None
+    def test_lppool(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
             [make_node("LpPool", ["X"], ["Y"], kernel_shape=[2, 2])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 3, 3))])
 
-    def test_lppool_3D(self):  # type: () -> None
+    def test_lppool_3D(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4, 4))],
             [make_node("LpPool", ["X"], ["Y"], kernel_shape=[2, 2, 2])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 3, 3, 3))])
 
-    def test_lppool_with_padding(self):  # type: () -> None
+    def test_lppool_with_padding(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
             [make_node("LpPool", ["X"], ["Y"], kernel_shape=[2, 2], pads=[1, 1, 2, 2])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 6, 6))])
 
-    def test_lppool_with_padding_and_stride(self):  # type: () -> None
+    def test_lppool_with_padding_and_stride(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
             [make_node("LpPool", ["X"], ["Y"], kernel_shape=[2, 2], pads=[1, 1, 2, 2], strides=[2, 2])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 3, 3))])
 
-    def test_roipool(self):  # type: () -> None
+    def test_roipool(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4)),
             ("rois", TensorProto.INT64, (2, 5))],
@@ -1681,14 +1681,14 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (2, 3, 2, 2))])
 
-    def test_lp_norm(self):  # type: () -> None
+    def test_lp_norm(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4, 5, 6, 7))],
             [make_node('LpNormalization', ['x'], ['out'])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.FLOAT, (3, 4, 5, 6, 7))])
 
-    def test_instance_norm(self):  # type: () -> None
+    def test_instance_norm(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4, 5, 6, 7)),
              ('scale', TensorProto.FLOAT, (4,)),
@@ -1697,28 +1697,28 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.FLOAT, (3, 4, 5, 6, 7))])
 
-    def test_global_maxpool(self):  # type: () -> None
+    def test_global_maxpool(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
             [make_node("GlobalMaxPool", ["X"], ["Y"])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 1, 1))])
 
-    def test_global_averagepool(self):  # type: () -> None
+    def test_global_averagepool(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
             [make_node("GlobalAveragePool", ["X"], ["Y"])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 1, 1))])
 
-    def test_global_lppool(self):  # type: () -> None
+    def test_global_lppool(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
             [make_node("GlobalLpPool", ["X"], ["Y"])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 1, 1))])
 
-    def test_conv_transpose(self):  # type: () -> None
+    def test_conv_transpose(self) -> None:
         graph = self._make_graph(
             [('X', TensorProto.FLOAT, (25, 48, 16, 16)),
              ('W', TensorProto.FLOAT, (48, 32, 3, 3))],
@@ -1726,7 +1726,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('Y', TensorProto.FLOAT, (25, 32, 33, 33))])
 
-    def test_conv_transpose_with_pads(self):  # type: () -> None
+    def test_conv_transpose_with_pads(self) -> None:
         graph = self._make_graph(
             [('X', TensorProto.FLOAT, (25, 48, 16, 16)),
              ('W', TensorProto.FLOAT, (48, 32, 3, 3))],
@@ -1734,7 +1734,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('Y', TensorProto.FLOAT, (25, 32, 30, 30))])
 
-    def test_conv_transpose_with_output_shape(self):  # type: () -> None
+    def test_conv_transpose_with_output_shape(self) -> None:
         graph = self._make_graph(
             [('X', TensorProto.FLOAT, (25, 48, 16, 16)),
              ('W', TensorProto.FLOAT, (48, 32, 3, 3))],
@@ -1742,7 +1742,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('Y', TensorProto.FLOAT, (25, 32, 36, 36))])
 
-    def test_conv_transpose_with_kernel_shape(self):  # type: () -> None
+    def test_conv_transpose_with_kernel_shape(self) -> None:
         graph = self._make_graph(
             [('X', TensorProto.FLOAT, (25, 48, 16, 16)),
              ('W', TensorProto.FLOAT, (48, 32, None, None))],
@@ -1750,7 +1750,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('Y', TensorProto.FLOAT, (25, 32, 30, 30))])
 
-    def test_conv_transpose_with_dilations(self):  # type: () -> None
+    def test_conv_transpose_with_dilations(self) -> None:
         graph = self._make_graph(
             [('X', TensorProto.FLOAT, (25, 48, 16, 16)),
              ('W', TensorProto.FLOAT, (48, 32, 3, 3))],
@@ -1758,7 +1758,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('Y', TensorProto.FLOAT, (25, 32, 34, 34))])
 
-    def test_conv_transpose_with_group(self):  # type: () -> None
+    def test_conv_transpose_with_group(self) -> None:
         graph = self._make_graph(
             [('X', TensorProto.FLOAT, (25, 48, 16, 16)),
              ('W', TensorProto.FLOAT, (48, 32, 3, 3))],
@@ -1766,7 +1766,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('Y', TensorProto.FLOAT, (25, 64, 30, 30))])
 
-    def test_conv_transpose_with_group_and_output_shape(self):  # type: () -> None
+    def test_conv_transpose_with_group_and_output_shape(self) -> None:
         graph = self._make_graph(
             [('X', TensorProto.FLOAT, (25, 48, 16, 16)),
              ('W', TensorProto.FLOAT, (48, 32, 3, 3))],
@@ -1774,7 +1774,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('Y', TensorProto.FLOAT, (25, 64, 36, 36))])
 
-    def test_conv_transpose_with_pads_and_auto_pads(self):  # type: () -> None
+    def test_conv_transpose_with_pads_and_auto_pads(self) -> None:
         # This test should fail because pads cannot be used simultaneously with auto_pad
         graph = self._make_graph(
             [('X', TensorProto.FLOAT, (1, 1, 2, 2)),
@@ -1784,7 +1784,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self.assertRaises(onnx.shape_inference.InferenceError, onnx.shape_inference.infer_shapes, helper.make_model(graph), strict_mode=True)
 
-    def test_conv_transpose_auto_pads(self):  # type: () -> None
+    def test_conv_transpose_auto_pads(self) -> None:
         graph = self._make_graph(
             [('X', TensorProto.FLOAT, (25, 48, 16, 16)),
              ('W', TensorProto.FLOAT, (48, 32, 3, 3))],
@@ -1794,7 +1794,7 @@ class TestShapeInference(unittest.TestCase):
             graph,
             [make_tensor_value_info('Y', TensorProto.FLOAT, (25, 32, 32, 32))])
 
-    def test_mvn_function_output_shape(self):  # type: () -> None
+    def test_mvn_function_output_shape(self) -> None:
         graph = self._make_graph(
             [('X', TensorProto.FLOAT, (25, 48, 16, 16))],
             [make_node('MeanVarianceNormalization', 'X', 'Y', axes=[0, 2, 3])],
@@ -1802,7 +1802,7 @@ class TestShapeInference(unittest.TestCase):
         )
         self._assert_inferred(graph, [make_tensor_value_info('Y', TensorProto.FLOAT, (25, 48, 16, 16))])
 
-    def test_scan(self):    # type: () -> None
+    def test_scan(self) -> None:
         batch_size = 1
         seq_len = 'sequence'
         input_size = 2
@@ -1838,7 +1838,7 @@ class TestShapeInference(unittest.TestCase):
              make_tensor_value_info('scan_output', TensorProto.FLOAT, (batch_size, seq_len, input_size))],
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 8)])
 
-    def test_scan_opset9(self):    # type: () -> None
+    def test_scan_opset9(self) -> None:
         seq_len = 'sequence'
         input_size = 2
         loop_state_size = 3
@@ -1873,7 +1873,7 @@ class TestShapeInference(unittest.TestCase):
              make_tensor_value_info('scan_output', TensorProto.FLOAT, (seq_len, input_size))],
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 9)])
 
-    def test_scan_opset9_axes(self):    # type: () -> None
+    def test_scan_opset9_axes(self) -> None:
         axis_0_len = 'axis0'
         seq_len = 'sequence'
         input_size = 2
@@ -1909,7 +1909,7 @@ class TestShapeInference(unittest.TestCase):
              make_tensor_value_info('scan_output', TensorProto.FLOAT, (seq_len, axis_0_len, input_size))],
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 9)])
 
-    def test_scan_opset9_output_axes(self):    # type: () -> None
+    def test_scan_opset9_output_axes(self) -> None:
         axis_0_len = 'axis0'
         seq_len = 'sequence'
         input_size = 2
@@ -1942,7 +1942,7 @@ class TestShapeInference(unittest.TestCase):
              make_tensor_value_info('scan_output', TensorProto.FLOAT, (axis_0_len, seq_len, input_size))],
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 9)])
 
-    def test_scan_opset9_negative_axes(self):    # type: () -> None
+    def test_scan_opset9_negative_axes(self) -> None:
         axis_0_len = 'axis0'
         seq_len = 'sequence'
         input_size = 2
@@ -1975,7 +1975,7 @@ class TestShapeInference(unittest.TestCase):
              make_tensor_value_info('scan_output', TensorProto.FLOAT, (axis_0_len, seq_len, input_size))],
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 9)])
 
-    def test_if_ver1(self):  # type: () -> None
+    def test_if_ver1(self) -> None:
 
         # Create a simple If node where the 'then' subgraph adds to the current value, and the 'else' subgraph
         # subtracts.
@@ -2010,7 +2010,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_value_info('if_output', TensorProto.FLOAT, (1,))],
             opset_imports=[make_opsetid(ONNX_DOMAIN, 10)])
 
-    def test_if(self):  # type: () -> None
+    def test_if(self) -> None:
 
         # Create a simple If node where the 'then' subgraph adds to the current value, and the 'else' subgraph
         # subtracts.
@@ -2042,7 +2042,7 @@ class TestShapeInference(unittest.TestCase):
 
         self._assert_inferred(graph, [make_tensor_value_info('if_output', TensorProto.FLOAT, (1,))])
 
-    def test_if_with_different_shapes_in_then_else_branches(self):  # type: () -> None
+    def test_if_with_different_shapes_in_then_else_branches(self) -> None:
 
         # Create a simple If node where the 'then' subgraph adds to the current value, and the 'else' subgraph
         # subtracts.
@@ -2074,7 +2074,7 @@ class TestShapeInference(unittest.TestCase):
 
         self._assert_inferred(graph, [make_tensor_value_info('if_output', TensorProto.FLOAT, (None,))])  # type: ignore
 
-    def test_if_with_different_optional_shapes_in_then_else_branches(self):  # type: () -> None
+    def test_if_with_different_optional_shapes_in_then_else_branches(self) -> None:
         # Create a simple If node where the 'then' subgraph adds to the current value, and the 'else' subgraph
         # subtracts.
         # can't use self._make_graph for the subgraphs as that add more inputs for the Reshape operations it inserts.
@@ -2113,7 +2113,7 @@ class TestShapeInference(unittest.TestCase):
         output_optional_vi = helper.make_value_info('if_output', output_optional_type_proto)
         self._assert_inferred(graph, [output_optional_vi])  # type: ignore
 
-    def test_maxunpool_shape_without_output_shape(self):  # type: () -> None
+    def test_maxunpool_shape_without_output_shape(self) -> None:
         graph = self._make_graph(
             [('xT', TensorProto.FLOAT, (1, 1, 2, 2)),
              ('xI', TensorProto.FLOAT, (1, 1, 2, 2))],
@@ -2121,7 +2121,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('Y', TensorProto.FLOAT, (1, 1, 4, 4))])
 
-    def test_maxunpool_shape_with_output_shape(self):  # type: () -> None
+    def test_maxunpool_shape_with_output_shape(self) -> None:
         graph = self._make_graph(
             [('xT', TensorProto.FLOAT, (1, 1, 2, 2)),
              ('xI', TensorProto.FLOAT, (1, 1, 2, 2)),
@@ -2130,7 +2130,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_value_info("Y", TensorProto.FLOAT, None)])
         self._assert_inferred(graph, [make_tensor_value_info("Y", TensorProto.FLOAT, None)])
 
-    def test_onehot_without_axis(self):  # type: () -> None
+    def test_onehot_without_axis(self) -> None:
         graph = self._make_graph(
             [('indices', TensorProto.INT64, (2, 2)),
              ('depth', TensorProto.INT64, ()),
@@ -2139,7 +2139,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('Y', TensorProto.FLOAT, (2, 2, None))])  # type: ignore
 
-    def test_onehot_with_axis(self):  # type: () -> None
+    def test_onehot_with_axis(self) -> None:
         graph = self._make_graph(
             [('indices', TensorProto.INT64, (2, 3, 5)),
              ('depth', TensorProto.INT64, (1, )),
@@ -2148,7 +2148,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('Y', TensorProto.FLOAT, (2, None, 3, 5))])  # type: ignore
 
-    def test_loop(self):    # type: () -> None
+    def test_loop(self) -> None:
         # can't use self._make_graph for the subgraph as it add more inputs for the Reshape operations it inserts.
         # this breaks the subgraph inferencing as it expects the number of inputs passed from Loop to match
         # the GraphProto, but Loop knows nothing about the additional inputs.
@@ -2183,7 +2183,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_value_info('loop_state_final', TensorProto.FLOAT, None),  # shape may change between iterations
              make_tensor_value_info('loop_output', TensorProto.FLOAT, (None, 3))])  # type: ignore
 
-    def test_loop_no_state(self):    # type: () -> None
+    def test_loop_no_state(self) -> None:
         input_value_infos = [make_tensor_value_info('iter_num_in', TensorProto.INT64, (1,)),
                              make_tensor_value_info('cond_in', TensorProto.UNDEFINED, None)]
         output_value_infos = [make_tensor_value_info('cond_out', TensorProto.UNDEFINED, None),
@@ -2210,7 +2210,7 @@ class TestShapeInference(unittest.TestCase):
             graph,
             [make_tensor_value_info('loop_output', TensorProto.FLOAT, (None, 3))])  # type: ignore
 
-    def test_constantofshape_with_input_shape(self):  # type: () -> None
+    def test_constantofshape_with_input_shape(self) -> None:
         graph = self._make_graph([],
             [make_node("Constant", [], ['shape'],
                        value=make_tensor('shape', TensorProto.INT64, (3,), (3, 4, 5))),
@@ -2220,14 +2220,14 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_value_info('shape', TensorProto.INT64, (3,)),
              make_tensor_value_info('y', TensorProto.INT32, (3, 4, 5))])  # type: ignore
 
-    def test_constantofshape_without_input_shape(self):  # type: () -> None
+    def test_constantofshape_without_input_shape(self) -> None:
         graph = self._make_graph([('shape', TensorProto.INT64, (3, ))],
             [make_node("ConstantOfShape", ['shape'], ['y'], value=make_tensor('value', TensorProto.UINT8, (1, ), (2, )))],
             [])
         self._assert_inferred(graph,
             [make_tensor_value_info('y', TensorProto.UINT8, (None, None, None))])  # type: ignore
 
-    def test_constantofshape_with_symbolic_shape(self):  # type: () -> None
+    def test_constantofshape_with_symbolic_shape(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4, 5))],
             [make_node("Shape", ['x'], ['shape']),
@@ -2237,14 +2237,14 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_value_info('shape', TensorProto.INT64, (3,)),
              make_tensor_value_info('y', TensorProto.INT32, (3, 4, 5))], data_prop=True)  # type: ignore
 
-    def test_constantofshape_without_input_shape_scalar(self):  # type: () -> None
+    def test_constantofshape_without_input_shape_scalar(self) -> None:
         graph = self._make_graph([('shape', TensorProto.INT64, (0, ))],
             [make_node("ConstantOfShape", ['shape'], ['y'], value=make_tensor('value', TensorProto.UINT8, (1, ), (2, )))],
             [])
         self._assert_inferred(graph,
             [make_tensor_value_info('y', TensorProto.UINT8, ())])  # type: ignore
 
-    def test_constantofshape_with_shape_zero(self):  # type: () -> None
+    def test_constantofshape_with_shape_zero(self) -> None:
         graph = self._make_graph([],
             [make_node("Constant", [], ['shape'],
                        value=make_tensor('shape', TensorProto.INT64, (1,), (0,))),
@@ -2254,7 +2254,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_value_info('shape', TensorProto.INT64, (1,)),
              make_tensor_value_info('y', TensorProto.INT32, (0,))])  # type: ignore
 
-    def test_convinteger(self):  # type: () -> None
+    def test_convinteger(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.UINT8, (3, 4, 5, 6, 7)),
              ('y', TensorProto.UINT8, (5, 4, 2, 4, 3))],
@@ -2262,7 +2262,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.INT32, (3, 5, 4, 1, 3))])
 
-    def test_convinetger_dilations(self):  # type: () -> None
+    def test_convinetger_dilations(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.UINT8, (30, 4, 8, 8, 8)),
              ('y', TensorProto.INT8, (50, 4, 3, 3, 3)),
@@ -2272,7 +2272,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.INT32, (30, 50, 6, 4, 2))])
 
-    def test_convinteger_strides(self):  # type: () -> None
+    def test_convinteger_strides(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.INT8, (30, 4, 8, 8, 8)),
              ('y', TensorProto.INT8, (50, 4, 3, 3, 3)),
@@ -2282,7 +2282,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.INT32, (30, 50, 6, 3, 2))])
 
-    def test_convineteger_pads(self):  # type: () -> None
+    def test_convineteger_pads(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.UINT8, (30, 4, 7, 6, 4)),
              ('y', TensorProto.INT8, (50, 4, 3, 3, 3))],
@@ -2290,7 +2290,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.INT32, (30, 50, 6, 6, 6))])
 
-    def test_convineteger_group(self):  # type: () -> None
+    def test_convineteger_group(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.INT8, (30, 4, 8, 8, 8)),
              ('y', TensorProto.INT8, (4, 1, 8, 8, 8))],
@@ -2298,7 +2298,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.INT32, (30, 4, 1, 1, 1))])
 
-    def test_convineteger_partial_missing_shape(self):  # type: () -> None
+    def test_convineteger_partial_missing_shape(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.UINT8, (30, 4, None, 6, 4)),
              ('y', TensorProto.UINT8, (50, 4, 3, 3, 3)),
@@ -2308,7 +2308,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.INT32, (30, 50, None, 6, 6))])  # type: ignore
 
-    def test_convineteger_partial_missing_weight_shape(self):  # type: () -> None
+    def test_convineteger_partial_missing_weight_shape(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.UINT8, (30, 4, 7, 6, 4)),
              ('y', TensorProto.UINT8, (50, 4, None, 3, 3))],
@@ -2316,7 +2316,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.INT32, None)])
 
-    def test_qlinearconv(self):  # type: () -> None
+    def test_qlinearconv(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.UINT8, (3, 4, 5, 6, 7)),
              ('x_scale', TensorProto.FLOAT, ()),
@@ -2330,7 +2330,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.UINT8, (3, 5, 4, 1, 3))])
 
-    def test_qlinearconv_dilations(self):  # type: () -> None
+    def test_qlinearconv_dilations(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.UINT8, (30, 4, 8, 8, 8)),
              ('x_scale', TensorProto.FLOAT, ()),
@@ -2344,7 +2344,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.UINT8, (30, 50, 6, 4, 2))])
 
-    def test_qlinearconv_strides(self):  # type: () -> None
+    def test_qlinearconv_strides(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.INT8, (30, 4, 8, 8, 8)),
              ('x_scale', TensorProto.FLOAT, ()),
@@ -2358,7 +2358,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT8, (30, 50, 6, 3, 2))])
 
-    def test_qlinearconv_pads(self):  # type: () -> None
+    def test_qlinearconv_pads(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.UINT8, (30, 4, 7, 6, 4)),
              ('x_scale', TensorProto.FLOAT, ()),
@@ -2372,7 +2372,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.UINT8, (30, 50, 6, 6, 6))])
 
-    def test_qlinearconv_group(self):  # type: () -> None
+    def test_qlinearconv_group(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.INT8, (30, 4, 8, 8, 8)),
              ('x_scale', TensorProto.FLOAT, ()),
@@ -2386,7 +2386,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT8, (30, 4, 1, 1, 1))])
 
-    def test_qlinearconv_partial_missing_shape(self):  # type: () -> None
+    def test_qlinearconv_partial_missing_shape(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.UINT8, (30, 4, None, 6, 4)),
              ('x_scale', TensorProto.FLOAT, ()),
@@ -2400,7 +2400,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.UINT8, (30, 50, None, 6, 6))])  # type: ignore
 
-    def test_qlinearconv_partial_missing_weight_shape(self):  # type: () -> None
+    def test_qlinearconv_partial_missing_weight_shape(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.UINT8, (30, 4, 7, 6, 4)),
              ('x_scale', TensorProto.FLOAT, ()),
@@ -2414,7 +2414,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.UINT8, None)])
 
-    def _make_qlinearmatmul_test(self, shape1, shape2):  # type: (Sequence[int], Sequence[int]) -> None
+    def _make_qlinearmatmul_test(self, shape1: Sequence[int], shape2: Sequence[int]) -> None:
         expected_out_shape = np.matmul(np.arange(np.product(shape1)).reshape(shape1),
                                        np.arange(np.product(shape2)).reshape(shape2)).shape
         graph = self._make_graph(
@@ -2430,7 +2430,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.UINT8, expected_out_shape)])
 
-    def test_qlinearmatmul(self):  # type: () -> None
+    def test_qlinearmatmul(self) -> None:
         self._make_qlinearmatmul_test((3,), (3,))
         self._make_qlinearmatmul_test((4, 2), (2, 4))
         self._make_qlinearmatmul_test((2,), (2, 3))
@@ -2438,7 +2438,7 @@ class TestShapeInference(unittest.TestCase):
         self._make_qlinearmatmul_test((5, 1, 4, 2), (1, 3, 2, 3))
         self._make_qlinearmatmul_test((4, 2), (3, 2, 3))
 
-    def _make_qlinearmatmul_test_allow_unknown(self, shape1, shape2, expected_out_shape):  # type: (Any, Any, Any) -> None
+    def _make_qlinearmatmul_test_allow_unknown(self, shape1: Any, shape2: Any, expected_out_shape: Any) -> None:
         graph = self._make_graph(
             [('a', TensorProto.UINT8, shape1),
              ('a_scale', TensorProto.FLOAT, ()),
@@ -2452,7 +2452,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.UINT8, expected_out_shape)])
 
-    def test_qlinearmatmul_allow_unknown(self):  # type: () -> None
+    def test_qlinearmatmul_allow_unknown(self) -> None:
         self._make_qlinearmatmul_test_allow_unknown((None,), (None,), ())
         self._make_qlinearmatmul_test_allow_unknown((3,), (None,), ())
         self._make_qlinearmatmul_test_allow_unknown((2,), (2, "a"), ("a",))
@@ -2464,7 +2464,7 @@ class TestShapeInference(unittest.TestCase):
         self._make_qlinearmatmul_test_allow_unknown(None, ("a", 2, 5), None)
         self._make_qlinearmatmul_test_allow_unknown(None, None, None)
 
-    def _make_matmulinteger_test(self, shape1, shape2):  # type: (Sequence[int], Sequence[int]) -> None
+    def _make_matmulinteger_test(self, shape1: Sequence[int], shape2: Sequence[int]) -> None:
         expected_out_shape = np.matmul(np.arange(np.product(shape1)).reshape(shape1),
                                        np.arange(np.product(shape2)).reshape(shape2)).shape
         graph = self._make_graph(
@@ -2476,7 +2476,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('Y', TensorProto.INT32, expected_out_shape)])
 
-    def test_matmulinteger(self):  # type: () -> None
+    def test_matmulinteger(self) -> None:
         self._make_matmulinteger_test((2,), (2,))
         self._make_matmulinteger_test((1, 2), (2, 3))
         self._make_matmulinteger_test((2,), (2, 3))
@@ -2484,7 +2484,7 @@ class TestShapeInference(unittest.TestCase):
         self._make_matmulinteger_test((5, 1, 4, 2), (1, 3, 2, 3))
         self._make_matmulinteger_test((4, 2), (3, 2, 3))
 
-    def test_quantizelinear(self):  # type: () -> None
+    def test_quantizelinear(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (30, 4, 5)),
              ('y_scale', TensorProto.FLOAT, ()),
@@ -2493,7 +2493,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.UINT8, (30, 4, 5))])
 
-    def test_quantizelinear_default_zp(self):  # type: () -> None
+    def test_quantizelinear_default_zp(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (30, 4, 5)),
              ('y_scale', TensorProto.FLOAT, ())],
@@ -2501,7 +2501,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.UINT8, (30, 4, 5))])
 
-    def test_quantizelinear_optional_input(self):  # type: () -> None
+    def test_quantizelinear_optional_input(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (30, 4, 5)),
              ('y_scale', TensorProto.FLOAT, ())],
@@ -2509,7 +2509,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.UINT8, (30, 4, 5))])
 
-    def test_dequantizelinear(self):  # type: () -> None
+    def test_dequantizelinear(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.UINT8, (30, 4, 5)),
              ('x_scale', TensorProto.FLOAT, ()),
@@ -2518,7 +2518,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (30, 4, 5))])
 
-    def test_dynamicquantizelinear(self):  # type: () -> None
+    def test_dynamicquantizelinear(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (30, 4, 5))],
             [make_node('DynamicQuantizeLinear', ['x'], ['y', 'y_scale', 'y_zero_point'])],
@@ -2527,7 +2527,7 @@ class TestShapeInference(unittest.TestCase):
                                       make_tensor_value_info('y_scale', TensorProto.FLOAT, ()),
                                       make_tensor_value_info('y_zero_point', TensorProto.UINT8, ())])
 
-    def test_reversesequence(self):  # type: () -> None
+    def test_reversesequence(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (4, 5, 6)),
              ('sequence_lens', TensorProto.INT64, (5,))],
@@ -2535,7 +2535,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (4, 5, 6))])
 
-    def test_unique_without_axis(self):  # type: () -> None
+    def test_unique_without_axis(self) -> None:
         graph = self._make_graph(
             [('X', TensorProto.FLOAT, (2, 4, 2))],
             [make_node('Unique', ['X'], ['Y', 'indices', 'inverse_indices', 'counts'])],
@@ -2545,7 +2545,7 @@ class TestShapeInference(unittest.TestCase):
                                       make_tensor_value_info('inverse_indices', TensorProto.INT64, (None,)),  # type: ignore
                                       make_tensor_value_info('counts', TensorProto.INT64, (None,))])  # type: ignore
 
-    def test_unique_with_axis(self):  # type: () -> None
+    def test_unique_with_axis(self) -> None:
         graph = self._make_graph(
             [('X', TensorProto.FLOAT, (2, 4, 2))],
             [make_node('Unique', ['X'], ['Y', 'indices', 'inverse_indices', 'counts'], axis=1)],
@@ -2555,7 +2555,7 @@ class TestShapeInference(unittest.TestCase):
                                       make_tensor_value_info('inverse_indices', TensorProto.INT64, (None,)),  # type: ignore
                                       make_tensor_value_info('counts', TensorProto.INT64, (None,))])  # type: ignore
 
-    def test_det(self):  # type: () -> None
+    def test_det(self) -> None:
         graph = self._make_graph(
             [('X', TensorProto.FLOAT, (3, 3))],
             [make_node('Det', ['X'], ['Y'])],
@@ -2568,7 +2568,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('Y', TensorProto.FLOAT, (4, 5, 6))])
 
-    def test_tile(self):  # type: () -> None
+    def test_tile(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (4, 5, 6)),
              ('repeats', TensorProto.INT64, (3,))],
@@ -2577,7 +2577,7 @@ class TestShapeInference(unittest.TestCase):
             initializer=[make_tensor('repeats', TensorProto.INT64, (3,), (1, 2, 3))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (4, 10, 18))])
 
-    def test_tile_raw_input_data(self):  # type: () -> None
+    def test_tile_raw_input_data(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (4, 5, 6)),
              ('repeats', TensorProto.INT64, (3,))],
@@ -2587,7 +2587,7 @@ class TestShapeInference(unittest.TestCase):
                                      vals=np.array([1, 2, 3], dtype='<i8').tobytes(), raw=True)])  # Feed raw bytes (force little endian ordering like onnx standard) for test purpose
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (4, 10, 18))])
 
-    def test_tile_rank_inference(self):  # type: () -> None
+    def test_tile_rank_inference(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (4, 5, 6)),
              ('repeats', TensorProto.INT64, (3,))],
@@ -2595,7 +2595,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (None, None, None))])  # type: ignore
 
-    def test_linearclassifier_1D_input(self):  # type: () -> None
+    def test_linearclassifier_1D_input(self) -> None:
         if ONNX_ML:
             graph = self._make_graph(
                 [('x', TensorProto.FLOAT, (5,))],
@@ -2605,7 +2605,7 @@ class TestShapeInference(unittest.TestCase):
                                           make_tensor_value_info('z', TensorProto.FLOAT, (1, 2))],
                                           opset_imports=[make_opsetid(ONNX_ML_DOMAIN, 1), make_opsetid(ONNX_DOMAIN, 11)])
 
-    def test_linearclassifier_2D_input(self):  # type: () -> None
+    def test_linearclassifier_2D_input(self) -> None:
         if ONNX_ML:
             graph = self._make_graph(
                 [('x', TensorProto.FLOAT, (4, 5))],
@@ -2615,7 +2615,7 @@ class TestShapeInference(unittest.TestCase):
                                           make_tensor_value_info('z', TensorProto.FLOAT, (4, 3))],
                                           opset_imports=[make_opsetid(ONNX_ML_DOMAIN, 1), make_opsetid(ONNX_DOMAIN, 11)])
 
-    def test_roialign_symbolic(self):   # type: () -> None
+    def test_roialign_symbolic(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, ('N', 'C', 'H', 'W')),
              ('rois', TensorProto.FLOAT, ('num_rois', 4)),
@@ -2624,7 +2624,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, ('num_rois', 'C', 10, 5))])  # type: ignore
 
-    def test_roialign_symbolic_defaults(self):   # type: () -> None
+    def test_roialign_symbolic_defaults(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, ('N', 'C', 'H', 'W')),
              ('rois', TensorProto.FLOAT, ('num_rois', 4)),
@@ -2633,7 +2633,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, ('num_rois', 'C', 1, 1))])  # type: ignore
 
-    def test_roialign_num_rois(self):   # type: () -> None
+    def test_roialign_num_rois(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, ('N', 'C', 'H', 'W')),
              ('rois', TensorProto.FLOAT, ('num_rois', 4)),
@@ -2642,7 +2642,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (15, 'C', 1, 1))])  # type: ignore
 
-    def test_label_encoder_string_int64(self):  # type: () -> None
+    def test_label_encoder_string_int64(self) -> None:
         if ONNX_ML:
             string_list = ['A', 'm', 'y']
             float_list = [94.17, 36.00]
@@ -2690,11 +2690,11 @@ class TestShapeInference(unittest.TestCase):
                                   opset_imports=[make_opsetid(ONNX_ML_DOMAIN, 2), make_opsetid(ONNX_DOMAIN, 11)])
 
     def make_sparse(self,
-                    shape,  # type: Sequence[int]
-                    values,  # type: Sequence[int]
-                    indices_shape,  # type: Sequence[int]
-                    indices  # type: Sequence[int]
-                    ):  # type: (...) -> SparseTensorProto
+                    shape: Sequence[int],
+                    values: Sequence[int],
+                    indices_shape: Sequence[int],
+                    indices: Sequence[int]
+                    ) -> SparseTensorProto:
         sparse = SparseTensorProto()
         sparse.dims.extend(shape)
         nnz = len(values)
@@ -2702,7 +2702,7 @@ class TestShapeInference(unittest.TestCase):
         sparse.indices.CopyFrom(helper.make_tensor('spind', TensorProto.INT64, indices_shape, indices))
         return sparse
 
-    def test_constant_sparse(self):  # type: () -> None
+    def test_constant_sparse(self) -> None:
         y_shape = [100]
         y_value = self.make_sparse(y_shape, [13, 17, 19], [3], [9, 27, 81])
         graph = self._make_graph(
@@ -2711,14 +2711,14 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, y_shape)])  # type: ignore
 
-    def test_constant_value_int(self):  # type: () -> None
+    def test_constant_value_int(self) -> None:
         graph = self._make_graph(
             [],
             [make_node('Constant', [], ['y'], value_int=42)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, [])])
 
-    def test_constant_value_ints(self):  # type: () -> None
+    def test_constant_value_ints(self) -> None:
         value_ints = [1, 2, 3]
         graph = self._make_graph(
             [],
@@ -2726,14 +2726,14 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, [len(value_ints)])])
 
-    def test_constant_value_float(self):  # type: () -> None
+    def test_constant_value_float(self) -> None:
         graph = self._make_graph(
             [],
             [make_node('Constant', [], ['y'], value_float=1.42)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, [])])
 
-    def test_constant_value_floats(self):  # type: () -> None
+    def test_constant_value_floats(self) -> None:
         value_floats = [1.0, 1.1, 1.2]
         graph = self._make_graph(
             [],
@@ -2741,14 +2741,14 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, [len(value_floats)])])
 
-    def test_constant_value_string(self):  # type: () -> None
+    def test_constant_value_string(self) -> None:
         graph = self._make_graph(
             [],
             [make_node('Constant', [], ['y'], value_string="String value")],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.STRING, [])])
 
-    def test_constant_value_strings(self):  # type: () -> None
+    def test_constant_value_strings(self) -> None:
         value_strings = ["o", "n", "n", "x"]
         graph = self._make_graph(
             [],
@@ -2756,7 +2756,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.STRING, [len(value_strings)])])
 
-    def test_range(self):  # type: () -> None
+    def test_range(self) -> None:
         graph = self._make_graph(
             [('start', TensorProto.FLOAT, ()),
              ('limit', TensorProto.FLOAT, ()),
@@ -2768,7 +2768,7 @@ class TestShapeInference(unittest.TestCase):
                          make_tensor('delta', TensorProto.FLOAT, (), (2,))])
         self._assert_inferred(graph, [make_tensor_value_info('output', TensorProto.FLOAT, (2,))])
 
-    def test_range_rank_inference(self):  # type: () -> None
+    def test_range_rank_inference(self) -> None:
         graph = self._make_graph(
             [('start', TensorProto.INT32, ()),
              ('limit', TensorProto.INT32, ()),
@@ -2779,7 +2779,7 @@ class TestShapeInference(unittest.TestCase):
                          make_tensor('limit', TensorProto.INT32, (), (5,))])  # Missing 'delta' initializer
         self._assert_inferred(graph, [make_tensor_value_info('output', TensorProto.INT32, (None,))])  # type: ignore
 
-    def test_gathernd(self):  # type: () -> None
+    def test_gathernd(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (4, 5, 6)),
              ('indices', TensorProto.INT64, (2,))],
@@ -2787,7 +2787,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (6,))])
 
-    def test_gathernd_batchdim_1(self):  # type: () -> None
+    def test_gathernd_batchdim_1(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 2, 2)),
              ('indices', TensorProto.INT64, (2, 1))],
@@ -2795,7 +2795,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (2, 2))])
 
-    def test_cumsum(self):  # type: () -> None
+    def test_cumsum(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 3)),
              ('axis', TensorProto.FLOAT, (1,))],
@@ -2803,7 +2803,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (2, 3))])
 
-    def test_nonmaxsuppression(self):  # type: () -> None
+    def test_nonmaxsuppression(self) -> None:
         graph = self._make_graph(
             [('boxes', TensorProto.FLOAT, (1, 3, 4)),
              ('scores', TensorProto.FLOAT, (1, 5, 3))],
@@ -2811,14 +2811,14 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, (None, 3))])  # type: ignore
 
-    def test_sequence_empty(self):  # type: () -> None
+    def test_sequence_empty(self) -> None:
         graph = self._make_graph(
             [],
             [make_node('SequenceEmpty', [], ['output'])],
             [])
         self._assert_inferred(graph, [make_tensor_sequence_value_info('output', TensorProto.FLOAT, None)])  # type: ignore
 
-    def test_sequence_construct(self):  # type: () -> None
+    def test_sequence_construct(self) -> None:
         graph = self._make_graph(
             [('input1', TensorProto.FLOAT, (2, 3, 4)),
              ('input2', TensorProto.FLOAT, (2, 3, 4)),
@@ -2828,7 +2828,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph,
             [make_tensor_sequence_value_info('output_sequence', TensorProto.FLOAT, (2, 3, 4))])  # type: ignore
 
-    def test_sequence_construct_one_input(self):  # type: () -> None
+    def test_sequence_construct_one_input(self) -> None:
         graph = self._make_graph(
             [('input1', TensorProto.FLOAT, (2, 3, 4))],
             [make_node('SequenceConstruct', ['input1'], ['output_sequence'])],
@@ -2836,7 +2836,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph,
             [make_tensor_sequence_value_info('output_sequence', TensorProto.FLOAT, (2, 3, 4))])  # type: ignore
 
-    def test_sequence_construct_diff_rank(self):  # type: () -> None
+    def test_sequence_construct_diff_rank(self) -> None:
         graph = self._make_graph(
             [('input1', TensorProto.FLOAT, (2, 3, 4)),
              ('input2', TensorProto.FLOAT, (2, 3)),
@@ -2846,7 +2846,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph,
             [make_tensor_sequence_value_info('output_sequence', TensorProto.FLOAT, None)])  # type: ignore
 
-    def test_sequence_construct_diff_dim_size(self):  # type: () -> None
+    def test_sequence_construct_diff_dim_size(self) -> None:
         graph = self._make_graph(
             [('input1', TensorProto.FLOAT, (2, 3, 4)),
              ('input2', TensorProto.FLOAT, (2, 3, 5)),
@@ -2856,7 +2856,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph,
             [make_tensor_sequence_value_info('output_sequence', TensorProto.FLOAT, (2, 3, None))])  # type: ignore
 
-    def test_sequence_insert(self):  # type: () -> None
+    def test_sequence_insert(self) -> None:
         graph = self._make_graph(
             [('input1', TensorProto.FLOAT, (2, 3, 4)),
              ('input2', TensorProto.FLOAT, (2, 3, 4)),
@@ -2870,7 +2870,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_sequence_value_info('in_sequence', TensorProto.FLOAT, (2, 3, 4)),
              make_tensor_sequence_value_info('output_sequence', TensorProto.FLOAT, (2, 3, 4))])  # type: ignore
 
-    def test_sequence_insert_diff_rank(self):  # type: () -> None
+    def test_sequence_insert_diff_rank(self) -> None:
         graph = self._make_graph(
             [('input1', TensorProto.FLOAT, (2, 3, 4)),
              ('input2', TensorProto.FLOAT, (2, 3, 4)),
@@ -2884,7 +2884,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_sequence_value_info('in_sequence', TensorProto.FLOAT, (2, 3, 4)),
              make_tensor_sequence_value_info('output_sequence', TensorProto.FLOAT, None)])  # type: ignore
 
-    def test_sequence_insert_diff_shape(self):  # type: () -> None
+    def test_sequence_insert_diff_shape(self) -> None:
         graph = self._make_graph(
             [('input1', TensorProto.FLOAT, (2, 3, 4)),
              ('input2', TensorProto.FLOAT, (2, 3, 4)),
@@ -2898,7 +2898,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_sequence_value_info('in_sequence', TensorProto.FLOAT, (2, None, 4)),  # type: ignore
              make_tensor_sequence_value_info('output_sequence', TensorProto.FLOAT, (2, None, None))])  # type: ignore
 
-    def test_sequence_at(self):  # type: () -> None
+    def test_sequence_at(self) -> None:
         graph = self._make_graph(
             [('input1', TensorProto.FLOAT, (2, 3, 4)),
              ('input2', TensorProto.FLOAT, (2, 3, 4)),
@@ -2912,7 +2912,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_sequence_value_info('in_sequence', TensorProto.FLOAT, (2, 3, 4)),
              make_tensor_value_info('output', TensorProto.FLOAT, (2, 3, 4))])  # type: ignore
 
-    def test_sequence_at_unknown_shape(self):  # type: () -> None
+    def test_sequence_at_unknown_shape(self) -> None:
         graph = self._make_graph(
             [('input1', TensorProto.FLOAT, (2, 3, 4)),
              ('input2', TensorProto.FLOAT, (2, 3)),
@@ -2926,7 +2926,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_sequence_value_info('in_sequence', TensorProto.FLOAT, None),
              make_tensor_value_info('output', TensorProto.FLOAT, None)])  # type: ignore
 
-    def test_sequence_at_unknown_dim_size(self):  # type: () -> None
+    def test_sequence_at_unknown_dim_size(self) -> None:
         graph = self._make_graph(
             [('input1', TensorProto.FLOAT, (2, 3, 4)),
              ('input2', TensorProto.FLOAT, (2, 3, 5)),
@@ -2940,7 +2940,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_sequence_value_info('in_sequence', TensorProto.FLOAT, (2, 3, None)),  # type: ignore
              make_tensor_value_info('output', TensorProto.FLOAT, (2, 3, None))])  # type: ignore
 
-    def test_sequence_erase(self):  # type: () -> None
+    def test_sequence_erase(self) -> None:
         graph = self._make_graph(
             [('input1', TensorProto.FLOAT, (2, 3, 4)),
              ('input2', TensorProto.FLOAT, (2, 3, 4)),
@@ -2954,7 +2954,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_sequence_value_info('in_sequence', TensorProto.FLOAT, (2, 3, 4)),
              make_tensor_sequence_value_info('output_sequence', TensorProto.FLOAT, (2, 3, 4))])  # type: ignore
 
-    def test_sequence_erase_diff_dim_size(self):  # type: () -> None
+    def test_sequence_erase_diff_dim_size(self) -> None:
         graph = self._make_graph(
             [('input1', TensorProto.FLOAT, (2, 3, 'x')),
              ('input2', TensorProto.FLOAT, (2, 3, 'x')),
@@ -2968,7 +2968,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_sequence_value_info('in_sequence', TensorProto.FLOAT, (2, None, 'x')),  # type: ignore
              make_tensor_sequence_value_info('output_sequence', TensorProto.FLOAT, (2, None, 'x'))])  # type: ignore
 
-    def test_sequence_length(self):  # type: () -> None
+    def test_sequence_length(self) -> None:
         graph = self._make_graph(
             [('input1', TensorProto.FLOAT, (2, 3, 'x')),
              ('input2', TensorProto.FLOAT, (2, 3, 'x')),
@@ -2981,7 +2981,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_sequence_value_info('in_sequence', TensorProto.FLOAT, (2, 3, 'x')),
              make_tensor_value_info('len', TensorProto.INT64, ())])  # type: ignore
 
-    def test_split_to_sequence(self):  # type: () -> None
+    def test_split_to_sequence(self) -> None:
         graph = self._make_graph(
             [('input', TensorProto.FLOAT, (6, 4)),
              ('split', TensorProto.INT32, (2,))],
@@ -2991,7 +2991,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph,
             [make_tensor_sequence_value_info('output_sequence', TensorProto.FLOAT, (3, 4))])  # type: ignore
 
-    def test_split_to_sequence_scalar(self):  # type: () -> None
+    def test_split_to_sequence_scalar(self) -> None:
         graph = self._make_graph(
             [('input', TensorProto.FLOAT, (6, 4)),
              ('split', TensorProto.INT32, ())],
@@ -3001,7 +3001,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph,
             [make_tensor_sequence_value_info('output_sequence', TensorProto.FLOAT, (2, 4))])  # type: ignore
 
-    def test_split_to_sequence_keepdims(self):  # type: () -> None
+    def test_split_to_sequence_keepdims(self) -> None:
         graph = self._make_graph(
             [('input', TensorProto.FLOAT, (6, 4))],
             [make_node('SplitToSequence', ['input'], ['output_sequence'], keepdims=1)],
@@ -3009,7 +3009,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph,
             [make_tensor_sequence_value_info('output_sequence', TensorProto.FLOAT, (1, 4))])  # type: ignore
 
-    def test_split_to_sequence_not_keepdims(self):  # type: () -> None
+    def test_split_to_sequence_not_keepdims(self) -> None:
         graph = self._make_graph(
             [('input', TensorProto.FLOAT, (6, 4))],
             [make_node('SplitToSequence', ['input'], ['output_sequence'], keepdims=0)],
@@ -3017,7 +3017,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph,
             [make_tensor_sequence_value_info('output_sequence', TensorProto.FLOAT, (4, ))])  # type: ignore
 
-    def test_split_to_sequence_ignore_keepdims(self):  # type: () -> None
+    def test_split_to_sequence_ignore_keepdims(self) -> None:
         graph = self._make_graph(
             [('input', TensorProto.FLOAT, (6, 4)),
              ('split', TensorProto.INT32, (2,))],
@@ -3027,7 +3027,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph,
             [make_tensor_sequence_value_info('output_sequence', TensorProto.FLOAT, (3, 4))])  # type: ignore
 
-    def test_split_to_sequence_axis(self):  # type: () -> None
+    def test_split_to_sequence_axis(self) -> None:
         graph = self._make_graph(
             [('input', TensorProto.FLOAT, (6, 4))],
             [make_node('SplitToSequence', ['input'], ['output_sequence'], axis=1)],
@@ -3035,7 +3035,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph,
             [make_tensor_sequence_value_info('output_sequence', TensorProto.FLOAT, (6, 1))])  # type: ignore
 
-    def test_split_to_sequence_neg_axis(self):  # type: () -> None
+    def test_split_to_sequence_neg_axis(self) -> None:
         graph = self._make_graph(
             [('input', TensorProto.FLOAT, (6, 4))],
             [make_node('SplitToSequence', ['input'], ['output_sequence'], axis=-2)],
@@ -3043,7 +3043,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph,
             [make_tensor_sequence_value_info('output_sequence', TensorProto.FLOAT, (1, 4))])  # type: ignore
 
-    def test_split_to_sequence_split_sizes(self):  # type: () -> None
+    def test_split_to_sequence_split_sizes(self) -> None:
         graph = self._make_graph(
             [('input', TensorProto.FLOAT, (6, 4)),
              ('split', TensorProto.INT32, (3,))],
@@ -3053,7 +3053,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph,
             [make_tensor_sequence_value_info('output_sequence', TensorProto.FLOAT, (None, 4))])  # type: ignore
 
-    def test_split_to_sequence_non_divisible(self):  # type: () -> None
+    def test_split_to_sequence_non_divisible(self) -> None:
         graph = self._make_graph(
             [('input', TensorProto.FLOAT, (6, 4)),
              ('split', TensorProto.INT32, ())],
@@ -3063,7 +3063,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph,
             [make_tensor_sequence_value_info('output_sequence', TensorProto.FLOAT, (None, 4))])  # type: ignore
 
-    def test_concat_from_sequence(self):  # type: () -> None
+    def test_concat_from_sequence(self) -> None:
         graph = self._make_graph(
             [('input1', TensorProto.FLOAT, (2, 3, 'x')),
              ('input2', TensorProto.FLOAT, (2, 3, 'x')),
@@ -3076,7 +3076,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_sequence_value_info('in_sequence', TensorProto.FLOAT, (2, 3, 'x')),
              make_tensor_value_info('out', TensorProto.FLOAT, (None, 3, 'x'))])  # type: ignore
 
-    def test_concat_from_sequence_unknown_shape(self):  # type: () -> None
+    def test_concat_from_sequence_unknown_shape(self) -> None:
         graph = self._make_graph(
             [('input1', TensorProto.FLOAT, (2, 3, 'x')),
              ('input2', TensorProto.FLOAT, (2, 3)),
@@ -3089,7 +3089,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_sequence_value_info('in_sequence', TensorProto.FLOAT, None),
              make_tensor_value_info('out', TensorProto.FLOAT, None)])  # type: ignore
 
-    def test_concat_from_sequence_unknown_dim_size(self):  # type: () -> None
+    def test_concat_from_sequence_unknown_dim_size(self) -> None:
         graph = self._make_graph(
             [('input1', TensorProto.FLOAT, (2, 3, 'x')),
              ('input2', TensorProto.FLOAT, (2, 4, 'x')),
@@ -3102,7 +3102,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_sequence_value_info('in_sequence', TensorProto.FLOAT, (2, None, 'x')),  # type: ignore
              make_tensor_value_info('out', TensorProto.FLOAT, (None, None, 'x'))])  # type: ignore
 
-    def test_concat_from_sequence_axis(self):  # type: () -> None
+    def test_concat_from_sequence_axis(self) -> None:
         graph = self._make_graph(
             [('input1', TensorProto.FLOAT, (2, 3, 'x')),
              ('input2', TensorProto.FLOAT, (2, 4, 'x')),
@@ -3115,7 +3115,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_sequence_value_info('in_sequence', TensorProto.FLOAT, (2, None, 'x')),  # type: ignore
              make_tensor_value_info('out', TensorProto.FLOAT, (2, None, None))])  # type: ignore
 
-    def test_concat_from_sequence_neg_axis(self):  # type: () -> None
+    def test_concat_from_sequence_neg_axis(self) -> None:
         graph = self._make_graph(
             [('input1', TensorProto.FLOAT, (2, 3, 'x')),
              ('input2', TensorProto.FLOAT, (2, 4, 'x')),
@@ -3128,7 +3128,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_sequence_value_info('in_sequence', TensorProto.FLOAT, (2, None, 'x')),  # type: ignore
              make_tensor_value_info('out', TensorProto.FLOAT, (None, None, 'x'))])  # type: ignore
 
-    def test_concat_from_sequence_new_axis(self):  # type: () -> None
+    def test_concat_from_sequence_new_axis(self) -> None:
         graph = self._make_graph(
             [('input1', TensorProto.FLOAT, (2, 3, 'x')),
              ('input2', TensorProto.FLOAT, (2, 3, 'x')),
@@ -3141,7 +3141,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_sequence_value_info('in_sequence', TensorProto.FLOAT, (2, 3, 'x')),
              make_tensor_value_info('out', TensorProto.FLOAT, (2, 3, None, 'x'))])  # type: ignore
 
-    def test_concat_from_sequence_neg_new_axis(self):  # type: () -> None
+    def test_concat_from_sequence_neg_new_axis(self) -> None:
         graph = self._make_graph(
             [('input1', TensorProto.FLOAT, (2, 3, 'x')),
              ('input2', TensorProto.FLOAT, (2, 3, 'x')),
@@ -3154,7 +3154,7 @@ class TestShapeInference(unittest.TestCase):
             [make_tensor_sequence_value_info('in_sequence', TensorProto.FLOAT, (2, 3, 'x')),
              make_tensor_value_info('out', TensorProto.FLOAT, (2, 3, 'x', None))])  # type: ignore
 
-    def test_adagrad(self):  # type: () -> None
+    def test_adagrad(self) -> None:
         graph = self._make_graph(
             [('R', TensorProto.FLOAT, ()),  # scalar's shape is ()
              ('T', TensorProto.INT64, ()),  # scalar's shape is ()
@@ -3171,7 +3171,7 @@ class TestShapeInference(unittest.TestCase):
              make_tensor_value_info('H_new', TensorProto.FLOAT, (1, 2))],
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 12), helper.make_opsetid(AI_ONNX_PREVIEW_TRAINING_DOMAIN, 1)])
 
-    def test_adagrad_multiple(self):  # type: () -> None
+    def test_adagrad_multiple(self) -> None:
         graph = self._make_graph(
             [('R', TensorProto.FLOAT, ()),  # scalar's shape is ()
              ('T', TensorProto.INT64, ()),  # scalar's shape is ()
@@ -3193,7 +3193,7 @@ class TestShapeInference(unittest.TestCase):
              make_tensor_value_info('H2_new', TensorProto.FLOAT, (3, 4))],
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 12), helper.make_opsetid(AI_ONNX_PREVIEW_TRAINING_DOMAIN, 1)])
 
-    def test_momentum(self):  # type: () -> None
+    def test_momentum(self) -> None:
         graph = self._make_graph(
             [('R', TensorProto.FLOAT, ()),  # scalar's shape is ()
              ('T', TensorProto.INT64, ()),  # scalar's shape is ()
@@ -3210,7 +3210,7 @@ class TestShapeInference(unittest.TestCase):
              make_tensor_value_info('V_new', TensorProto.FLOAT, (1, 2))],
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 12), helper.make_opsetid(AI_ONNX_PREVIEW_TRAINING_DOMAIN, 1)])
 
-    def test_momentum_multiple(self):  # type: () -> None
+    def test_momentum_multiple(self) -> None:
         graph = self._make_graph(
             [('R', TensorProto.FLOAT, ()),  # scalar's shape is ()
              ('T', TensorProto.INT64, ()),  # scalar's shape is ()
@@ -3234,7 +3234,7 @@ class TestShapeInference(unittest.TestCase):
              make_tensor_value_info('V2_new', TensorProto.FLOAT, (3, 4))],
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 12), helper.make_opsetid(AI_ONNX_PREVIEW_TRAINING_DOMAIN, 1)])
 
-    def test_adam(self):  # type: () -> None
+    def test_adam(self) -> None:
         graph = self._make_graph(
             [('R', TensorProto.FLOAT, ()),  # scalar's shape is ()
              ('T', TensorProto.INT64, ()),  # scalar's shape is ()
@@ -3256,7 +3256,7 @@ class TestShapeInference(unittest.TestCase):
             infos,
             opset_imports=[make_opsetid(AI_ONNX_PREVIEW_TRAINING_DOMAIN, 1), make_opsetid(ONNX_DOMAIN, 12)])
 
-    def test_adam_multiple(self):  # type: () -> None
+    def test_adam_multiple(self) -> None:
         graph = self._make_graph(
             [('R', TensorProto.FLOAT, ()),  # scalar's shape is ()
              ('T', TensorProto.INT64, ()),  # scalar's shape is ()
@@ -3286,21 +3286,21 @@ class TestShapeInference(unittest.TestCase):
             infos,
             opset_imports=[make_opsetid(AI_ONNX_PREVIEW_TRAINING_DOMAIN, 1), make_opsetid(ONNX_DOMAIN, 12)])
 
-    def test_pad_opset10(self):  # type: () -> None
+    def test_pad_opset10(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (1, None, 2))],
             [make_node('Pad', 'x', 'y', pads=[1, 3, 1, 1, 0, 1])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (3, None, 4))], opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 10)])  # type: ignore
 
-    def test_constant_pad_2d_opset10(self):  # type: () -> None
+    def test_constant_pad_2d_opset10(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 3, 4, 4))],
             [make_node('Pad', 'x', 'y', pads=[0, 0, 3, 1, 0, 0, 4, 2], mode="constant", value=2.0)],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (2, 3, 11, 7))], opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 10)])
 
-    def test_pad(self):  # type: () -> None
+    def test_pad(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (1, None, 2)),
              ('pads', TensorProto.INT64, (6,))],
@@ -3309,7 +3309,7 @@ class TestShapeInference(unittest.TestCase):
             initializer=[make_tensor('pads', TensorProto.INT64, (6,), (1, 3, 1, 1, 0, 1,))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (3, None, 4))])  # type: ignore
 
-    def test_gatherelements_basic(self):  # type: () -> None
+    def test_gatherelements_basic(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (6,)),
              ('indices', TensorProto.INT64, (2,))],
@@ -3317,7 +3317,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (2,))])
 
-    def test_gatherelements_indices_missing_shape(self):  # type: () -> None
+    def test_gatherelements_indices_missing_shape(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (6,)),
              ('indices', TensorProto.INT64, None)],  # type: ignore
@@ -3325,14 +3325,14 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, None)])  # type: ignore
 
-    def test_einsum_transpose(self):  # type: () -> None
+    def test_einsum_transpose(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4))],
             [make_node('Einsum', ['x'], ['y'], equation='ij->ji')],
             [],)
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (None, None))])  # type: ignore
 
-    def test_einsum_dot(self):  # type: () -> None
+    def test_einsum_dot(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (1,)),
              ('y', TensorProto.FLOAT, (1,))],
@@ -3340,7 +3340,7 @@ class TestShapeInference(unittest.TestCase):
             [],)
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, ())])  # type: ignore
 
-    def test_einsum_scalar(self):  # type: () -> None
+    def test_einsum_scalar(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, ()),
              ('y', TensorProto.FLOAT, ())],
@@ -3348,7 +3348,7 @@ class TestShapeInference(unittest.TestCase):
             [],)
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, ())])  # type: ignore
 
-    def test_einsum_outer_prod(self):  # type: () -> None
+    def test_einsum_outer_prod(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 5)),
              ('y', TensorProto.FLOAT, (7, 9))],
@@ -3356,21 +3356,21 @@ class TestShapeInference(unittest.TestCase):
             [],)
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (None, None, None, None))])  # type: ignore
 
-    def test_einsum_sum_along_dim(self):  # type: () -> None
+    def test_einsum_sum_along_dim(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4))],
             [make_node('Einsum', ['x'], ['y'], equation='i j->i ')],
             [],)
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (None, ))])  # type: ignore
 
-    def test_einsum_ellipsis(self):  # type: () -> None
+    def test_einsum_ellipsis(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4, 4))],
             [make_node('Einsum', ['x'], ['y'], equation='... ii ->... i')],
             [],)
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (None, None))])  # type: ignore
 
-    def test_einsum_ellipsis_2(self):  # type: () -> None
+    def test_einsum_ellipsis_2(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 2, 2)),
              ('y', TensorProto.FLOAT, (2, 2, 2))],
@@ -3379,7 +3379,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph,
                               [make_tensor_value_info('z', TensorProto.FLOAT, (None, None, None))])  # type: ignore
 
-    def test_einsum_ellipsis_3(self):  # type: () -> None
+    def test_einsum_ellipsis_3(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 2, 2)),
              ('y', TensorProto.FLOAT, (2, 2, 2))],
@@ -3388,7 +3388,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph,
                               [make_tensor_value_info('z', TensorProto.FLOAT, (None, None, None))])  # type: ignore
 
-    def test_einsum_contraction(self):  # type: () -> None
+    def test_einsum_contraction(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (5, 6, 7, 8)),
              ('y', TensorProto.FLOAT, (8, 9, 10))],
@@ -3397,7 +3397,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph,
                               [make_tensor_value_info('z', TensorProto.FLOAT, (None, None, None, None, None))])  # type: ignore
 
-    def test_einsum_contraction_2(self):  # type: () -> None
+    def test_einsum_contraction_2(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4, 5)),
              ('y', TensorProto.FLOAT, (3, 5))],
@@ -3406,7 +3406,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph,
                               [make_tensor_value_info('z', TensorProto.FLOAT, (None, None))])  # type: ignore
 
-    def test_einsum_batch_matmul(self):  # type: () -> None
+    def test_einsum_batch_matmul(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (5, 2, 3)),
              ('y', TensorProto.FLOAT, (5, 3, 4))],
@@ -3414,7 +3414,7 @@ class TestShapeInference(unittest.TestCase):
             [],)
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (None, None, None))])  # type: ignore
 
-    def test_einsum_left_hand_eqn(self):  # type: () -> None
+    def test_einsum_left_hand_eqn(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (2, 3)),
              ('y', TensorProto.FLOAT, (3, 4))],
@@ -3422,7 +3422,7 @@ class TestShapeInference(unittest.TestCase):
             [],)
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (None, None, None, None))])  # type: ignore
 
-    def test_einsum_incorrect_num_inputs(self):  # type: () -> None
+    def test_einsum_incorrect_num_inputs(self) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 3)),
              ("y", TensorProto.FLOAT, (2, 3)),
@@ -3431,7 +3431,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self.assertRaises(onnx.shape_inference.InferenceError, self._inferred, graph)
 
-    def test_negative_log_likehood_shape_is_NCdd(self):  # type: () -> None
+    def test_negative_log_likehood_shape_is_NCdd(self) -> None:
         N, C = 3, 4
         graph = self._make_graph(
             [('input', TensorProto.FLOAT, (N, C)),
@@ -3440,7 +3440,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('loss', TensorProto.FLOAT, (N, ))])  # type: ignore
 
-    def test_negative_log_likehood_shape_is_NC_with_weight(self):  # type: () -> None
+    def test_negative_log_likehood_shape_is_NC_with_weight(self) -> None:
         N, C = 3, 4
         graph = self._make_graph(
             [('input', TensorProto.FLOAT, (N, C)),
@@ -3450,7 +3450,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('loss', TensorProto.FLOAT, (N, ))])  # type: ignore
 
-    def test_negative_log_likehood_shape_is_NC_reduction_mean(self):  # type: () -> None
+    def test_negative_log_likehood_shape_is_NC_reduction_mean(self) -> None:
         N, C = 3, 4
         graph = self._make_graph(
             [('input', TensorProto.FLOAT, (N, C)),
@@ -3459,7 +3459,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('loss', TensorProto.FLOAT, ())])  # type: ignore
 
-    def test_negative_log_likehood_shape_is_NC_with_weight_reduction_mean(self):  # type: () -> None
+    def test_negative_log_likehood_shape_is_NC_with_weight_reduction_mean(self) -> None:
         N, C = 3, 4
         graph = self._make_graph(
             [('input', TensorProto.FLOAT, (N, C)),
@@ -3469,7 +3469,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('loss', TensorProto.FLOAT, ())])  # type: ignore
 
-    def test_negative_log_likehood_shape_is_NCd1d2(self):  # type: () -> None
+    def test_negative_log_likehood_shape_is_NCd1d2(self) -> None:
         N, C, d1, d2 = 3, 4, 5, 6
         graph = self._make_graph(
             [("input", TensorProto.FLOAT, (N, C, d1, d2)),
@@ -3478,7 +3478,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('loss', TensorProto.FLOAT, (N, d1, d2))])  # type: ignore
 
-    def test_negative_log_likehood_shape_is_NCd1d2_with_weight(self):  # type: () -> None
+    def test_negative_log_likehood_shape_is_NCd1d2_with_weight(self) -> None:
         N, C, d1, d2 = 3, 4, 5, 6
         graph = self._make_graph(
             [("input", TensorProto.FLOAT, (N, C, d1, d2)),
@@ -3488,7 +3488,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('loss', TensorProto.FLOAT, (N, d1, d2))])  # type: ignore
 
-    def test_negative_log_likehood_shape_is_NCd1d2_reduction_sum(self):  # type: () -> None
+    def test_negative_log_likehood_shape_is_NCd1d2_reduction_sum(self) -> None:
         N, C, d1, d2 = 3, 4, 5, 6
         graph = self._make_graph(
             [("input", TensorProto.FLOAT, (N, C, d1, d2)),
@@ -3497,7 +3497,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('loss', TensorProto.FLOAT, ())])  # type: ignore
 
-    def test_negative_log_likehood_shape_is_NCd1d2_with_weight_reduction_mean(self):  # type: () -> None
+    def test_negative_log_likehood_shape_is_NCd1d2_with_weight_reduction_mean(self) -> None:
         N, C, d1, d2 = 3, 4, 5, 6
         graph = self._make_graph(
             [("input", TensorProto.FLOAT, (N, C, d1, d2)),
@@ -3507,7 +3507,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('loss', TensorProto.FLOAT, ())])  # type: ignore
 
-    def test_negative_log_likehood_input_target_shape_mismatch(self):  # type: () -> None
+    def test_negative_log_likehood_input_target_shape_mismatch(self) -> None:
         N, C, d1, d2 = 3, 4, 5, 6
         graph = self._make_graph(
             [("input", TensorProto.FLOAT, (N, d1, d2)),
@@ -3518,7 +3518,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self.assertRaises(onnx.shape_inference.InferenceError, self._inferred, graph)
 
-    def test_negative_log_likehood_input_weight_shape_mismatch(self):  # type: () -> None
+    def test_negative_log_likehood_input_weight_shape_mismatch(self) -> None:
         N, C, d1, d2 = 3, 4, 5, 6
         graph = self._make_graph(
             [("input", TensorProto.FLOAT, (N, C, d1, d2)),
@@ -3529,7 +3529,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self.assertRaises(checker.ValidationError, self._inferred, graph)
 
-    def test_softmax_cross_entropy_none(self):  # type: () -> None
+    def test_softmax_cross_entropy_none(self) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 3)),
              ("y", TensorProto.FLOAT, (2,))],
@@ -3537,7 +3537,7 @@ class TestShapeInference(unittest.TestCase):
             [],)
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (2,))])  # type: ignore
 
-    def test_softmax_cross_entropy_mean(self):  # type: () -> None
+    def test_softmax_cross_entropy_mean(self) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 3)),
              ("y", TensorProto.FLOAT, (2,))],
@@ -3545,7 +3545,7 @@ class TestShapeInference(unittest.TestCase):
             [],)
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, ())])  # type: ignore
 
-    def test_softmax_cross_entropy_none_NCD1D2(self):  # type: () -> None
+    def test_softmax_cross_entropy_none_NCD1D2(self) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 3, 5, 8)),
              ("y", TensorProto.FLOAT, (2, 5, 8))],
@@ -3553,7 +3553,7 @@ class TestShapeInference(unittest.TestCase):
             [],)
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, (2, 5, 8))])  # type: ignore
 
-    def test_softmax_cross_entropy_mean_NCD1D2(self):  # type: () -> None
+    def test_softmax_cross_entropy_mean_NCD1D2(self) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 3, 4, 5)),
              ("y", TensorProto.FLOAT, (2, 4, 5))],
@@ -3561,7 +3561,7 @@ class TestShapeInference(unittest.TestCase):
             [],)
         self._assert_inferred(graph, [make_tensor_value_info('z', TensorProto.FLOAT, ())])  # type: ignore
 
-    def test_celu_function_output_shape(self):  # type: () -> None
+    def test_celu_function_output_shape(self) -> None:
         graph = self._make_graph(
             [('X', TensorProto.FLOAT, (25, 48, 16, 16))],
             [make_node('Celu', ['X'], ['Y'], alpha=2.0)],
@@ -3589,7 +3589,7 @@ class TestShapeInference(unittest.TestCase):
         graph = helper.make_graph(nodes, "test", inputs=inputs, outputs=[], initializer=initializer, value_info=[])
         return helper.make_model(graph)
 
-    def test_infer_with_initializer_without_input_above_ir4(self):  # type: () -> None
+    def test_infer_with_initializer_without_input_above_ir4(self) -> None:
         # This is for testing IR>=4: some tensors can only exist in initializer and not in input
         # So shape_inference should make use of initializer shapes
         initializer_shape = (8, 7)
@@ -3601,7 +3601,7 @@ class TestShapeInference(unittest.TestCase):
         z_shape = (z_tenor.type.tensor_type.shape.dim[0].dim_value, z_tenor.type.tensor_type.shape.dim[1].dim_value)
         assert z_shape == initializer_shape
 
-    def test_infer_with_initializer_without_input_below_ir4(self):  # type: () -> None
+    def test_infer_with_initializer_without_input_below_ir4(self) -> None:
         # This is for testing IR<4: tensors must exist both in initializer and input
         # So shape_inference should not make use of initializer shapes
         # Use (None, None) as empty input
@@ -3616,7 +3616,7 @@ class TestShapeInference(unittest.TestCase):
         # If the input is not updated by the initializer, the output shape will keep empty (0, 0)
         assert z_shape == (0, 0)
 
-    def test_infer_initializer_input_mismatch(self):  # type: () -> None
+    def test_infer_initializer_input_mismatch(self) -> None:
         # Catch error if initializer and input mismatch
         initializer_shape = (8, 7)
         input_shape = (4, 3)
@@ -3624,28 +3624,28 @@ class TestShapeInference(unittest.TestCase):
         # Inferred shape and existing shape differ in dimension 0
         self.assertRaises(onnx.shape_inference.InferenceError, onnx.shape_inference.infer_shapes, original_model, strict_mode=True)
 
-    def test_infer_initializer_input_consistency_all_none(self):  # type: () -> None
+    def test_infer_initializer_input_consistency_all_none(self) -> None:
         initializer_shape = (8, 7)
         input_shape = (None, None)  # accepatble
         original_model = self.prepare_input_initializer_tensors(initializer_shape, input_shape)
 
         onnx.shape_inference.infer_shapes(original_model, strict_mode=True)
 
-    def test_infer_initializer_input_consistency_single_none(self):  # type: () -> None
+    def test_infer_initializer_input_consistency_single_none(self) -> None:
         initializer_shape = (8, 7)
         input_shape = (None, 7)  # accepatble
         original_model = self.prepare_input_initializer_tensors(initializer_shape, input_shape)
 
         onnx.shape_inference.infer_shapes(original_model, strict_mode=True)
 
-    def test_infer_initializer_input_consistency_differnt_rank(self):  # type: () -> None
+    def test_infer_initializer_input_consistency_differnt_rank(self) -> None:
         initializer_shape = (8, 7, 9)
         input_shape = (None, 7)  # accepatble
         original_model = self.prepare_input_initializer_tensors(initializer_shape, input_shape)
         # Inferred shape and existing shape differ in rank: (3) vs (2)
         self.assertRaises(onnx.shape_inference.InferenceError, onnx.shape_inference.infer_shapes, original_model, strict_mode=True)
 
-    def test_infer_initializer_input_consistency_all_none_serialized(self):  # type: () -> None
+    def test_infer_initializer_input_consistency_all_none_serialized(self) -> None:
         # Reuse test_infer_initializer_input_consistency_all_none test case and check with
         # Serialized model
         initializer_shape = (8, 7)
@@ -3654,7 +3654,7 @@ class TestShapeInference(unittest.TestCase):
 
         onnx.shape_inference.infer_shapes(original_model.SerializeToString(), strict_mode=True)
 
-    def test_trilu_upper(self):  # type: () -> None
+    def test_trilu_upper(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4, 5)),
              ('k', TensorProto.INT64, ())],
@@ -3663,7 +3663,7 @@ class TestShapeInference(unittest.TestCase):
             initializer=[make_tensor('k', TensorProto.INT64, (), (2,))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (3, 4, 5))])  # type: ignore
 
-    def test_trilu_lower(self):  # type: () -> None
+    def test_trilu_lower(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4, 5)),
              ('k', TensorProto.INT64, ())],
@@ -3672,7 +3672,7 @@ class TestShapeInference(unittest.TestCase):
             initializer=[make_tensor('k', TensorProto.INT64, (), (10,))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.FLOAT, (3, 4, 5))])  # type: ignore
 
-    def test_trilu_upper_zero(self):  # type: () -> None
+    def test_trilu_upper_zero(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.INT64, (0, 5)),
              ('k', TensorProto.INT64, ())],
@@ -3681,14 +3681,14 @@ class TestShapeInference(unittest.TestCase):
             initializer=[make_tensor('k', TensorProto.INT64, (), (5,))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, (0, 5))])  # type: ignore
 
-    def test_trilu_lower_one(self):  # type: () -> None
+    def test_trilu_lower_one(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.INT32, (3, 1, 5))],
             [make_node('Trilu', ['x'], ['y'], upper=0)],
             [],)
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT32, (3, 1, 5))])  # type: ignore
 
-    def test_batch_norm_train(self):  # type: () -> None
+    def test_batch_norm_train(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4, 5, 6, 7)),
              ('scale', TensorProto.FLOAT, (4,)),
@@ -3703,7 +3703,7 @@ class TestShapeInference(unittest.TestCase):
                                       make_tensor_value_info('output_var', TensorProto.FLOAT, (4,)),  # type: ignore
                                       ])
 
-    def test_batch_norm_train_dim_param(self):  # type: () -> None
+    def test_batch_norm_train_dim_param(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 'C', 5, 6, 7)),
              ('scale', TensorProto.FLOAT, ('C',)),
@@ -3718,7 +3718,7 @@ class TestShapeInference(unittest.TestCase):
                                       make_tensor_value_info('output_var', TensorProto.FLOAT, ('C',)),  # type: ignore
                                       ])
 
-    def test_batch_norm_train_with_diff_type(self):  # type: () -> None
+    def test_batch_norm_train_with_diff_type(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT16, (3, 4, 5, 6, 7)),
              ('scale', TensorProto.FLOAT16, (4,)),
@@ -3733,7 +3733,7 @@ class TestShapeInference(unittest.TestCase):
                                       make_tensor_value_info('output_var', TensorProto.FLOAT, (4,)),  # type: ignore
                                       ])
 
-    def test_batch_norm_test(self):  # type: () -> None
+    def test_batch_norm_test(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4, 5, 6, 7)),
              ('scale', TensorProto.FLOAT, (4,)),
@@ -3745,7 +3745,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.FLOAT, (3, 4, 5, 6, 7))])  # type: ignore
 
-    def test_batch_norm_test_no_dim(self):  # type: () -> None
+    def test_batch_norm_test_no_dim(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3, 4, None, None, None)),
              ('scale', TensorProto.FLOAT, (4,)),
@@ -3757,7 +3757,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.FLOAT, (3, 4, None, None, None))])  # type: ignore
 
-    def test_batch_norm_train_no_shape(self):  # type: () -> None
+    def test_batch_norm_train_no_shape(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, None),
              ('scale', TensorProto.FLOAT, None),
@@ -3772,28 +3772,28 @@ class TestShapeInference(unittest.TestCase):
                                       make_tensor_value_info('running_var', TensorProto.FLOAT, ('C',)),  # type: ignore
                                       ])
 
-    def test_nonzero(self):  # type: () -> None
+    def test_nonzero(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (None,))],
             [make_node('NonZero', ['x'], ['out'])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.INT64, (1, None))])  # type: ignore
 
-    def test_nonzero_no_shape(self):  # type: () -> None
+    def test_nonzero_no_shape(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, None)],
             [make_node('NonZero', ['x'], ['out'])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.INT64, (None, None))])  # type: ignore
 
-    def test_nonzero_existing_dim_param(self):  # type: () -> None
+    def test_nonzero_existing_dim_param(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (3,))],
             [make_node('NonZero', ['x'], ['y'])],
             [make_tensor_value_info('y', TensorProto.INT64, (None, 'NZ'))])
         self._assert_inferred(graph, [make_tensor_value_info('y', TensorProto.INT64, (1, 'NZ'))])  # type: ignore
 
-    def test_optional_construct_empty_tensor(self):  # type: () -> None
+    def test_optional_construct_empty_tensor(self) -> None:
         tensor_type_proto = helper.make_tensor_type_proto(elem_type=TensorProto.FLOAT, shape=[1, 2, 3])
         optional_type_proto = helper.make_optional_type_proto(tensor_type_proto)
         optional_val_info = helper.make_value_info(
@@ -3805,7 +3805,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [optional_val_info])  # type: ignore
 
-    def test_optional_construct_empty_sequence(self):  # type: () -> None
+    def test_optional_construct_empty_sequence(self) -> None:
         tensor_type_proto = helper.make_tensor_type_proto(elem_type=TensorProto.INT32, shape=[1, 2, 3])
         sequence_type_proto = helper.make_sequence_type_proto(tensor_type_proto)
         optional_type_proto = helper.make_optional_type_proto(sequence_type_proto)
@@ -3818,7 +3818,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [optional_val_info])  # type: ignore
 
-    def test_optional_construct_tensor(self):  # type: () -> None
+    def test_optional_construct_tensor(self) -> None:
         tensor_type_proto = helper.make_tensor_type_proto(elem_type=TensorProto.FLOAT, shape=[2, 3, 4])
         optional_type_proto = helper.make_optional_type_proto(tensor_type_proto)
         optional_val_info = helper.make_value_info(
@@ -3830,7 +3830,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [optional_val_info])  # type: ignore
 
-    def test_optional_construct_sequence(self):  # type: () -> None
+    def test_optional_construct_sequence(self) -> None:
         tensor_type_proto = helper.make_tensor_type_proto(elem_type=TensorProto.INT64, shape=[2, 3, 0])
         sequence_type_proto = helper.make_sequence_type_proto(tensor_type_proto)
         sequence_val_info = helper.make_value_info(
@@ -3847,7 +3847,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [sequence_val_info, optional_val_info])  # type: ignore
 
-    def test_optional_tensor_has_element(self):  # type: () -> None
+    def test_optional_tensor_has_element(self) -> None:
         tensor_type_proto = helper.make_tensor_type_proto(elem_type=TensorProto.FLOAT, shape=[2, 3, 4])
         optional_type_proto = helper.make_optional_type_proto(tensor_type_proto)
         optional_val_info = helper.make_value_info(
@@ -3861,7 +3861,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph, [optional_val_info,
                                       make_tensor_value_info('output', TensorProto.BOOL, None)])  # type: ignore
 
-    def test_optional_sequence_has_element(self):  # type: () -> None
+    def test_optional_sequence_has_element(self) -> None:
         tensor_type_proto = helper.make_tensor_type_proto(elem_type=TensorProto.FLOAT, shape=[0, 3, 4])
         sequence_type_proto = helper.make_sequence_type_proto(tensor_type_proto)
         sequence_val_info = helper.make_value_info(
@@ -3880,7 +3880,7 @@ class TestShapeInference(unittest.TestCase):
         self._assert_inferred(graph, [sequence_val_info, optional_val_info,
                                       make_tensor_value_info('output', TensorProto.BOOL, None)])  # type: ignore
 
-    def test_optional_tensor_get_element(self):  # type: () -> None
+    def test_optional_tensor_get_element(self) -> None:
         tensor_type_proto = helper.make_tensor_type_proto(elem_type=TensorProto.DOUBLE, shape=[2, 1, 4])
         tensor_val_into = helper.make_value_info(
             name='output',
@@ -3896,7 +3896,7 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [optional_val_info, tensor_val_into])  # type: ignore
 
-    def test_optional_sequence_get_element(self):  # type: () -> None
+    def test_optional_sequence_get_element(self) -> None:
         tensor_type_proto = helper.make_tensor_type_proto(elem_type=TensorProto.INT32, shape=[2, 0, 4])
         sequence_type_proto = helper.make_sequence_type_proto(tensor_type_proto)
         sequence_val_into = helper.make_value_info(
@@ -3917,14 +3917,14 @@ class TestShapeInference(unittest.TestCase):
             [])
         self._assert_inferred(graph, [optional_val_info, sequence_val_into, output_val_into])  # type: ignore
 
-    def test_where_bfloat(self):  # type: () -> None
+    def test_where_bfloat(self) -> None:
         graph = self._make_graph(
             [('cond', TensorProto.BOOL, (10,)), ('x', TensorProto.BFLOAT16, (10,)), ('y', TensorProto.BFLOAT16, (10,))],
             [make_node('Where', ['cond', 'x', 'y'], ['out'])],
             [])
         self._assert_inferred(graph, [make_tensor_value_info('out', TensorProto.BFLOAT16, (10,))])  # type: ignore
 
-    def test_parse_data_with_unsupported_tensor_type(self):  # type: () -> None
+    def test_parse_data_with_unsupported_tensor_type(self) -> None:
         model = helper.make_model(
             graph=helper.make_graph(
                 name='graph_with_unsupported_type',
@@ -3940,7 +3940,7 @@ class TestShapeInference(unittest.TestCase):
         inferred_model = onnx.shape_inference.infer_shapes(model)
         self.assertFalse(inferred_model.graph.output[0].type.tensor_type.HasField('shape'))
 
-    def test_parse_data_with_undefined_tensor_type(self):  # type: () -> None
+    def test_parse_data_with_undefined_tensor_type(self) -> None:
         model = helper.make_model(
             graph=helper.make_graph(
                 name='graph_with_undefined_type',
@@ -3957,7 +3957,7 @@ class TestShapeInference(unittest.TestCase):
         inferred_model = onnx.shape_inference.infer_shapes(model)
         self.assertFalse(inferred_model.graph.output[0].type.tensor_type.HasField('shape'))
 
-    def test_gridsample(self):  # type: () -> None
+    def test_gridsample(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, (1, 1, 3, 3)),
              ('grid', TensorProto.INT64, (1, 3, 3, 2))],
@@ -3967,7 +3967,7 @@ class TestShapeInference(unittest.TestCase):
             graph,
             [make_tensor_value_info('y', TensorProto.FLOAT, (1, 1, 3, 3))])  # type: ignore
 
-    def test_gridsample_defaults(self):  # type: () -> None
+    def test_gridsample_defaults(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, ('N', 'C', 'H', 'W')),
              ('grid', TensorProto.FLOAT, ('N', 'H_out', 'W_out', 2))],
@@ -3977,7 +3977,7 @@ class TestShapeInference(unittest.TestCase):
             graph,
             [make_tensor_value_info('y', TensorProto.FLOAT, ('N', 'C', 'H_out', 'W_out'))])  # type: ignore
 
-    def test_gridsample_no_dim(self):  # type: () -> None
+    def test_gridsample_no_dim(self) -> None:
         graph = self._make_graph(
             [('x', TensorProto.FLOAT, ('N', 'C', None, None)),
              ('grid', TensorProto.FLOAT, ('N', None, None, 2))],

--- a/onnx/test/symbolic_shape_test.py
+++ b/onnx/test/symbolic_shape_test.py
@@ -14,7 +14,7 @@ import unittest
 
 class TestSymbolicShape(unittest.TestCase):
 
-    def _assert_valueinfo_shape(self, onnx_model, value_infos):  # type: (ModelProto, List[ValueInfoProto]) -> None
+    def _assert_valueinfo_shape(self, onnx_model: ModelProto, value_infos: List[ValueInfoProto]) -> None:
         """
             Assert onnx_model.value_info should be the same as expected value_infos
             Instead of exact symbol, use -1 to represent symbolic shape in expected value_infos
@@ -37,7 +37,7 @@ class TestSymbolicShape(unittest.TestCase):
                 else:
                     assert dim.dim_value == expected_dim.dim_value, '{}'.format(onnx_model)
 
-    def _count_unique_dim_param_number(self, onnx_model):  # type: (ModelProto) -> int
+    def _count_unique_dim_param_number(self, onnx_model: ModelProto) -> int:
         """
            return the total number of unique symbolic shape
         """
@@ -51,7 +51,7 @@ class TestSymbolicShape(unittest.TestCase):
                     symbol_shape_set.add(dim.dim_param)
         return len(symbol_shape_set)
 
-    def _get_shape_from_name(self, onnx_model, name):  # type: (ModelProto, Text) -> Optional[TensorShapeProto]
+    def _get_shape_from_name(self, onnx_model: ModelProto, name: Text) -> Optional[TensorShapeProto]:
         """
             Get shape from tensor_type or sparse_tensor_type according to given name
         """
@@ -66,7 +66,7 @@ class TestSymbolicShape(unittest.TestCase):
                     return v.type.sparse_tensor_type.shape
         return None
 
-    def test_concat_enable_symbolic(self):  # type: () -> None
+    def test_concat_enable_symbolic(self) -> None:
         concat = helper.make_node('Concat', inputs=['A', 'B'], outputs=['C'], name='Concat', axis=1)
         cast = onnx.helper.make_node('Cast',
             inputs=['C'],
@@ -85,7 +85,7 @@ class TestSymbolicShape(unittest.TestCase):
         # the symbolic shape of C and output should be the same
         assert self._get_shape_from_name(inferred_model, 'C') == self._get_shape_from_name(inferred_model, 'output')
 
-    def test_two_symbolic_concat(self):  # type: () -> None
+    def test_two_symbolic_concat(self) -> None:
         concat1 = helper.make_node('Concat', inputs=['A', 'B'], outputs=['C'], name='Concat', axis=1)
         concat2 = helper.make_node('Concat', inputs=['C', 'D'], outputs=['E'], name='Concat', axis=1)
         cast = onnx.helper.make_node('Cast',
@@ -108,7 +108,7 @@ class TestSymbolicShape(unittest.TestCase):
         # the symbolic shape of E and output should be the same
         assert self._get_shape_from_name(inferred_model, 'E') == self._get_shape_from_name(inferred_model, 'output')
 
-    def test_duplicate_symbolic_shape(self):  # type: () -> None
+    def test_duplicate_symbolic_shape(self) -> None:
         concat1 = helper.make_node('Concat', inputs=['A', 'B'], outputs=['C'], name='Concat', axis=1)
         concat2 = helper.make_node('Concat', inputs=['C', 'D'], outputs=['E'], name='Concat', axis=1)
         cast = onnx.helper.make_node('Cast',
@@ -133,7 +133,7 @@ class TestSymbolicShape(unittest.TestCase):
         # inferred: {'unk_0', 'unk__1', 'unk__2', 'unk__3'}
         assert inferred_count == original_count + 2, '%s%s' % (inferred_model, onnx_model)
 
-    def test_unknown_shape(self):  # type: () -> None
+    def test_unknown_shape(self) -> None:
         concat = helper.make_node('Concat', inputs=['A', 'B'], outputs=['C'], name='Concat', axis=1)
         cast = onnx.helper.make_node('Cast',
             inputs=['C'],

--- a/onnx/test/test_backend_test.py
+++ b/onnx/test/test_backend_test.py
@@ -35,10 +35,10 @@ import numpy  # type: ignore
 class DummyBackend(onnx.backend.base.Backend):
     @classmethod
     def prepare(cls,
-                model,  # type: ModelProto
-                device='CPU',  # type: Text
-                **kwargs  # type: Any
-                ):  # type: (...) -> Optional[onnx.backend.base.BackendRep]
+                model: ModelProto,
+                device: Text = 'CPU',
+                **kwargs: Any
+                ) -> Optional[onnx.backend.base.BackendRep]:
         super(DummyBackend, cls).prepare(model, device, **kwargs)
 
         # test shape inference
@@ -61,18 +61,18 @@ class DummyBackend(onnx.backend.base.Backend):
 
     @classmethod
     def run_node(cls,
-                 node,  # type: NodeProto
-                 inputs,  # type: Any
-                 device='CPU',  # type: Text
-                 outputs_info=None,  # type: Optional[Sequence[Tuple[numpy.dtype, Tuple[int, ...]]]]
-                 **kwargs  # type: Any
-                 ):  # type: (...) -> Optional[Tuple[Any, ...]]
+                 node: NodeProto,
+                 inputs: Any,
+                 device: Text = 'CPU',
+                 outputs_info: Optional[Sequence[Tuple[numpy.dtype, Tuple[int, ...]]]] = None,
+                 **kwargs: Any
+                 ) -> Optional[Tuple[Any, ...]]:
         super(DummyBackend, cls).run_node(node, inputs, device=device, outputs_info=outputs_info)
         raise BackendIsNotSupposedToImplementIt(
             "This is the dummy backend test that doesn't verify the results but does run the checker")
 
     @classmethod
-    def supports_device(cls, device):  # type: (Text) -> bool
+    def supports_device(cls, device: Text) -> bool:
         d = Device(device)
         if d.type == DeviceType.CPU:
             return True
@@ -84,7 +84,7 @@ test_coverage_safelist = set(
      'resnet50', 'shufflenet', 'SingleRelu', 'squeezenet_old', 'vgg19', 'zfnet'])
 
 
-def do_enforce_test_coverage_safelist(model):  # type: (ModelProto) -> bool
+def do_enforce_test_coverage_safelist(model: ModelProto) -> bool:
     if model.graph.name not in test_coverage_safelist:
         return False
     for node in model.graph.node:

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -25,19 +25,19 @@ import sys
 
 class TestLoadExternalDataBase(unittest.TestCase):
 
-    def setUp(self):  # type: () -> None
-        self.temp_dir = tempfile.mkdtemp()  # type: Text
+    def setUp(self) -> None:
+        self.temp_dir: Text = tempfile.mkdtemp()
         self.initializer_value = np.arange(6).reshape(3, 2).astype(np.float32) + 512
         self.attribute_value = np.arange(6).reshape(2, 3).astype(np.float32) + 256
         self.model_filename = self.create_test_model()
 
-    def tearDown(self):  # type: () -> None
+    def tearDown(self) -> None:
         shutil.rmtree(self.temp_dir)
 
-    def get_temp_model_filename(self):  # type: () -> Text
+    def get_temp_model_filename(self) -> Text:
         return os.path.join(self.temp_dir, str(uuid.uuid4()) + '.onnx')
 
-    def create_external_data_tensor(self, value, tensor_name):  # type: (List[Any], Text) -> TensorProto
+    def create_external_data_tensor(self, value: List[Any], tensor_name: Text) -> TensorProto:
         tensor = from_array(np.array(value))
         tensor.name = tensor_name
         tensor_filename = "{}.bin".format(tensor_name)
@@ -49,7 +49,7 @@ class TestLoadExternalDataBase(unittest.TestCase):
         tensor.data_location = onnx.TensorProto.EXTERNAL
         return tensor
 
-    def create_test_model(self):  # type: () -> Text
+    def create_test_model(self) -> Text:
 
         constant_node = onnx.helper.make_node(
             'Constant',
@@ -74,13 +74,13 @@ class TestLoadExternalDataBase(unittest.TestCase):
 
         return model_filename
 
-    def test_check_model(self):  # type: () -> None
+    def test_check_model(self) -> None:
         checker.check_model(self.model_filename)
 
 
 class TestLoadExternalData(TestLoadExternalDataBase):
 
-    def test_load_external_data(self):  # type: () -> None
+    def test_load_external_data(self) -> None:
         model = onnx.load_model(self.model_filename)
         initializer_tensor = model.graph.initializer[0]
         self.assertTrue(np.allclose(to_array(initializer_tensor), self.initializer_value))
@@ -88,7 +88,7 @@ class TestLoadExternalData(TestLoadExternalDataBase):
         attribute_tensor = model.graph.node[0].attribute[0].t
         self.assertTrue(np.allclose(to_array(attribute_tensor), self.attribute_value))
 
-    def test_load_external_data_for_model(self):  # type: () -> None
+    def test_load_external_data_for_model(self) -> None:
         model = onnx.load_model(self.model_filename, load_external_data=False)
         load_external_data_for_model(model, self.temp_dir)
         initializer_tensor = model.graph.initializer[0]
@@ -97,7 +97,7 @@ class TestLoadExternalData(TestLoadExternalDataBase):
         attribute_tensor = model.graph.node[0].attribute[0].t
         self.assertTrue(np.allclose(to_array(attribute_tensor), self.attribute_value))
 
-    def test_save_external_data(self):  # type: () -> None
+    def test_save_external_data(self) -> None:
         model = onnx.load_model(self.model_filename)
 
         temp_dir = os.path.join(self.temp_dir, "save_copy")
@@ -115,7 +115,7 @@ class TestLoadExternalData(TestLoadExternalDataBase):
 
 class TestLoadExternalDataSingleFile(TestLoadExternalDataBase):
 
-    def create_external_data_tensors(self, tensors_data):  # type: (List[Tuple[List[Any],Any]]) -> List[TensorProto]
+    def create_external_data_tensors(self, tensors_data: List[Tuple[List[Any],Any]]) -> List[TensorProto]:
         tensor_filename = "tensors.bin"
         tensors = []
 
@@ -136,7 +136,7 @@ class TestLoadExternalDataSingleFile(TestLoadExternalDataBase):
 
         return tensors
 
-    def test_load_external_single_file_data(self):  # type: () -> None
+    def test_load_external_single_file_data(self) -> None:
         model = onnx.load_model(self.model_filename)
 
         initializer_tensor = model.graph.initializer[0]
@@ -145,7 +145,7 @@ class TestLoadExternalDataSingleFile(TestLoadExternalDataBase):
         attribute_tensor = model.graph.node[0].attribute[0].t
         self.assertTrue(np.allclose(to_array(attribute_tensor), self.attribute_value))
 
-    def test_save_external_single_file_data(self):  # type: () -> None
+    def test_save_external_single_file_data(self) -> None:
         model = onnx.load_model(self.model_filename)
 
         temp_dir = os.path.join(self.temp_dir, "save_copy")
@@ -163,13 +163,13 @@ class TestLoadExternalDataSingleFile(TestLoadExternalDataBase):
 
 class TestSaveAllTensorsAsExternalData(TestLoadExternalDataBase):
 
-    def setUp(self):  # type: () -> None
-        self.temp_dir = tempfile.mkdtemp()  # type: Text
+    def setUp(self) -> None:
+        self.temp_dir: Text = tempfile.mkdtemp()
         self.initializer_value = np.arange(6).reshape(3, 2).astype(np.float32) + 512
         self.attribute_value = np.arange(6).reshape(2, 3).astype(np.float32) + 256
         self.model = self.create_test_model_proto()
 
-    def create_data_tensors(self, tensors_data):  # type: (List[Tuple[List[Any],Any]]) -> List[TensorProto]
+    def create_data_tensors(self, tensors_data: List[Tuple[List[Any],Any]]) -> List[TensorProto]:
         tensors = []
         for (value, tensor_name) in tensors_data:
             tensor = from_array(np.array(value))
@@ -178,7 +178,7 @@ class TestSaveAllTensorsAsExternalData(TestLoadExternalDataBase):
 
         return tensors
 
-    def create_test_model_proto(self):  # type: () -> ModelProto
+    def create_test_model_proto(self) -> ModelProto:
         tensors = self.create_data_tensors([
             (self.attribute_value, "attribute_value"),
             (self.initializer_value, "input_value"),
@@ -200,10 +200,10 @@ class TestSaveAllTensorsAsExternalData(TestLoadExternalDataBase):
                                   initializer=[tensors[1]])
         return helper.make_model(graph)
 
-    def test_check_model(self):  # type: () -> None
+    def test_check_model(self) -> None:
         checker.check_model(self.model)
 
-    def test_convert_model_to_external_data_with_size_threshold(self):  # type: () -> None
+    def test_convert_model_to_external_data_with_size_threshold(self) -> None:
         model_file_path = self.get_temp_model_filename()
 
         convert_model_to_external_data(self.model, size_threshold=1024)
@@ -213,7 +213,7 @@ class TestSaveAllTensorsAsExternalData(TestLoadExternalDataBase):
         initializer_tensor = model.graph.initializer[0]
         self.assertFalse(initializer_tensor.HasField("data_location"))
 
-    def test_convert_model_to_external_data_without_size_threshold(self):  # type: () -> None
+    def test_convert_model_to_external_data_without_size_threshold(self) -> None:
         model_file_path = self.get_temp_model_filename()
         convert_model_to_external_data(self.model, size_threshold=0)
         onnx.save_model(self.model, model_file_path)
@@ -223,7 +223,7 @@ class TestSaveAllTensorsAsExternalData(TestLoadExternalDataBase):
         self.assertTrue(initializer_tensor.HasField("data_location"))
         self.assertTrue(np.allclose(to_array(initializer_tensor), self.initializer_value))
 
-    def test_convert_model_to_external_data_from_one_file_with_location(self):  # type: () -> None
+    def test_convert_model_to_external_data_from_one_file_with_location(self) -> None:
         model_file_path = self.get_temp_model_filename()
         external_data_file = str(uuid.uuid4())
 
@@ -249,7 +249,7 @@ class TestSaveAllTensorsAsExternalData(TestLoadExternalDataBase):
         self.assertEqual(attribute_tensor.data_location, TensorProto.DEFAULT)
         self.assertTrue(np.allclose(to_array(attribute_tensor), self.attribute_value))
 
-    def test_convert_model_to_external_data_from_one_file_without_location_uses_model_name(self):  # type: () -> None
+    def test_convert_model_to_external_data_from_one_file_without_location_uses_model_name(self) -> None:
         model_file_path = self.get_temp_model_filename()
 
         convert_model_to_external_data(self.model, size_threshold=0, all_tensors_to_one_file=True)
@@ -258,7 +258,7 @@ class TestSaveAllTensorsAsExternalData(TestLoadExternalDataBase):
         self.assertTrue(Path.isfile(model_file_path))
         self.assertTrue(Path.isfile(os.path.join(self.temp_dir, model_file_path)))
 
-    def test_convert_model_to_external_data_one_file_per_tensor_without_attribute(self):  # type: () -> None
+    def test_convert_model_to_external_data_one_file_per_tensor_without_attribute(self) -> None:
         model_file_path = self.get_temp_model_filename()
 
         convert_model_to_external_data(self.model, size_threshold=0, all_tensors_to_one_file=False, convert_attribute=False)
@@ -268,7 +268,7 @@ class TestSaveAllTensorsAsExternalData(TestLoadExternalDataBase):
         self.assertTrue(Path.isfile(os.path.join(self.temp_dir, "input_value")))
         self.assertFalse(Path.isfile(os.path.join(self.temp_dir, "attribute_value")))
 
-    def test_convert_model_to_external_data_one_file_per_tensor_with_attribute(self):  # type: () -> None
+    def test_convert_model_to_external_data_one_file_per_tensor_with_attribute(self) -> None:
         model_file_path = self.get_temp_model_filename()
 
         convert_model_to_external_data(self.model, size_threshold=0, all_tensors_to_one_file=False, convert_attribute=True)
@@ -278,7 +278,7 @@ class TestSaveAllTensorsAsExternalData(TestLoadExternalDataBase):
         self.assertTrue(Path.isfile(os.path.join(self.temp_dir, "input_value")))
         self.assertTrue(Path.isfile(os.path.join(self.temp_dir, "attribute_value")))
 
-    def test_convert_model_to_external_data_does_not_convert_attribute_values(self):  # type: () -> None
+    def test_convert_model_to_external_data_does_not_convert_attribute_values(self) -> None:
         model_file_path = self.get_temp_model_filename()
 
         convert_model_to_external_data(self.model, size_threshold=0, convert_attribute=False, all_tensors_to_one_file=False)
@@ -294,7 +294,7 @@ class TestSaveAllTensorsAsExternalData(TestLoadExternalDataBase):
         attribute_tensor = model.graph.node[0].attribute[0].t
         self.assertFalse(attribute_tensor.HasField("data_location"))
 
-    def test_convert_model_to_external_data_converts_attribute_values(self):  # type: () -> None
+    def test_convert_model_to_external_data_converts_attribute_values(self) -> None:
         model_file_path = self.get_temp_model_filename()
 
         convert_model_to_external_data(self.model, size_threshold=0, convert_attribute=True)
@@ -310,7 +310,7 @@ class TestSaveAllTensorsAsExternalData(TestLoadExternalDataBase):
         self.assertTrue(np.allclose(to_array(attribute_tensor), self.attribute_value))
         self.assertTrue(attribute_tensor.HasField("data_location"))
 
-    def test_save_model_does_not_convert_to_external_data_and_saves_the_model(self):  # type: () -> None
+    def test_save_model_does_not_convert_to_external_data_and_saves_the_model(self) -> None:
         model_file_path = self.get_temp_model_filename()
         onnx.save_model(self.model, model_file_path, save_as_external_data=False)
         self.assertTrue(Path.isfile(model_file_path))
@@ -322,7 +322,7 @@ class TestSaveAllTensorsAsExternalData(TestLoadExternalDataBase):
         attribute_tensor = model.graph.node[0].attribute[0].t
         self.assertFalse(attribute_tensor.HasField("data_location"))
 
-    def test_save_model_does_convert_and_saves_the_model(self):  # type: () -> None
+    def test_save_model_does_convert_and_saves_the_model(self) -> None:
         model_file_path = self.get_temp_model_filename()
         onnx.save_model(self.model,
                         model_file_path,
@@ -342,7 +342,7 @@ class TestSaveAllTensorsAsExternalData(TestLoadExternalDataBase):
         self.assertFalse(attribute_tensor.HasField("data_location"))
         self.assertTrue(np.allclose(to_array(attribute_tensor), self.attribute_value))
 
-    def test_save_model_without_loading_external_data(self):  # type: () -> None
+    def test_save_model_without_loading_external_data(self) -> None:
         model_file_path = self.get_temp_model_filename()
         onnx.save_model(self.model,
                         model_file_path,
@@ -369,7 +369,7 @@ class TestSaveAllTensorsAsExternalData(TestLoadExternalDataBase):
         self.assertFalse(attribute_tensor.HasField("data_location"))
         self.assertTrue(np.allclose(to_array(attribute_tensor), self.attribute_value))
 
-    def test_save_model_with_existing_raw_data_should_override(self):  # type: () -> None
+    def test_save_model_with_existing_raw_data_should_override(self) -> None:
         model_file_path = self.get_temp_model_filename()
         original_raw_data = self.model.graph.initializer[0].raw_data
         onnx.save_model(self.model, model_file_path, save_as_external_data=True, size_threshold=0)
@@ -384,20 +384,20 @@ class TestSaveAllTensorsAsExternalData(TestLoadExternalDataBase):
 
 
 class TestExternalDataToArray(unittest.TestCase):
-    def setUp(self):  # type: () -> None
-        self.temp_dir = tempfile.mkdtemp()  # type: Text
-        self.model_file_path = os.path.join(self.temp_dir, 'model.onnx')  # type: Text
+    def setUp(self) -> None:
+        self.temp_dir: Text = tempfile.mkdtemp()
+        self.model_file_path: Text = os.path.join(self.temp_dir, 'model.onnx')
         self.large_data = np.random.rand(10, 60, 100).astype(np.float32)
         self.small_data = (200, 300)
         self.model = self.create_test_model()
 
-    def tearDown(self):  # type: () -> None
+    def tearDown(self) -> None:
         shutil.rmtree(self.temp_dir)
 
-    def get_temp_model_filename(self):  # type: () -> Text
+    def get_temp_model_filename(self) -> Text:
         return os.path.join(self.temp_dir, str(uuid.uuid4()) + '.onnx')
 
-    def create_test_model(self):  # type: () -> ModelProto
+    def create_test_model(self) -> ModelProto:
         X = helper.make_tensor_value_info('X', TensorProto.FLOAT, self.large_data.shape)
         input_init = helper.make_tensor(name='X', data_type=TensorProto.FLOAT,
             dims=self.large_data.shape, vals=self.large_data.tobytes(), raw=True)
@@ -429,10 +429,10 @@ class TestExternalDataToArray(unittest.TestCase):
         model = helper.make_model(graph_def, producer_name='onnx-example')
         return model
 
-    def test_check_model(self):  # type: () -> None
+    def test_check_model(self) -> None:
         checker.check_model(self.model)
 
-    def test_reshape_inference_with_external_data_fail(self):  # type: () -> None
+    def test_reshape_inference_with_external_data_fail(self) -> None:
         onnx.save_model(self.model, self.model_file_path, save_as_external_data=True, all_tensors_to_one_file=False, size_threshold=0)
         model_without_external_data = onnx.load(self.model_file_path, load_external_data=False)
         # Shape inference of Reshape uses ParseData
@@ -441,7 +441,7 @@ class TestExternalDataToArray(unittest.TestCase):
         self.assertRaises(shape_inference.InferenceError, shape_inference.infer_shapes,
             model_without_external_data, strict_mode=True)
 
-    def test_to_array_with_external_data(self):  # type: () -> None
+    def test_to_array_with_external_data(self) -> None:
         onnx.save_model(self.model,
                         self.model_file_path,
                         save_as_external_data=True,
@@ -453,7 +453,7 @@ class TestExternalDataToArray(unittest.TestCase):
         loaded_large_data = to_array(model.graph.initializer[0], self.temp_dir)
         self.assertTrue(np.allclose(loaded_large_data, self.large_data))
 
-    def test_save_model_with_external_data_multiple_times(self):  # type: () -> None
+    def test_save_model_with_external_data_multiple_times(self) -> None:
         # Test onnx.save should respectively handle typical tensor and external tensor properly
         # 1st save: save two tensors which have raw_data
         # Only w_large will be stored as external tensors since it's larger than 1024

--- a/onnx/test/test_with_ort.py
+++ b/onnx/test/test_with_ort.py
@@ -3,7 +3,7 @@
 # This file is for testing ONNX with ONNXRuntime during ONNX Release
 # Create a general scenario to use ONNXRuntime with ONNX
 
-def example_test_with_ort():  # type: () -> None
+def example_test_with_ort() -> None:
     import onnx
     import numpy  # type: ignore
     import onnxruntime as rt  # type: ignore

--- a/onnx/test/tools_test.py
+++ b/onnx/test/tools_test.py
@@ -12,7 +12,7 @@ from onnx import helper, TensorProto
 
 
 class TestToolsFunctions(unittest.TestCase):
-    def test_update_inputs_outputs_dim(self):  # type: () -> None
+    def test_update_inputs_outputs_dim(self) -> None:
         node_def = helper.make_node(
             "Conv",
             inputs=['x', 'W'],

--- a/onnx/test/training_tool_test.py
+++ b/onnx/test/training_tool_test.py
@@ -13,7 +13,7 @@ from onnx import helper, numpy_helper, shape_inference, TensorProto
 
 
 class TestTrainingTool(unittest.TestCase):
-    def test_training_info_proto(self):  # type: () -> None
+    def test_training_info_proto(self) -> None:
         # Inference graph.
         A_shape = [2, 2]
         A_name = 'A'

--- a/onnx/test/utils_test.py
+++ b/onnx/test/utils_test.py
@@ -15,7 +15,7 @@ from onnx import helper, TensorProto
 
 
 class TestUtilityFunctions(unittest.TestCase):
-    def test_extract_model(self):  # type: () -> None
+    def test_extract_model(self) -> None:
         def create_tensor(name):  # type: ignore
             return helper.make_tensor_value_info(name, TensorProto.FLOAT, [1, 2])
         A0 = create_tensor("A0")

--- a/onnx/test/version_converter_test.py
+++ b/onnx/test/version_converter_test.py
@@ -20,10 +20,10 @@ class TestVersionConverter(unittest.TestCase):
 
     def _converted(
             self,
-            graph,  # type: GraphProto
-            initial_version,  # type: OperatorSetIdProto
-            target_version  # type: int
-    ):  # type: (...) -> ModelProto
+            graph: GraphProto,
+            initial_version: OperatorSetIdProto,
+            target_version: int
+    ) -> ModelProto:
         orig_model = helper.make_model(graph, producer_name='onnx-test', opset_imports=[initial_version])
         # print(type(orig_model))
         converted_model = onnx.version_converter.convert_version(orig_model,
@@ -32,8 +32,8 @@ class TestVersionConverter(unittest.TestCase):
         return converted_model
 
     # Test 1: Backwards Incompatible Conversion: Reshape: 8 -> 2
-    def test_backwards_incompatible(self):  # type: () -> None
-        def test():  # type: () -> None
+    def test_backwards_incompatible(self) -> None:
+        def test() -> None:
             nodes = [helper.make_node('Add', ["W", "Z"], ["shape"]),
                         helper.make_node('Reshape', ["X", "shape"], ["A"]),
                         helper.make_node('Add', ["A", "W"], ["Y"])]
@@ -48,7 +48,7 @@ class TestVersionConverter(unittest.TestCase):
         self.assertRaises(RuntimeError, test)
 
     # Test 2: Backwards Compatible Conversion (No Adaptations): Add: 3 -> 2
-    def test_backwards_compatible(self):  # type: () -> None
+    def test_backwards_compatible(self) -> None:
         nodes = [helper.make_node('Add', ["X1", "X2"], ["Y"])]
         graph = helper.make_graph(
             nodes,
@@ -63,8 +63,8 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 2
 
     # Test 3: Non-Existent Op Conversion: Cos: 8 -> 6
-    def test_non_existent_op(self):  # type: () -> None
-        def test():  # type: () -> None
+    def test_non_existent_op(self) -> None:
+        def test() -> None:
             nodes = [helper.make_node('Cos', ["X"], ["Y"])]
             graph = helper.make_graph(
                 nodes,
@@ -75,7 +75,7 @@ class TestVersionConverter(unittest.TestCase):
         self.assertRaises(RuntimeError, test)
 
     # Test Add Adapter: 8 -> 5
-    def test_add_8_5(self):  # type: () -> None
+    def test_add_8_5(self) -> None:
         nodes = [helper.make_node('Add', ["X1", "X2"], ["Y"])]
         graph = helper.make_graph(
             nodes,
@@ -90,7 +90,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 5
 
     # Test Add Adapter: 5 -> 8
-    def test_add_5_8(self):  # type: () -> None
+    def test_add_5_8(self) -> None:
         nodes = [helper.make_node('Add', ["X1", "X2"], ["Y"])]
         graph = helper.make_graph(
             nodes,
@@ -105,7 +105,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 8
 
     # Test Add Adapter: 5 -> 8, requiring insertion of an Unsqueeze node
-    def test_add_5_8_with_unsqueeze(self):  # type: () -> None
+    def test_add_5_8_with_unsqueeze(self) -> None:
         nodes = [helper.make_node('Add', ["X1", "X2"], ["Y"], axis=0, broadcast=1)]
         graph = helper.make_graph(
             nodes,
@@ -121,7 +121,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 8
 
     # Test Mul Adapter: 8 -> 5
-    def test_mul_8_5(self):  # type: () -> None
+    def test_mul_8_5(self) -> None:
         nodes = [helper.make_node('Mul', ["X1", "X2"], ["Y"])]
         graph = helper.make_graph(
             nodes,
@@ -136,7 +136,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 5
 
     # Test Mul Adapter: 5 -> 8
-    def test_mul_5_8(self):  # type: () -> None
+    def test_mul_5_8(self) -> None:
         nodes = [helper.make_node('Mul', ["X1", "X2"], ["Y"])]
         graph = helper.make_graph(
             nodes,
@@ -151,7 +151,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 8
 
     # Test Gemm Adapter: 1 -> 8
-    def test_gemm_up(self):  # type: () -> None
+    def test_gemm_up(self) -> None:
         nodes = [helper.make_node('Gemm', ["A", "B", "C"], ["Y"])]
         graph = helper.make_graph(
             nodes,
@@ -167,7 +167,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 8
 
     # Test Gemm Adapter: 8 -> 1
-    def test_gemm_down(self):  # type: () -> None
+    def test_gemm_down(self) -> None:
         nodes = [helper.make_node('Gemm', ["A", "B", "C"], ["Y"])]
         graph = helper.make_graph(
             nodes,
@@ -183,7 +183,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 1
 
     # Test Relu Adapter: 5 -> 7
-    def test_relu_5_7(self):  # type: () -> None
+    def test_relu_5_7(self) -> None:
         nodes = [helper.make_node('Relu', ["X"], ["Y"])]
         graph = helper.make_graph(
             nodes,
@@ -197,7 +197,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 7
 
     # Test Relu Adapter: 7 -> 5
-    def test_relu_7_5(self):  # type: () -> None
+    def test_relu_7_5(self) -> None:
         nodes = [helper.make_node('Relu', ["X"], ["Y"])]
         graph = helper.make_graph(
             nodes,
@@ -211,7 +211,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 5
 
     # Test BatchNormalization Adapter: 8 -> 5
-    def test_batch_normalization_8_5(self):  # type: () -> None
+    def test_batch_normalization_8_5(self) -> None:
         nodes = [helper.make_node('BatchNormalization', ["X", "scale", "B",
             "mean", "var"], ["Y"])]
         graph = helper.make_graph(
@@ -230,7 +230,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 5
 
     # Test BatchNormalization Adapter: 5 -> 8
-    def test_batch_normalization_5_8(self):  # type: () -> None
+    def test_batch_normalization_5_8(self) -> None:
         nodes = [helper.make_node('BatchNormalization', ["X", "scale", "B",
             "mean", "var"], ["Y"])]
         graph = helper.make_graph(
@@ -249,7 +249,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 8
 
     # Test Concat Adapter: 3 -> 5
-    def test_concat_3_5(self):  # type: () -> None
+    def test_concat_3_5(self) -> None:
         nodes = [helper.make_node('Concat', ["X1", "X2", "X3",
             "X4", "X5"], ["Y"])]
         graph = helper.make_graph(
@@ -268,7 +268,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 5
 
     # Test Concat Adapter: 5 -> 3
-    def test_concat_5_3(self):  # type: () -> None
+    def test_concat_5_3(self) -> None:
         nodes = [helper.make_node('Concat', ["X1", "X2", "X3",
             "X4", "X5"], ["Y"], axis=0)]
         graph = helper.make_graph(
@@ -287,7 +287,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 3
 
     # Test Reshape Adapter: 6 -> 4
-    def test_reshape_6_4(self):  # type: () -> None
+    def test_reshape_6_4(self) -> None:
         nodes = [helper.make_node('Constant', [], ["shape"],
                     value=helper.make_tensor("", TensorProto.INT64, [1],
                         [5])),
@@ -304,7 +304,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 4
 
     # Test Reshape Adapter: 4 -> 6
-    def test_reshape_4_6(self):  # type: () -> None
+    def test_reshape_4_6(self) -> None:
         nodes = [helper.make_node('Reshape', ["X"], ["Y"], shape=[5])]
         graph = helper.make_graph(
             nodes,
@@ -319,7 +319,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 6
 
     # Test Sum Adapter: 7 -> 8
-    def test_sum_7_8(self):  # type: () -> None
+    def test_sum_7_8(self) -> None:
         nodes = [helper.make_node('Sum', ["data_0", "data_1", "data_2",
             "data_3", "data_4"], ["sum"])]
         graph = helper.make_graph(
@@ -338,7 +338,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 8
 
     # Test Sum Adapter: 5 -> 8
-    def test_sum_5_8(self):  # type: () -> None
+    def test_sum_5_8(self) -> None:
         nodes = [helper.make_node('Sum', ["data_0", "data_1", "data_2",
             "data_3", "data_4"], ["sum"])]
         graph = helper.make_graph(
@@ -357,7 +357,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 7
 
     # Test Sum Adapter: 8 -> 5
-    def test_sum_8_5(self):  # type: () -> None
+    def test_sum_8_5(self) -> None:
         nodes = [helper.make_node('Sum', ["data_0", "data_1", "data_2",
             "data_3", "data_4"], ["sum"])]
         graph = helper.make_graph(
@@ -376,7 +376,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 5
 
     # Test AveragePool Adapter: 1 -> 8
-    def test_averagepool_up(self):  # type: () -> None
+    def test_averagepool_up(self) -> None:
         nodes = [helper.make_node('AveragePool', ["X"], ["Y"], kernel_shape=[1, 1])]
         graph = helper.make_graph(
             nodes,
@@ -390,7 +390,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 8
 
     # Test AveragePool Adapter: 8 -> 1
-    def test_averagepool_down(self):  # type: () -> None
+    def test_averagepool_down(self) -> None:
         nodes = [helper.make_node('AveragePool', ["X"], ["Y"], kernel_shape=[1, 1])]
         graph = helper.make_graph(
             nodes,
@@ -404,7 +404,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 1
 
     # Test Dropout Adapter: 1 -> 8
-    def test_dropout_up(self):  # type: () -> None
+    def test_dropout_up(self) -> None:
         nodes = [helper.make_node('Dropout', ["data"], ["output"], is_test=1)]
         graph = helper.make_graph(
             nodes,
@@ -418,7 +418,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 8
 
     # Test Dropout Adapter: 8 -> 1
-    def test_dropout_down(self):  # type: () -> None
+    def test_dropout_down(self) -> None:
         nodes = [helper.make_node('Dropout', ["data"], ["output"])]
         graph = helper.make_graph(
             nodes,
@@ -432,7 +432,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 1
 
     # Test Max Adapter: 7 -> 8
-    def test_max_7_8(self):  # type: () -> None
+    def test_max_7_8(self) -> None:
         from_opset = 7
         to_opset = 8
         data_type = TensorProto.FLOAT
@@ -457,7 +457,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test Min Adapter: 7 -> 8
-    def test_min_7_8(self):  # type: () -> None
+    def test_min_7_8(self) -> None:
         from_opset = 7
         to_opset = 8
         data_type = TensorProto.FLOAT
@@ -482,7 +482,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test Mean Adapter: 7 -> 8
-    def test_mean_7_8(self):  # type: () -> None
+    def test_mean_7_8(self) -> None:
         from_opset = 7
         to_opset = 8
         data_type = TensorProto.FLOAT
@@ -507,7 +507,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test MaxPool Adapter: 1 -> 8
-    def test_maxpool_up(self):  # type: () -> None
+    def test_maxpool_up(self) -> None:
         nodes = [helper.make_node('MaxPool', ["X"], ["Y"], kernel_shape=[1, 1])]
         graph = helper.make_graph(
             nodes,
@@ -521,7 +521,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 8
 
     # Test Upsample Adapter: 6 -> 7
-    def test_upsample_6_7(self):    # type: () -> None
+    def test_upsample_6_7(self) -> None:
         from_opset = 6
         to_opset = 7
         data_type = TensorProto.FLOAT
@@ -553,7 +553,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test MaxPool Adapter: 8 -> 1
-    def test_maxpool_down(self):  # type: () -> None
+    def test_maxpool_down(self) -> None:
         nodes = [helper.make_node('MaxPool', ["X"], ["Y"], kernel_shape=[1, 1])]
         graph = helper.make_graph(
             nodes,
@@ -567,7 +567,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 1
 
     # Test BatchNormalization Adapter: 8 -> 9
-    def test_batch_normalization_8_9(self):  # type: () -> None
+    def test_batch_normalization_8_9(self) -> None:
         from_opset = 8
         to_opset = 9
         data_type = TensorProto.FLOAT
@@ -599,7 +599,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test BatchNormalization Adapter: 9 -> 8
-    def test_batchnormalization_9_8(self):  # type: () -> None
+    def test_batchnormalization_9_8(self) -> None:
         from_opset = 9
         to_opset = 8
         data_type = TensorProto.FLOAT
@@ -628,7 +628,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test Constant Adapter: 8 -> 9
-    def test_constant_8_9(self):  # type: () -> None
+    def test_constant_8_9(self) -> None:
         from_opset = 8
         to_opset = 9
         data_type = TensorProto.FLOAT
@@ -655,7 +655,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test Constant Adapter: 9 -> 8
-    def test_constant_9_8(self):  # type: () -> None
+    def test_constant_9_8(self) -> None:
         from_opset = 9
         to_opset = 8
         data_type = TensorProto.UINT64
@@ -682,7 +682,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test Flatten Adapter: 8 -> 9
-    def test_flatten_8_9(self):  # type: () -> None
+    def test_flatten_8_9(self) -> None:
         from_opset = 8
         to_opset = 9
         data_type = TensorProto.FLOAT
@@ -707,7 +707,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test Flatten Adapter: 9 -> 8
-    def test_flatten_9_8(self):  # type: () -> None
+    def test_flatten_9_8(self) -> None:
         from_opset = 9
         to_opset = 8
         data_type = TensorProto.UINT64
@@ -732,7 +732,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test PRelu Adapter: 8 -> 9
-    def test_prelu_8_9(self):  # type: () -> None
+    def test_prelu_8_9(self) -> None:
         from_opset = 8
         to_opset = 9
         data_type = TensorProto.FLOAT
@@ -758,7 +758,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test PRelu Adapter: 9 -> 8
-    def test_prelu_9_8(self):  # type: () -> None
+    def test_prelu_9_8(self) -> None:
         from_opset = 9
         to_opset = 8
         data_type = TensorProto.UINT64
@@ -784,7 +784,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test Greater Adapter: 8 -> 9
-    def test_greater_8_9(self):  # type: () -> None
+    def test_greater_8_9(self) -> None:
         from_opset = 8
         to_opset = 9
         data_type = TensorProto.FLOAT
@@ -810,7 +810,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test Greater Adapter: 9 -> 8
-    def test_greater_9_8(self):  # type: () -> None
+    def test_greater_9_8(self) -> None:
         from_opset = 9
         to_opset = 8
         data_type = TensorProto.UINT64
@@ -836,7 +836,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test Less Adapter: 8 -> 9
-    def test_less_8_9(self):  # type: () -> None
+    def test_less_8_9(self) -> None:
         from_opset = 8
         to_opset = 9
         data_type = TensorProto.FLOAT
@@ -862,7 +862,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test Less Adapter: 9 -> 8
-    def test_less_9_8(self):  # type: () -> None
+    def test_less_9_8(self) -> None:
         from_opset = 9
         to_opset = 8
         data_type = TensorProto.UINT64
@@ -888,7 +888,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test MatMul Adapter: 8 -> 9
-    def test_matmul_8_9(self):  # type: () -> None
+    def test_matmul_8_9(self) -> None:
         from_opset = 8
         to_opset = 9
         data_type = TensorProto.FLOAT
@@ -913,7 +913,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test MatMul Adapter: 9 -> 8
-    def test_matmul_9_8(self):  # type: () -> None
+    def test_matmul_9_8(self) -> None:
         from_opset = 9
         to_opset = 8
         data_type = TensorProto.UINT64
@@ -938,7 +938,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test Gemm Adapter: 8 -> 9
-    def test_gemm_8_9(self):  # type: () -> None
+    def test_gemm_8_9(self) -> None:
         from_opset = 8
         to_opset = 9
         data_type = TensorProto.FLOAT
@@ -964,7 +964,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test Gemm Adapter: 9 -> 8
-    def test_gemm_9_8(self):  # type: () -> None
+    def test_gemm_9_8(self) -> None:
         from_opset = 9
         to_opset = 8
         data_type = TensorProto.UINT64
@@ -990,7 +990,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test Upsample Adapter: 8 -> 9
-    def test_upsample_8_9(self):  # type: () -> None
+    def test_upsample_8_9(self) -> None:
         from_opset = 8
         to_opset = 9
         data_type = TensorProto.FLOAT
@@ -1020,7 +1020,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test Helper for Upsample Adapter: 9 -> 8
-    def helper_upsample_with_initializer(self, raw_scale=False):  # type: (bool) -> None
+    def helper_upsample_with_initializer(self, raw_scale: bool = False) -> None:
         from_opset = 9
         to_opset = 8
         data_type = TensorProto.FLOAT
@@ -1052,7 +1052,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test Helper for Upsample Adapter: 9 -> 8
-    def helper_upsample_with_constant(self, raw_scale=False):  # type: (bool) -> None
+    def helper_upsample_with_constant(self, raw_scale: bool = False) -> None:
         from_opset = 9
         to_opset = 8
         data_type = TensorProto.FLOAT
@@ -1087,23 +1087,23 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test Upsample Adapter: 9 -> 8
-    def test_upsample_with_constant_node_9_8(self):  # type: () -> None
+    def test_upsample_with_constant_node_9_8(self) -> None:
         self.helper_upsample_with_constant(raw_scale=False)
 
     # Test Upsample Adapter: 9 -> 8
-    def test_upsample_with_initializer_9_8(self):  # type: () -> None
+    def test_upsample_with_initializer_9_8(self) -> None:
         self.helper_upsample_with_initializer(raw_scale=False)
 
     # Test Upsample Adapter: 9 -> 8
-    def test_upsample_with_raw_initializer_9_8(self):  # type: () -> None
+    def test_upsample_with_raw_initializer_9_8(self) -> None:
         self.helper_upsample_with_constant(raw_scale=True)
 
     # Test Upsample Adapter: 9 -> 8
-    def test_upsample_with_raw_constant_node_9_8(self):  # type: () -> None
+    def test_upsample_with_raw_constant_node_9_8(self) -> None:
         self.helper_upsample_with_constant(raw_scale=True)
 
     # Test Scan Adapter: 8 -> 9
-    def test_scan_8_9(self):  # type: () -> None
+    def test_scan_8_9(self) -> None:
         from_opset = 8
         to_opset = 9
         data_type = TensorProto.FLOAT
@@ -1143,7 +1143,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     # Test Cast Adapter: 8 -> 9
-    def test_cast_8_9(self):  # type: () -> None
+    def test_cast_8_9(self) -> None:
         from_opset = 8
         to_opset = 9
         data_type_from = TensorProto.FLOAT
@@ -1169,7 +1169,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
 
     #Test Split Adapter: 13 -> 12
-    def test_split_13_12(self):  # type: () -> None
+    def test_split_13_12(self) -> None:
         nodes = [helper.make_node('Constant', [], ["split"],
                                   value=helper.make_tensor("", TensorProto.INT64, [2],
                                                            [2, 3])),
@@ -1187,7 +1187,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 12
 
     # Test Split Adapter: 12 -> 13
-    def test_split_12_13(self):  # type: () -> None
+    def test_split_12_13(self) -> None:
         nodes = [helper.make_node('Split', ["X"], ["Y1", "Y2"], split=[2, 3])]
         graph = helper.make_graph(
             nodes,
@@ -1203,7 +1203,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 13
 
     # Test AxesInputToAttribute Adapter: 13 -> 12
-    def test_axes_input_to_attr_13_12(self):  # type: () -> None
+    def test_axes_input_to_attr_13_12(self) -> None:
         nodes = [helper.make_node('Constant', [], ["axes"],
                                   value=helper.make_tensor("", TensorProto.INT64, [1],
                                                            [0])),
@@ -1220,7 +1220,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 12
 
     # Test AxesAttributeToInput Adapter: 12 -> 13
-    def test_axes_attr_to_input_12_13(self):  # type: () -> None
+    def test_axes_attr_to_input_12_13(self) -> None:
         nodes = [helper.make_node('ReduceSum', ["X"], ["Y"], axes=[0])]
         graph = helper.make_graph(
             nodes,
@@ -1234,7 +1234,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == 13
 
     # Test Slice Adapter: 9 -> 10
-    def test_slice_9_10(self):  # type: () -> None
+    def test_slice_9_10(self) -> None:
         nodes = [helper.make_node('Slice', ["X"], ["Y"],
                                   axes=[0, 1],
                                   starts=[0, 0],
@@ -1256,7 +1256,7 @@ class TestVersionConverter(unittest.TestCase):
         assert len(converted_model.graph.node[3].attribute) == 0
 
     # Test RNN Adapter: 13 -> 14
-    def test_rnn_13_14(self):  # type: () -> None
+    def test_rnn_13_14(self) -> None:
         from_opset = 13
         to_opset = 14
         data_type = TensorProto.FLOAT
@@ -1291,7 +1291,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.graph.node[0].attribute[1].name == "layout"
 
     # Test GRU Adapter: 13 -> 14
-    def test_gru_13_14(self):  # type: () -> None
+    def test_gru_13_14(self) -> None:
         from_opset = 13
         to_opset = 14
         data_type = TensorProto.FLOAT
@@ -1326,7 +1326,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.graph.node[0].attribute[1].name == "layout"
 
     # Test LSTM Adapter: 13 -> 14
-    def test_lstm_13_14(self):  # type: () -> None
+    def test_lstm_13_14(self) -> None:
         from_opset = 13
         to_opset = 14
         data_type = TensorProto.FLOAT
@@ -1361,7 +1361,7 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.graph.node[0].attribute[1].name == "layout"
 
     # Test RNN Adapter: 14 -> 13
-    def test_rnn_14_13(self):  # type: () -> None
+    def test_rnn_14_13(self) -> None:
         from_opset = 14
         to_opset = 13
         data_type = TensorProto.FLOAT
@@ -1396,7 +1396,7 @@ class TestVersionConverter(unittest.TestCase):
         assert len(converted_model.graph.node[0].attribute) == 1
 
     # Test GRU Adapter: 14 -> 13
-    def test_gru_14_13(self):  # type: () -> None
+    def test_gru_14_13(self) -> None:
         from_opset = 14
         to_opset = 13
         data_type = TensorProto.FLOAT
@@ -1431,7 +1431,7 @@ class TestVersionConverter(unittest.TestCase):
         assert len(converted_model.graph.node[0].attribute) == 1
 
     # Test LSTM Adapter: 14 -> 13
-    def test_lstm_14_13(self):  # type: () -> None
+    def test_lstm_14_13(self) -> None:
         from_opset = 14
         to_opset = 13
         data_type = TensorProto.FLOAT
@@ -1466,7 +1466,7 @@ class TestVersionConverter(unittest.TestCase):
         assert len(converted_model.graph.node[0].attribute) == 1
 
     # Test that subgraphs are converted
-    def test_if_subgraph_10_11(self):  # type: () -> None
+    def test_if_subgraph_10_11(self) -> None:
         from_opset = 10
         to_opset = 11
         data_type = TensorProto.FLOAT
@@ -1529,7 +1529,7 @@ class TestVersionConverter(unittest.TestCase):
 
     # Use initializer as node inputs (instead of graph input)
     # to test whether IR (version_converter) can handle it
-    def test_initializer_not_in_input_above_ir4(self):  # type: () -> None
+    def test_initializer_not_in_input_above_ir4(self) -> None:
         nodes = [helper.make_node('BatchNormalization', ["X", "scale", "B",
             "mean", "var"], ["Y"])]
 

--- a/onnx/tools/net_drawer.py
+++ b/onnx/tools/net_drawer.py
@@ -37,20 +37,20 @@ BLOB_STYLE = {'shape': 'octagon'}
 _NodeProducer = Callable[[NodeProto, int], pydot.Node]
 
 
-def _escape_label(name):  # type: (Text) -> Text
+def _escape_label(name: Text) -> Text:
     # json.dumps is poor man's escaping
     return json.dumps(name)
 
 
-def _form_and_sanitize_docstring(s):  # type: (Text) -> Text
+def _form_and_sanitize_docstring(s: Text) -> Text:
     url = 'javascript:alert('
     url += _escape_label(s).replace('"', '\'').replace('<', '').replace('>', '')
     url += ')'
     return url
 
 
-def GetOpNodeProducer(embed_docstring=False, **kwargs):  # type: (bool, **Any) -> _NodeProducer
-    def ReallyGetOpNode(op, op_id):  # type: (NodeProto, int) -> pydot.Node
+def GetOpNodeProducer(embed_docstring: bool = False, **kwargs: Any) -> _NodeProducer:
+    def ReallyGetOpNode(op: NodeProto, op_id: int) -> pydot.Node:
         if op.name:
             node_name = '%s/%s (op#%d)' % (op.name, op.op_type, op_id)
         else:
@@ -68,17 +68,17 @@ def GetOpNodeProducer(embed_docstring=False, **kwargs):  # type: (bool, **Any) -
 
 
 def GetPydotGraph(
-    graph,  # type: GraphProto
-    name=None,  # type: Optional[Text]
-    rankdir='LR',  # type: Text
-    node_producer=None,  # type: Optional[_NodeProducer]
-    embed_docstring=False,  # type: bool
-):  # type: (...) -> pydot.Dot
+    graph: GraphProto,
+    name: Optional[Text] = None,
+    rankdir: Text = 'LR',
+    node_producer: Optional[_NodeProducer] = None,
+    embed_docstring: bool = False,
+) -> pydot.Dot:
     if node_producer is None:
         node_producer = GetOpNodeProducer(embed_docstring=embed_docstring, **OP_STYLE)
     pydot_graph = pydot.Dot(name, rankdir=rankdir)
-    pydot_nodes = {}  # type: Dict[Text, pydot.Node]
-    pydot_node_counts = defaultdict(int)  # type: Dict[Text, int]
+    pydot_nodes: Dict[Text, pydot.Node] = {}
+    pydot_node_counts: Dict[Text, int] = defaultdict(int)
     for op_id, op in enumerate(graph.node):
         op_node = node_producer(op, op_id)
         pydot_graph.add_node(op_node)
@@ -110,7 +110,7 @@ def GetPydotGraph(
     return pydot_graph
 
 
-def main():  # type: () -> None
+def main() -> None:
     parser = argparse.ArgumentParser(description="ONNX net drawer")
     parser.add_argument(
         "--input",

--- a/onnx/tools/update_model_dims.py
+++ b/onnx/tools/update_model_dims.py
@@ -11,7 +11,7 @@ from onnx import ModelProto, ValueInfoProto
 import onnx.checker
 
 
-def update_inputs_outputs_dims(model, input_dims, output_dims):  # type: (ModelProto, Dict[Text, List[Any]], Dict[Text, List[Any]]) -> ModelProto
+def update_inputs_outputs_dims(model: ModelProto, input_dims: Dict[Text, List[Any]], output_dims: Dict[Text, List[Any]]) -> ModelProto:
     """
         This function updates the dimension sizes of the model's inputs and outputs to the values
         provided in input_dims and output_dims. if the dim value provided is negative, a unique dim_param
@@ -36,9 +36,9 @@ def update_inputs_outputs_dims(model, input_dims, output_dims):  # type: (ModelP
                 updated_model = update_inputs_outputs_dims(model, input_dims, output_dims)
                 onnx.save(updated_model, 'model.onnx')
     """
-    dim_param_set = set()  # type: Set[Text]
+    dim_param_set: Set[Text] = set()
 
-    def init_dim_param_set(dim_param_set, value_infos):  # type: (Set[Text], List[ValueInfoProto]) -> None
+    def init_dim_param_set(dim_param_set: Set[Text], value_infos: List[ValueInfoProto]) -> None:
         for info in value_infos:
             shape = info.type.tensor_type.shape
             for dim in shape.dim:
@@ -49,7 +49,7 @@ def update_inputs_outputs_dims(model, input_dims, output_dims):  # type: (ModelP
     init_dim_param_set(dim_param_set, model.graph.output)  # type: ignore
     init_dim_param_set(dim_param_set, model.graph.value_info)  # type: ignore
 
-    def update_dim(tensor, dim, j, name):  # type: (ValueInfoProto, Any, int, Text) -> None
+    def update_dim(tensor: ValueInfoProto, dim: Any, j: int, name: Text) -> None:
         dim_proto = tensor.type.tensor_type.shape.dim[j]
         if isinstance(dim, int):
             if dim >= 0:

--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -16,7 +16,7 @@ from onnx import ModelProto, NodeProto, TensorProto, ValueInfoProto, FunctionPro
 
 
 class Extractor:
-    def __init__(self, model):  # type: (ModelProto) -> None
+    def __init__(self, model: ModelProto) -> None:
         self.model = onnx.shape_inference.infer_shapes(model)
         self.graph = self.model.graph
         self.wmap = self._build_name2obj_dict(self.graph.initializer)
@@ -44,18 +44,18 @@ class Extractor:
         new_io_tensors_map = self._build_name2obj_dict(new_io_tensors)
         return [new_io_tensors_map[name] for name in io_names_to_extract]
 
-    def _collect_new_inputs(self, names):  # type: (List[Text]) -> List[ValueInfoProto]
+    def _collect_new_inputs(self, names: List[Text]) -> List[ValueInfoProto]:
         return self._collect_new_io_core(self.graph.input, names)  # type: ignore
 
-    def _collect_new_outputs(self, names):  # type: (List[Text]) -> List[ValueInfoProto]
+    def _collect_new_outputs(self, names: List[Text]) -> List[ValueInfoProto]:
         return self._collect_new_io_core(self.graph.output, names)  # type: ignore
 
     def _dfs_search_reachable_nodes(
             self,
-            node_output_name,  # type: Text
-            graph_input_names,  # type: List[Text]
-            reachable_nodes,  # type: List[NodeProto]
-    ):  # type: (...) -> None
+            node_output_name: Text,
+            graph_input_names: List[Text],
+            reachable_nodes: List[NodeProto],
+    ) -> None:
         if node_output_name in graph_input_names:
             return
         for node in self.graph.node:
@@ -69,9 +69,9 @@ class Extractor:
 
     def _collect_reachable_nodes(
             self,
-            input_names,  # type: List[Text]
-            output_names,  # type: List[Text]
-    ):  # type: (...) -> List[NodeProto]
+            input_names: List[Text],
+            output_names: List[Text],
+    ) -> List[NodeProto]:
         reachable_nodes = list()  # type: ignore
         for name in output_names:
             self._dfs_search_reachable_nodes(name, input_names, reachable_nodes)
@@ -81,14 +81,14 @@ class Extractor:
 
     def _collect_referred_local_functions(
             self,
-            nodes,  # type: List[NodeProto]
-    ):  # type: (...) -> List[FunctionProto]
+            nodes: List[NodeProto],
+    ) -> List[FunctionProto]:
         # a node in a model graph may refer a function.
         # a function contains nodes, some of which may in turn refer a function.
         # we need to find functions referred by graph nodes and
         # by nodes used to define functions.
         def find_referred_funcs(nodes, referred_local_functions):  # type: ignore
-            new_nodes = []  # type: List[NodeProto]
+            new_nodes: List[NodeProto] = []
             for node in nodes:
                 # check if the node is a function op
                 match_function = next((
@@ -101,7 +101,7 @@ class Extractor:
 
             return new_nodes
 
-        referred_local_functions = []  # type: List[FunctionProto]
+        referred_local_functions: List[FunctionProto] = []
         new_nodes = find_referred_funcs(nodes, referred_local_functions)
         while new_nodes:
             new_nodes = find_referred_funcs(new_nodes, referred_local_functions)
@@ -110,8 +110,8 @@ class Extractor:
 
     def _collect_reachable_tensors(
             self,
-            nodes,  # type: List[NodeProto]
-    ):  # type: (...) -> Tuple[List[TensorProto], List[ValueInfoProto]]
+            nodes: List[NodeProto],
+    ) -> Tuple[List[TensorProto], List[ValueInfoProto]]:
         all_tensors_name = set()
         for node in nodes:
             for name in node.input:
@@ -127,13 +127,13 @@ class Extractor:
 
     def _make_model(
             self,
-            nodes,  # type: List[NodeProto]
-            inputs,  # type: List[ValueInfoProto]
-            outputs,  # type: List[ValueInfoProto]
-            initializer,  # type: List[TensorProto]
-            value_info,  # type: List[ValueInfoProto]
-            local_functions  # type: List[FunctionProto]
-    ):  # type: (...) -> ModelProto
+            nodes: List[NodeProto],
+            inputs: List[ValueInfoProto],
+            outputs: List[ValueInfoProto],
+            initializer: List[TensorProto],
+            value_info: List[ValueInfoProto],
+            local_functions: List[FunctionProto]
+    ) -> ModelProto:
         name = 'Extracted from {' + self.graph.name + '}'
         graph = onnx.helper.make_graph(nodes, name, inputs, outputs, initializer=initializer,
                                       value_info=value_info)
@@ -148,9 +148,9 @@ class Extractor:
 
     def extract_model(
             self,
-            input_names,  # type: List[Text]
-            output_names,  # type: List[Text]
-    ):  # type: (...) -> ModelProto
+            input_names: List[Text],
+            output_names: List[Text],
+    ) -> ModelProto:
         inputs = self._collect_new_inputs(input_names)
         outputs = self._collect_new_outputs(output_names)
         nodes = self._collect_reachable_nodes(input_names, output_names)
@@ -162,12 +162,12 @@ class Extractor:
 
 
 def extract_model(
-        input_path,  # type: Text
-        output_path,  # type: Text
-        input_names,  # type: List[Text]
-        output_names,  # type: List[Text]
-        check_model=True,  # type: bool
-):  # type: (...) -> None
+        input_path: Text,
+        output_path: Text,
+        input_names: List[Text],
+        output_names: List[Text],
+        check_model: bool = True,
+) -> None:
     """Extracts sub-model from an ONNX model.
 
     The sub-model is defined by the names of the input and output tensors *exactly*.

--- a/onnx/version_converter.py
+++ b/onnx/version_converter.py
@@ -165,7 +165,7 @@ Unsupported adapters:
 """
 
 
-def convert_version(model, target_version):  # type: (ModelProto, int) -> ModelProto
+def convert_version(model: ModelProto, target_version: int) -> ModelProto:
     if not isinstance(model, ModelProto):
         raise ValueError('VersionConverter only accepts ModelProto as model, incorrect type: {}'.format(type(model)))
     if not isinstance(target_version, int):


### PR DESCRIPTION
**Description**
- runs [com2ann](https://github.com/ilevkivskyi/com2ann) to automatically convert typing hints to annotations
- specifically, ran `com2ann onnx/.`

**Motivation and Context**
- Current typehints are done in Python 2 comment style, we only support Python 3 now
- see also https://github.com/onnx/onnx/issues/3964#issuecomment-1021949910