### PR TITLE
[Ready to Merge] extract_model run time optimization

### DIFF
--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -54,9 +54,9 @@ class Extractor:
         if node_output_name in graph_input_names:
             return
         for node in self.graph.node:
-            if node in reachable_nodes:
-                continue
             if node_output_name not in node.output:
+                continue
+            if node in reachable_nodes:
                 continue
             reachable_nodes.append(node)
             for name in node.input:

--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -54,6 +54,7 @@ class Extractor:
         if node_output_name in graph_input_names:
             return
         for node in self.graph.node:
+            # check output_name first to reduce run time
             if node_output_name not in node.output:
                 continue
             if node in reachable_nodes:


### PR DESCRIPTION
Signed-off-by: Kyle Sayers <kylesayrs@gmail.com>

**Description**
This change decreases `extract_model`'s run time by first checking for a non-matching node_output_name and then checking if the node has been reached yet. The speedup is because, for each node, the number of `node.output`s is likely to be small while the number of `reachable_nodes` can be quite large.

**Motivation and Context**
- This change solves run time issues which severely limits the practical usefulness of `extract_model` for large graphs
- Use cases such as zero shot embedding pipelines benefit from being able to dynamically and quickly extract models