### PR TITLE
Fix Python 3.10 CI failure: Remove unused LooseVersion

### DIFF
--- a/onnx/examples/np_array_tensorproto.ipynb
+++ b/onnx/examples/np_array_tensorproto.ipynb
@@ -21,7 +21,6 @@
     "import onnx\n",
     "import os\n",
     "from onnx import numpy_helper\n",
-    "from distutils.version import LooseVersion\n",
     "\n",
     "\n",
     "# Preprocessing: create a Numpy array\n",


### PR DESCRIPTION
**Description**
Remove unused LooseVersion

**Motivation and Context**
CIs for Python 3.10 failed due to additional warnings for deprecated LooseVersion. It should be removed because it is used.
