### PR TITLE
Fix crash: only traverse graph to add symbols if symbol table presents

### DIFF
--- a/onnx/shape_inference/implementation.cc
+++ b/onnx/shape_inference/implementation.cc
@@ -428,7 +428,9 @@ class ShapeInferenceImplBase {
   }
 
   void process(GraphProto& graph) {
-    TraverseGraphsToAddExistingSymbols(graph, *symbol_table);
+    if (symbol_table) {
+      TraverseGraphsToAddExistingSymbols(graph, *symbol_table);
+    }
     for (auto& vi : *graph.mutable_value_info()) {
       updateType(vi);
     }


### PR DESCRIPTION
**Description**
Fix crash: only traverse graph to add symbols if symbol table presents

**Motivation and Context**
To clarify: it is unrelated to data propagation and TraverseGraphsToAddExistingSymbols was included in the basic shape inference to enable shape inference to infer symbolic shapes for unknown dimensions. After it was added, ONNX graph-level shape inference "always" traverses the whole graph to add existing symbols so current ONNX always presents symbol_table.

However, it's possible that some users rely on C++ ONNX shape inference code and they don't want to infer symbolic shapes at all by making symbol_table as nullptr. ONNX shouldn't crash for that case. Therefore, **checking nullptr for symbol_table every time before dereferencing symbol_table is required.**

Possible further improvement: to simplify API contract, perhaps always create an empty symbol_table if it does not present? but it will disable the option for users not to run symbolic shape inference.

cc @liqunfu @gramalingam