### PR TITLE
Specify default value for score_threshold attribute of NMS

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -13127,9 +13127,9 @@ Other versions of this operator: <a href="Changelog.md#NonMaxSuppression-10">10<
 <dt><tt>max_output_boxes_per_class</tt> (optional) : tensor(int64)</dt>
 <dd>Integer representing the maximum number of boxes to be selected per batch per class. It is a scalar. Default to 0, which means no output.</dd>
 <dt><tt>iou_threshold</tt> (optional) : tensor(float)</dt>
-<dd>Float representing the threshold for deciding whether boxes overlap too much with respect to IOU. It is scalar. Value range [0, 1]. Default to 0.</dd>
+<dd>Float representing the threshold for deciding whether boxes overlap too much with respect to IOU. It is scalar. Value range [0, 1]. Default to 0.0.</dd>
 <dt><tt>score_threshold</tt> (optional) : tensor(float)</dt>
-<dd>Float representing the threshold for deciding when to remove boxes based on score. It is a scalar.</dd>
+<dd>Float representing the threshold for deciding when to remove boxes based on score. It is a scalar. Default to 0.0.</dd>
 </dl>
 
 #### Outputs


### PR DESCRIPTION
**Description**
- NonMaxSuppression operator specification does not specify a default value for the `score_threshold` attribute.

**Motivation and Context**
- Default values must be specified for optional attributes in the Operator specifications.

Signed-off-by: Rajeev Rao <rajeevrao@nvidia.com>