### PR TITLE
add is_constant_initializer in ir.h

### DIFF
--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -994,6 +994,9 @@ struct Graph final {
     }
     return initializers_.end();
   }
+  bool is_constant_initializer(const Value* value) const {
+    return value->node() == initializer_node_;
+  }
   ArrayRef<Value*> inputs() {
     return input_->outputs();
   }


### PR DESCRIPTION
**Description**
Add `Graph::is_constant_initializer(const Value*) const` in ir.h

**Motivation and Context**
- Why is this change required? What problem does it solve?

    I'm developing [onnx optimizer](https://github.com/onnx/optimizer) and find that it is helpful to have an `is_constant_initializer` method to check whether a Value is an initializer but not an input (a.k.a. a [constant initializer](https://github.com/onnx/onnx/blob/main/docs/IR.md#graphs)). Only constant initializers can be safely eliminated or fused.