### PR TITLE
Fix version_converter crash: use %d to print integer

### DIFF
--- a/onnx/version_converter/convert.h
+++ b/onnx/version_converter/convert.h
@@ -70,7 +70,7 @@ class DefaultVersionConverter : public BaseVersionConverter {
     void assertInVersionRange(int64_t version) const {
       ONNX_ASSERTM(version >= version_range.first && version <=
           version_range.second,
-          "Warning: invalid version (must be between %s and %s)",
+          "Warning: invalid version (must be between %d and %d)",
           version_range.first, version_range.second);
     }
 


### PR DESCRIPTION
**Description**
Fix version_converter crash: use %d to print integer


**Motivation and Context**
Closes https://github.com/onnx/onnx/issues/4178. Current version_converter crashes when the target version is higher than the latest opset_version.
