### PR TITLE
Fix mapping TensorProto to NumPy for bfloat16 (#4234)

### DIFF
--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -333,7 +333,8 @@ def make_tensor(
         assert not raw, "Can not use raw_data to store string type"
 
     # Check number of vals specified equals tensor size
-    expected_size = 1 if (not raw) else (mapping.TENSOR_TYPE_TO_NP_TYPE[data_type].itemsize)
+    storage_type = mapping.TENSOR_TYPE_TO_STORAGE_TENSOR_TYPE[data_type]
+    expected_size = 1 if (not raw) else (mapping.TENSOR_TYPE_TO_NP_TYPE[storage_type].itemsize)
     # Flatten a numpy array if its rank > 1
     if type(vals) is np.ndarray and len(vals.shape) > 1:
         vals = vals.flatten()

--- a/onnx/mapping.py
+++ b/onnx/mapping.py
@@ -3,6 +3,7 @@
 from onnx import TensorProto, SequenceProto, OptionalProto
 import numpy as np  # type: ignore
 
+# This map is used for converting TensorProto values into Numpy arrays
 TENSOR_TYPE_TO_NP_TYPE = {
     int(TensorProto.FLOAT): np.dtype('float32'),
     int(TensorProto.UINT8): np.dtype('uint8'),
@@ -13,7 +14,7 @@ TENSOR_TYPE_TO_NP_TYPE = {
     int(TensorProto.INT64): np.dtype('int64'),
     int(TensorProto.BOOL): np.dtype('bool'),
     int(TensorProto.FLOAT16): np.dtype('float16'),
-    int(TensorProto.BFLOAT16): np.dtype('uint16'),  # native numpy does not support bfloat16
+    int(TensorProto.BFLOAT16): np.dtype('float32'),  # Native numpy does not support bfloat16 so now use float32 for bf16 values
     int(TensorProto.DOUBLE): np.dtype('float64'),
     int(TensorProto.COMPLEX64): np.dtype('complex64'),
     int(TensorProto.COMPLEX128): np.dtype('complex128'),
@@ -23,9 +24,10 @@ TENSOR_TYPE_TO_NP_TYPE = {
 }
 
 # Currently native numpy does not support bfloat16 so TensorProto.BFLOAT16 is ignored for now
-# Numpy float16 array is only reversed to TensorProto.FLOAT16
+# Numpy float32 array is only reversed to TensorProto.FLOAT
 NP_TYPE_TO_TENSOR_TYPE = {v: k for k, v in TENSOR_TYPE_TO_NP_TYPE.items() if k != TensorProto.BFLOAT16}
 
+# This map indicates what storage-type is used in the protobuf (serialized) representation for TensorProto
 TENSOR_TYPE_TO_STORAGE_TENSOR_TYPE = {
     int(TensorProto.FLOAT): int(TensorProto.FLOAT),
     int(TensorProto.UINT8): int(TensorProto.INT32),

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -419,8 +419,8 @@ class TestHelperTensorFunctions(unittest.TestCase):
 
     def test_make_bfloat16_tensor(self) -> None:
         # numpy doesn't support bf16, so we have to compute the correct result manually
-        #   np_array = np.random.randn(2, 3).astype(np.float16)
-        np_array = np.array([[1.0, 2.0], [3.0, 4.0], [0.099853515625, 0.099365234375], [0.0998535081744, 0.1], [np.nan, np.inf]])
+        np_array = np.array([[1.0, 2.0], [3.0, 4.0], [0.099853515625, 0.099365234375], [0.0998535081744, 0.1], [np.nan, np.inf]],
+            dtype=np.float32)
         np_results = np.array([
             [struct.unpack('!f', bytes.fromhex('3F800000'))[0],   # 1.0
              struct.unpack('!f', bytes.fromhex('40000000'))[0]],  # 2.0
@@ -445,8 +445,8 @@ class TestHelperTensorFunctions(unittest.TestCase):
 
     def test_make_bfloat16_tensor_with_raw(self) -> None:
         # numpy doesn't support bf16, so we have to compute the correct result manually
-        #   np_array = np.random.randn(8, 7).astype(np.float16)
-        np_array = np.array([[1.0, 2.0], [3.0, 4.0], [0.099853515625, 0.099365234375], [0.0998535081744, 0.1], [np.nan, np.inf]])
+        np_array = np.array([[1.0, 2.0], [3.0, 4.0], [0.099853515625, 0.099365234375], [0.0998535081744, 0.1], [np.nan, np.inf]],
+            dtype=np.float32)
         np_results = np.array([
             [struct.unpack('!f', bytes.fromhex('3F800000'))[0],   # 1.0
              struct.unpack('!f', bytes.fromhex('40000000'))[0]],  # 2.0


### PR DESCRIPTION
* fix mapping for bfloat16

Signed-off-by: Chun-Wei Chen <jacky82226@gmail.com>

* fix typo

Signed-off-by: Chun-Wei Chen <jacky82226@gmail.com>

* remove old comments

Signed-off-by: Chun-Wei Chen <jacky82226@gmail.com>

* use storage_type for expected size instead

Signed-off-by: Chun-Wei Chen <jacky82226@gmail.com>

* nit: add comments for maps

Signed-off-by: Chun-Wei Chen <jacky82226@gmail.com>

* better comments for maps

Signed-off-by: Chun-Wei Chen <jacky82226@gmail.com>
(cherry picked from commit c2825db5276419cf74c0f23dd3dea8fd5ef7adad)

**Description**
- Describe your changes.

**Motivation and Context**
- Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here.
