### PR TITLE
Remove pyflakes from CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,13 +21,7 @@ jobs:
           # Change reporter level if you need.
           # GitHub Status Check won't become failure with a warning.
           level: error
-          filter_mode: file
-      - name: pyflakes
-        uses: reviewdog/action-pyflakes@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-check
-          level: warning
+          filter_mode: diff_context
       - name: misspell # Check spellings as well
         uses: reviewdog/action-misspell@v1
         with:
@@ -42,7 +36,7 @@ jobs:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check
           level: info
-          filter_mode: file
+          filter_mode: diff_context
       - name: pylint
         uses: dciborow/action-pylint@0.0.7
         with:


### PR DESCRIPTION
**Description**

pyflakes does not support diff_context, creating too much noise. So we disable it.

- Set diff_context in all other checks
- We do not need to reenable pyflakes because flake8 is supposed to include pyflakes. We just need to configure properly