### PR TITLE
Fix bf16 Support

### DIFF
--- a/onnx/mapping.py
+++ b/onnx/mapping.py
@@ -13,7 +13,7 @@ TENSOR_TYPE_TO_NP_TYPE = {
     int(TensorProto.INT64): np.dtype('int64'),
     int(TensorProto.BOOL): np.dtype('bool'),
     int(TensorProto.FLOAT16): np.dtype('float16'),
-    int(TensorProto.BFLOAT16): np.dtype('float16'),  # native numpy does not support bfloat16
+    int(TensorProto.BFLOAT16): np.dtype('uint16'),  # native numpy does not support bfloat16
     int(TensorProto.DOUBLE): np.dtype('float64'),
     int(TensorProto.COMPLEX64): np.dtype('complex64'),
     int(TensorProto.COMPLEX128): np.dtype('complex128'),

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -3,6 +3,7 @@
 import sys
 
 import numpy as np  # type: ignore
+import numpy.typing as nptyping  # type: ignore
 from onnx import TensorProto, MapProto, SequenceProto, OptionalProto
 from onnx import mapping, helper
 from onnx.external_data_helper import load_external_data_for_tensor, uses_external_data
@@ -11,6 +12,12 @@ from typing import Sequence, Any, Optional, Text, List, Dict
 
 def combine_pairs_to_complex(fa: Sequence[int]) -> Sequence[np.complex64]:
     return [complex(fa[i * 2], fa[i * 2 + 1]) for i in range(len(fa) // 2)]
+
+
+# convert ndarray of bf16 (as uint32) to f32 (as uint32)
+def bfloat16_to_float32(data: np.ndarray, dims: nptyping._ShapeLike) -> np.ndarray:
+    shift = lambda x: x << 16  # noqa: E731
+    return shift(data.astype(np.int32)).reshape(dims).view(np.float32)
 
 
 def to_array(tensor: TensorProto, base_dir: Text = "") -> np.ndarray:
@@ -49,19 +56,30 @@ def to_array(tensor: TensorProto, base_dir: Text = "") -> np.ndarray:
         if sys.byteorder == 'big':
             # Convert endian from little to big
             convert_endian(tensor)
+
+        # manually convert bf16 since there's no numpy support
+        if tensor_dtype == TensorProto.BFLOAT16:
+            data = np.frombuffer(tensor.raw_data, dtype=np.int16)
+            return bfloat16_to_float32(data, dims)
+
         return np.frombuffer(
             tensor.raw_data,
             dtype=np_dtype).reshape(dims)
     else:
-        # float16/bfloat16 is stored as int32 (uint16 type); Need view to get the original value
-        if (tensor_dtype == TensorProto.FLOAT16
-                or tensor_dtype == TensorProto.BFLOAT16):
+        # float16 is stored as int32 (uint16 type); Need view to get the original value
+        if tensor_dtype == TensorProto.FLOAT16:
             return (
                 np.asarray(
                     tensor.int32_data,
                     dtype=np.uint16)
                 .reshape(dims)
                 .view(np.float16))
+
+        # bfloat16 is stored as int32 (uint16 type); no numpy support for bf16
+        if tensor_dtype == TensorProto.BFLOAT16:
+            data = np.asarray(tensor.int32_data, dtype=np.int32)
+            return bfloat16_to_float32(data, dims)
+
         data = getattr(tensor, storage_field)
         if (tensor_dtype == TensorProto.COMPLEX64
                 or tensor_dtype == TensorProto.COMPLEX128):


### PR DESCRIPTION
**Fix bf16 Support**
Fix bfloat16 support in helper and numpy_helper.py. 

**Motivation and Context**
Without native bfloat16 support in numpy implementing bfloat16 support for ONNX is a bit complicated. Recently support was added by encoding bfloat16 as float16. this is not correct as this is a lossy encoding; it's also a bit confusing as a design and indeed broke some bespoke tools on my end that didn't expect the bfloat16 to be encoded as float16 in the ONNX file.

### Open Questions
I've implemented some changes here that give rudimentary support (not completely broken) but i do have a two questions that i believe need to be answered before committing these changes.
1. what is the proper binary encoding of bfloat16 in ONNX protobuf format (is this documented? should it be?)
2. it appears that "raw" encoding and normal encoding for 16-bit values are of different sizes, is this intended?

### Not implemented Changes
1. support for big-endian encodings is not implemented in my code
2. support for "correct" truncation of NaN payloads is not implemented when converting from f32->bf16 in my code


Addresses #4189 