### PR TITLE
Clarify that op_type is case sensitive

### DIFF
--- a/docs/IR.md
+++ b/docs/IR.md
@@ -160,7 +160,7 @@ The properties of an operator definition are:
 
 Name|Type|Description
 |---|---|---|
-op_type|string|The name of the operator, as used in graph nodes. MUST be unique within the operator set’s domain.
+op_type|string|The name of the operator (case sensitive), as used in graph nodes. MUST be unique within the operator set’s domain.
 since_version|int64|The version of the operator set when this operator was introduced.
 status|OperatorStatus|One of ‘EXPERIMENTAL’ or ‘STABLE.’
 doc_string|string|A human-readable documentation string for this operator. Markdown is allowed.


### PR DESCRIPTION
This is consistent with current precedent. e.g. ONNX Runtime fails with "conv ... Error No Op registered for conv with domain_version of 7", as it must be "Conv".

Signed-off-by: Dwayne Robinson <dwayner@microsoft.com>

**Description**
- Update IR.md to clarify op type case sensitivity.

**Motivation and Context**
- *Why is this change required? What problem does it solve?* To clarify behavior.
- *If it fixes an open issue, please link to the issue here.* https://github.com/onnx/onnx/issues/1934
