### PR TITLE
Loose NumPy requirement to grant more flexibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy >= 1.16.6
+numpy >= 1.16.6 # TODO: update once TensorFlow 2.6 is end of life
 protobuf >= 3.12.2
 typing-extensions >= 3.6.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy >= 1.21.5
+numpy >= 1.16.6
 protobuf >= 3.12.2
 typing-extensions >= 3.6.2.1


### PR DESCRIPTION
**Description**
Loose NumPy requirement to grant more flexibility.

**Motivation and Context**
Closes https://github.com/onnx/onnx/issues/4053. Some old TensorFlow versions are not compatible with NumPy>=1.20. Recently ONNX bumped its NumPy version for building wheels: https://github.com/onnx/onnx/pull/4001 because of Python 3.10 support and resolving vulnerability issue from old NumPy. However, ONNX itself does not have strict dependency on NumPy. IMO, it should be OK to make minimum version requirement for NumPy lower to grant more flexibility for ONNX downstream repos.

cc @fatcat-z