### PR TITLE
Specify pairwise conversion behavior for the Cast op

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -15023,6 +15023,22 @@ This version of the operator has been available since version 13 of the default 
   For example, a 64-bit float 3.1415926459 may be round to a 32-bit float 3.141592. Similarly, converting
   an integer 36 to Boolean may produce 1 because we truncate bits which can't be stored in the targeted type.
 
+  In more detail, the conversion among numerical types should follow these rules:
+
+  * Casting from floating point to:
+    * floating point: +/- infinity if OOR (out of range).
+    * fixed point: undefined if OOR.
+    * bool: +/- 0.0 to False; all else to True.
+  * Casting from fixed point to:
+    * floating point: +/- infinity if OOR. (+ infinity in the case of uint)
+    * fixed point: when OOR, discard higher bits and reinterpret (with respect to two's complement representation for
+  signed types). For example, 200 (int16) -> -56 (int8).
+    * bool: zero to False; nonzero to True.
+  * Casting from bool to:
+    * floating point: `{1.0, 0.0}`.
+    * fixed point: `{1, 0}`.
+    * bool: no change.
+
 #### Version
 
 This version of the operator has been available since version 13 of the default ONNX operator set.

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -2497,6 +2497,22 @@ expect(node, inputs=[size], outputs=[y],
   For example, a 64-bit float 3.1415926459 may be round to a 32-bit float 3.141592. Similarly, converting
   an integer 36 to Boolean may produce 1 because we truncate bits which can't be stored in the targeted type.
 
+  In more detail, the conversion among numerical types should follow these rules:
+
+  * Casting from floating point to:
+    * floating point: +/- infinity if OOR (out of range).
+    * fixed point: undefined if OOR.
+    * bool: +/- 0.0 to False; all else to True.
+  * Casting from fixed point to:
+    * floating point: +/- infinity if OOR. (+ infinity in the case of uint)
+    * fixed point: when OOR, discard higher bits and reinterpret (with respect to two's complement representation for
+  signed types). For example, 200 (int16) -> -56 (int8).
+    * bool: zero to False; nonzero to True.
+  * Casting from bool to:
+    * floating point: `{1.0, 0.0}`.
+    * fixed point: `{1, 0}`.
+    * bool: no change.
+
 #### Version
 
 This version of the operator has been available since version 13 of the default ONNX operator set.

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -33,6 +33,22 @@ Conversion from a numerical type to any numerical type is always allowed.
 User must be aware of precision loss and value change caused by range difference between two types.
 For example, a 64-bit float 3.1415926459 may be round to a 32-bit float 3.141592. Similarly, converting
 an integer 36 to Boolean may produce 1 because we truncate bits which can't be stored in the targeted type.
+
+In more detail, the conversion among numerical types should follow these rules:
+
+* Casting from floating point to:
+  * floating point: +/- infinity if OOR (out of range).
+  * fixed point: undefined if OOR.
+  * bool: +/- 0.0 to False; all else to True.
+* Casting from fixed point to:
+  * floating point: +/- infinity if OOR. (+ infinity in the case of uint)
+  * fixed point: when OOR, discard higher bits and reinterpret (with respect to two's complement representation for
+signed types). For example, 200 (int16) -> -56 (int8).
+  * bool: zero to False; nonzero to True.
+* Casting from bool to:
+  * floating point: `{1.0, 0.0}`.
+  * fixed point: `{1, 0}`.
+  * bool: no change.
 )DOC";
 
 ONNX_OPERATOR_SET_SCHEMA(


### PR DESCRIPTION
Signed-off-by: Yuan Yao <yuanyao@nvidia.com>

**Description**
Add more details for conversion among numerical types for the Cast op

**Motivation and Context**
In the previous version of the spec for Cast, not much detail is given for out-of-range conversion among numerical types. Here we explicitly list all the pair-wise conversions and indicate when to expect undefined behavior.

Suggestions are welcome for conversions to/from string types, from people to whom string conversions are relevant.
