### PR TITLE
Clarify minimum version of Protobuf required by ONNX

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,25 +126,15 @@ pip install -e .
 
 ### Linux
 
-First, you need to install protobuf.
+First, you need to install protobuf. The minimum Protobuf version required by ONNX is 3.12.2.
 
-Ubuntu users: the quickest way to install protobuf is to run
-
+Ubuntu 22.04 (and newer) users may choose to install protobuf via
 ```bash
 apt-get install python3-pip python3-dev libprotobuf-dev protobuf-compiler
 ```
+In this case, it is recommended to add `-DONNX_USE_PROTOBUF_SHARED_LIBS=ON` to CMAKE_ARGS in the ONNX build step.
 
-Then you can build ONNX as:
-```
-export CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=ON"
-git clone --recursive https://github.com/onnx/onnx.git
-cd onnx
-# prefer lite proto
-set CMAKE_ARGS=-DONNX_USE_LITE_PROTO=ON
-pip install -e .
-```
-
-Otherwise, you may need to install it from source. You can use the following commands to do it:
+A more general way is to build and install it from source. You can use the following commands to do it:
 
 Debian/Ubuntu:
 ```

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ In this case, it is required to add `-DONNX_USE_PROTOBUF_SHARED_LIBS=ON` to CMAK
 A more general way is to build and install it from source. See the instructions below for more details.
 
 <details>
-  <summary>Installing Protobuf from source</summary>
+  <summary> Installing Protobuf from source </summary>
 
   Debian/Ubuntu:
   ```bash
@@ -163,9 +163,9 @@ A more general way is to build and install it from source. See the instructions 
     make install
   ```
 
-Here "-DCMAKE_POSITION_INDEPENDENT_CODE=ON" is crucial. By default static libraries are built without "-fPIC" flag, they are not position independent code. But shared libraries must be position independent code. Python C/C++ extensions(like ONNX) are shared libraries. So if a static library was not built with "-fPIC", it can't be linked to such a shared library.
+  Here "-DCMAKE_POSITION_INDEPENDENT_CODE=ON" is crucial. By default static libraries are built without "-fPIC" flag, they are not position independent code. But shared libraries must be position independent code. Python C/C++ extensions(like ONNX) are shared libraries. So if a static library was not built with "-fPIC", it can't be linked to such a shared library.
 
-Once build is successful, update PATH to include protobuf paths.
+  Once build is successful, update PATH to include protobuf paths.
 
 </details>
 
@@ -180,7 +180,8 @@ set CMAKE_ARGS=-DONNX_USE_LITE_PROTO=ON
 pip install -e .
 ```
 
-* **Mac**
+### Mac
+
 ```
 export NUM_CORES=`sysctl -n hw.ncpu`
 brew update

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ pip install -e .
 
 ### Linux
 
-First, you need to install protobuf. The minimum Protobuf version required by ONNX is 3.12.2.
+First, you need to install protobuf. The minimum Protobuf version required by ONNX is 3.0.0.
 
 Ubuntu 22.04 (and newer) users may choose to install protobuf via
 ```bash

--- a/README.md
+++ b/README.md
@@ -126,43 +126,49 @@ pip install -e .
 
 ### Linux
 
-First, you need to install protobuf. The minimum Protobuf version required by ONNX is 3.0.0.
+First, you need to install protobuf. The minimum Protobuf compiler (protoc) version required by ONNX is 3.0.0.
 
-Ubuntu 22.04 (and newer) users may choose to install protobuf via
+Ubuntu 18.04 (and newer) users may choose to install protobuf via
 ```bash
 apt-get install python3-pip python3-dev libprotobuf-dev protobuf-compiler
 ```
-In this case, it is recommended to add `-DONNX_USE_PROTOBUF_SHARED_LIBS=ON` to CMAKE_ARGS in the ONNX build step.
+In this case, it is required to add `-DONNX_USE_PROTOBUF_SHARED_LIBS=ON` to CMAKE_ARGS in the ONNX build step.
 
-A more general way is to build and install it from source. You can use the following commands to do it:
+A more general way is to build and install it from source. See the instructions below for more details.
 
-Debian/Ubuntu:
-```
-git clone https://github.com/protocolbuffers/protobuf.git
-cd protobuf
-git checkout v3.16.0
-git submodule update --init --recursive
-mkdir build_source && cd build_source
-cmake ../cmake -Dprotobuf_BUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_SYSCONFDIR=/etc -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release
-make -j$(nproc)
-make install
-```
+<details>
+  <summary>Installing Protobuf from source</summary>
 
-CentOS/RHEL/Fedora:
-```
-git clone https://github.com/protocolbuffers/protobuf.git
-cd protobuf
-git checkout v3.16.0
-git submodule update --init --recursive
-mkdir build_source && cd build_source
-cmake ../cmake  -DCMAKE_INSTALL_LIBDIR=lib64 -Dprotobuf_BUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_SYSCONFDIR=/etc -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release
-make -j$(nproc)
-make install
-```
+  Debian/Ubuntu:
+  ```bash
+    git clone https://github.com/protocolbuffers/protobuf.git
+    cd protobuf
+    git checkout v3.16.0
+    git submodule update --init --recursive
+    mkdir build_source && cd build_source
+    cmake ../cmake -Dprotobuf_BUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_SYSCONFDIR=/etc -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release
+    make -j$(nproc)
+    make install
+  ```
+
+  CentOS/RHEL/Fedora:
+  ```bash
+    git clone https://github.com/protocolbuffers/protobuf.git
+    cd protobuf
+    git checkout v3.16.0
+    git submodule update --init --recursive
+    mkdir build_source && cd build_source
+    cmake ../cmake  -DCMAKE_INSTALL_LIBDIR=lib64 -Dprotobuf_BUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_SYSCONFDIR=/etc -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release
+    make -j$(nproc)
+    make install
+  ```
 
 Here "-DCMAKE_POSITION_INDEPENDENT_CODE=ON" is crucial. By default static libraries are built without "-fPIC" flag, they are not position independent code. But shared libraries must be position independent code. Python C/C++ extensions(like ONNX) are shared libraries. So if a static library was not built with "-fPIC", it can't be linked to such a shared library.
 
 Once build is successful, update PATH to include protobuf paths.
+
+</details>
+
 
 Then you can build ONNX as:
 ```


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

**Description**
- Clarify the minimum version required of ONNX in the README.md. As older Ubuntu users will get not compatible versions of protobuf when installing from the ubuntu repositories.

**Motivation and Context**
- Avoid confusion.