### PR TITLE
added prerequisit level about python

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Stay up to date with the latest ONNX news. [[Facebook](https://www.facebook.com/
 numpy >= 1.16.6
 protobuf >= 3.12.2
 typing-extensions >= 3.6.2.1
+python >= 3.6
 ```
 
 ## Official Python packages


### PR DESCRIPTION
Signed-off-by: Alexandre Eichenberger <alexe@us.ibm.com>

It was mentioned today at the ONNX SC meeting that the current support for python is 3.6 or up. Since it was not listed in the README prerequisites, I though it might be good to be explicit so that when it is bumped up in the future, folks will be clear about it.