### PR TITLE
[BUG] Use correct pytest types in backend

### DIFF
--- a/onnx/backend/test/report/__init__.py
+++ b/onnx/backend/test/report/__init__.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import pytest  # type: ignore
-import _pytest
+import _pytest  # type: ignore
 
 from .coverage import Coverage
 from typing import Dict, Text, Sequence, Any, List

--- a/onnx/backend/test/report/__init__.py
+++ b/onnx/backend/test/report/__init__.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import pytest  # type: ignore
+import _pytest
 
 from .coverage import Coverage
 from typing import Dict, Text, Sequence, Any, List
@@ -23,7 +24,7 @@ def _add_mark(mark: Any, bucket: Text) -> None:
         _coverage.add_proto(proto, bucket, mark.args[1] == 'RealModel')
 
 
-def pytest_runtest_call(item: pytest.nodes.Item) -> None:
+def pytest_runtest_call(item: _pytest.nodes.Item) -> None:
     mark = item.get_closest_marker('onnx_coverage')
     if mark:
         assert item.nodeid not in _marks
@@ -39,7 +40,7 @@ def pytest_runtest_logreport(report: Any) -> None:
 
 
 @pytest.hookimpl(trylast=True)  # type: ignore
-def pytest_terminal_summary(terminalreporter: pytest.terminal.TerminalReporter, exitstatus: int) -> None:
+def pytest_terminal_summary(terminalreporter: _pytest.terminal.TerminalReporter, exitstatus: int) -> None:
     for mark in _marks.values():
         _add_mark(mark, 'loaded')
     _coverage.report_text(terminalreporter)


### PR DESCRIPTION
Signed-off-by: Kevin Chen <kevinch@nvidia.com>

**Description**
- Fix incorrect type annotations in backend test reporting

**Motivation and Context**
-  https://github.com/onnx/onnx/pull/3962 introduced type annotations, but types `pytest.nodes.Item` and `pytest.terminal.TerminalReporter` belong to `_pytest` instead of `pytest`
