### PR TITLE
[WIP] experimental: c export of ModelProto in python package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,9 +456,12 @@ if(BUILD_ONNX_PYTHON)
     if(EXISTS "${ONNX_ROOT}/third_party/pybind11/include/pybind11/pybind11.h")
       add_subdirectory("${ONNX_ROOT}/third_party/pybind11")
     else()
-      message(FATAL_ERROR "cannot find pybind")
+      message(FATAL_ERROR "cannot find pybind11")
     endif()
   endif()
+  message(STATUS "ONNX_ROOT=${ONNX_ROOT}")
+  message(STATUS "pybind11_INCLUDE_DIRS=${pybind11_INCLUDE_DIRS}")
+  message(STATUS "PYTHON_INCLUDE_DIRS=${PYTHON_INCLUDE_DIRS}")
 
   target_include_directories(onnx_cpp2py_export PUBLIC
     "${pybind11_INCLUDE_DIRS}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,7 +438,13 @@ if(BUILD_ONNX_PYTHON)
     endif()
   endif()
 
-  add_library(onnx_cpp2py_export MODULE "${ONNX_ROOT}/onnx/cpp2py_export.cc")
+  add_library(onnx_cpp2py_export MODULE 
+      "${ONNX_ROOT}/onnx/cpp2py_export.cc"
+      "${ONNX_ROOT}/pybind11_protobuf/native_proto_caster.cc"
+      "${ONNX_ROOT}/pybind11_protobuf/proto_cast_util.cc"
+      "${ONNX_ROOT}/pybind11_protobuf/proto_utils.cc"
+      "${ONNX_ROOT}/pybind11_protobuf/proto.cc"
+      )
   set_target_properties(onnx_cpp2py_export PROPERTIES PREFIX "")
   set_target_properties(onnx_cpp2py_export
                         PROPERTIES COMPILE_FLAGS "-fvisibility=hidden")

--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -16,6 +16,7 @@
 #include "onnx/py_utils.h"
 #include "onnx/shape_inference/implementation.h"
 #include "onnx/version_converter/convert.h"
+#include "pybind11_protobuf/native_proto_caster.h"
 
 namespace ONNX_NAMESPACE {
 namespace py = pybind11;
@@ -32,6 +33,7 @@ static std::tuple<bool, py::bytes, py::bytes> Parse(const char* cstr) {
 }
 
 PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
+  pybind11_protobuf::ImportNativeProtoCasters();
   onnx_cpp2py_export.doc() = "Python interface to onnx";
 
   onnx_cpp2py_export.attr("ONNX_ML") = py::bool_(
@@ -250,6 +252,10 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
   checker.def("check_model", [](const py::bytes& bytes) -> void {
     ModelProto proto{};
     ParseProtoFromPyBytes(&proto, bytes);
+    checker::check_model(proto);
+  });
+
+  checker.def("check_model_c", [](ModelProto proto) -> void {
     checker::check_model(proto);
   });
 

--- a/pybind11_protobuf/LICENSE
+++ b/pybind11_protobuf/LICENSE
@@ -1,0 +1,36 @@
+Copyright (c) 2019-2021 The Pybind Development Team. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+You are under no obligation whatsoever to provide any bug fixes, patches, or
+upgrades to the features, functionality or performance of the source code
+("Enhancements") to anyone; however, if you choose to make your Enhancements
+available either publicly, or directly to the author of this software, without
+imposing a separate written license agreement for such Enhancements, then you
+hereby grant the following license: a non-exclusive, royalty-free perpetual
+license to install, use, modify, prepare derivative works, incorporate into
+other computer software, distribute, and sublicense such enhancements or
+derivative works thereof, in binary and source code form.

--- a/pybind11_protobuf/enum_type_caster.h
+++ b/pybind11_protobuf/enum_type_caster.h
@@ -9,9 +9,9 @@
 #include <string>
 #include <type_traits>
 
-#include <google/protobuf/descriptor.h>
-#include <google/protobuf/generated_enum_reflection.h>
-#include <google/protobuf/generated_enum_util.h>
+#include "google/protobuf/descriptor.h"
+#include "google/protobuf/generated_enum_reflection.h"
+#include "google/protobuf/generated_enum_util.h"
 
 // pybind11 type_caster specialization which translates Proto::Enum types
 // to/from ints. This will have ODR conflicts when users specify wrappers for
@@ -41,7 +41,7 @@ namespace pybind11_protobuf {
 template <typename EnumType>
 struct enum_type_caster {
  private:
-  using T = typename std::underlying_type<EnumType>::type;
+  using T = std::underlying_type_t<EnumType>;
   using base_caster = pybind11::detail::make_caster<T>;
 
  public:
@@ -100,10 +100,11 @@ constexpr bool pybind11_protobuf_enable_enum_type_caster(...) { return true; }
 // ::google::protobuf::is_proto_enum.
 template <typename EnumType>
 struct type_caster<EnumType,
-                   typename std::enable_if<(::google::protobuf::is_proto_enum<EnumType>::value &&
+                   std::enable_if_t<(::google::protobuf::is_proto_enum<EnumType>::value &&
                                      pybind11_protobuf_enable_enum_type_caster(
-                                         static_cast<EnumType*>(nullptr)))>::type>
+                                         static_cast<EnumType*>(nullptr)))>>
     : public pybind11_protobuf::enum_type_caster<EnumType> {};
+
 }  // namespace detail
 }  // namespace pybind11
 

--- a/pybind11_protobuf/enum_type_caster.h
+++ b/pybind11_protobuf/enum_type_caster.h
@@ -1,0 +1,110 @@
+#ifndef PYBIND11_PROTOBUF_ENUM_TYPE_CASTER_H_
+#define PYBIND11_PROTOBUF_ENUM_TYPE_CASTER_H_
+
+#include <Python.h>
+#include <pybind11/cast.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
+
+#include <string>
+#include <type_traits>
+
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/generated_enum_reflection.h>
+#include <google/protobuf/generated_enum_util.h>
+
+// pybind11 type_caster specialization which translates Proto::Enum types
+// to/from ints. This will have ODR conflicts when users specify wrappers for
+// enums using py::enum_<T>.
+//
+// ::google::protobuf::is_proto_enum and ::google::protobuf::GetEnumDescriptor are require
+//
+// NOTE: The protobuf compiler does not generate ::google::protobuf::is_proto_enum traits
+// for enumerations of oneof fields.
+//
+// Example:
+//  #include <pybind11/pybind11.h>
+//  #include "pybind11_protobuf/proto_enum_casters.h"
+//
+//  MyMessage::EnumType GetMessageEnum() { ... }
+//  PYBIND11_MODULE(my_module, m) {
+//    m.def("get_message_enum", &GetMessageEnum);
+//  }
+//
+// Users of enum_type_caster based extensions need dependencies on:
+// deps = [ "@com_google_protobuf//:protobuf_python" ]
+//
+
+namespace pybind11_protobuf {
+
+// Implementation details for pybind11 enum casting.
+template <typename EnumType>
+struct enum_type_caster {
+ private:
+  using T = typename std::underlying_type<EnumType>::type;
+  using base_caster = pybind11::detail::make_caster<T>;
+
+ public:
+  static constexpr auto name = pybind11::detail::_<EnumType>();
+
+  // cast converts from C++ -> Python
+  static pybind11::handle cast(EnumType src,
+                               pybind11::return_value_policy policy,
+                               pybind11::handle p) {
+    return base_caster::cast(static_cast<T>(src), policy, p);
+  }
+
+  // load converts from Python -> C++
+  bool load(pybind11::handle src, bool convert) {
+    base_caster base;
+    if (base.load(src, convert)) {
+      T v = static_cast<T>(base);
+      if (::google::protobuf::GetEnumDescriptor<EnumType>()->FindValueByNumber(v) ==
+          nullptr) {
+        throw pybind11::value_error("Invalid value " + std::to_string(v) +
+                                    " for ::google::protobuf::Enum " +
+                                    pybind11::type_id<EnumType>());
+      }
+      value = static_cast<EnumType>(v);
+      return true;
+    }
+    // When convert is true, then the enum could be resolved via
+    // FindValueByName.
+    return false;
+  }
+
+  explicit operator EnumType() { return value; }
+
+  template <typename>
+  using cast_op_type = EnumType;
+
+ private:
+  EnumType value;
+};
+
+}  // namespace pybind11_protobuf
+namespace pybind11 {
+namespace detail {
+
+// ADL function to enable/disable specializations of proto enum type_caster<>
+// provided by pybind11_protobuf. Defaults to enabled. To disable the
+// pybind11_protobuf enum_type_caster for a specific enum type, define a
+// constexpr function in the same namespace, like:
+//
+//  constexpr bool pybind11_protobuf_enable_enum_type_caster(tensorflow::DType*)
+//  { return false; }
+//
+constexpr bool pybind11_protobuf_enable_enum_type_caster(...) { return true; }
+
+// Specialization of pybind11::detail::type_caster<T> for types satisfying
+// ::google::protobuf::is_proto_enum.
+template <typename EnumType>
+struct type_caster<EnumType,
+                   typename std::enable_if<(::google::protobuf::is_proto_enum<EnumType>::value &&
+                                     pybind11_protobuf_enable_enum_type_caster(
+                                         static_cast<EnumType*>(nullptr)))>::type>
+    : public pybind11_protobuf::enum_type_caster<EnumType> {};
+}  // namespace detail
+}  // namespace pybind11
+
+#endif  // PYBIND11_PROTOBUF_ENUM_TYPE_CASTER_H_

--- a/pybind11_protobuf/native_proto_caster.cc
+++ b/pybind11_protobuf/native_proto_caster.cc
@@ -1,4 +1,4 @@
-#include "native_proto_caster.h"
+#include "pybind11_protobuf/native_proto_caster.h"
 
 void pybind11_proto_casters_collision() {
   // This symbol intentionally defined to cause ODR violations. It exists in:

--- a/pybind11_protobuf/native_proto_caster.cc
+++ b/pybind11_protobuf/native_proto_caster.cc
@@ -1,0 +1,22 @@
+#include "native_proto_caster.h"
+
+void pybind11_proto_casters_collision() {
+  // This symbol intentionally defined to cause ODR violations. It exists in:
+  //   * proto_casters.cc
+  //   * native_proto_caster.cc
+
+  // Avoid mixing pybind11 type_caster<> specializations for ::google::protobuf::Message
+  // types in the same build target. This violates the ODR rule for
+  // type_caster<::google::protobuf::Message> as well as other potential types, and can lead
+  // to hard to diagnose bugs, crashes, and other mysterious bad behavior.
+
+  // To investigate duplicate symbol errors, try:
+  /*
+  bazel query somepath(//x, //third_party/pybind11_protobuf:native_proto_caster)
+  bazel query somepath(//x, //third_party/pybind11_protobuf:proto_casters)
+  */
+
+  // See https://github.com/pybind/pybind11/issues/2695 for more details.
+}
+
+

--- a/pybind11_protobuf/native_proto_caster.h
+++ b/pybind11_protobuf/native_proto_caster.h
@@ -1,10 +1,10 @@
 #ifndef PYBIND11_PROTOBUF_NATIVE_PROTO_CASTERS_H_
 #define PYBIND11_PROTOBUF_NATIVE_PROTO_CASTERS_H_
 
+#include <Python.h>
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
-#include <Python.h>
 
 #include <functional>
 #include <memory>
@@ -13,9 +13,9 @@
 #include <type_traits>
 #include <utility>
 
-#include <google/protobuf/message.h>
-#include "enum_type_caster.h"
-#include "proto_caster_impl.h"
+#include "google/protobuf/message.h"
+#include "pybind11_protobuf/enum_type_caster.h"
+#include "pybind11_protobuf/proto_caster_impl.h"
 
 // NOTE: This directly currently contains 2 mutually incompatible
 // implementations of pybind11::type_caster<> for ::google::protobuf::Message types due to
@@ -82,9 +82,9 @@ constexpr bool pybind11_protobuf_enable_type_caster(...) { return true; }
 template <typename ProtoType>
 struct type_caster<
     ProtoType,
-    typename std::enable_if<(std::is_base_of<::google::protobuf::Message, ProtoType>::value &&
+    std::enable_if_t<(std::is_base_of<::google::protobuf::Message, ProtoType>::value &&
                       pybind11_protobuf_enable_type_caster(
-                          static_cast<ProtoType *>(nullptr)))>::type>
+                          static_cast<ProtoType *>(nullptr)))>>
     : public pybind11_protobuf::proto_caster<
           ProtoType, pybind11_protobuf::native_cast_impl> {};
 
@@ -101,9 +101,9 @@ struct type_caster<
 template <typename ProtoType, typename HolderType>
 struct move_only_holder_caster<
     ProtoType, HolderType,
-    typename std::enable_if<(std::is_base_of<::google::protobuf::Message, ProtoType>::value &&
+    std::enable_if_t<(std::is_base_of<::google::protobuf::Message, ProtoType>::value &&
                       pybind11_protobuf_enable_type_caster(
-                          static_cast<ProtoType *>(nullptr)))>::type> {
+                          static_cast<ProtoType *>(nullptr)))>> {
  private:
   using Base = type_caster<intrinsic_t<ProtoType>>;
   static constexpr bool const_element =
@@ -153,9 +153,9 @@ struct move_only_holder_caster<
 template <typename ProtoType, typename HolderType>
 struct copyable_holder_caster<
     ProtoType, HolderType,
-    typename std::enable_if<(std::is_base_of<::google::protobuf::Message, ProtoType>::value &&
+    std::enable_if_t<(std::is_base_of<::google::protobuf::Message, ProtoType>::value &&
                       pybind11_protobuf_enable_type_caster(
-                          static_cast<ProtoType *>(nullptr)))>::type> {
+                          static_cast<ProtoType *>(nullptr)))>> {
  private:
   using Base = type_caster<intrinsic_t<ProtoType>>;
   static constexpr bool const_element =

--- a/pybind11_protobuf/native_proto_caster.h
+++ b/pybind11_protobuf/native_proto_caster.h
@@ -1,0 +1,209 @@
+#ifndef PYBIND11_PROTOBUF_NATIVE_PROTO_CASTERS_H_
+#define PYBIND11_PROTOBUF_NATIVE_PROTO_CASTERS_H_
+
+#include <pybind11/cast.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
+#include <Python.h>
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include <google/protobuf/message.h>
+#include "enum_type_caster.h"
+#include "proto_caster_impl.h"
+
+// NOTE: This directly currently contains 2 mutually incompatible
+// implementations of pybind11::type_caster<> for ::google::protobuf::Message types due to
+// C++ ODR violations.  Only one of the following is allowed:
+//   * proto_casters.h        (legacy)
+//   * native_proto_caster.h  (preferred)
+//
+// When possible, please convert code and all dependencies to the preferred
+// native_proto_caster.h implementation.
+
+// pybind11::type_caster<> specialization for ::google::protobuf::Message types that
+// that convets protocol buffer objects between C++ and python representations.
+// This binder supports binaries linked with both native python protos
+// and fast cpp python protos.
+//
+// When passing protos between python and C++, if possible, an underlying C++
+// object may have ownership transferred, or may be copied if both instances
+// use the same underlying protocol buffer Reflection instance.  If not, the
+// object is serialized and deserialized.
+//
+// Dynamically generated protos are only partially supported at present.
+//
+// To use native_proto_caster, include this file in the binding definition
+// file.
+//
+// Example:
+//
+// #include <pybind11/pybind11.h>
+// #include "pybind11_protobuf/native_proto_caster.h"
+//
+// MyMessage GetMessage() { ... }
+// PYBIND11_MODULE(my_module, m) {
+//   pybind11_protobuf::ImportNativeProtoCasters();
+//
+//   m.def("get_message", &GetMessage);
+// }
+//
+// Users of native_proto_caster based extensions need dependencies on:
+// deps = [ "@com_google_protobuf//:protobuf_python" ]
+//
+
+namespace pybind11_protobuf {
+
+// Imports modules for protobuf conversion. This not thread safe and
+// is required to be called from a PYBIND11_MODULE definition before use.
+inline void ImportNativeProtoCasters() { InitializePybindProtoCastUtil(); }
+
+}  // namespace pybind11_protobuf
+namespace pybind11 {
+namespace detail {
+
+// ADL function to enable/disable specializations of type_caster<> provided by
+// pybind11_protobuf. Defaults to enabled. To disable the pybind11_protobuf
+// proto_caster for a specific proto type, define a constexpr function in the
+// same namespace, like:
+//
+//  constexpr bool pybind11_protobuf_enable_type_caster(MyProto*)
+//  { return false; }
+//
+constexpr bool pybind11_protobuf_enable_type_caster(...) { return true; }
+
+// pybind11 type_caster<> specialization for c++ protocol buffer types using
+// inheritance from google::proto_caster<>.
+template <typename ProtoType>
+struct type_caster<
+    ProtoType,
+    typename std::enable_if<(std::is_base_of<::google::protobuf::Message, ProtoType>::value &&
+                      pybind11_protobuf_enable_type_caster(
+                          static_cast<ProtoType *>(nullptr)))>::type>
+    : public pybind11_protobuf::proto_caster<
+          ProtoType, pybind11_protobuf::native_cast_impl> {};
+
+// NOTE: If smart_holders becomes the default we will need to change this to
+//    type_caster<std::unique_ptr<ProtoType, D>, ...
+// Until then using that form is ambiguous due to the existing specialization
+// that does *not* forward a sfinae clause. Or we could add an sfinae clause
+// to the existing specialization, but that's a *much* larger change.
+// Anyway, the existing specializations fully forward to these.
+
+// move_only_holder_caster enables using move-only holder types such as
+// std::unique_ptr. It uses type_caster<Proto> to manage the conversion
+// and construct a holder type.
+template <typename ProtoType, typename HolderType>
+struct move_only_holder_caster<
+    ProtoType, HolderType,
+    typename std::enable_if<(std::is_base_of<::google::protobuf::Message, ProtoType>::value &&
+                      pybind11_protobuf_enable_type_caster(
+                          static_cast<ProtoType *>(nullptr)))>::type> {
+ private:
+  using Base = type_caster<intrinsic_t<ProtoType>>;
+  static constexpr bool const_element =
+      std::is_const<typename HolderType::element_type>::value;
+
+ public:
+  static constexpr auto name = Base::name;
+
+  // C++->Python.
+  static handle cast(HolderType &&src, return_value_policy, handle p) {
+    auto *ptr = holder_helper<HolderType>::get(src);
+    if (!ptr) return none().release();
+    return Base::cast(std::move(*ptr), return_value_policy::move, p);
+  }
+
+  // Convert Python->C++.
+  bool load(handle src, bool convert) {
+    Base base;
+    if (!base.load(src, convert)) {
+      return false;
+    }
+    holder = base.as_unique_ptr();
+    return true;
+  }
+
+  // PYBIND11_TYPE_CASTER
+  explicit operator HolderType *() { return &holder; }
+  explicit operator HolderType &() { return holder; }
+  explicit operator HolderType &&() && { return std::move(holder); }
+
+  template <typename T_>
+  using cast_op_type = pybind11::detail::movable_cast_op_type<T_>;
+
+ protected:
+  HolderType holder;
+};
+
+// copyable_holder_caster enables using copyable holder types such as
+// std::shared_ptr. It uses type_caster<Proto> to manage the conversion
+// and construct a copy of the proto, then returns the shared_ptr.
+//
+// NOTE: When using pybind11 bindings, std::shared_ptr<Proto> is almost
+// never correct, as it always makes a copy. It's mostly useful for handling
+// methods that return a shared_ptr<const T>, which the caller never intends
+// to mutate and where copy semantics will work just as well.
+//
+template <typename ProtoType, typename HolderType>
+struct copyable_holder_caster<
+    ProtoType, HolderType,
+    typename std::enable_if<(std::is_base_of<::google::protobuf::Message, ProtoType>::value &&
+                      pybind11_protobuf_enable_type_caster(
+                          static_cast<ProtoType *>(nullptr)))>::type> {
+ private:
+  using Base = type_caster<intrinsic_t<ProtoType>>;
+  static constexpr bool const_element =
+      std::is_const<typename HolderType::element_type>::value;
+
+ public:
+  static constexpr auto name = Base::name;
+
+  // C++->Python.
+  static handle cast(const HolderType &src, return_value_policy, handle p) {
+    // The default path calls into cast_holder so that the holder/deleter
+    // gets added to the proto. Here we just make a copy
+    const auto *ptr = holder_helper<HolderType>::get(src);
+    if (!ptr) return none().release();
+    return Base::cast(*ptr, return_value_policy::copy, p);
+  }
+
+  // Convert Python->C++.
+  bool load(handle src, bool convert) {
+    Base base;
+    if (!base.load(src, convert)) {
+      return false;
+    }
+    // This always makes a copy, but it could, in some cases, grab a reference
+    // and construct a shared_ptr, since the intention is clearly to mutate
+    // the existing object...
+    holder = base.as_unique_ptr();
+    return true;
+  }
+
+  explicit operator HolderType &() { return holder; }
+
+  template <typename>
+  using cast_op_type = HolderType &;
+
+ protected:
+  HolderType holder;
+};
+
+// NOTE: We also need to add support and/or test classes:
+//
+//  ::google::protobuf::Descriptor
+//  ::google::protobuf::EnumDescriptor
+//  ::google::protobuf::EnumValueDescriptor
+//  ::google::protobuf::FieldDescriptor
+//
+
+}  // namespace detail
+}  // namespace pybind11
+
+#endif  // PYBIND11_PROTOBUF_FAST_CPP_PROTO_CASTERS_H_

--- a/pybind11_protobuf/proto.cc
+++ b/pybind11_protobuf/proto.cc
@@ -1,0 +1,16 @@
+// Copyright (c) 2019 The Pybind Development Team. All rights reserved.
+//
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#include "proto_utils.h"
+
+namespace pybind11 {
+namespace google {
+
+PYBIND11_MODULE(proto, m) {
+  RegisterProtoBindings(m);
+}
+
+}  // namespace google
+}  // namespace pybind11

--- a/pybind11_protobuf/proto.cc
+++ b/pybind11_protobuf/proto.cc
@@ -3,14 +3,16 @@
 // All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-#include "proto_utils.h"
+#include "pybind11_protobuf/proto_utils.h"
 
 namespace pybind11 {
 namespace google {
 
+/*
 PYBIND11_MODULE(proto, m) {
   RegisterProtoBindings(m);
 }
+*/
 
 }  // namespace google
 }  // namespace pybind11

--- a/pybind11_protobuf/proto_cast_util.cc
+++ b/pybind11_protobuf/proto_cast_util.cc
@@ -1,4 +1,4 @@
-#include "proto_cast_util.h"
+#include "pybind11_protobuf/proto_cast_util.h"
 
 #include <Python.h>
 #include <pybind11/cast.h>
@@ -12,16 +12,16 @@
 #include <type_traits>
 #include <utility>
 
-#include <google/protobuf/descriptor.pb.h>
-#include <google/protobuf/descriptor.h>
-#include <google/protobuf/dynamic_message.h>
-#include <google/protobuf/message.h>
-//#include "python/google/protobuf/proto_api.h"
-//#include "absl/container/flat_hash_map.h"
-//#include "absl/strings/numbers.h"
-//#include "absl/strings/str_replace.h"
-//#include "absl/strings/str_split.h"
-//#include "absl/types/optional.h"
+#include "google/protobuf/descriptor.pb.h"
+#include "google/protobuf/descriptor.h"
+#include "google/protobuf/dynamic_message.h"
+#include "google/protobuf/message.h"
+#include "python/google/protobuf/proto_api.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/strings/numbers.h"
+#include "absl/strings/str_replace.h"
+#include "absl/strings/str_split.h"
+#include "absl/types/optional.h"
 
 namespace py = pybind11;
 

--- a/pybind11_protobuf/proto_cast_util.cc
+++ b/pybind11_protobuf/proto_cast_util.cc
@@ -1,0 +1,810 @@
+#include "proto_cast_util.h"
+
+#include <Python.h>
+#include <pybind11/cast.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
+
+#include <initializer_list>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include <google/protobuf/descriptor.pb.h>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/dynamic_message.h>
+#include <google/protobuf/message.h>
+//#include "python/google/protobuf/proto_api.h"
+//#include "absl/container/flat_hash_map.h"
+//#include "absl/strings/numbers.h"
+//#include "absl/strings/str_replace.h"
+//#include "absl/strings/str_split.h"
+//#include "absl/types/optional.h"
+
+namespace py = pybind11;
+
+using ::google::protobuf::Descriptor;
+using ::google::protobuf::DescriptorDatabase;
+using ::google::protobuf::DescriptorPool;
+using ::google::protobuf::DescriptorProto;
+using ::google::protobuf::DynamicMessageFactory;
+using ::google::protobuf::FileDescriptor;
+using ::google::protobuf::FileDescriptorProto;
+using ::google::protobuf::Message;
+using ::google::protobuf::MessageFactory;
+using ::google::protobuf::python::PyProto_API;
+using ::google::protobuf::python::PyProtoAPICapsuleName;
+
+namespace pybind11_protobuf {
+namespace {
+
+std::string PythonPackageForDescriptor(const FileDescriptor* file) {
+  std::vector<std::pair<const absl::string_view, std::string>> replacements;
+  replacements.emplace_back("/", ".");
+  replacements.emplace_back(".proto", "_pb2");
+  std::string name = file->name();
+  return absl::StrReplaceAll(name, replacements);
+}
+
+// Resolves the class name of a descriptor via d->containing_type()
+py::object ResolveDescriptor(py::object p, const Descriptor* d) {
+  return d->containing_type() ? ResolveDescriptor(p, d->containing_type())
+                                    .attr(d->name().c_str())
+                              : p.attr(d->name().c_str());
+}
+
+// Returns true if an exception is an import error.
+bool IsImportError(py::error_already_set& e) {
+#if ((PY_MAJOR_VERSION > 3) || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 6))
+  return e.matches(PyExc_ImportError) || e.matches(PyExc_ModuleNotFoundError);
+#else
+  return e.matches(PyExc_ImportError);
+#endif
+}
+
+// Resolves a sequence of python attrs starting from obj.
+// If any does not exist, returns nullopt.
+absl::optional<py::object> ResolveAttrs(
+    py::handle obj, std::initializer_list<const char*> names) {
+  py::object tmp;
+  for (const char* name : names) {
+    PyObject* attr = PyObject_GetAttrString(obj.ptr(), name);
+    if (attr == nullptr) {
+      PyErr_Clear();
+      return absl::nullopt;
+    }
+    tmp = py::reinterpret_steal<py::object>(attr);
+    obj = py::handle(attr);
+  }
+  return tmp;
+}
+
+// Resolves a single attribute using the python MRO (method resolution order).
+// Mimics PyObject_GetAttrString.
+//
+// Unfortunately the metaclass mechanism used by protos (fast_cpp_protos) does
+// not leave __dict__ in a state where the default getattr functions find the
+// base class methods, so we resolve those using MRO.
+absl::optional<py::object> ResolveAttrMRO(py::handle obj, const char* name) {
+  PyObject* attr;
+  const auto* t = Py_TYPE(obj.ptr());
+  if (!t->tp_mro) {
+    PyObject* attr = PyObject_GetAttrString(obj.ptr(), name);
+    if (attr) {
+      return py::reinterpret_steal<py::object>(attr);
+    }
+    PyErr_Clear();
+    return absl::nullopt;
+  }
+
+  auto unicode = py::reinterpret_steal<py::object>(PyUnicode_FromString(name));
+  auto bases = py::reinterpret_borrow<py::tuple>(t->tp_mro);
+  for (py::handle h : bases) {
+    auto base = reinterpret_cast<PyTypeObject*>(h.ptr());
+    if (base->tp_getattr) {
+      attr = (*base->tp_getattr)(obj.ptr(), const_cast<char*>(name));
+      if (attr) {
+        return py::reinterpret_steal<py::object>(attr);
+      }
+      PyErr_Clear();
+    }
+    if (base->tp_getattro) {
+      attr = (*base->tp_getattro)(obj.ptr(), unicode.ptr());
+      if (attr) {
+        return py::reinterpret_steal<py::object>(attr);
+      }
+      PyErr_Clear();
+    }
+  }
+  return absl::nullopt;
+}
+
+absl::optional<std::string> CastToOptionalString(py::handle src) {
+  // Avoid pybind11::cast because it throws an exeption.
+  pybind11::detail::make_caster<std::string> c;
+  if (c.load(src, false)) {
+    return pybind11::detail::cast_op<std::string>(std::move(c));
+  }
+  return absl::nullopt;
+}
+
+#if defined(GOOGLE_PROTOBUF_VERSION)
+// The current version, represented as a single integer to make comparison
+// easier:  major * 10^6 + minor * 10^3 + micro
+uint64_t VersionStringToNumericVersion(absl::string_view version_str) {
+  std::vector<absl::string_view> split = absl::StrSplit(version_str, '.');
+  uint64_t major = 0, minor = 0, micro = 0;
+  if (split.size() == 3 &&  //
+      absl::SimpleAtoi(split[0], &major) &&
+      absl::SimpleAtoi(split[1], &minor) &&
+      absl::SimpleAtoi(split[2], &micro)) {
+    return major * 1000000 + minor * 1000 + micro;
+  }
+  return 0;
+}
+#endif
+
+class GlobalState {
+ public:
+  // Global state singleton intentionally leaks at program termination.
+  // If destructed along with other static variables, it causes segfaults
+  // due to order of destruction conflict with python threads. See
+  // https://github.com/pybind/pybind11/issues/1598
+  static GlobalState* instance() {
+    static auto instance = new GlobalState();
+    return instance;
+  }
+
+  py::handle global_pool() { return global_pool_; }
+  const PyProto_API* py_proto_api() { return py_proto_api_; }
+  bool using_fast_cpp() const { return using_fast_cpp_; }
+
+  // Allocate a python proto message instance using the native python
+  // allocations.
+  py::object PyMessageInstance(const Descriptor* descriptor);
+
+  // Allocates a fast cpp proto python object, also returning
+  // the embedded c++ proto2 message type. The returned message
+  // pointer cannot be null.
+  std::pair<py::object, Message*> PyFastCppProtoMessageInstance(
+      const Descriptor* descriptor);
+
+  // Import (and cache) a python module.
+  py::module_ ImportCached(const std::string& module_name);
+
+ private:
+  GlobalState();
+
+  const PyProto_API* py_proto_api_ = nullptr;
+  bool using_fast_cpp_ = false;
+  py::object global_pool_;
+  py::object factory_;
+  py::object find_message_type_by_name_;
+  py::object get_prototype_;
+
+  absl::flat_hash_map<std::string, py::module_> import_cache_;
+};
+
+GlobalState::GlobalState() {
+  assert(PyGILState_Check());
+
+  // pybind11_protobuf casting needs a dependency on proto internals to work.
+  try {
+    ImportCached("google.protobuf.descriptor");
+    auto descriptor_pool =
+        ImportCached("google.protobuf.descriptor_pool");
+    auto message_factory =
+        ImportCached("google.protobuf.message_factory");
+    global_pool_ = descriptor_pool.attr("Default")();
+    factory_ = message_factory.attr("MessageFactory")(global_pool_);
+    find_message_type_by_name_ = global_pool_.attr("FindMessageTypeByName");
+    get_prototype_ = factory_.attr("GetPrototype");
+  } catch (py::error_already_set& e) {
+    if (IsImportError(e)) {
+      std::cerr << "Add a python dependency on "
+                   "\"@com_google_protobuf//:protobuf_python\"" << std::endl;
+    }
+
+    // TODO(pybind11-infra): narrow down to expected exception(s).
+    e.restore();
+    PyErr_Print();
+
+    global_pool_ = {};
+    factory_ = {};
+    find_message_type_by_name_ = {};
+    get_prototype_ = {};
+  }
+
+  // determine the proto implementation.
+  auto type =
+      ImportCached("google.protobuf.internal.api_implementation")
+          .attr("Type")();
+  using_fast_cpp_ = (CastToOptionalString(type).value_or("") == "cpp");
+
+#if defined(PYBIND11_PROTOBUF_ENABLE_PYPROTO_API)
+  // DANGER: The only way to guarantee that the PyProto_API doesn't have
+  // incompatible ABI changes is to ensure that the python protobuf .so
+  // and all other extension .so files are built with the exact same
+  // environment, including compiler, flags, etc. It's also expected
+  // that the global_pool() objects are the same. And there's no way for
+  // bazel to do that right now.
+  //
+  // Otherwise, we're left with (1), the  PyProto_API module reaching into the
+  // internals of a potentially incompatible Descriptor type from this CU, (2)
+  // this CU reaching into the potentially incompatible internals of PyProto_API
+  // implementation, or (3) disabling access to PyProto_API unless compile
+  // options suggest otherwise.
+  //
+  // By default (3) is used, however if the define is set *and* the version
+  // matches, then pybind11_protobuf will assume that this will work.
+  py_proto_api_ =
+      static_cast<PyProto_API*>(PyCapsule_Import(PyProtoAPICapsuleName(), 0));
+  if (py_proto_api_ == nullptr) {
+    // The module implementing fast cpp protos is not loaded, clear the error.
+    assert(!using_fast_cpp_);
+    PyErr_Clear();
+  }
+#else
+  py_proto_api_ = nullptr;
+  using_fast_cpp_ = false;
+#endif
+
+#if defined(GOOGLE_PROTOBUF_VERSION)
+  /// The C++ version of PyProto_API must match that loaded by python,
+  /// otherwise the details of the underlying implementation may cause
+  /// crashes. This limits the ability to pass some protos from C++ to
+  /// python.
+  if (py_proto_api_) {
+    auto version =
+        ResolveAttrs(ImportCached("google.protobuf"), {"__version__"});
+    std::string version_str =
+        version ? CastToOptionalString(*version).value_or("") : "";
+    if (GOOGLE_PROTOBUF_VERSION != VersionStringToNumericVersion(version_str)) {
+      std::cerr << "Python version " << version_str
+                << " does not match C++ version " << GOOGLE_PROTOBUF_VERSION
+                << std::endl;
+      using_fast_cpp_ = false;
+      py_proto_api_ = nullptr;
+    }
+  }
+#endif
+}
+
+py::module_ GlobalState::ImportCached(const std::string& module_name) {
+  auto cached = import_cache_.find(module_name);
+  if (cached != import_cache_.end()) {
+    return cached->second;
+  }
+  auto module = py::module_::import(module_name.c_str());
+  import_cache_[module_name] = module;
+  return module;
+}
+
+py::object GlobalState::PyMessageInstance(const Descriptor* descriptor) {
+  auto module_name = PythonPackageForDescriptor(descriptor->file());
+  if (!module_name.empty()) {
+    auto cached = import_cache_.find(module_name);
+    if (cached != import_cache_.end()) {
+      return ResolveDescriptor(cached->second, descriptor)();
+    }
+  }
+
+  // First attempt to construct the proto from the global pool.
+  if (global_pool_) {
+    try {
+      auto d = find_message_type_by_name_(descriptor->full_name());
+      auto p = get_prototype_(d);
+      return p();
+    } catch (...) {
+      // TODO(pybind11-infra): narrow down to expected exception(s).
+      PyErr_Clear();
+    }
+  }
+
+  // If that fails, attempt to import the module.
+  if (!module_name.empty()) {
+    try {
+      return ResolveDescriptor(ImportCached(module_name), descriptor)();
+    } catch (py::error_already_set& e) {
+      // TODO(pybind11-infra): narrow down to expected exception(s).
+      e.restore();
+      PyErr_Print();
+    }
+  }
+
+  throw py::type_error("Cannot construct a protocol buffer message type " +
+                       descriptor->full_name() +
+                       " in python. Is there a missing dependency on module " +
+                       module_name + "?");
+}
+
+std::pair<py::object, Message*> GlobalState::PyFastCppProtoMessageInstance(
+    const Descriptor* descriptor) {
+  assert(descriptor != nullptr);
+  assert(py_proto_api_ != nullptr);
+
+  // Create a PyDescriptorPool, temporarily, it will be used by the NewMessage
+  // API call which will store it in the classes it creates.
+  //
+  // Note: Creating Python classes is a bit expensive, it might be a good idea
+  // for client code to create the pool once, and store it somewhere along with
+  // the C++ pool; then Python pools and classes are cached and reused.
+  // Otherwise, consecutives calls to this function may or may not reuse
+  // previous classes, depending on whether the returned instance has been
+  // kept alive.
+  //
+  // IMPORTANT CAVEAT: The C++ DescriptorPool must not be deallocated while
+  // there are any messages using it.
+  // Furthermore, since the cache uses the DescriptorPool address, allocating
+  // a new DescriptorPool with the same address is likely to use dangling
+  // pointers.
+  // It is probably better for client code to keep the C++ DescriptorPool alive
+  // until the end of the process.
+  // TODO(amauryfa): Add weakref or on-deletion callbacks to C++ DescriptorPool.
+  py::object descriptor_pool = py::reinterpret_steal<py::object>(
+      py_proto_api_->DescriptorPool_FromPool(descriptor->file()->pool()));
+  if (descriptor_pool.ptr() == nullptr) {
+    throw py::error_already_set();
+  }
+
+  py::object result = py::reinterpret_steal<py::object>(
+      py_proto_api_->NewMessage(descriptor, nullptr));
+  if (result.ptr() == nullptr) {
+    throw py::error_already_set();
+  }
+  Message* message = py_proto_api_->GetMutableMessagePointer(result.ptr());
+  if (message == nullptr) {
+    throw py::error_already_set();
+  }
+  return {std::move(result), message};
+}
+
+// Create C++ DescriptorPools based on Python DescriptorPools.
+// The Python pool will provide message definitions when they are needed.
+// This gives an efficient way to create C++ Messages from Python definitions.
+class PythonDescriptorPoolWrapper {
+ public:
+  // The singleton which handles multiple wrapped pools.
+  // It is never deallocated, but data corresponding to a Python pool
+  // is cleared when the pool is destroyed.
+  static PythonDescriptorPoolWrapper* instance() {
+    static auto instance = new PythonDescriptorPoolWrapper();
+    return instance;
+  }
+
+  // To build messages these 3 objects often come together:
+  // - a DescriptorDatabase provides the representation of .proto files.
+  // - a DescriptorPool manages the live descriptors with cross-linked pointers.
+  // - a MessageFactory manages the proto instances and their memory layout.
+  struct Data {
+    std::unique_ptr<DescriptorDatabase> database;
+    std::unique_ptr<const DescriptorPool> pool;
+    std::unique_ptr<MessageFactory> factory;
+  };
+
+  // Return (and maybe create) a C++ DescriptorPool that corresponds to the
+  // given Python DescriptorPool.
+  // The returned pointer has the same lifetime as the Python DescriptorPool:
+  // its data will be deleted when the Python object is deleted.
+  const Data* GetPoolFromPythonPool(py::handle python_pool) {
+    PyObject* key = python_pool.ptr();
+    // Get or create an entry for this key.
+    auto& pool_entry = pools_map[key];
+    if (pool_entry.database) {
+      // Found in cache, return it.
+      return &pool_entry;
+    }
+
+    // An attempt at cleanup could be made by using a py::weakref to the
+    // underlying python pool, and removing the map entry when the pool
+    // disappears, that is fundamentally unsafe because (1) a cloned c++ object
+    // may outlive the python pool, and (2) for the fast_cpp_proto case, there's
+    // no support for weak references.
+
+    auto database = absl::make_unique<DescriptorPoolDatabase>(
+        py::reinterpret_borrow<py::object>(python_pool));
+    auto pool = absl::make_unique<DescriptorPool>(database.get());
+    auto factory = absl::make_unique<DynamicMessageFactory>(pool.get());
+    // When wrapping the Python descriptor_poool.Default(), apply an important
+    // optimization:
+    // - the pool is based on the C++ generated_pool(), so that compiled
+    //   C++ modules can be found without using the DescriptorDatabase and
+    //   the Python DescriptorPool.
+    // - the MessageFactory returns instances of C++ compiled messages when
+    //   possible: some methods are much more optimized, and the created
+    //   Message can be cast to the C++ class.  We use this last property in
+    //   the proto_caster class.
+    // This is done only for the Default pool, because generated C++ modules
+    // and generated Python modules are built from the same .proto sources.
+    if (python_pool.is(GlobalState::instance()->global_pool())) {
+      pool->internal_set_underlay(DescriptorPool::generated_pool());
+      factory->SetDelegateToGeneratedFactory(true);
+    }
+
+    // Cache the created objects.
+    pool_entry = Data{std::move(database), std::move(pool), std::move(factory)};
+    return &pool_entry;
+  }
+
+ private:
+  PythonDescriptorPoolWrapper() = default;
+
+  // Similar to DescriptorPoolDatabase: wraps a Python DescriptorPool
+  // as a DescriptorDatabase.
+  class DescriptorPoolDatabase : public DescriptorDatabase {
+   public:
+    DescriptorPoolDatabase(py::object python_pool)
+        : pool_(std::move(python_pool)) {}
+
+    // These 3 methods implement DescriptorDatabase and delegate to
+    // the Python DescriptorPool.
+
+    // Find a file by file name.
+    bool FindFileByName(const std::string& filename,
+                        FileDescriptorProto* output) override {
+      try {
+        auto file = pool_.attr("FindFileByName")(filename);
+        return CopyToFileDescriptorProto(file, output);
+      } catch (py::error_already_set& e) {
+        std::cerr << "FindFileByName " << filename << " raised an error";
+
+        // This prints and clears the error.
+        e.restore();
+        PyErr_Print();
+      }
+      return false;
+    }
+
+    // Find the file that declares the given fully-qualified symbol name.
+    bool FindFileContainingSymbol(const std::string& symbol_name,
+                                  FileDescriptorProto* output) override {
+      try {
+        auto file = pool_.attr("FindFileContainingSymbol")(symbol_name);
+        return CopyToFileDescriptorProto(file, output);
+      } catch (py::error_already_set& e) {
+        std::cerr << "FindFileContainingSymbol " << symbol_name
+                   << " raised an error";
+
+        // This prints and clears the error.
+        e.restore();
+        PyErr_Print();
+      }
+      return false;
+    }
+
+    // Find the file which defines an extension extending the given message type
+    // with the given field number.
+    bool FindFileContainingExtension(const std::string& containing_type,
+                                     int field_number,
+                                     FileDescriptorProto* output) override {
+      try {
+        auto descriptor = pool_.attr("FindMessageTypeByName")(containing_type);
+        auto file =
+            pool_.attr("FindExtensionByNymber")(descriptor, field_number)
+                .attr("file");
+        return CopyToFileDescriptorProto(file, output);
+      } catch (py::error_already_set& e) {
+        std::cerr << "FindFileContainingExtension " << containing_type << " "
+                   << field_number << " raised an error";
+
+        // This prints and clears the error.
+        e.restore();
+        PyErr_Print();
+      }
+      return false;
+    }
+
+   private:
+    bool CopyToFileDescriptorProto(py::handle py_file_descriptor,
+                                   FileDescriptorProto* output) {
+      if (GlobalState::instance()->py_proto_api()) {
+        try {
+          py::object c_proto = py::reinterpret_steal<py::object>(
+              GlobalState::instance()
+                  ->py_proto_api()
+                  ->NewMessageOwnedExternally(output, nullptr));
+          if (c_proto) {
+            py_file_descriptor.attr("CopyToProto")(c_proto);
+            return true;
+          }
+        } catch (py::error_already_set& e) {
+          std::cerr << "CopyToFileDescriptorProto raised an error";
+
+          // This prints and clears the error.
+          e.restore();
+          PyErr_Print();
+        }
+      }
+
+      py::object wire = py_file_descriptor.attr("serialized_pb");
+      const char* bytes = PYBIND11_BYTES_AS_STRING(wire.ptr());
+      return output->ParsePartialFromArray(bytes,
+                                           PYBIND11_BYTES_SIZE(wire.ptr()));
+    }
+
+    py::object pool_;  // never dereferenced.
+  };
+
+  // This map caches the wrapped objects, indexed by DescriptorPool address.
+  absl::flat_hash_map<PyObject*, Data> pools_map;
+};
+
+}  // namespace
+
+void InitializePybindProtoCastUtil() {
+  assert(PyGILState_Check());
+  GlobalState::instance();
+}
+
+void ImportProtoDescriptorModule(const Descriptor* descriptor) {
+  assert(PyGILState_Check());
+  if (!descriptor) return;
+  auto module_name = PythonPackageForDescriptor(descriptor->file());
+  if (module_name.empty()) return;
+  try {
+    GlobalState::instance()->ImportCached(module_name);
+  } catch (py::error_already_set& e) {
+    if (IsImportError(e)) {
+      std::cerr << "Python module " << module_name << " unavailable."
+                 << std::endl;
+    } else {
+      std::cerr << "ImportDescriptorModule raised an error";
+      // This prints and clears the error.
+      e.restore();
+      PyErr_Print();
+    }
+  }
+}
+
+const Message* PyProtoGetCppMessagePointer(py::handle src) {
+  assert(PyGILState_Check());
+  if (!GlobalState::instance()->py_proto_api()) return nullptr;
+  auto* ptr =
+      GlobalState::instance()->py_proto_api()->GetMessagePointer(src.ptr());
+  if (ptr == nullptr) {
+    // Clear the type_error set by GetMessagePointer sets a type_error when
+    // src was not a wrapped C++ proto message.
+    PyErr_Clear();
+    return nullptr;
+  }
+  return ptr;
+}
+
+absl::optional<std::string> PyProtoDescriptorName(py::handle py_proto) {
+  assert(PyGILState_Check());
+  auto py_full_name = ResolveAttrs(py_proto, {"DESCRIPTOR", "full_name"});
+  if (py_full_name) {
+    return CastToOptionalString(*py_full_name);
+  }
+  return absl::nullopt;
+}
+
+bool PyProtoIsCompatible(py::handle py_proto, const Descriptor* descriptor) {
+  assert(PyGILState_Check());
+  assert(descriptor->file()->pool() == DescriptorPool::generated_pool());
+
+  auto py_descriptor = ResolveAttrs(py_proto, {"DESCRIPTOR"});
+  if (!py_descriptor) {
+    // Not a valid protobuf -- missing DESCRIPTOR.
+    return false;
+  }
+
+  // Test full_name equivalence.
+  {
+    auto py_full_name = ResolveAttrs(*py_descriptor, {"full_name"});
+    if (!py_full_name) {
+      // Not a valid protobuf -- missing DESCRIPTOR.full_name
+      return false;
+    }
+    auto full_name = CastToOptionalString(*py_full_name);
+    if (!full_name || *full_name != descriptor->full_name()) {
+      // Name mismatch.
+      return false;
+    }
+  }
+
+  // The C++ descriptor is compiled in (see above assert), so the py_proto
+  // is expected to be from the global pool, i.e. the DESCRIPTOR.file.pool
+  // instance is the global python pool, and not a custom pool.
+  auto py_pool = ResolveAttrs(*py_descriptor, {"file", "pool"});
+  if (py_pool) {
+    return py_pool->is(GlobalState::instance()->global_pool());
+  }
+
+  // The py_proto is missing a DESCRIPTOR.file.pool, but the name matches.
+  // This will not happen with a native python implementation, but does
+  // occur with the deprecated :proto_casters, and could happen with other
+  // mocks.  Returning true allows the caster to call PyProtoCopyToCProto.
+  return true;
+}
+
+bool PyProtoCopyToCProto(py::handle py_proto, Message* message) {
+  assert(PyGILState_Check());
+  auto serialize_fn = ResolveAttrMRO(py_proto, "SerializePartialToString");
+  if (!serialize_fn) {
+    throw py::type_error(
+        "SerializePartialToString method not found; is this a " +
+        message->GetDescriptor()->full_name());
+  }
+  auto wire = (*serialize_fn)();
+  const char* bytes = PYBIND11_BYTES_AS_STRING(wire.ptr());
+  if (!bytes) {
+    throw py::type_error("SerializePartialToString failed; is this a " +
+                         message->GetDescriptor()->full_name());
+  }
+  return message->ParsePartialFromArray(bytes, PYBIND11_BYTES_SIZE(wire.ptr()));
+}
+
+void CProtoCopyToPyProto(Message* message, py::handle py_proto) {
+  assert(PyGILState_Check());
+  auto merge_fn = ResolveAttrMRO(py_proto, "MergeFromString");
+  if (!merge_fn) {
+    throw py::type_error("MergeFromString method not found; is this a " +
+                         message->GetDescriptor()->full_name());
+  }
+
+  auto serialized = message->SerializePartialAsString();
+#if PY_MAJOR_VERSION >= 3
+  auto view = py::memoryview::from_memory(serialized.data(), serialized.size());
+#else
+  py::bytearray view(serialized);
+#endif
+  (*merge_fn)(view);
+}
+
+std::unique_ptr<Message> AllocateCProtoFromPythonSymbolDatabase(
+    py::handle src, const std::string& full_name) {
+  assert(PyGILState_Check());
+  auto pool = ResolveAttrs(src, {"DESCRIPTOR", "file", "pool"});
+  if (!pool) {
+    throw py::type_error("Object is not a valid protobuf");
+  }
+
+  auto pool_data =
+      PythonDescriptorPoolWrapper::instance()->GetPoolFromPythonPool(*pool);
+  // The following call will query the DescriptorDatabase, which fetches the
+  // necessary Python descriptors and feeds them into the C++ pool.
+  // The result stays cached as long as the Python pool stays alive.
+  const Descriptor* descriptor =
+      pool_data->pool->FindMessageTypeByName(full_name);
+  if (!descriptor) {
+    throw py::type_error("Could not find descriptor: " + full_name);
+  }
+  const Message* prototype = pool_data->factory->GetPrototype(descriptor);
+  if (!prototype) {
+    throw py::type_error("Unable to get prototype for " + full_name);
+  }
+  return std::unique_ptr<Message>(prototype->New());
+}
+
+namespace {
+
+std::string ReturnValuePolicyName(py::return_value_policy policy) {
+  switch (policy) {
+    case py::return_value_policy::automatic:
+      return "automatic";
+    case py::return_value_policy::automatic_reference:
+      return "automatic_reference";
+    case py::return_value_policy::take_ownership:
+      return "take_ownership";
+    case py::return_value_policy::copy:
+      return "copy";
+    case py::return_value_policy::move:
+      return "move";
+    case py::return_value_policy::reference:
+      return "reference";
+    case py::return_value_policy::reference_internal:
+      return "reference_internal";
+    default:
+      return "INVALID_ENUM_VALUE";
+  }
+}
+
+}  // namespace
+
+py::handle GenericPyProtoCast(Message* src, py::return_value_policy policy,
+                              py::handle parent, bool is_const) {
+  assert(src != nullptr);
+  assert(PyGILState_Check());
+  auto py_proto =
+      GlobalState::instance()->PyMessageInstance(src->GetDescriptor());
+
+  CProtoCopyToPyProto(src, py_proto);
+  return py_proto.release();
+}
+
+py::handle GenericFastCppProtoCast(Message* src, py::return_value_policy policy,
+                                   py::handle parent, bool is_const) {
+  assert(policy != pybind11::return_value_policy::automatic);
+  assert(policy != pybind11::return_value_policy::automatic_reference);
+  assert(src != nullptr);
+  assert(PyGILState_Check());
+  assert(GlobalState::instance()->py_proto_api() != nullptr);
+
+  switch (policy) {
+    case py::return_value_policy::move:
+    case py::return_value_policy::take_ownership: {
+      std::pair<py::object, Message*> descriptor_pair =
+          GlobalState::instance()->PyFastCppProtoMessageInstance(
+              src->GetDescriptor());
+      py::object& result = descriptor_pair.first;
+      Message* result_message = descriptor_pair.second;
+
+      if (result_message->GetReflection() == src->GetReflection()) {
+        // The internals may be Swapped iff the protos use the same Reflection
+        // instance.
+        result_message->GetReflection()->Swap(src, result_message);
+      } else {
+        auto serialized = src->SerializePartialAsString();
+        if (!result_message->ParseFromString(serialized)) {
+          throw py::type_error(
+              "Failed to copy protocol buffer with mismatched descriptor");
+        }
+      }
+      return result.release();
+    } break;
+
+    case py::return_value_policy::copy: {
+      std::pair<py::object, Message*> descriptor_pair =
+          GlobalState::instance()->PyFastCppProtoMessageInstance(
+              src->GetDescriptor());
+      py::object& result = descriptor_pair.first;
+      Message* result_message = descriptor_pair.second;
+
+      if (result_message->GetReflection() == src->GetReflection()) {
+        // The internals may be copied iff the protos use the same Reflection
+        // instance.
+        result_message->CopyFrom(*src);
+      } else {
+        auto serialized = src->SerializePartialAsString();
+        if (!result_message->ParseFromString(serialized)) {
+          throw py::type_error(
+              "Failed to copy protocol buffer with mismatched descriptor");
+        }
+      }
+      return result.release();
+    } break;
+
+    case py::return_value_policy::reference:
+    case py::return_value_policy::reference_internal: {
+      // NOTE: Reference to const are currently unsafe to return.
+      py::object result = py::reinterpret_steal<py::object>(
+          GlobalState::instance()->py_proto_api()->NewMessageOwnedExternally(
+              src, nullptr));
+      if (policy == py::return_value_policy::reference_internal) {
+        py::detail::keep_alive_impl(result, parent);
+      }
+      return result.release();
+    } break;
+
+    default:
+      std::string message("pybind11_protobuf unhandled return_value_policy::");
+      throw py::cast_error(message + ReturnValuePolicyName(policy));
+  }
+}
+
+py::handle GenericProtoCast(Message* src, py::return_value_policy policy,
+                            py::handle parent, bool is_const) {
+  assert(src != nullptr);
+  assert(PyGILState_Check());
+
+  // Return a native python-allocated proto when:
+  // 1. The binary does not have a py_proto_api instance, or
+  // 2. a) the proto is from the default pool and
+  //    b) the binary is not using fast_cpp_protos.
+  if ((GlobalState::instance()->py_proto_api() == nullptr) ||
+      (src->GetDescriptor()->file()->pool() ==
+           DescriptorPool::generated_pool() &&
+       !GlobalState::instance()->using_fast_cpp())) {
+    return GenericPyProtoCast(src, policy, parent, is_const);
+  }
+
+  // If this is a dynamically generated proto, then we're going to need to
+  // construct a mapping between C++ pool() and python pool(), and then
+  // use the PyProto_API to make it work.
+  return GenericFastCppProtoCast(src, policy, parent, is_const);
+}
+
+}  // namespace pybind11_protobuf

--- a/pybind11_protobuf/proto_cast_util.h
+++ b/pybind11_protobuf/proto_cast_util.h
@@ -1,0 +1,63 @@
+#ifndef PYBIND11_PROTOBUF_PROTO_CAST_UTIL_H_
+#define PYBIND11_PROTOBUF_PROTO_CAST_UTIL_H_
+
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/message.h>
+
+namespace pybind11_protobuf {
+
+// Initialize internal proto cast dependencies, which includes importing
+// various protobuf-related modules.
+void InitializePybindProtoCastUtil();
+
+// Imports a module pertaining to a given ::google::protobuf::Descriptor, if possible.
+void ImportProtoDescriptorModule(const ::google::protobuf::Descriptor *);
+
+// Returns a ::google::protobuf::Message* from a cpp_fast_proto, if backed by C++.
+const ::google::protobuf::Message *PyProtoGetCppMessagePointer(pybind11::handle src);
+
+// Returns the protocol buffer's py_proto.DESCRIPTOR.full_name attribute.
+std::string PyProtoDescriptorName(pybind11::handle py_proto);
+
+// Return whether py_proto is compatible with the C++ descriptor.
+// The py_proto name must match the C++ Descriptor::full_name(), and is
+// expected to originate from the python default pool, which means that
+// this method will return false for dynamic protos.
+bool PyProtoIsCompatible(pybind11::handle py_proto,
+                         const ::google::protobuf::Descriptor *descriptor);
+
+// Allocates a C++ protocol buffer for a given name.
+std::unique_ptr<::google::protobuf::Message> AllocateCProtoFromPythonSymbolDatabase(
+    pybind11::handle src, const std::string &full_name);
+
+// Serialize the py_proto and deserialize it into the provided message.
+// Caller should enforce any type identity that is required.
+bool PyProtoCopyToCProto(pybind11::handle py_proto, ::google::protobuf::Message *message);
+void CProtoCopyToPyProto(::google::protobuf::Message *message, pybind11::handle py_proto);
+
+// Returns a handle to a python protobuf suitably
+pybind11::handle GenericFastCppProtoCast(::google::protobuf::Message *src,
+                                         pybind11::return_value_policy policy,
+                                         pybind11::handle parent,
+                                         bool is_const);
+
+pybind11::handle GenericPyProtoCast(::google::protobuf::Message *src,
+                                    pybind11::return_value_policy policy,
+                                    pybind11::handle parent, bool is_const);
+
+pybind11::handle GenericProtoCast(::google::protobuf::Message *src,
+                                  pybind11::return_value_policy policy,
+                                  pybind11::handle parent, bool is_const);
+
+}  // namespace pybind11_protobuf
+
+#endif  // PYBIND11_PROTOBUF_PROTO_CAST_UTIL_H_

--- a/pybind11_protobuf/proto_cast_util.h
+++ b/pybind11_protobuf/proto_cast_util.h
@@ -10,8 +10,8 @@
 #include <type_traits>
 #include <utility>
 
-#include <google/protobuf/descriptor.h>
-#include <google/protobuf/message.h>
+#include "google/protobuf/descriptor.h"
+#include "google/protobuf/message.h"
 
 namespace pybind11_protobuf {
 
@@ -26,7 +26,7 @@ void ImportProtoDescriptorModule(const ::google::protobuf::Descriptor *);
 const ::google::protobuf::Message *PyProtoGetCppMessagePointer(pybind11::handle src);
 
 // Returns the protocol buffer's py_proto.DESCRIPTOR.full_name attribute.
-std::string PyProtoDescriptorName(pybind11::handle py_proto);
+absl::optional<std::string> PyProtoDescriptorName(pybind11::handle py_proto);
 
 // Return whether py_proto is compatible with the C++ descriptor.
 // The py_proto name must match the C++ Descriptor::full_name(), and is

--- a/pybind11_protobuf/proto_caster_impl.h
+++ b/pybind11_protobuf/proto_caster_impl.h
@@ -1,0 +1,303 @@
+#ifndef PYBIND11_PROTOBUF_PROTO_CASTER_IMPL_H_
+#define PYBIND11_PROTOBUF_PROTO_CASTER_IMPL_H_
+
+//#include <Python.h>
+#include <pybind11/cast.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include <google/protobuf/descriptor.pb.h>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/message.h>
+#include "proto_cast_util.h"
+
+// Enables unsafe conversions; currently these are a work in progress.
+#if !defined(PYBIND11_PROTOBUF_UNSAFE)
+#define PYBIND11_PROTOBUF_UNSAFE 0
+#endif
+
+namespace pybind11_protobuf {
+
+// pybind11 constructs c++ references using the following mechanism, for
+// example:
+//
+// type_caster<T> caster;
+// caster.load(handle, /*convert=*/ false);
+// call(pybind11::detail::cast_op<const T&>(caster));
+//
+template <typename ProtoType>
+struct proto_caster_load_impl {
+  static_assert(
+      std::is_same<ProtoType, pybind11::detail::intrinsic_t<ProtoType>>::value,
+      "");
+
+  // load converts from Python -> C++
+  bool load(pybind11::handle src, bool convert) {
+    // When given a none, treat it as a nullptr.
+    if (src.is_none()) {
+      value = nullptr;
+      return true;
+    }
+    // NOTE: We might need to know whether the proto has extensions that
+    // are python-only.
+
+    // Attempt to use the PyProto_API to get an underlying C++ message pointer
+    // from the object.
+    const ::google::protobuf::Message *message =
+        pybind11_protobuf::PyProtoGetCppMessagePointer(src);
+    if (message && message->GetReflection() ==
+                       ProtoType::default_instance().GetReflection()) {
+      // If the capability were available, then we could probe PyProto_API and
+      // allow c++ mutability based on the python reference count.
+      value = static_cast<const ProtoType *>(message);
+      return true;
+    }
+
+    // The incoming object is not a compatible fast_cpp_proto, so check whether
+    // it is otherwise compatible, then serialize it and deserialize into a
+    // native C++ proto type.
+    if (!pybind11_protobuf::PyProtoIsCompatible(src, ProtoType::descriptor())) {
+      return false;
+    }
+    owned = std::unique_ptr<ProtoType>(new ProtoType());
+    value = owned.get();
+    return pybind11_protobuf::PyProtoCopyToCProto(src, owned.get());
+  }
+
+  // ensure_owned ensures that the owned member contains a copy of the
+  // ::google::protobuf::Message.
+  void ensure_owned() {
+    if (value && !owned) {
+      owned = std::unique_ptr<ProtoType>(value->New());
+      *owned = *value;
+      value = owned.get();
+    }
+  }
+
+  const ProtoType *value;
+  std::unique_ptr<ProtoType> owned;
+};
+
+template <>
+struct proto_caster_load_impl<::google::protobuf::Message> {
+  using ProtoType = ::google::protobuf::Message;
+
+  bool load(pybind11::handle src, bool convert) {
+    if (src.is_none()) {
+      value = nullptr;
+      return true;
+    }
+
+    // Attempt to use the PyProto_API to get an underlying C++ message pointer
+    // from the object.
+    value = pybind11_protobuf::PyProtoGetCppMessagePointer(src);
+    if (value && value->GetDescriptor() && value->GetDescriptor()->file() &&
+        value->GetDescriptor()->file()->pool() ==
+            ::google::protobuf::DescriptorPool::generated_pool()) {
+      // Only messages in the same generated_pool() can be referenced directly.
+      return true;
+    }
+
+    // `src` is not a C++ proto instance from the generated_pool,
+    // so create a compatible native C++ proto.
+    auto descriptor_name = pybind11_protobuf::PyProtoDescriptorName(src);
+    if (descriptor_name.empty()) {
+      return false;
+    }
+    owned.reset(static_cast<ProtoType *>(
+        pybind11_protobuf::AllocateCProtoFromPythonSymbolDatabase(
+            src, descriptor_name)
+            .release()));
+    value = owned.get();
+    return pybind11_protobuf::PyProtoCopyToCProto(src, owned.get());
+  }
+
+  // ensure_owned ensures that the owned member contains a copy of the
+  // ::google::protobuf::Message.
+  void ensure_owned() {
+    if (value && !owned) {
+      owned = std::unique_ptr<ProtoType>(value->New());
+      owned->CopyFrom(*value);
+      value = owned.get();
+    }
+  }
+
+  const ::google::protobuf::Message *value;
+  std::unique_ptr<::google::protobuf::Message> owned;
+};
+
+struct fast_cpp_cast_impl {
+  inline static pybind11::handle cast_impl(::google::protobuf::Message *src,
+                                           pybind11::return_value_policy policy,
+                                           pybind11::handle parent,
+                                           bool is_const) {
+    if (src == nullptr) return pybind11::none().release();
+
+#if PYBIND11_PROTOBUF_UNSAFE
+    if (is_const &&
+        (policy == pybind11::return_value_policy::reference ||
+         policy == pybind11::return_value_policy::reference_internal)) {
+      throw pybind11::type_error(
+          "Cannot return a const reference to a ::google::protobuf::Message derived "
+          "type.  Consider setting return_value_policy::copy in the "
+          "pybind11 def().");
+    }
+#else
+    // references are inherently unsafe, so convert them to copies.
+    if (policy == pybind11::return_value_policy::reference ||
+        policy == pybind11::return_value_policy::reference_internal) {
+      policy = pybind11::return_value_policy::copy;
+    }
+#endif
+
+    return pybind11_protobuf::GenericFastCppProtoCast(src, policy, parent,
+                                                      is_const);
+  }
+};
+
+struct native_cast_impl {
+  inline static pybind11::handle cast_impl(::google::protobuf::Message *src,
+                                           pybind11::return_value_policy policy,
+                                           pybind11::handle parent,
+                                           bool is_const) {
+    if (src == nullptr) return pybind11::none().release();
+
+    // references are inherently unsafe, so convert them to copies.
+    if (policy == pybind11::return_value_policy::reference ||
+        policy == pybind11::return_value_policy::reference_internal) {
+      policy = pybind11::return_value_policy::copy;
+    }
+
+    return pybind11_protobuf::GenericProtoCast(src, policy, parent, false);
+  }
+};
+
+// pybind11 type_caster specialization for c++ protocol buffer types.
+template <typename ProtoType, typename CastBase>
+struct proto_caster : public proto_caster_load_impl<ProtoType>,
+                      protected CastBase {
+ private:
+  using Loader = proto_caster_load_impl<ProtoType>;
+  using CastBase::cast_impl;
+  using Loader::ensure_owned;
+  using Loader::owned;
+  using Loader::value;
+
+ public:
+  static constexpr auto name = pybind11::detail::_<ProtoType>();
+
+  // cast converts from C++ -> Python
+  //
+  // return_value_policy handling differs from the behavior for
+  // py::class_-wrapped objects because because protocol buffer objects usually
+  // need to be copied across the C++/python boundary as they contain internal
+  // pointers which are unsafe to modify. See:
+  // https://pybind11.readthedocs.io/en/stable/advanced/functions.html#return-value-policies
+  static pybind11::handle cast(ProtoType &&src,
+                               pybind11::return_value_policy policy,
+                               pybind11::handle parent) {
+    return cast_impl(&src, pybind11::return_value_policy::move, parent, false);
+  }
+
+  static pybind11::handle cast(const ProtoType *src,
+                               pybind11::return_value_policy policy,
+                               pybind11::handle parent) {
+    std::unique_ptr<const ProtoType> wrapper;
+    if (policy == pybind11::return_value_policy::automatic ||
+        policy == pybind11::return_value_policy::automatic_reference) {
+      policy = pybind11::return_value_policy::copy;
+    } else if (policy == pybind11::return_value_policy::take_ownership) {
+      wrapper.reset(src);
+    }
+    return cast_impl(const_cast<ProtoType *>(src), policy, parent, true);
+  }
+
+  static pybind11::handle cast(ProtoType *src,
+                               pybind11::return_value_policy policy,
+                               pybind11::handle parent) {
+    std::unique_ptr<ProtoType> wrapper;
+    if (policy == pybind11::return_value_policy::automatic_reference) {
+      policy = pybind11::return_value_policy::copy;
+    } else if (policy == pybind11::return_value_policy::automatic ||
+               policy == pybind11::return_value_policy::take_ownership) {
+      policy = pybind11::return_value_policy::take_ownership;
+      wrapper.reset(src);
+    }
+    return cast_impl(src, policy, parent, false);
+  }
+
+  static pybind11::handle cast(ProtoType const &src,
+                               pybind11::return_value_policy policy,
+                               pybind11::handle parent) {
+    if (policy == pybind11::return_value_policy::automatic ||
+        policy == pybind11::return_value_policy::automatic_reference) {
+      policy = pybind11::return_value_policy::copy;
+    }
+    return cast_impl(const_cast<ProtoType *>(&src), policy, parent, true);
+  }
+
+  static pybind11::handle cast(ProtoType &src,
+                               pybind11::return_value_policy policy,
+                               pybind11::handle parent) {
+    if (policy == pybind11::return_value_policy::automatic ||
+        policy == pybind11::return_value_policy::automatic_reference) {
+      policy = pybind11::return_value_policy::copy;
+    }
+    return cast_impl(&src, policy, parent, false);
+  }
+
+  std::unique_ptr<ProtoType> as_unique_ptr() {
+    ensure_owned();
+    return std::move(owned);
+  }
+
+  // PYBIND11_TYPE_CASTER
+  explicit operator const ProtoType *() { return value; }
+  explicit operator const ProtoType &() {
+    if (!value) throw pybind11::reference_cast_error();
+    return *value;
+  }
+  explicit operator ProtoType &&() && {
+    if (!value) throw pybind11::reference_cast_error();
+    ensure_owned();
+    return std::move(*owned);
+  }
+
+#if PYBIND11_PROTOBUF_UNSAFE
+  // The following unsafe conversions are not enabled:
+  explicit operator ProtoType *() { return const_cast<ProtoType *>(value); }
+  explicit operator ProtoType &() {
+    if (!value) throw pybind11::reference_cast_error();
+    return *const_cast<ProtoType *>(value);
+  }
+#endif
+
+  // cast_op_type determines which operator overload to call for a given c++
+  // input parameter type.
+  // clang-format off
+  template <typename T_>
+  using cast_op_type = typename
+      std::conditional<
+          std::is_same<
+              typename std::remove_reference<T_>::type, const ProtoType *>::value,
+                  const ProtoType *,
+      std::conditional<
+          std::is_same<
+               typename std::remove_reference<T_>::type, ProtoType *>::value, ProtoType *,
+      std::conditional<
+          std::is_same<T_, const ProtoType &>::value, const ProtoType &,
+      std::conditional<std::is_same<T_, ProtoType &>::value, ProtoType &,
+      /*default is T&&*/ T_>>>>::type;
+  // clang-format on
+};
+
+}  // namespace pybind11_protobuf
+
+#endif  // PYBIND11_PROTOBUF_PROTO_CASTER_IMPL_H_

--- a/pybind11_protobuf/proto_utils.cc
+++ b/pybind11_protobuf/proto_utils.cc
@@ -3,18 +3,17 @@
 // All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-#include "proto_utils.h"
+#include "pybind11_protobuf/proto_utils.h"
 
 #include <memory>
 #include <stdexcept>
 #include <string>
 #include <typeindex>
 
-#include <google/protobuf/any.pb.h>
-#include <google/protobuf/descriptor.pb.h>
-#include <google/protobuf/descriptor.h>
-#include <google/protobuf/message.h>
-//#include "absl/strings/string_view.h"
+#include "google/protobuf/any.pb.h"
+#include "google/protobuf/descriptor.pb.h"
+#include "google/protobuf/descriptor.h"
+#include "google/protobuf/message.h"
 
 namespace pybind11 {
 namespace google {

--- a/pybind11_protobuf/proto_utils.cc
+++ b/pybind11_protobuf/proto_utils.cc
@@ -1,0 +1,1305 @@
+// Copyright (c) 2019 The Pybind Development Team. All rights reserved.
+//
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#include "proto_utils.h"
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <typeindex>
+
+#include <google/protobuf/any.pb.h>
+#include <google/protobuf/descriptor.pb.h>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/message.h>
+//#include "absl/strings/string_view.h"
+
+namespace pybind11 {
+namespace google {
+namespace {
+
+// A type used with DispatchFieldDescriptor to represent a generic enum value.
+struct GenericEnum {};
+
+// Calls Handler<Type>::HandleField(field_desc, ...) with the Type that
+// corresponds to the value of the cpp_type enum in the field descriptor.
+// Returns the result of that function. The return type of that function
+// cannot depend on the Type template parameter (ie, all instantiations of
+// Handler must return the same type).
+//
+// This works by instantiating a template class for each possible type of proto
+// field. That template class is a template parameter (look up 'template
+// template class'). Ideally this would be a template function, but template
+// template functions don't exist in C++, so you must define a class with a
+// static member function (HandleField) which will be called.
+template <template <typename> class Handler, typename... Args>
+auto DispatchFieldDescriptor(const ::google::protobuf::FieldDescriptor* field_desc,
+                             Args... args)
+    -> decltype(Handler<int32_t>::HandleField(field_desc, args...)) {
+  // If this field is a map, the field_desc always describes a message with
+  // 2 fields: key and value. In that case, dispatch based on the value type.
+  // In all other cases, the value type is the same as the field type.
+  const ::google::protobuf::FieldDescriptor* field_value_desc = field_desc;
+  if (field_desc->is_map())
+    field_value_desc = field_desc->message_type()->FindFieldByName("value");
+  switch (field_value_desc->cpp_type()) {
+    case ::google::protobuf::FieldDescriptor::CPPTYPE_INT32:
+      return Handler<int32_t>::HandleField(field_desc, args...);
+    case ::google::protobuf::FieldDescriptor::CPPTYPE_INT64:
+      return Handler<int64_t>::HandleField(field_desc, args...);
+    case ::google::protobuf::FieldDescriptor::CPPTYPE_UINT32:
+      return Handler<uint32_t>::HandleField(field_desc, args...);
+    case ::google::protobuf::FieldDescriptor::CPPTYPE_UINT64:
+      return Handler<uint64_t>::HandleField(field_desc, args...);
+    case ::google::protobuf::FieldDescriptor::CPPTYPE_FLOAT:
+      return Handler<float>::HandleField(field_desc, args...);
+    case ::google::protobuf::FieldDescriptor::CPPTYPE_DOUBLE:
+      return Handler<double>::HandleField(field_desc, args...);
+    case ::google::protobuf::FieldDescriptor::CPPTYPE_BOOL:
+      return Handler<bool>::HandleField(field_desc, args...);
+    case ::google::protobuf::FieldDescriptor::CPPTYPE_STRING:
+      return Handler<std::string>::HandleField(field_desc, args...);
+    case ::google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE:
+      return Handler<::google::protobuf::Message>::HandleField(field_desc, args...);
+    case ::google::protobuf::FieldDescriptor::CPPTYPE_ENUM:
+      return Handler<GenericEnum>::HandleField(field_desc, args...);
+    default:
+      throw std::runtime_error("Unknown cpp_type: " +
+                               std::to_string(field_desc->cpp_type()));
+  }
+}
+
+// Calls pybind11::cast, but change the exception type to type_error.
+template <typename T>
+T CastOrTypeError(handle arg) {
+  try {
+    return cast<T>(arg);
+  } catch (const cast_error& e) {
+    throw type_error(e.what());
+  }
+}
+
+// Base class for type-agnostic functionality and data shared between all
+// specializations of the ProtoFieldContainer (see below).
+class ProtoFieldContainerBase {
+ public:
+  // Accesses the field indicated by `field_desc` in the given `proto`. `parent`
+  // should be passed if and only if `proto` is a map key-value pair message.
+  // In that case, it should point to the message which contains the map field.
+  // (ie, the parent of the key-value pair). In all other cases, `proto` is
+  // also the parent, which is indicated by passing nullptr for `parent`.
+  ProtoFieldContainerBase(::google::protobuf::Message* proto,
+                          const ::google::protobuf::FieldDescriptor* field_desc,
+                          ::google::protobuf::Message* parent = nullptr)
+      : proto_(proto),
+        parent_(parent ? parent : proto),
+        field_desc_(field_desc),
+        reflection_(proto->GetReflection()) {}
+
+  // Return the size of a repeated field.
+  int Size() const { return reflection_->FieldSize(*proto_, field_desc_); }
+
+  // Clear the field.
+  void Clear() { this->reflection_->ClearField(proto_, field_desc_); }
+
+  // Add is only available for embedded message fields; abort for all others.
+  void Add() { std::abort(); }
+
+ protected:
+  // Throws an exception if the index is bad, adjusting for negative indexes
+  // (which are relative to the end of the list). Returns the adjusted index.
+  int CheckIndex(int idx) const {
+    int size = Size();
+    if (idx < 0) idx += size;  // Negative numbers index from the end.
+    if (idx < 0 || idx >= size) {
+      // This is faster than throwing a std::out_of_range exception.
+      PyErr_SetString(PyExc_IndexError, "list index out of range");
+      throw error_already_set();
+    }
+    return idx;
+  }
+
+  // Adjusts the index for negative values and clamps it to 0 or Size, which is
+  // the standard logic for inserting list values. Returns the adjusted index.
+  int ClampIndex(int idx) const {
+    int size = Size();
+    if (idx < 0) idx += size;  // Negative numbers index from the end.
+    if (idx < 0) idx = 0;
+    if (idx > size) idx = size;
+    return idx;
+  }
+
+  // Cast `inst` and keep its parent alive until `inst` is no longer referenced.
+  // Use this when (and only when) casting message, map and repeated fields.
+  template <typename T>
+  object CastAndKeepAlive(T* inst, return_value_policy policy) const {
+    object py_inst = cast(inst, policy);
+    // parent_ should be owned by a python object, and it's important to pass
+    // the owning python object to keep_alive_impl. If a new python object is
+    // created here, the original one would not be kept alive by py_inst and
+    // memory could be freed too early. Cast uses a registry which maps C++
+    // pointers to their corresponding python objects to return the owning
+    // python object rather than creating a new one.
+    object py_parent = cast(parent_, return_value_policy::reference);
+    detail::keep_alive_impl(py_inst, py_parent);
+    return py_inst;
+  }
+
+  ::google::protobuf::Message* proto_;
+  ::google::protobuf::Message* parent_;
+  const ::google::protobuf::FieldDescriptor* field_desc_;
+  const ::google::protobuf::Reflection* reflection_;
+};
+
+// Create a template-specialization based reflection interface,
+// which can be used with template meta-programming.
+//
+// Proto ProtoFieldContainer should be the only thing in this file that
+// that directly uses the native reflection interface. All other accesses
+// into the proto should go through the ProtoFieldContainer.
+//
+// Specializations should implement the following functions:
+// cpp_type Get(int idx) const: Returns the value of the field, at the given
+//   index if it is a repeated field (idx is ignored for singular fields).
+// object GetPython(int idx) const: Converts the return value of
+//   of Get(idx) to a python object.
+// void Set(int idx, cpp_type value): Sets the value of the field, at the given
+//   index if it is a repeated field (idx is ignored for singular fields).
+// void SetPython(int idx, handle value): Sets the value of the field from the
+//   given python value.
+// void Append(handle value): Converts and adds the value to a repeated field.
+// std::string ElementRepr(int idx) const: Convert the element to a string.
+//
+// Note: cpp_type may not be exactly the same as the template argument type-
+// it could be a reference or a pointer to that type. Use ProtoFieldAccess<T>
+// To get the exact type that is returned by the Get() method.
+template <typename T>
+class ProtoFieldContainer {};
+
+// Create specializations of that template class for each numeric type.
+// Unfortunately the type name is in the function names used to access the
+// field, so the only way to do this is with a macro.
+#define NUMERIC_FIELD_REFLECTION_SPECIALIZATION(func_type, cpp_type)     \
+  template <>                                                            \
+  class ProtoFieldContainer<cpp_type> : public ProtoFieldContainerBase { \
+   public:                                                               \
+    using ProtoFieldContainerBase::ProtoFieldContainerBase;              \
+    cpp_type Get(int idx) const {                                        \
+      if (field_desc_->is_repeated()) {                                  \
+        return reflection_->GetRepeated##func_type(*proto_, field_desc_, \
+                                                   CheckIndex(idx));     \
+      } else {                                                           \
+        return reflection_->Get##func_type(*proto_, field_desc_);        \
+      }                                                                  \
+    }                                                                    \
+    object GetPython(int idx) const { return cast(Get(idx)); }           \
+    void Set(int idx, cpp_type value) {                                  \
+      if (field_desc_->is_repeated()) {                                  \
+        reflection_->SetRepeated##func_type(proto_, field_desc_,         \
+                                            CheckIndex(idx), value);     \
+      } else {                                                           \
+        reflection_->Set##func_type(proto_, field_desc_, value);         \
+      }                                                                  \
+    }                                                                    \
+    void SetPython(int idx, handle value) {                              \
+      Set(idx, CastOrTypeError<cpp_type>(value));                        \
+    }                                                                    \
+    void Append(handle value) {                                          \
+      reflection_->Add##func_type(proto_, field_desc_,                   \
+                                  CastOrTypeError<cpp_type>(value));     \
+    }                                                                    \
+    std::string ElementRepr(int idx) const {                             \
+      return std::to_string(Get(idx));                                   \
+    }                                                                    \
+  }
+
+NUMERIC_FIELD_REFLECTION_SPECIALIZATION(Int32, int32_t);
+NUMERIC_FIELD_REFLECTION_SPECIALIZATION(Int64, int64_t);
+NUMERIC_FIELD_REFLECTION_SPECIALIZATION(UInt32, uint32_t);
+NUMERIC_FIELD_REFLECTION_SPECIALIZATION(UInt64, uint64_t);
+NUMERIC_FIELD_REFLECTION_SPECIALIZATION(Float, float);
+NUMERIC_FIELD_REFLECTION_SPECIALIZATION(Double, double);
+NUMERIC_FIELD_REFLECTION_SPECIALIZATION(Bool, bool);
+#undef NUMERIC_FIELD_REFLECTION_SPECIALIZATION
+
+// Specialization for strings.
+template <>
+class ProtoFieldContainer<std::string> : public ProtoFieldContainerBase {
+ public:
+  using ProtoFieldContainerBase::ProtoFieldContainerBase;
+  const std::string& Get(int idx) const {
+    if (field_desc_->is_repeated()) {
+      return reflection_->GetRepeatedStringReference(*proto_, field_desc_,
+                                                     CheckIndex(idx), &scratch);
+    } else {
+      return reflection_->GetStringReference(*proto_, field_desc_, &scratch);
+    }
+  }
+  object GetPython(int idx) const {
+    // Convert the given value to a python string or bytes object.
+    // If byte fields are returned as standard strings, pybind11 will attempt
+    // to decode them as utf-8. However, some byte sequences are illegal in
+    // utf-8, and will result in an error. To allow any arbitrary byte sequence
+    // for a bytes field, we have to convert it to a python bytes type.
+    if (field_desc_->type() == ::google::protobuf::FieldDescriptor::TYPE_BYTES)
+      return bytes(Get(idx));
+    else
+      return str(Get(idx));
+  }
+  void Set(int idx, std::string value) {
+    if (field_desc_->is_repeated()) {
+      reflection_->SetRepeatedString(proto_, field_desc_, CheckIndex(idx),
+                                     std::move(value));
+    } else {
+      reflection_->SetString(proto_, field_desc_, std::move(value));
+    }
+  }
+  void SetPython(int idx, handle value) {
+    Set(idx, CastOrTypeError<std::string>(value));
+  }
+  void Append(handle value) {
+    reflection_->AddString(proto_, field_desc_,
+                           CastOrTypeError<std::string>(value));
+  }
+  std::string ElementRepr(int idx) const {
+    if (field_desc_->type() == ::google::protobuf::FieldDescriptor::TYPE_BYTES)
+      return "<Binary String>";
+    else
+      return "'" + Get(idx) + "'";
+  }
+
+ private:
+  mutable std::string scratch;
+};
+
+// Specialization for messages.
+template <>
+class ProtoFieldContainer<::google::protobuf::Message> : public ProtoFieldContainerBase {
+ public:
+  using ProtoFieldContainerBase::ProtoFieldContainerBase;
+  ::google::protobuf::Message* Get(int idx) const {
+    ::google::protobuf::Message* message;
+    if (field_desc_->is_repeated()) {
+      message = reflection_->MutableRepeatedMessage(proto_, field_desc_,
+                                                    CheckIndex(idx));
+    } else {
+      message = reflection_->MutableMessage(proto_, field_desc_);
+    }
+    return message;
+  }
+  object GetPython(int idx) const {
+    return this->CastAndKeepAlive(Get(idx), return_value_policy::reference);
+  }
+  void Set(int idx, ::google::protobuf::Message* value) {
+    if (value->GetTypeName() != field_desc_->message_type()->full_name())
+      throw type_error("Cannot set field from invalid type.");
+    Get(idx)->CopyFrom(*value);
+  }
+  void SetPython(int idx, handle value) {
+    // Value could be a native or wrapped C++ proto.
+    CheckValueType(value);
+    Get(idx)->ParseFromString(PyProtoSerializeToString(value));
+  }
+  void Append(handle value) {
+    CheckValueType(value);
+    reflection_->AddAllocatedMessage(
+        proto_, field_desc_,
+        PyProtoAllocateAndCopyMessage<::google::protobuf::Message>(value).release());
+  }
+  ::google::protobuf::Message* Add(kwargs kwargs_in = kwargs()) {
+    // Use a unique_ptr because it will automatically free memory if
+    // ProtoInitFields throws an exception.
+    std::unique_ptr<::google::protobuf::Message> new_msg = std::unique_ptr<::google::protobuf::Message>(
+        reflection_
+            ->GetMutableRepeatedFieldRef<::google::protobuf::Message>(proto_, field_desc_)
+            .NewMessage());
+    ProtoInitFields(new_msg.get(), kwargs_in);
+    // Transfer ownership of the new message to the proto repeated field.
+    auto new_msg_raw_ptr = new_msg.release();
+    reflection_->AddAllocatedMessage(proto_, field_desc_, new_msg_raw_ptr);
+    return new_msg_raw_ptr;
+  }
+  std::string ElementRepr(int idx) const {
+    return Get(idx)->ShortDebugString();
+  }
+
+ private:
+  void CheckValueType(handle value) {
+    if (!PyProtoCheckType(value, field_desc_->message_type()->full_name()))
+      throw type_error("Cannot set field from invalid type.");
+  }
+};
+
+// Specialization for enums.
+template <>
+class ProtoFieldContainer<GenericEnum> : public ProtoFieldContainerBase {
+ public:
+  using ProtoFieldContainerBase::ProtoFieldContainerBase;
+  const ::google::protobuf::EnumValueDescriptor* GetDesc(int idx) const {
+    if (field_desc_->is_repeated()) {
+      return reflection_->GetRepeatedEnum(*proto_, field_desc_,
+                                          CheckIndex(idx));
+    } else {
+      return reflection_->GetEnum(*proto_, field_desc_);
+    }
+  }
+  int Get(int idx) const { return GetDesc(idx)->number(); }
+  object GetPython(int idx) const { return cast(Get(idx)); }
+  void Set(int idx, int value) {
+    if (field_desc_->is_repeated()) {
+      reflection_->SetRepeatedEnumValue(proto_, field_desc_, CheckIndex(idx),
+                                        value);
+    } else {
+      reflection_->SetEnumValue(proto_, field_desc_, value);
+    }
+  }
+  void SetPython(int idx, handle value) {
+    Set(idx, CastOrTypeError<int>(value));
+  }
+  void Append(handle value) {
+    reflection_->AddEnumValue(proto_, field_desc_, CastOrTypeError<int>(value));
+  }
+  std::string ElementRepr(int idx) const { return GetDesc(idx)->name(); }
+};
+
+// A container for a repeated field.
+template <typename T>
+class RepeatedFieldContainer : public ProtoFieldContainer<T> {
+ public:
+  using ProtoFieldContainer<T>::ProtoFieldContainer;
+  object GetPythonContainer() const {
+    return this->CastAndKeepAlive(this, return_value_policy::copy);
+  }
+  void Extend(handle src) {
+    if (!isinstance<sequence>(src))
+      throw std::invalid_argument("Extend: Passed value is not a sequence.");
+    auto values = reinterpret_borrow<sequence>(src);
+    for (auto value : values) this->Append(value);
+  }
+  void Insert(int idx, handle value) {
+    idx = this->ClampIndex(idx);
+    // Append a new element to the end.
+    this->Append(value);
+    // Slide all existing values up one index.
+    for (int dst = this->Size() - 1; dst > idx; --dst)
+      SwapElements(dst, dst - 1);
+  }
+  void Delete(int idx) {
+    idx = this->CheckIndex(idx);
+    // Slide all existing values down one index.
+    for (int dst = idx; dst < this->Size() - 1; ++dst)
+      SwapElements(dst, dst + 1);
+    // Remove the last value
+    this->reflection_->RemoveLast(this->proto_, this->field_desc_);
+  }
+  object GetItem(int index) { return this->GetPython(index); }
+  void DelItem(int index) { Delete(index); }
+  void SetItem(int index, handle value) { this->SetPython(index, value); }
+  object GetSlice(slice slice) {
+    size_t start, stop, step, slice_length;
+    if (!slice.compute(this->Size(), &start, &stop, &step, &slice_length))
+      throw error_already_set();
+    list seq;
+    for (size_t i = 0; i < slice_length; ++i) {
+      seq.append(this->GetPython(start));
+      start += step;
+    }
+    return seq;
+  }
+  void SetSlice(slice slice, handle values) {
+    size_t start, stop, step, slice_length;
+    if (!slice.compute(this->Size(), &start, &stop, &step, &slice_length))
+      throw error_already_set();
+    for (size_t i = 0; i < slice_length; ++i) {
+      this->SetPython(start, values[int_(i)]);
+      start += step;
+    }
+  }
+  void DelSlice(slice slice) {
+    size_t start, stop, step, slice_length, field_length = this->Size();
+    if (!slice.compute(field_length, &start, &stop, &step, &slice_length))
+      throw error_already_set();
+    if (slice_length == field_length) {
+      this->Clear();  // More efficient than removing all elements one-by-one.
+    } else {
+      for (size_t i = 0; i < slice_length; ++i) {
+        stop -= step;
+        Delete(stop);
+      }
+    }
+  }
+  std::string Repr() const {
+    if (this->Size() == 0) return "[]";
+    std::string repr = "[";
+    for (int i = 0; i < this->Size(); ++i) repr += this->ElementRepr(i) + ", ";
+    repr.pop_back();
+    repr.back() = ']';
+    return repr;
+  }
+
+ protected:
+  void SwapElements(int i1, int i2) {
+    this->reflection_->SwapElements(this->proto_, this->field_desc_, i1, i2);
+  }
+};
+
+// Struct which can be used with DispatchFieldDescriptor to find (or add)
+// the map pair (key, value) message with the given key.
+template <typename KeyT>
+struct FindMapPair {
+  static ::google::protobuf::Message* HandleField(const ::google::protobuf::FieldDescriptor* key_desc,
+                                      ::google::protobuf::Message* proto,
+                                      const ::google::protobuf::FieldDescriptor* map_desc,
+                                      handle key, bool add_key = true) {
+    // When using the proto reflection API, maps are represented as repeated
+    // message fields (messages with 2 elements: 'key' and 'value'). If protocol
+    // buffers guarrantee a consistent (and useful) ordering of elements,
+    // it should be possible to do this search in O(log(n)) time. However, that
+    // requires more knowledge of protobuf internals than I have, so for now
+    // assume a random ordering of elements, in which case a O(n) search is
+    // the best you can do.
+    RepeatedFieldContainer<::google::protobuf::Message> map_field(proto, map_desc);
+    for (int i = 0; i < map_field.Size(); ++i) {
+      ::google::protobuf::Message* kv_pair = map_field.Get(i);
+      if (ProtoFieldContainer<KeyT>(kv_pair, key_desc).GetPython(-1).equal(key))
+        return kv_pair;
+    }
+    // Key not found
+    if (!add_key) return nullptr;
+    ::google::protobuf::Message* new_kv_pair = map_field.Add();
+    ProtoFieldContainer<KeyT>(new_kv_pair, key_desc).SetPython(-1, key);
+    return new_kv_pair;
+  }
+};
+
+// Struct which can be used with DispatchFieldDescriptor to get the value of
+// the map key.
+template <typename KeyType>
+struct GetMapKey {
+  static object HandleField(const ::google::protobuf::FieldDescriptor* key_desc,
+                            ::google::protobuf::Message* kv_pair, ::google::protobuf::Message* parent) {
+    return ProtoFieldContainer<KeyType>(kv_pair, key_desc, parent)
+        .GetPython(-1);
+  }
+};
+
+// Struct which can be used with DispatchFieldDescriptor to get the string
+// representation of the map key.
+template <typename KeyType>
+struct GetMapKeyRepr {
+  static std::string HandleField(const ::google::protobuf::FieldDescriptor* key_desc,
+                                 ::google::protobuf::Message* kv_pair) {
+    return ProtoFieldContainer<KeyType>(kv_pair, key_desc).ElementRepr(-1);
+  }
+};
+
+// Container for a map field.
+template <typename MappedType>
+class MapFieldContainer : public RepeatedFieldContainer<::google::protobuf::Message> {
+ public:
+  MapFieldContainer(::google::protobuf::Message* proto,
+                    const ::google::protobuf::FieldDescriptor* map_desc)
+      : RepeatedFieldContainer<::google::protobuf::Message>(proto, map_desc),
+        key_desc_(map_desc->message_type()->FindFieldByName("key")),
+        value_desc_(map_desc->message_type()->FindFieldByName("value")) {}
+  using RepeatedFieldContainer<::google::protobuf::Message>::RepeatedFieldContainer;
+  object GetPythonContainer() const {
+    return this->CastAndKeepAlive(this, return_value_policy::copy);
+  }
+  // GetItem automatically inserts missing keys, which matches native
+  // python protos, not dicts (see http://go/pythonprotobuf#undefined).
+  object GetItem(handle key) const {
+    return GetValueContainer(key).GetPython(-1);
+  }
+  void SetItem(handle key, handle value) {
+    GetValueContainer(key).SetPython(-1, value);
+  }
+  void UpdateFromDict(dict values) {
+    for (auto& item : values) SetItem(item.first, item.second);
+  }
+  void UpdateFromKWArgs(kwargs values) { UpdateFromDict(values); }
+  void UpdateFromHandle(handle values) {
+    if (!isinstance<dict>(values))
+      throw std::invalid_argument("Update: Passed value is not a dictionary.");
+    UpdateFromDict(reinterpret_borrow<dict>(values));
+  }
+  bool Contains(handle key) const {
+    return DispatchFieldDescriptor<FindMapPair>(key_desc_, proto_, field_desc_,
+                                                key, false) != nullptr;
+  }
+  std::string Repr() const {
+    if (Size() == 0) return "{}";
+    std::string repr = "{";
+    for (int i = 0; i < Size(); ++i) {
+      ::google::protobuf::Message* kv_pair = Get(i);
+      repr += DispatchFieldDescriptor<GetMapKeyRepr>(key_desc_, kv_pair) +
+              ": " +
+              ProtoFieldContainer<MappedType>(kv_pair, value_desc_)
+                  .ElementRepr(-1) +
+              ", ";
+    }
+    repr.pop_back();
+    repr.back() = '}';
+    return repr;
+  }
+  std::function<std::unique_ptr<::google::protobuf::Message>(kwargs)>
+  GetEntryClassFactory() {
+    return [descriptor = field_desc_->message_type()](kwargs kwargs_in) {
+      return PyProtoAllocateMessage(descriptor, kwargs_in);
+    };
+  }
+
+  // Iterator class for maps.
+  class Iterator {
+   public:
+    // First argument is the container, second is a member function to extract
+    // the appropriate value from a key-value pair message (ie, this function
+    // should return either the key, the value, or a (key, value) tuple).
+    Iterator(MapFieldContainer* container,
+             object (MapFieldContainer::*value_helper)(::google::protobuf::Message*))
+        : container_(container), value_helper_(value_helper) {}
+
+    auto* iter() { return this; }
+    object next() {
+      if (idx_ >= container_->Size()) throw stop_iteration();
+      return (container_->*value_helper_)(container_->Get(idx_++));
+    }
+
+   private:
+    MapFieldContainer* container_;
+    object (MapFieldContainer::*value_helper_)(::google::protobuf::Message*);
+    int idx_ = 0;
+  };
+
+  Iterator KeyIterator() { return Iterator(this, &MapFieldContainer::GetKey); }
+  Iterator ValueIterator() {
+    return Iterator(this, &MapFieldContainer::GetValue);
+  }
+  Iterator ItemIterator() {
+    return Iterator(this, &MapFieldContainer::GetTuple);
+  }
+
+ protected:
+  // Note that the helper functions bellow all pass the message which contains
+  // the key-value pair to the ProtoFieldContainer as the 3rd argument.
+
+  // Get the ProtoFieldContainer for the value corresponding to the given key.
+  ProtoFieldContainer<MappedType> GetValueContainer(handle key) const {
+    ::google::protobuf::Message* kv_pair = DispatchFieldDescriptor<FindMapPair>(
+        key_desc_, proto_, field_desc_, key);
+    return ProtoFieldContainer<MappedType>(kv_pair, value_desc_, proto_);
+  }
+
+  // Get the key out of the given key-value message.
+  object GetKey(::google::protobuf::Message* kv_pair) {
+    return DispatchFieldDescriptor<GetMapKey>(key_desc_, kv_pair, proto_);
+  }
+
+  // Get the value out of the given key-value message.
+  object GetValue(::google::protobuf::Message* kv_pair) {
+    return ProtoFieldContainer<MappedType>(kv_pair, value_desc_, proto_)
+        .GetPython(-1);
+  }
+
+  // Get the given key-value pair as a message.
+  object GetTuple(::google::protobuf::Message* kv_pair) {
+    return make_tuple(GetKey(kv_pair), GetValue(kv_pair));
+  }
+
+  const ::google::protobuf::FieldDescriptor* key_desc_;
+  const ::google::protobuf::FieldDescriptor* value_desc_;
+};
+
+const ::google::protobuf::FieldDescriptor* GetFieldDescriptor(
+    ::google::protobuf::Message* message, absl::string_view name,
+    PyObject* error_type = PyExc_AttributeError) {
+  auto* field_desc =
+  message->GetDescriptor()->FindFieldByName(std::string(name));
+
+  if (!field_desc) {
+    std::string error_str =
+        "'" + message->GetTypeName() + "' object has no attribute '";
+    error_str.append(std::string(name));
+    error_str.append("'");
+    PyErr_SetString(error_type, error_str.c_str());
+    throw error_already_set();
+  }
+  return field_desc;
+}
+
+// Struct used with DispatchFieldDescriptor to get the value of a field.
+template <typename ValueType>
+struct TemplatedProtoGetField {
+  static object HandleField(const ::google::protobuf::FieldDescriptor* field_desc,
+                            ::google::protobuf::Message* proto) {
+    if (field_desc->is_map()) {
+      return MapFieldContainer<ValueType>(proto, field_desc)
+          .GetPythonContainer();
+    } else if (field_desc->is_repeated()) {
+      return RepeatedFieldContainer<ValueType>(proto, field_desc)
+          .GetPythonContainer();
+    } else {  // Singular field.
+      return ProtoFieldContainer<ValueType>(proto, field_desc).GetPython(-1);
+    }
+  }
+};
+
+// Struct used with DispatchFieldDescriptor to set the value of a field.
+template <typename ValueType>
+struct TemplatedProtoSetField {
+  static void HandleField(const ::google::protobuf::FieldDescriptor* field_desc,
+                          ::google::protobuf::Message* proto, handle value) {
+    if (field_desc->is_map()) {
+      MapFieldContainer<ValueType> map_field(proto, field_desc);
+      map_field.Clear();
+      map_field.UpdateFromHandle(value);
+    } else if (field_desc->is_repeated()) {
+      RepeatedFieldContainer<ValueType> repeated_field(proto, field_desc);
+      repeated_field.Clear();
+      repeated_field.Extend(value);
+    } else {  // Singular field.
+      ProtoFieldContainer<ValueType>(proto, field_desc).SetPython(-1, value);
+    }
+  }
+};
+
+// Wrapper around ::google::protobuf::Message::FindInitializationErrors.
+std::vector<std::string> MessageFindInitializationErrors(
+    ::google::protobuf::Message* message) {
+  std::vector<std::string> errors;
+  message->FindInitializationErrors(&errors);
+  return errors;
+}
+
+// Wrapper around ::google::protobuf::Message::ListFields.
+std::vector<tuple> MessageListFields(::google::protobuf::Message* message) {
+  std::vector<const ::google::protobuf::FieldDescriptor*> fields;
+  message->GetReflection()->ListFields(*message, &fields);
+  std::vector<tuple> result;
+  result.reserve(fields.size());
+  for (auto* field_desc : fields) {
+    result.push_back(
+        make_tuple(cast(field_desc, return_value_policy::reference),
+                   ProtoGetField(message, field_desc)));
+  }
+  return result;
+}
+
+// Wrapper around ::google::protobuf::Message::HasField.
+bool MessageHasField(::google::protobuf::Message* message, absl::string_view field_name) {
+  auto* oneof_desc = message->GetDescriptor()->FindOneofByName(std::string(field_name));
+  if (oneof_desc) {
+    return message->GetReflection()->HasOneof(*message, oneof_desc);
+  }
+  auto* field_desc = GetFieldDescriptor(message, field_name, PyExc_ValueError);
+  return message->GetReflection()->HasField(*message, field_desc);
+}
+
+void MessageClearField(::google::protobuf::Message* message, absl::string_view field_name) {
+  auto* oneof_desc = message->GetDescriptor()->FindOneofByName(std::string(field_name));
+  if (oneof_desc) {
+    message->GetReflection()->ClearOneof(message, oneof_desc);
+    return;
+  }
+
+  auto* field_desc = GetFieldDescriptor(message, field_name, PyExc_ValueError);
+  message->GetReflection()->ClearField(message, field_desc);
+}
+
+const std::string* MessageWhichOneof(::google::protobuf::Message* message,
+                                     absl::string_view oneof_group) {
+  auto* oneof_desc = message->GetDescriptor()->FindOneofByName(std::string(oneof_group));
+  if (!oneof_desc) {
+    std::string error_str = "Requested oneof does not exist: ";
+    error_str.append(std::string(oneof_group));
+    throw std::invalid_argument(error_str);
+  }
+
+  auto* field_desc =
+      message->GetReflection()->GetOneofFieldDescriptor(*message, oneof_desc);
+  if (!field_desc) return nullptr;
+  return &field_desc->name();
+}
+
+// Wrapper around ::google::protobuf::Message::SerializeAsString.
+// The only valid kwarg is "deterministic", which should be a boolean and, if
+// true, causes maps to be serialized with deterministic order. Keyword
+// arguments are used here because the native python implementation does not
+// allow this to be passed as a positional argument, and we want to match that.
+bytes MessageSerializeAsString(::google::protobuf::Message* msg, kwargs kwargs_in,
+                               bool partial) {
+  static constexpr char kwargs_key[] = "deterministic";
+  std::string result;
+  bool deterministic = false;
+  if (!kwargs_in.empty()) {
+    if (kwargs_in.size() == 1 && kwargs_in.contains(kwargs_key)) {
+      deterministic = bool_(kwargs_in[kwargs_key]);
+    } else {
+      throw std::invalid_argument(
+          "Invalid kwargs; the only valid key is 'deterministic'");
+    }
+  }
+  if (deterministic) {
+    ::google::protobuf::io::StringOutputStream string_stream(&result);
+    ::google::protobuf::io::CodedOutputStream coded_stream(&string_stream);
+    coded_stream.SetSerializationDeterministic(true);
+    if (partial) {
+      msg->SerializePartialToCodedStream(&coded_stream);
+    } else {
+      msg->SerializeToCodedStream(&coded_stream);
+    }
+  } else {
+    if (partial) {
+      result = msg->SerializePartialAsString();
+    } else {
+      result = msg->SerializeAsString();
+    }
+  }
+  return bytes(result);
+}
+
+// Wrapper to generate the python message Descriptor.fields property.
+list MessageFields(const ::google::protobuf::Descriptor* descriptor) {
+  list result;
+  for (int i = 0; i < descriptor->field_count(); ++i)
+    result.append(cast(descriptor->field(i), return_value_policy::reference));
+  return result;
+}
+
+// Wrapper to generate the python message Descriptor.fields_by_name property.
+dict MessageFieldsByName(const ::google::protobuf::Descriptor* descriptor) {
+  dict result;
+  for (int i = 0; i < descriptor->field_count(); ++i) {
+    auto* field_desc = descriptor->field(i);
+    result[cast(field_desc->name())] =
+        cast(field_desc, return_value_policy::reference);
+  }
+  return result;
+}
+
+// Wrapper to generate the python EnumDescriptor.values_by_number property.
+dict EnumValuesByNumber(const ::google::protobuf::EnumDescriptor* enum_descriptor) {
+  dict result;
+  for (int i = 0; i < enum_descriptor->value_count(); ++i) {
+    auto* value_desc = enum_descriptor->value(i);
+    result[cast(value_desc->number())] =
+        cast(value_desc, return_value_policy::reference);
+  }
+  return result;
+}
+
+// Wrapper to generate the python EnumDescriptor.values_by_name property.
+dict EnumValuesByName(const ::google::protobuf::EnumDescriptor* enum_descriptor) {
+  dict result;
+  for (int i = 0; i < enum_descriptor->value_count(); ++i) {
+    auto* value_desc = enum_descriptor->value(i);
+    result[cast(value_desc->name())] =
+        cast(value_desc, return_value_policy::reference);
+  }
+  return result;
+}
+
+// Class to add python bindings to a RepeatedFieldContainer.
+// This corresponds to the repeated field API:
+// https://developers.google.com/protocol-buffers/docs/reference/python-generated#repeated-fields
+// https://developers.google.com/protocol-buffers/docs/reference/python-generated#repeated-message-fields
+template <typename T>
+class RepeatedFieldBindings : public class_<RepeatedFieldContainer<T>> {
+ public:
+  RepeatedFieldBindings(handle scope, const std::string& name)
+      : class_<RepeatedFieldContainer<T>>(scope, name.c_str()) {
+    // Repeated message fields support `add` but not `__setitem__`.
+    if (std::is_same<T, ::google::protobuf::Message>::value) {
+      this->def("add", &RepeatedFieldContainer<T>::Add,
+                return_value_policy::reference_internal);
+    } else {
+      this->def("__setitem__", &RepeatedFieldContainer<T>::SetItem);
+      this->def("__setitem__", &RepeatedFieldContainer<T>::SetSlice);
+    }
+    this->def("__repr__", &RepeatedFieldContainer<T>::Repr);
+    this->def("__len__", &RepeatedFieldContainer<T>::Size);
+    this->def("__getitem__", &RepeatedFieldContainer<T>::GetItem);
+    this->def("__getitem__", &RepeatedFieldContainer<T>::GetSlice);
+    this->def("__delitem__", &RepeatedFieldContainer<T>::DelItem);
+    this->def("__delitem__", &RepeatedFieldContainer<T>::DelSlice);
+    this->def("MergeFrom", &RepeatedFieldContainer<T>::Extend);
+    this->def("extend", &RepeatedFieldContainer<T>::Extend);
+    this->def("append", &RepeatedFieldContainer<T>::Append);
+    this->def("insert", &RepeatedFieldContainer<T>::Insert);
+  }
+};
+
+// Class to add python bindings to a MapFieldContainer.
+// This corresponds to the map field API:
+// https://developers.google.com/protocol-buffers/docs/reference/python-generated#map-fields
+template <typename T>
+class MapFieldBindings : public class_<MapFieldContainer<T>> {
+ public:
+  MapFieldBindings(handle scope, const std::string& name)
+      : class_<MapFieldContainer<T>>(scope, name.c_str()) {
+    // Mapped message fields don't support item assignment.
+    if (std::is_same<T, ::google::protobuf::Message>::value) {
+      this->def("__setitem__", [](void*, int, handle) {
+        throw value_error("Cannot assign to message in a map field.");
+      });
+    } else {
+      this->def("__setitem__", &MapFieldContainer<T>::SetItem);
+    }
+    this->def("__repr__", &MapFieldContainer<T>::Repr);
+    this->def("__len__", &MapFieldContainer<T>::Size);
+    this->def("__contains__", &MapFieldContainer<T>::Contains);
+    this->def("__getitem__", &MapFieldContainer<T>::GetItem);
+    this->def("__iter__", &MapFieldContainer<T>::KeyIterator,
+              keep_alive<0, 1>());
+    this->def("keys", &MapFieldContainer<T>::KeyIterator, keep_alive<0, 1>());
+    this->def("values", &MapFieldContainer<T>::ValueIterator,
+              keep_alive<0, 1>());
+    this->def("items", &MapFieldContainer<T>::ItemIterator, keep_alive<0, 1>());
+    this->def("update", &MapFieldContainer<T>::UpdateFromDict);
+    this->def("update", &MapFieldContainer<T>::UpdateFromKWArgs);
+    this->def("clear", &MapFieldContainer<T>::Clear);
+    this->def("GetEntryClass", &MapFieldContainer<T>::GetEntryClassFactory,
+              "Returns a factory function which can be called with keyword "
+              "Arguments to create an instance of the map entry class (ie, "
+              "a message with `key` and `value` fields). Used by text_format.");
+  }
+};
+
+// Class to add python bindings to a map field iterator.
+template <typename T>
+class MapFieldIteratorBindings
+    : public class_<typename MapFieldContainer<T>::Iterator> {
+ public:
+  MapFieldIteratorBindings(handle scope, const std::string& name)
+      : class_<typename MapFieldContainer<T>::Iterator>(
+            scope, (name + "Iterator").c_str()) {
+    this->def("__iter__", &MapFieldContainer<T>::Iterator::iter);
+    this->def("__next__", &MapFieldContainer<T>::Iterator::next);
+  }
+};
+
+// Function to instantiate the given Bindings class with each of the types
+// supported by protobuffers.
+template <template <typename> class Bindings>
+void BindEachFieldType(module& module, const std::string& name) {
+  Bindings<int32_t>(module, name + "Int32");
+  Bindings<int64_t>(module, name + "Int64");
+  Bindings<uint32_t>(module, name + "UInt32");
+  Bindings<uint64_t>(module, name + "UInt64");
+  Bindings<float>(module, name + "Float");
+  Bindings<double>(module, name + "Double");
+  Bindings<bool>(module, name + "Bool");
+  Bindings<std::string>(module, name + "String");
+  Bindings<::google::protobuf::Message>(module, name + "Message");
+  Bindings<GenericEnum>(module, name + "Enum");
+}
+
+// Define a property in the given class_ with the given name which is constant
+// for the life of an object instance. The generator function will be invoked
+// the first time the property is accessed. The result of this function will
+// be cached and returned for all future accesses, without invoking the
+// generator function again. dynamic_attr() must have been passed to the class_
+// constructor or you will get "AttributeError: can't set attribute".
+// The given policy is applied to the return value of the generator function.
+template <typename Class, typename Return, typename... Args>
+void DefConstantProperty(
+    class_<detail::intrinsic_t<Class>>* pyclass, const std::string& name,
+    std::function<Return(Class, Args...)> generator,
+    return_value_policy policy = return_value_policy::automatic_reference) {
+  auto wrapper = [generator, name, policy](handle pyinst, Args... args) {
+    std::string cache_name = "_cache_" + name;
+    if (!hasattr(pyinst, cache_name.c_str())) {
+      // Invoke the generator and cache the result.
+      Return result =
+          generator(cast<Class>(pyinst), std::forward<Args>(args)...);
+      setattr(
+          pyinst, cache_name.c_str(),
+          detail::make_caster<object>::cast(std::move(result), policy, pyinst));
+    }
+    return getattr(pyinst, cache_name.c_str());
+  };
+  pyclass->def_property_readonly(name.c_str(), wrapper);
+}
+
+// Same as above, but for a function pointer rather than a std::function.
+template <typename Class, typename Return, typename... Args>
+void DefConstantProperty(
+    class_<detail::intrinsic_t<Class>>* pyclass, const std::string& name,
+    Return (*generator)(Class, Args...),
+    return_value_policy policy = return_value_policy::automatic_reference) {
+  DefConstantProperty(pyclass, name,
+                      std::function<Return(Class, Args...)>(generator), policy);
+}
+
+}  // namespace
+
+bool PyProtoFullName(handle py_proto, std::string* name) {
+  if (hasattr(py_proto, "DESCRIPTOR")) {
+    auto descriptor = py_proto.attr("DESCRIPTOR");
+    if (hasattr(descriptor, "full_name")) {
+      if (name) *name = cast<std::string>(descriptor.attr("full_name"));
+      return true;
+    }
+  }
+  return false;
+}
+
+bool PyProtoCheckType(handle py_proto, const std::string& expected_type) {
+  std::string name;
+  if (PyProtoFullName(py_proto, &name)) return name == expected_type;
+  return false;
+}
+
+void PyProtoCheckTypeOrThrow(handle py_proto,
+                             const std::string& expected_type) {
+  std::string name;
+  if (!PyProtoFullName(py_proto, &name)) {
+    auto builtins = module::import(PYBIND11_BUILTINS_MODULE);
+    std::string type_str =
+        str(builtins.attr("repr")(builtins.attr("type")(py_proto)));
+    throw type_error("Expected a proto, got a " + type_str + ".");
+  } else if (name != expected_type) {
+    throw type_error("Passed proto is the wrong type. Expected " +
+                     expected_type + " but got " + name + ".");
+  }
+}
+
+std::string PyProtoSerializeToString(handle py_proto) {
+  if (hasattr(py_proto, "SerializeToString"))
+    return cast<std::string>(py_proto.attr("SerializeToString")());
+  throw std::invalid_argument("Passed python object is not a proto.");
+}
+
+const ::google::protobuf::Descriptor* PyProtoGetDescriptor(handle py_proto) {
+  detail::make_caster<::google::protobuf::Message> caster;
+  if (caster.load(py_proto, true)) {
+    // Native C++ proto, so we can get the descriptor directly.
+    return detail::cast_op<::google::protobuf::Message*>(caster)->GetDescriptor();
+  }
+
+  // Look the descriptor based on the proto's type name.
+  std::string full_type_name;
+  if (isinstance<bytes>(py_proto)) {
+    full_type_name = py_proto.cast<std::string>();
+  } else if (isinstance<str>(py_proto)) {
+    full_type_name = str(py_proto);
+  } else if (!PyProtoFullName(py_proto, &full_type_name)) {
+    throw std::invalid_argument("Could not get the name of the proto.");
+  }
+  const ::google::protobuf::Descriptor* descriptor =
+      ::google::protobuf::DescriptorPool::generated_pool()->FindMessageTypeByName(
+          full_type_name);
+  if (!descriptor)
+    throw std::runtime_error("Proto Descriptor not found: " + full_type_name);
+  return descriptor;
+}
+
+template <>
+std::unique_ptr<::google::protobuf::Message> PyProtoAllocateMessage(handle py_proto,
+                                                        kwargs kwargs_in) {
+  return PyProtoAllocateMessage(PyProtoGetDescriptor(py_proto), kwargs_in);
+}
+
+std::unique_ptr<::google::protobuf::Message> PyProtoAllocateMessage(
+    const ::google::protobuf::Descriptor* descriptor, kwargs kwargs_in) {
+  const ::google::protobuf::Message* prototype =
+      ::google::protobuf::MessageFactory::generated_factory()->GetPrototype(descriptor);
+  if (!prototype) {
+    throw std::runtime_error(
+        "Not able to generate prototype for descriptor of: " +
+        descriptor->full_name());
+  }
+  auto message = std::unique_ptr<::google::protobuf::Message>(prototype->New());
+  ProtoInitFields(message.get(), kwargs_in);
+  return message;
+}
+
+bool AnyPackFromPyProto(handle py_proto, ::google::protobuf::Any* any_proto) {
+  std::string name;
+  if (!PyProtoFullName(py_proto, &name)) return false;
+  any_proto->set_type_url("type.googleapis.com/" + name);
+  any_proto->set_value(PyProtoSerializeToString(py_proto));
+  return true;
+}
+
+bool AnyUnpackToPyProto(const ::google::protobuf::Any& any_proto,
+                        handle py_proto) {
+  // Check that py_proto is a proto message of the same type that is stored
+  // in the any_proto.
+  std::string any_type, proto_type;
+  if (!(PyProtoFullName(py_proto, &proto_type) &&
+        ::google::protobuf::Any::ParseAnyTypeUrl(
+            std::string(any_proto.type_url()), &any_type) &&
+        proto_type == any_type))
+    return false;
+  // Unpack. The serialized string is not copied if py_proto is a wrapped C
+  // proto, and copied once if py_proto is a native python proto.
+  detail::type_caster_base<::google::protobuf::Message> caster;
+  if (caster.load(py_proto, false)) {
+    return static_cast<::google::protobuf::Message&>(caster).ParseFromString(
+         std::string(any_proto.value()));
+  } else {
+    bytes serialized(nullptr, any_proto.value().size());
+    std::string any_string = any_proto.value();
+    strncpy(PYBIND11_BYTES_AS_STRING(serialized.ptr()),
+            any_string.c_str(), any_string.size());
+    getattr(py_proto, "ParseFromString")(serialized);
+    return true;
+  }
+}
+
+object ProtoGetField(::google::protobuf::Message* message, absl::string_view name) {
+  return ProtoGetField(message, GetFieldDescriptor(message, name));
+}
+
+object ProtoGetField(::google::protobuf::Message* message,
+                     const ::google::protobuf::FieldDescriptor* field_desc) {
+  return DispatchFieldDescriptor<TemplatedProtoGetField>(field_desc, message);
+}
+
+void ProtoSetField(::google::protobuf::Message* message, absl::string_view name,
+                   handle value) {
+  ProtoSetField(message, GetFieldDescriptor(message, name), value);
+}
+
+void ProtoSetField(::google::protobuf::Message* message,
+                   const ::google::protobuf::FieldDescriptor* field_desc, handle value) {
+  if (field_desc->is_map() || field_desc->is_repeated() ||
+      field_desc->type() == ::google::protobuf::FieldDescriptor::TYPE_MESSAGE) {
+    std::string error = "Assignment not allowed to field \"" +
+                        field_desc->name() + "\" in protocol message object.";
+    PyErr_SetString(PyExc_AttributeError, error.c_str());
+    throw error_already_set();
+  }
+  DispatchFieldDescriptor<TemplatedProtoSetField>(field_desc, message, value);
+}
+
+void ProtoInitFields(::google::protobuf::Message* message, kwargs kwargs_in) {
+  // NOTE: This uses pybind11 casters to construct strings, so it needs to
+  // be wrapped by loader_life_support.
+  pybind11::detail::loader_life_support life_support;
+
+  for (auto& item : kwargs_in) {
+    DispatchFieldDescriptor<TemplatedProtoSetField>(
+        GetFieldDescriptor(message, cast<absl::string_view>(item.first)),
+        message, item.second);
+  }
+}
+
+void ProtoCopyFrom(::google::protobuf::Message* msg, handle other) {
+  PyProtoCheckTypeOrThrow(other, msg->GetTypeName());
+  detail::type_caster_base<::google::protobuf::Message> caster;
+  if (caster.load(other, false)) {
+    msg->CopyFrom(static_cast<::google::protobuf::Message&>(caster));
+  } else {
+    if (!msg->ParseFromString(PyProtoSerializeToString(other)))
+      throw std::runtime_error("Error copying message.");
+  }
+}
+
+void ProtoMergeFrom(::google::protobuf::Message* msg, handle other) {
+  PyProtoCheckTypeOrThrow(other, msg->GetTypeName());
+  detail::type_caster_base<::google::protobuf::Message> caster;
+  if (caster.load(other, false)) {
+    msg->MergeFrom(static_cast<::google::protobuf::Message&>(caster));
+  } else {
+    if (!msg->MergeFromString(PyProtoSerializeToString(other)))
+      throw std::runtime_error("Error merging message.");
+  }
+}
+
+void RegisterProtoBindings(module m) {
+  // Return whether the given python object is a wrapped C proto.
+  m.def("is_wrapped_c_proto_deprecated", &IsWrappedCProto, arg("src"));
+
+  // Construct and optionally initialize a wrapped C proto.
+  m.def("make_wrapped_c_proto", &PyProtoAllocateMessage<::google::protobuf::Message>,
+        arg("type"),
+        "Returns a wrapped C proto of the given type. The type may be passed "
+        "as a string ('package_name.MessageName'), an instance of a native "
+        "python proto, or an instance of a wrapped C proto. Fields may be "
+        "initialized with keyword arguments, as with the native constructors. "
+        "The C++ version of the proto library for your message type must be "
+        "linked in for this to work.");
+
+  // Add bindings for the descriptor class.
+  class_<::google::protobuf::Descriptor> message_desc_c(m, "Descriptor", dynamic_attr());
+  DefConstantProperty(&message_desc_c, "fields_by_name", &MessageFieldsByName);
+  DefConstantProperty(&message_desc_c, "fields", &MessageFields);
+  message_desc_c
+      .def_property_readonly("full_name", &::google::protobuf::Descriptor::full_name)
+      .def_property_readonly("name", &::google::protobuf::Descriptor::name)
+      .def_property_readonly("has_options",
+                             [](::google::protobuf::Descriptor*) { return true; })
+      .def(
+          "GetOptions",
+          [](::google::protobuf::Descriptor* descriptor) -> const ::google::protobuf::Message* {
+            return &descriptor->options();
+          },
+          return_value_policy::reference);
+
+  // Add bindings for the enum descriptor class.
+  class_<::google::protobuf::EnumDescriptor> enum_desc_c(m, "EnumDescriptor",
+                                             dynamic_attr());
+  DefConstantProperty(&enum_desc_c, "values_by_number", &EnumValuesByNumber);
+  DefConstantProperty(&enum_desc_c, "values_by_name", &EnumValuesByName);
+  enum_desc_c.def_property_readonly("name", &::google::protobuf::EnumDescriptor::name);
+
+  // Add bindings for the enum value descriptor class.
+  class_<::google::protobuf::EnumValueDescriptor>(m, "EnumValueDescriptor")
+      .def_property_readonly("name", &::google::protobuf::EnumValueDescriptor::name)
+      .def_property_readonly("number", &::google::protobuf::EnumValueDescriptor::number);
+
+  // Add bindings for the field descriptor class.
+  class_<::google::protobuf::FieldDescriptor> field_desc_c(m, "FieldDescriptor");
+  field_desc_c.def_property_readonly("name", &::google::protobuf::FieldDescriptor::name)
+      .def_property_readonly("type", &::google::protobuf::FieldDescriptor::type)
+      .def_property_readonly("cpp_type", &::google::protobuf::FieldDescriptor::cpp_type)
+      .def_property_readonly("containing_type",
+                             &::google::protobuf::FieldDescriptor::containing_type,
+                             return_value_policy::reference)
+      .def_property_readonly("message_type",
+                             &::google::protobuf::FieldDescriptor::message_type,
+                             return_value_policy::reference)
+      .def_property_readonly("enum_type", &::google::protobuf::FieldDescriptor::enum_type,
+                             return_value_policy::reference)
+      .def_property_readonly("is_extension",
+                             &::google::protobuf::FieldDescriptor::is_extension)
+      .def_property_readonly("label", &::google::protobuf::FieldDescriptor::label)
+      // Oneof fields are not currently supported.
+      .def_property_readonly("containing_oneof", [](void*) { return false; });
+
+  // Add Type enum values.
+  enum_<::google::protobuf::FieldDescriptor::Type>(field_desc_c, "Type")
+      .value("TYPE_DOUBLE", ::google::protobuf::FieldDescriptor::TYPE_DOUBLE)
+      .value("TYPE_FLOAT", ::google::protobuf::FieldDescriptor::TYPE_FLOAT)
+      .value("TYPE_INT64", ::google::protobuf::FieldDescriptor::TYPE_INT64)
+      .value("TYPE_UINT64", ::google::protobuf::FieldDescriptor::TYPE_UINT64)
+      .value("TYPE_INT32", ::google::protobuf::FieldDescriptor::TYPE_INT32)
+      .value("TYPE_FIXED64", ::google::protobuf::FieldDescriptor::TYPE_FIXED64)
+      .value("TYPE_FIXED32", ::google::protobuf::FieldDescriptor::TYPE_FIXED32)
+      .value("TYPE_BOOL", ::google::protobuf::FieldDescriptor::TYPE_BOOL)
+      .value("TYPE_STRING", ::google::protobuf::FieldDescriptor::TYPE_STRING)
+      .value("TYPE_GROUP", ::google::protobuf::FieldDescriptor::TYPE_GROUP)
+      .value("TYPE_MESSAGE", ::google::protobuf::FieldDescriptor::TYPE_MESSAGE)
+      .value("TYPE_BYTES", ::google::protobuf::FieldDescriptor::TYPE_BYTES)
+      .value("TYPE_UINT32", ::google::protobuf::FieldDescriptor::TYPE_UINT32)
+      .value("TYPE_ENUM", ::google::protobuf::FieldDescriptor::TYPE_ENUM)
+      .value("TYPE_SFIXED32", ::google::protobuf::FieldDescriptor::TYPE_SFIXED32)
+      .value("TYPE_SFIXED64", ::google::protobuf::FieldDescriptor::TYPE_SFIXED64)
+      .value("TYPE_SINT32", ::google::protobuf::FieldDescriptor::TYPE_SINT32)
+      .value("TYPE_SINT64", ::google::protobuf::FieldDescriptor::TYPE_SINT64)
+      .export_values();
+
+  // Add C++ Type enum values.
+  enum_<::google::protobuf::FieldDescriptor::CppType>(field_desc_c, "CppType")
+      .value("CPPTYPE_INT32", ::google::protobuf::FieldDescriptor::CPPTYPE_INT32)
+      .value("CPPTYPE_INT64", ::google::protobuf::FieldDescriptor::CPPTYPE_INT64)
+      .value("CPPTYPE_UINT32", ::google::protobuf::FieldDescriptor::CPPTYPE_UINT32)
+      .value("CPPTYPE_UINT64", ::google::protobuf::FieldDescriptor::CPPTYPE_UINT64)
+      .value("CPPTYPE_DOUBLE", ::google::protobuf::FieldDescriptor::CPPTYPE_DOUBLE)
+      .value("CPPTYPE_FLOAT", ::google::protobuf::FieldDescriptor::CPPTYPE_FLOAT)
+      .value("CPPTYPE_BOOL", ::google::protobuf::FieldDescriptor::CPPTYPE_BOOL)
+      .value("CPPTYPE_ENUM", ::google::protobuf::FieldDescriptor::CPPTYPE_ENUM)
+      .value("CPPTYPE_STRING", ::google::protobuf::FieldDescriptor::CPPTYPE_STRING)
+      .value("CPPTYPE_MESSAGE", ::google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE)
+      .export_values();
+
+  // Add Label enum values.
+  enum_<::google::protobuf::FieldDescriptor::Label>(field_desc_c, "Label")
+      .value("LABEL_OPTIONAL", ::google::protobuf::FieldDescriptor::LABEL_OPTIONAL)
+      .value("LABEL_REQUIRED", ::google::protobuf::FieldDescriptor::LABEL_REQUIRED)
+      .value("LABEL_REPEATED", ::google::protobuf::FieldDescriptor::LABEL_REPEATED)
+      .export_values();
+
+  // Add bindings for the base message class.
+  // These bindings use __getattr__, __setattr__ and the reflection interface
+  // to access message-specific fields, so no additional bindings are needed
+  // for derived message types.
+  class_<::google::protobuf::Message, std::shared_ptr<::google::protobuf::Message>>(m, "ProtoMessage")
+      .def_property_readonly("DESCRIPTOR", &::google::protobuf::Message::GetDescriptor,
+                             return_value_policy::reference)
+      .def_property_readonly(kIsWrappedCProtoAttr, [](void*) { return true; })
+      .def("__repr__", &::google::protobuf::Message::DebugString)
+      .def("__getattr__",
+           (object(*)(::google::protobuf::Message*, absl::string_view)) & ProtoGetField)
+      .def("__setattr__",
+           (void (*)(::google::protobuf::Message*, absl::string_view, handle)) &
+               ProtoSetField)
+      .def("SerializeToString",
+           [](::google::protobuf::Message* msg, kwargs kwargs_in) {
+             return MessageSerializeAsString(msg, kwargs_in, false);
+           })
+      .def("SerializePartialToString",
+           [](::google::protobuf::Message* msg, kwargs kwargs_in) {
+             return MessageSerializeAsString(msg, kwargs_in, true);
+           })
+      .def("ParseFromString", &::google::protobuf::Message::ParseFromString, arg("data"))
+      .def("MergeFromString", &::google::protobuf::Message::MergeFromString, arg("data"))
+      .def("ByteSize", &::google::protobuf::Message::ByteSizeLong)
+      .def("Clear", &::google::protobuf::Message::Clear)
+      .def("CopyFrom", &ProtoCopyFrom)
+      .def("MergeFrom", &ProtoMergeFrom)
+      .def("FindInitializationErrors", &MessageFindInitializationErrors,
+           "Slowly build a list of all required fields that are not set.")
+      .def("ListFields", &MessageListFields)
+      .def("HasField", &MessageHasField, arg("field_name"))
+      .def("ClearField", &MessageClearField, arg("field_name"))
+      .def("WhichOneof", &MessageWhichOneof, arg("oneof_group"),
+           return_value_policy::copy)
+      .def(MakePickler<::google::protobuf::Message>())
+      .def("__copy__",
+           [](object self) {
+             return PyProtoAllocateAndCopyMessage<::google::protobuf::Message>(self);
+           })
+      .def(
+          "__deepcopy__",
+          [](object self, dict) {
+            return PyProtoAllocateAndCopyMessage<::google::protobuf::Message>(self);
+          },
+          arg("memo"))
+      .def(
+          "SetInParent", [](::google::protobuf::Message*) {},
+          "No-op. Provided only for compatability with text_format.");
+
+  // Add bindings for the repeated field containers.
+  BindEachFieldType<RepeatedFieldBindings>(m, "Repeated");
+
+  // Add bindings for the map field containers.
+  BindEachFieldType<MapFieldBindings>(m, "Mapped");
+
+  // Add bindings for the map field iterators.
+  BindEachFieldType<MapFieldIteratorBindings>(m, "Mapped");
+
+  // Add bindings for the well-known-types.
+  // TODO(rwgk): Consider adding support for other types/methods defined in
+  // google3/net/proto2/python/internal/well_known_types.py
+  ConcreteProtoMessageBindings<::google::protobuf::Any>(m)
+      .def("Is",
+           [](const ::google::protobuf::Any& self, handle descriptor) {
+             std::string name;
+             if (!::google::protobuf::Any::ParseAnyTypeUrl(
+                     std::string(self.type_url()), &name))
+               return false;
+             return name == static_cast<std::string>(
+                                str(getattr(descriptor, "full_name")));
+           })
+      .def("TypeName",
+           [](const ::google::protobuf::Any& self) {
+             std::string name;
+             ::google::protobuf::Any::ParseAnyTypeUrl(
+                 std::string(self.type_url()), &name);
+             return name;
+           })
+      .def("Pack",
+           [](::google::protobuf::Any* self, handle py_proto) {
+             if (!AnyPackFromPyProto(py_proto, self))
+               throw std::invalid_argument("Failed to pack Any proto.");
+           })
+      .def("Unpack", &AnyUnpackToPyProto);
+}
+
+}  // namespace google
+}  // namespace pybind11

--- a/pybind11_protobuf/proto_utils.h
+++ b/pybind11_protobuf/proto_utils.h
@@ -1,0 +1,222 @@
+// Copyright (c) 2019 The Pybind Development Team. All rights reserved.
+//
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#ifndef PYBIND11_PROTOBUF_PROTO_UTILS_H_
+#define PYBIND11_PROTOBUF_PROTO_UTILS_H_
+
+#include <pybind11/cast.h>
+#include <pybind11/functional.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
+#include <pybind11/stl.h>
+
+#include <cstddef>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include <google/protobuf/any.pb.h>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/message.h>
+#include <google/protobuf/reflection.h>
+//#include "absl/strings/string_view.h"
+
+namespace pybind11 {
+namespace google {
+
+// Alias for checking whether a c++ type is a proto.
+template <typename T>
+static constexpr bool is_proto_v = std::is_base_of<::google::protobuf::Message, T>::value;
+
+// Name of the property which indicates whether a proto is a wrapped or native.
+constexpr char kIsWrappedCProtoAttr[] = "_is_wrapped_c_proto";
+
+// Returns true if the given python object is a wrapped C proto.
+inline bool IsWrappedCProto(handle handle) {
+  return hasattr(handle, kIsWrappedCProtoAttr);
+}
+
+// Gets the field with the given name from the given message as a python object.
+object ProtoGetField(::google::protobuf::Message* message, absl::string_view name);
+object ProtoGetField(::google::protobuf::Message* message,
+                     const ::google::protobuf::FieldDescriptor* field_desc);
+
+// Sets the field with the given name in the given message from a python object.
+// As in the native API, message, repeated, and map fields cannot be set.
+void ProtoSetField(::google::protobuf::Message* message, absl::string_view name,
+                   handle value);
+void ProtoSetField(::google::protobuf::Message* message,
+                   const ::google::protobuf::FieldDescriptor* field_desc, handle value);
+
+// Initializes the fields in the given message from the the keyword args.
+// Unlike ProtoSetField, this allows setting message, map and repeated fields.
+void ProtoInitFields(::google::protobuf::Message* message, kwargs kwargs_in);
+
+// Wrapper around ::google::protobuf::Message::CopyFrom which can efficiently copy from
+// either a wrapped C++ or native python proto. Throws an error if `other`
+// is not a proto of the correct type.
+void ProtoCopyFrom(::google::protobuf::Message* msg, handle other);
+
+// Wrapper around ::google::protobuf::Message::MergeFrom which can efficiently merge from
+// either a wrapped C++ or native python proto. Throws an error if `other`
+// is not a proto of the correct type.
+void ProtoMergeFrom(::google::protobuf::Message* msg, handle other);
+
+// If py_proto is a native c or wrapped python proto, sets name and returns
+// true. If py_proto is not a proto, returns false.
+bool PyProtoFullName(handle py_proto, std::string* name);
+
+// Returns whether py_proto is a proto and matches the expected_type.
+bool PyProtoCheckType(handle py_proto, const std::string& expected_type);
+// Throws a type error if py_proto is not a proto or the wrong message type.
+void PyProtoCheckTypeOrThrow(handle py_proto, const std::string& expected_type);
+
+// Returns whether py_proto is a proto and matches the ProtoType.
+template <typename ProtoType>
+bool PyProtoCheckType(handle py_proto) {
+  return PyProtoCheckType(py_proto, ProtoType::descriptor()->full_name());
+}
+
+// Returns whether py_proto is a proto based on whether it has a descriptor
+// with the name of the proto.
+template <>
+inline bool PyProtoCheckType<::google::protobuf::Message>(handle py_proto) {
+  return PyProtoFullName(py_proto, nullptr);
+}
+
+// Returns the serialized version of the given (native or wrapped) python proto.
+std::string PyProtoSerializeToString(handle py_proto);
+
+// Gets the descriptor for the proto specified by the argument, which can be a
+// native python proto, a wrapped C proto, or a string with the full type name.
+const ::google::protobuf::Descriptor* PyProtoGetDescriptor(handle py_proto);
+
+// Allocate and return the ProtoType given by the template argument.
+// py_proto is not used in this version, but is used by a specialization below.
+template <typename ProtoType>
+std::unique_ptr<ProtoType> PyProtoAllocateMessage(handle py_proto = handle(),
+                                                  kwargs kwargs_in = kwargs()) {
+  auto message = std::make_unique<ProtoType>();
+  ProtoInitFields(message.get(), kwargs_in);
+  return message;
+}
+
+// Specialization for the case that the template argument is a generic message.
+// The type is pulled from the py_proto, which can be a native python proto,
+// a wrapped C proto, or a string with the full type name.
+template <>
+std::unique_ptr<::google::protobuf::Message> PyProtoAllocateMessage(handle py_proto,
+                                                        kwargs kwargs_in);
+
+// Allocate and return a message instance for the given descriptor.
+std::unique_ptr<::google::protobuf::Message> PyProtoAllocateMessage(
+    const ::google::protobuf::Descriptor* descriptor, kwargs kwargs_in);
+
+// Allocate a C++ proto of the same type as py_proto and copy the contents
+// from py_proto. This works whether py_proto is a native or wrapped proto.
+// If expected_type is given and the type in py_proto does not match it, an
+// invalid argument error will be thrown.
+template <typename ProtoType>
+std::unique_ptr<ProtoType> PyProtoAllocateAndCopyMessage(handle py_proto) {
+  auto new_msg = PyProtoAllocateMessage<ProtoType>(py_proto);
+  ProtoCopyFrom(new_msg.get(), py_proto);
+  return new_msg;
+}
+
+// Pack an any proto from a proto, regardless of whether it is a native python
+// or wrapped c proto. Using the converter on a native python proto would
+// require serializing-deserializing-serializing again, while this always
+// requires only 1 serialization operation. Returns true on success.
+bool AnyPackFromPyProto(handle py_proto, ::google::protobuf::Any* any_proto);
+
+// Unpack the given any proto into the given py_proto, regardless of whether it
+// is a native python or wrapped c proto. Returns true on success.
+bool AnyUnpackToPyProto(const ::google::protobuf::Any& any_proto,
+                        handle py_proto);
+
+// Returns the pickle bindings (passed to class_::def) for ProtoType.
+template <typename ProtoType>
+decltype(auto) MakePickler() {
+  return pybind11::pickle(
+      [](ProtoType* message) {
+        return dict("serialized"_a = bytes(message->SerializeAsString()),
+                    "type_name"_a = message->GetTypeName());
+      },
+      [](dict d) {
+        auto message = PyProtoAllocateMessage<ProtoType>(d["type_name"]);
+        // TODO(b/145925674): skip creation of temporary string once bytes
+        // supports string_view casting.
+        message->ParseFromString(std::string(d["serialized"].cast<bytes>()));
+        return message;
+      });
+}
+
+// Add bindings for the given concrete ProtoType, returning the class_ instance
+// so that type-specific bindings can be added. This should only be used with
+// well known types (google3/net/proto2/python/internal/well_known_types.py);
+// all other message types should use RegisterProtoMessageType.
+template <typename ProtoType>
+auto ConcreteProtoMessageBindings(handle module) {
+  // Register the type.
+  auto* descriptor = ProtoType::GetDescriptor();
+  const char* registered_name = descriptor->name().c_str();
+  class_<ProtoType, ::google::protobuf::Message, std::shared_ptr<ProtoType>> message_c(
+      module, registered_name);
+  // Add a constructor.
+  message_c.def(init([](kwargs kwargs_in) {
+    return PyProtoAllocateMessage<ProtoType>(handle(), kwargs_in);
+  }));
+  // Create a pickler for this type (the base class pickler will fail).
+  message_c.def(MakePickler<ProtoType>());
+  message_c.def("__copy__", [](object self) {
+      return PyProtoAllocateAndCopyMessage<ProtoType>(self);
+      });
+  message_c.def("__deepcopy__", [](object self, dict) {
+      return PyProtoAllocateAndCopyMessage<ProtoType>(self);
+      }, arg("memo"));
+  // Add the descriptor as a static field.
+  message_c.def_readonly_static("DESCRIPTOR", descriptor);
+  // Add bindings for each field, to avoid the FindFieldByName lookup.
+  for (int i = 0; i < descriptor->field_count(); ++i) {
+    auto* field_desc = descriptor->field(i);
+    message_c.def_property(
+        field_desc->name().c_str(),
+        [field_desc](::google::protobuf::Message* message) {
+          return ProtoGetField(message, field_desc);
+        },
+        [field_desc](::google::protobuf::Message* message, handle value) {
+          ProtoSetField(message, field_desc, value);
+        });
+  }
+  return message_c;
+}
+
+// Registers the bindings for the proto base types in the given module. Can only
+// be called once; subsequent calls will fail due to duplicate registrations.
+void RegisterProtoBindings(module m);
+
+// If modifying the functions below, see
+// g3doc/pybind11_protobuf/README.md#importing-the-proto-module
+
+// Returns true if the proto module has been imported.
+inline bool IsProtoModuleImported() {
+  return detail::get_type_info(typeid(::google::protobuf::Message));
+}
+
+// In debug mode, throws a type error if the proto module is not imported.
+// No-opt if NDEBUG is defined, and inlined so the compiler can optimize it out.
+inline void CheckProtoModuleImported() {
+#ifndef NDEBUG
+  if (!IsProtoModuleImported())
+    throw type_error(
+        "Proto module has not been imported. Did you call ::pybind11::google"
+        "::ImportProtoModule() in your PYBIND11_MODULE definition?");
+#endif
+}
+
+}  // namespace google
+}  // namespace pybind11
+
+#endif  // PYBIND11_PROTOBUF_PROTO_UTILS_H_

--- a/pybind11_protobuf/proto_utils.h
+++ b/pybind11_protobuf/proto_utils.h
@@ -17,11 +17,10 @@
 #include <stdexcept>
 #include <string>
 
-#include <google/protobuf/any.pb.h>
-#include <google/protobuf/descriptor.h>
-#include <google/protobuf/message.h>
-#include <google/protobuf/reflection.h>
-//#include "absl/strings/string_view.h"
+#include "google/protobuf/any.pb.h"
+#include "google/protobuf/descriptor.h"
+#include "google/protobuf/message.h"
+#include "google/protobuf/reflection.h"
 
 namespace pybind11 {
 namespace google {
@@ -39,13 +38,13 @@ inline bool IsWrappedCProto(handle handle) {
 }
 
 // Gets the field with the given name from the given message as a python object.
-object ProtoGetField(::google::protobuf::Message* message, absl::string_view name);
+object ProtoGetField(::google::protobuf::Message* message, const std::string& name);
 object ProtoGetField(::google::protobuf::Message* message,
                      const ::google::protobuf::FieldDescriptor* field_desc);
 
 // Sets the field with the given name in the given message from a python object.
 // As in the native API, message, repeated, and map fields cannot be set.
-void ProtoSetField(::google::protobuf::Message* message, absl::string_view name,
+void ProtoSetField(::google::protobuf::Message* message, const std::string& name,
                    handle value);
 void ProtoSetField(::google::protobuf::Message* message,
                    const ::google::protobuf::FieldDescriptor* field_desc, handle value);

--- a/pybind11_protobuf/wrapped_proto_caster.h
+++ b/pybind11_protobuf/wrapped_proto_caster.h
@@ -1,0 +1,514 @@
+#ifndef PYBIND11_PROTOBUF_WRAPPED_PROTO_CASTER_H_
+#define PYBIND11_PROTOBUF_WRAPPED_PROTO_CASTER_H_
+
+#include <pybind11/cast.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include <google/protobuf/message.h>
+//#include "absl/status/statusor.h"
+//#include "absl/types/optional.h"
+#include "proto_cast_util.h"
+#include "proto_caster_impl.h"
+
+// pybind11::type_caster<> specialization for ::google::protobuf::Message types using
+// pybind11_protobuf::WrappedProto<> wrappers. When passing from C++ to
+// python a copy is always made. When passing from python to C++ a copy is
+// made for mutable and by-value types, but not for const reference types.
+//
+// This is intended as a migration aid until such a time as proto_casters.h
+// can be replaced with native_proto_caster.h.
+//
+// Example:
+//
+// #include <pybind11/pybind11.h>
+// #include "pybind11_protobuf/wrapped_proto_casters.h"
+//
+// MyMessage GetMessage() { ... }
+//
+// PYBIND11_MODULE(my_module, m) {
+//   pybind11_protobuf::ImportWrappedProtoCasters();
+//
+//   using pybind11_protobuf::WithWrappedProtos;
+//
+//   m.def("get_message", WithWrappedProtos(&GetMessage));
+// }
+//
+// Under the covers, WithWrappedProtos(...) maps by-const or by-value
+// proto::Message subtype method argument and return types to a transparent
+// wrapper, WrappedProto<T, Kind> types which are then handled by a specialized
+// pybind11::type_caster.
+//
+// Mutable types are not automatically converted, as the always-copy
+// semantics may be misleading for this conversion, and callers likely need to
+// make adjustments to the caller or return types of such code. Of particluar
+// note, builder-style classes may be better implemented independently in
+// python rather than attempting to wrap C++ counterparts.
+//
+//
+// Users of wrapped_proto_caster based extensions need dependencies on:
+// deps = [ "@com_google_protobuf//:protobuf_python" ]
+//
+
+namespace pybind11_protobuf {
+
+// Imports modules for protobuf conversion. This not thread safe and
+// is required to be called from a PYBIND11_MODULE definition before use.
+inline void ImportWrappedProtoCasters() { InitializePybindProtoCastUtil(); }
+
+/// Tag types for WrappedProto specialization.
+enum WrappedProtoKind : int { kConst, kValue, kMutable };
+
+/// WrappedProto<T, kind> wraps a ::google::protobuf::Message subtype, exposing implicit
+/// constructors and implicit cast operators. The ConstTag variant allows
+/// conversion to const; the MutableTag allows mutable conversion and enables
+/// the type-caster specialization to enforce that a copy is made.
+///
+/// WrappedProto<T, kMutable> ALWAYS creates a copy.
+/// WrappedProto<T, kValue> ALWAYS creates a copy.
+/// WrappedProto<T, kConst> may either copy or share the underlying class.
+template <typename ProtoType, WrappedProtoKind Kind>
+struct WrappedProto;
+
+template <typename ProtoType>
+struct WrappedProto<ProtoType, WrappedProtoKind::kMutable> {
+  using type = ProtoType;
+  static constexpr WrappedProtoKind kind = WrappedProtoKind::kMutable;
+  ProtoType* proto;
+
+  WrappedProto(ProtoType* p) : proto(p) {}
+  WrappedProto(ProtoType& p) : proto(&p) {}
+  ProtoType* get() noexcept { return proto; }
+
+  operator ProtoType*() noexcept { return proto; }
+  operator ProtoType&() {
+    if (!proto) throw pybind11::reference_cast_error();
+    return *proto;
+  }
+};
+
+template <typename ProtoType>
+struct WrappedProto<ProtoType, WrappedProtoKind::kConst> {
+  using type = ProtoType;
+  static constexpr WrappedProtoKind kind = WrappedProtoKind::kConst;
+  const ProtoType* proto;
+
+  WrappedProto(const ProtoType* p) : proto(p) {}
+  WrappedProto(const ProtoType& p) : proto(&p) {}
+  ProtoType* get() noexcept { return const_cast<ProtoType*>(proto); }
+
+  operator const ProtoType*() const noexcept { return proto; }
+  operator const ProtoType&() const {
+    if (!proto) throw pybind11::reference_cast_error();
+    return *proto;
+  }
+};
+
+template <typename ProtoType>
+struct WrappedProto<ProtoType, WrappedProtoKind::kValue> {
+  using type = ProtoType;
+  static constexpr WrappedProtoKind kind = WrappedProtoKind::kValue;
+  ProtoType proto;
+
+  WrappedProto(ProtoType&& p) : proto(std::move(p)) {}
+  ProtoType* get() noexcept { return &proto; }
+
+  operator ProtoType&&() && noexcept { return std::move(proto); }
+};
+
+// pybind11 type_caster specialization for WrappedProto<T>
+// c++ protocol buffer types.
+template <typename WrappedProtoType>
+struct wrapped_proto_caster : public pybind11_protobuf::proto_caster_load_impl<
+                                  typename WrappedProtoType::type>,
+                              protected pybind11_protobuf::native_cast_impl {
+  using Base = pybind11_protobuf::proto_caster_load_impl<
+      typename WrappedProtoType::type>;
+  using ProtoType = typename WrappedProtoType::type;
+  using Base::ensure_owned;
+  using Base::owned;
+  using Base::value;
+  using pybind11_protobuf::native_cast_impl::cast_impl;
+
+ public:
+  static constexpr auto name = pybind11::detail::_<WrappedProtoType>();
+
+  // cast converts from C++ -> Python
+  static pybind11::handle cast(WrappedProtoType src,
+                               pybind11::return_value_policy policy,
+                               pybind11::handle parent) {
+    if (src.get() == nullptr) return pybind11::none().release();
+    std::unique_ptr<ProtoType> owned;
+
+    if (WrappedProtoType::kind == WrappedProtoKind::kValue) {
+      // When the proto is by-value, it's always possible to move the contents
+      policy = pybind11::return_value_policy::move;
+    } else {
+      // Otherwise take a copy by default.
+      if (policy == pybind11::return_value_policy::automatic ||
+          policy == pybind11::return_value_policy::automatic_reference) {
+        policy = pybind11::return_value_policy::copy;
+      } else if (policy == pybind11::return_value_policy::take_ownership) {
+        owned.reset(const_cast<ProtoType*>(src.get()));
+      }
+    }
+    return cast_impl(
+        src.get(), policy, parent,
+        /*is_const*/ WrappedProtoKind::kConst == WrappedProtoType::kind);
+  }
+
+  // PYBIND11_TYPE_CASTER
+  template <WrappedProtoKind K>
+  typename std::enable_if<(K == WrappedProtoKind::kValue),
+                          WrappedProtoType>::type
+  convert() {
+    // WrappedProto<T, kValue> ALWAYS creates a copy.
+    if (owned) {
+      return std::move(*owned);
+    } else {
+      return ProtoType(*value);
+    }
+  }
+
+  template <WrappedProtoKind K>
+  typename std::enable_if<(K == WrappedProtoKind::kMutable),
+                          WrappedProtoType>::type
+  convert() {
+    // WrappedProto<T, kMutable> ALWAYS creates a copy.
+    ensure_owned();
+    return owned.get();
+  }
+
+  template <WrappedProtoKind K>
+  typename std::enable_if<(K == WrappedProtoKind::kConst),
+                          WrappedProtoType>::type
+  convert() {
+    return value;
+  }
+
+  explicit operator WrappedProtoType() {
+    return this->template convert<WrappedProtoType::kind>();
+  }
+
+  template <typename T_>
+  using cast_op_type = WrappedProtoType;
+};
+
+/// Support for wrapping methods using std::vector<ProtoType> with
+/// WithWrappedProto.
+///
+/// In the single-proto cases, a transparent wrapper, WrappedProto<Proto, Kind>,
+/// is used to select the native proto pybind11 type_caster<> and avoid ODR
+/// issues. That mechanism doesn't work very well for containers, since to
+/// convert from a std::vector<Wrapper<X>> to std::vector<X> involves a
+/// copy/move, even if the wrapper is trivial.
+///
+/// This workaround takes a similar tack to the WrappedProto<> transparent
+/// wrapper: Create a transparent wrapper of std::vector<T>, and implement a
+/// custom type_caster to delegate the conversion of the inner Proto type to
+/// native_proto_caster, avoiding the default pybind11 list_caster conversion
+/// and make_type_caster<> selection.  WrapHelper applies the rewrite to the
+/// functions.
+///
+/// NOTE: This always copies values, similar to WrappedProto<Kind, kValue>.
+
+/// WrappedProtoVector<T> wraps a std::vector<T>. It is used to add std::vector
+/// support for WithWrappedProtos by forwarding the internal T to the native
+/// proto casters.
+template <typename ProtoType>
+struct WrappedProtoVector {
+  std::vector<ProtoType> protos;
+
+  WrappedProtoVector() = default;
+
+  WrappedProtoVector(WrappedProtoVector&&) = default;
+  WrappedProtoVector(const WrappedProtoVector&) = default;
+  WrappedProtoVector& operator=(WrappedProtoVector&&) = default;
+  WrappedProtoVector& operator=(const WrappedProtoVector&) = default;
+
+  WrappedProtoVector(std::vector<ProtoType>&& p) : protos(std::move(p)) {}
+
+  operator std::vector<ProtoType>&&() && noexcept { return std::move(protos); }
+};
+
+// type_caster<> implementation for WrappedProtoVector. See
+// pybind11::list_caster.
+template <typename ProtoType>
+struct wrapped_proto_vector_caster {
+  static constexpr auto name =
+      (pybind11::detail::const_name("List[") +
+       pybind11::detail::_<ProtoType>() + pybind11::detail::const_name("]"));
+
+  // cast converts from Python -> C++
+  bool load(pybind11::handle src, bool convert) {
+    using load_impl = pybind11_protobuf::proto_caster_load_impl<ProtoType>;
+
+    if (!pybind11::isinstance<pybind11::sequence>(src) ||
+        pybind11::isinstance<pybind11::bytes>(src) ||
+        pybind11::isinstance<pybind11::str>(src)) {
+      return false;
+    }
+    auto s = pybind11::reinterpret_borrow<pybind11::sequence>(src);
+    value.protos.clear();
+    value.protos.reserve(s.size());
+    for (auto it : s) {
+      load_impl conv;
+      if (!conv.load(it, convert)) {
+        return false;
+      }
+      if (conv.owned) {
+        value.protos.emplace_back(std::move(*conv.owned));
+      } else {
+        value.protos.emplace_back(*conv.value);
+      }
+    }
+    return true;
+  }
+
+  // cast converts from C++ -> Python
+  static pybind11::handle cast(WrappedProtoVector<ProtoType> src,
+                               pybind11::return_value_policy policy,
+                               pybind11::handle parent) {
+    pybind11::list l(src.protos.size());
+    ssize_t index = 0;
+    for (auto&& value : src.protos) {
+      auto value_ = pybind11::reinterpret_steal<pybind11::object>(
+          pybind11_protobuf::native_cast_impl::cast_impl(
+              &value, pybind11::return_value_policy::move, parent,
+              /*is_const*/ false));
+      if (!value_) {
+        return pybind11::handle();
+      }
+      PyList_SET_ITEM(l.ptr(), index++,
+                      value_.release().ptr());  // steals a reference
+    }
+    return l.release();
+  }
+
+  explicit operator WrappedProtoVector<ProtoType>&&() && {
+    return std::move(value);
+  }
+
+  template <typename T_>
+  using cast_op_type = WrappedProtoVector<ProtoType>&&;
+
+  WrappedProtoVector<ProtoType> value;
+};
+
+// Implementation details for WithWrappedProtos
+namespace impl {
+
+template <typename T>
+using intrinsic_t =
+    typename pybind11::detail::intrinsic_t<std::remove_reference_t<T>>;
+
+template <typename T>
+constexpr WrappedProtoKind DetectKind() {
+  using no_ref_t = std::remove_reference_t<T>;
+  using base_t = intrinsic_t<no_ref_t>;
+
+  if (std::is_same<no_ref_t, const base_t*>::value) {
+    return WrappedProtoKind::kConst;
+  } else if (std::is_same<no_ref_t, base_t*>::value) {
+    return WrappedProtoKind::kMutable;
+  } else if (std::is_same<T, const base_t&>::value) {
+    return WrappedProtoKind::kConst;
+  } else if (std::is_same<T, base_t&>::value) {
+    return WrappedProtoKind::kMutable;
+  } else {
+    return WrappedProtoKind::kValue;
+  }
+}
+
+template <typename T, typename SFINAE = void>
+struct WrapHelper {
+  using type = T;
+};
+
+// Rewrite Proto to WrappedProto<Proto, Kind>
+template <typename ProtoType>
+struct WrapHelper<ProtoType,  //
+                  std::enable_if_t<std::is_base_of<
+                      ::google::protobuf::Message, intrinsic_t<ProtoType>>::value>> {
+  static constexpr auto kKind = DetectKind<ProtoType>();
+  static_assert(kKind != WrappedProtoKind::kMutable,
+                "WithWrappedProtos() does not support mutable ::google::protobuf::Message "
+                "parameters.");
+
+  using type = WrappedProto<intrinsic_t<ProtoType>, kKind>;
+};
+
+// absl::optional is also sometimes used as a wrapper for optional protos.
+template <typename ProtoType>
+struct WrapHelper<absl::optional<ProtoType>,  //
+                  std::enable_if_t<std::is_base_of<
+                      ::google::protobuf::Message, intrinsic_t<ProtoType>>::value>> {
+  static constexpr auto kKind = DetectKind<ProtoType>();
+  static_assert(kKind != WrappedProtoKind::kMutable,
+                "WithWrappedProtos() does not support mutable ::google::protobuf::Message "
+                "parameters.");
+
+  using type = absl::optional<WrappedProto<intrinsic_t<ProtoType>, kKind>>;
+};
+
+// absl::StatusOr is a common wrapper so also propagate WrappedProto into
+// StatusOr types.  When wrapped by WithWrappedProtos, ensure that
+// pybind11_abseil/status_casters.h is included and follow the instructions
+// there.
+template <typename ProtoType>
+struct WrapHelper<absl::StatusOr<ProtoType>,  //
+                  std::enable_if_t<std::is_base_of<
+                      ::google::protobuf::Message, intrinsic_t<ProtoType>>::value>> {
+  static constexpr auto kKind = DetectKind<ProtoType>();
+  static_assert(kKind != WrappedProtoKind::kMutable,
+                "WithWrappedProtos() does not support mutable ::google::protobuf::Message "
+                "parameters.");
+
+  using type = absl::StatusOr<WrappedProto<intrinsic_t<ProtoType>, kKind>>;
+};
+
+// Also rewrite std::vector<Proto> to WrappedProtoVector<Proto> when passed by
+// const reference or by value.
+template <typename ProtoType>
+struct WrapHelper<std::vector<ProtoType>,  //
+                  std::enable_if_t<std::is_base_of<
+                      ::google::protobuf::Message, intrinsic_t<ProtoType>>::value>> {
+  using type = WrappedProtoVector<ProtoType>;
+};
+template <typename ProtoType>
+struct WrapHelper<const std::vector<ProtoType>&,  //
+                  std::enable_if_t<std::is_base_of<
+                      ::google::protobuf::Message, intrinsic_t<ProtoType>>::value>> {
+  using type = WrappedProtoVector<ProtoType>;
+};
+
+// And absl::StatusOr<std::vector<Proto>>
+template <typename ProtoType>
+struct WrapHelper<absl::StatusOr<std::vector<ProtoType>>,  //
+                  std::enable_if_t<std::is_base_of<
+                      ::google::protobuf::Message, intrinsic_t<ProtoType>>::value>> {
+  using type = absl::StatusOr<WrappedProtoVector<ProtoType>>;
+};
+
+/// FunctionInvoker/ConstMemberInvoker/MemberInvoker are internal functions
+/// that expose calls with equivalent signatures, replacing ::google::protobuf::Message
+/// derived types with WrappedProto<T, ...> types.
+template <typename F, typename>
+struct FunctionInvoker;
+
+template <typename F, typename R, typename... Args>
+struct FunctionInvoker<F, R(Args...)> {
+  F f;
+  typename WrapHelper<R>::type operator()(
+      typename WrapHelper<Args>::type... args) const {
+    return f(std::forward<decltype(args)>(args)...);
+  }
+};
+
+template <typename F, typename R, typename... Args>
+struct FunctionInvoker<F, R(Args...) const> {
+  F f;
+  typename WrapHelper<R>::type operator()(
+      typename WrapHelper<Args>::type... args) const {
+    return f(std::forward<decltype(args)>(args)...);
+  }
+};
+
+template <typename C, typename R, typename... Args>
+struct ConstMemberInvoker {
+  static_assert(!std::is_base_of<::google::protobuf::Message, C>::value,
+                "WithWrappedProtos should not be used on methods generated by "
+                "the protocol buffer compiler");
+
+  R (C::*f)(Args...) const;
+  typename WrapHelper<R>::type operator()(
+      const C& c, typename WrapHelper<Args>::type... args) const {
+    return (c.*f)(std::forward<decltype(args)>(args)...);
+  }
+};
+
+template <typename C, typename R, typename... Args>
+struct MemberInvoker {
+  static_assert(!std::is_base_of<::google::protobuf::Message, C>::value,
+                "WithWrappedProtos should not be used on methods generated by "
+                "the protocol buffer compiler");
+
+  R (C::*f)(Args...);
+  typename WrapHelper<R>::type operator()(
+      C& c, typename WrapHelper<Args>::type... args) const {
+    return (c.*f)(std::forward<decltype(args)>(args)...);
+  }
+};
+
+/// Helper to extract a member function signature. A lambda or other functor's
+/// operator() signature can be extracted, when present, via:
+///   LambdaSignature<decltype(&T::operator())>::type
+template <typename>
+struct LambdaSignature;
+
+template <typename U, typename T>
+struct LambdaSignature<U T::*> {
+  using type = U;
+};
+
+}  // namespace impl
+
+/// WithWrappedProtos(...) wraps a function type and converts any
+/// ::google::protobuf::Message derived types into a WrappedProto<...> of the same
+/// underlying proto2 type.
+template <typename F, int&... ExplicitArgumentBarrier,
+          typename S = impl::LambdaSignature<decltype(&F::operator())>>
+auto WithWrappedProtos(F f) ->
+    typename impl::FunctionInvoker<F, typename S::type> {
+  return {std::move(f)};
+}
+
+template <typename R, typename... Args>
+impl::FunctionInvoker<R (*)(Args...), R(Args...)>  //
+WithWrappedProtos(R (*f)(Args...)) {
+  return {f};
+}
+
+template <typename R, typename C, typename... Args>
+impl::MemberInvoker<C, R, Args...>  //
+WithWrappedProtos(R (C::*f)(Args...)) {
+  return {f};
+}
+
+template <typename R, typename C, typename... Args>
+impl::ConstMemberInvoker<C, R, Args...>  //
+WithWrappedProtos(R (C::*f)(Args...) const) {
+  return {f};
+}
+
+}  // namespace pybind11_protobuf
+namespace pybind11 {
+namespace detail {
+
+// pybind11 type_caster<> specialization for c++ protocol buffer types using
+// inheritance from pybind11_protobuf::wrapped_proto_caster<>.
+template <typename ProtoType, pybind11_protobuf::WrappedProtoKind Kind>
+struct type_caster<
+    pybind11_protobuf::WrappedProto<ProtoType, Kind>,
+    std::enable_if_t<std::is_base_of<::google::protobuf::Message, ProtoType>::value>>
+    : public pybind11_protobuf::wrapped_proto_caster<
+          pybind11_protobuf::WrappedProto<ProtoType, Kind>> {};
+
+// pybind11 type_caster<> specialization for WrappedProtoVector<proto>.
+template <typename ProtoType>
+struct type_caster<
+    pybind11_protobuf::WrappedProtoVector<ProtoType>,
+    std::enable_if_t<std::is_base_of<::google::protobuf::Message, ProtoType>::value>>
+    : public pybind11_protobuf::wrapped_proto_vector_caster<ProtoType> {};
+
+}  // namespace detail
+}  // namespace pybind11
+
+#endif  // PYBIND11_PROTOBUF_WRAPPED_PROTO_CASTER_H_

--- a/pybind11_protobuf/wrapped_proto_caster.h
+++ b/pybind11_protobuf/wrapped_proto_caster.h
@@ -12,11 +12,9 @@
 #include <type_traits>
 #include <utility>
 
-#include <google/protobuf/message.h>
-//#include "absl/status/statusor.h"
-//#include "absl/types/optional.h"
-#include "proto_cast_util.h"
-#include "proto_caster_impl.h"
+#include "google/protobuf/message.h"
+#include "pybind11_protobuf/proto_cast_util.h"
+#include "pybind11_protobuf/proto_caster_impl.h"
 
 // pybind11::type_caster<> specialization for ::google::protobuf::Message types using
 // pybind11_protobuf::WrappedProto<> wrappers. When passing from C++ to


### PR DESCRIPTION
**Description**
Many functions serialize a proto into bytes then deserialized in the C++ binding (checked, infershapes, ...) It could be faster by avoiding this step. This PR tries to make ModelProto and other available through pybind11.

**Motivation and Context**
- Performance
