### PR TITLE
Ignore input.pb consistency check for test generation in CIs

### DIFF
--- a/.azure-pipelines/Linux-CI.yml
+++ b/.azure-pipelines/Linux-CI.yml
@@ -138,7 +138,7 @@ jobs:
       git status
       # Skip *output_*.pb because NumPy functions might behave differently on different platforms
       # Skip test_log's input.pb because it uses np.random, which might behave differently on different platforms
-      git diff --exit-code -- . ':!onnx/onnx-data.proto' ':!onnx/onnx-data.proto3' ':!*output_*.pb' ':!onnx/backend/test/data/node/test_log/test_data_set_0/input_0.pb'
+      git diff --exit-code -- . ':!onnx/onnx-data.proto' ':!onnx/onnx-data.proto3' ':!*output_*.pb' ':!*input_*.pb'
       if [ $? -ne 0 ]; then
         echo "git diff for test generation returned failures. Please check updated node test files"
         exit 1

--- a/.azure-pipelines/MacOS-CI.yml
+++ b/.azure-pipelines/MacOS-CI.yml
@@ -104,7 +104,7 @@ jobs:
 
       python onnx/backend/test/cmd_tools.py generate-data
       git status
-      git diff --exit-code -- . ':!onnx/onnx-data.proto' ':!onnx/onnx-data.proto3' ':!*output_*.pb' ':!onnx/backend/test/data/node/test_log/test_data_set_0/input_0.pb'
+      git diff --exit-code -- . ':!onnx/onnx-data.proto' ':!onnx/onnx-data.proto3' ':!*output_*.pb' ':!*input_*.pb'
       if [ $? -ne 0 ]; then
         echo "git diff for test generation returned failures. Please check updated node test files"
         exit 1

--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -73,7 +73,7 @@ jobs:
 
       python onnx/backend/test/cmd_tools.py generate-data
       git status
-      git diff --exit-code  -- . :!onnx/onnx-data.proto :!onnx/onnx-data.proto3 :!*output_*.pb :!onnx/backend/test/data/node/test_log/test_data_set_0/input_0.pb
+      git diff --exit-code  -- . :!onnx/onnx-data.proto :!onnx/onnx-data.proto3 :!*output_*.pb :!*input_*.pb
       IF NOT %ERRORLEVEL% EQU 0 (
         @echo "git diff for test generation returned failures. Please check updated node test files"
         EXIT 1


### PR DESCRIPTION
**Description**
Ignore input.pb consistency check for test generation in CIs

**Motivation and Context**
https://github.com/onnx/onnx/pull/3855 brought test generation consistency check in CIs. However, it will also check generated input.pb. It's possible that input uses numpy.random, which might behave differently on different platforms.