### PR TITLE
Check every dim has either `dim_param` or `dim_value` in getShapeInput

### DIFF
--- a/onnx/defs/shape_inference.cc
+++ b/onnx/defs/shape_inference.cc
@@ -441,9 +441,18 @@ TensorShapeProto getShapeInput(InferenceContext& ctx, size_t input_index, bool& 
   // Then, check symbolic input.
   const TensorShapeProto* symbolic_input = ctx.getSymbolicInput(input_index);
   if (symbolic_input) {
-    shape_input.CopyFrom(*symbolic_input);
-    found = true;
-    return shape_input;
+    bool valid = true;
+    for (int i = 0; i < symbolic_input->dim_size(); i++) {
+      if (!symbolic_input->dim(i).has_dim_param() && !symbolic_input->dim(i).has_dim_value()) {
+        valid = false;
+        break;
+      }
+    }
+    if (valid) {
+      shape_input.CopyFrom(*symbolic_input);
+      found = true;
+      return shape_input;
+    }
   }
 
   // Try rank inference.


### PR DESCRIPTION
**Description**
- Check each dim is valid when referring to symbolic input in shape inference.

**Motivation and Context**
- Sometimes, due to shape inference error (which is most likely caused by some hidden bugs), an inferred shape may contain a dimension that has neither `dim_param` or `dim_value`.
- We should fall back to rank inference in getShapeInput in this case, rather than continue to pass this illegal shape. 