### PR TITLE
Add detailed error message for saving 2GB proto

### DIFF
--- a/onnx/__init__.py
+++ b/onnx/__init__.py
@@ -73,7 +73,7 @@ def _serialize(proto: Union[bytes, google.protobuf.message.Message]) -> bytes:
         except:
             raise
         return result
-    raise TypeError(f'No SerializeToString method is detected. Neither proto is a str.\ntype is {type(proto)}')
+    raise TypeError(f"No SerializeToString method is detected. Neither proto is a str.\ntype is {type(proto)}")
 
 
 _Proto = TypeVar('_Proto', bound=google.protobuf.message.Message)
@@ -91,10 +91,10 @@ def _deserialize(s: bytes, proto: _Proto) -> _Proto:
         The proto instance filled in by s
     '''
     if not isinstance(s, bytes):
-        raise ValueError(f'Parameter s must be bytes, but got type: {type(s)}')
+        raise ValueError(f"Parameter s must be bytes, but got type: {type(s)}")
 
     if not (hasattr(proto, 'ParseFromString') and callable(proto.ParseFromString)):
-        raise ValueError(f'No ParseFromString method is detected. Type is {type(proto)}')
+        raise ValueError(f"No ParseFromString method is detected. Type is {type(proto)}")
 
     decoded = cast(Optional[int], proto.ParseFromString(s))
     if decoded is not None and decoded != len(s):

--- a/onnx/__init__.py
+++ b/onnx/__init__.py
@@ -63,7 +63,12 @@ def _serialize(proto: Union[bytes, google.protobuf.message.Message]) -> bytes:
     if isinstance(proto, bytes):
         return proto
     elif hasattr(proto, 'SerializeToString') and callable(proto.SerializeToString):
-        result = proto.SerializeToString()
+        try:
+            result = proto.SerializeToString()
+        except:
+            if proto.ByteSize() >= 2147483648:
+                print("The single proto is larger than 2GB. Please use save_as_external_data to save proto separately.")
+            raise
         return result
     else:
         raise TypeError('No SerializeToString method is detected. '

--- a/onnx/__init__.py
+++ b/onnx/__init__.py
@@ -67,7 +67,8 @@ def _serialize(proto: Union[bytes, google.protobuf.message.Message]) -> bytes:
             result = proto.SerializeToString()
         except ValueError as e:
             if proto.ByteSize() >= onnx.checker.MAXIMUM_PROTOBUF:
-                raise ValueError("The single proto is larger than 2GB. Please use save_as_external_data to save proto separately.") from e
+                raise ValueError("The proto size is larger than the 2 GB limit. "
+                    "Please use save_as_external_data to save tensors separately from the model file.") from e
             raise
         return result
     raise TypeError(f"No SerializeToString method is detected. Neither proto is a str.\ntype is {type(proto)}")

--- a/onnx/__init__.py
+++ b/onnx/__init__.py
@@ -70,8 +70,6 @@ def _serialize(proto: Union[bytes, google.protobuf.message.Message]) -> bytes:
                 raise ValueError("The single proto is larger than 2GB. Please use save_as_external_data to save proto separately.") from e
             else:
                 raise
-        except:
-            raise
         return result
     raise TypeError(f"No SerializeToString method is detected. Neither proto is a str.\ntype is {type(proto)}")
 

--- a/onnx/__init__.py
+++ b/onnx/__init__.py
@@ -68,8 +68,7 @@ def _serialize(proto: Union[bytes, google.protobuf.message.Message]) -> bytes:
         except ValueError as e:
             if proto.ByteSize() >= onnx.checker.MAXIMUM_PROTOBUF:
                 raise ValueError("The single proto is larger than 2GB. Please use save_as_external_data to save proto separately.") from e
-            else:
-                raise
+            raise
         return result
     raise TypeError(f"No SerializeToString method is detected. Neither proto is a str.\ntype is {type(proto)}")
 

--- a/onnx/__init__.py
+++ b/onnx/__init__.py
@@ -70,8 +70,7 @@ def _serialize(proto: Union[bytes, google.protobuf.message.Message]) -> bytes:
                 print("The single proto is larger than 2GB. Please use save_as_external_data to save proto separately.")
             raise
         return result
-    raise TypeError(f'No SerializeToString method is detected. '
-                        'neither proto is a str.\ntype is {}'.format(type(proto)))
+    raise TypeError(f'No SerializeToString method is detected. Neither proto is a str.\ntype is {type(proto)}')
 
 
 _Proto = TypeVar('_Proto', bound=google.protobuf.message.Message)

--- a/onnx/__init__.py
+++ b/onnx/__init__.py
@@ -62,7 +62,7 @@ def _serialize(proto: Union[bytes, google.protobuf.message.Message]) -> bytes:
     '''
     if isinstance(proto, bytes):
         return proto
-    elif hasattr(proto, 'SerializeToString') and callable(proto.SerializeToString):
+    if hasattr(proto, 'SerializeToString') and callable(proto.SerializeToString):
         try:
             result = proto.SerializeToString()
         except:
@@ -70,9 +70,8 @@ def _serialize(proto: Union[bytes, google.protobuf.message.Message]) -> bytes:
                 print("The single proto is larger than 2GB. Please use save_as_external_data to save proto separately.")
             raise
         return result
-    else:
-        raise TypeError('No SerializeToString method is detected. '
-                         'neither proto is a str.\ntype is {}'.format(type(proto)))
+    raise TypeError(f'No SerializeToString method is detected. '
+                        'neither proto is a str.\ntype is {}'.format(type(proto)))
 
 
 _Proto = TypeVar('_Proto', bound=google.protobuf.message.Message)


### PR DESCRIPTION
**Description**
Add detailed error message for saving 2GB proto.

**Motivation and Context**
Currently saving 2GB proto will simply get complaint from Protobuf.  To improve user experience, ONNX should suggest a possible solution in the error message.

cc @BowenBao not sure whether it is the right improvement you are looking for. Please review it. Thanks!
