### PR TITLE
Clarify and add helper for making attribute references

### DIFF
--- a/docs/IR.md
+++ b/docs/IR.md
@@ -327,8 +327,11 @@ ints|int64[]|A list of 64-bit integer values.
 strings|byte[][]|A list of UTF-8 strings.
 tensors|Tensor[]|A list of tensor values.
 graphs|Graph[]|A list of graphs.
+ref_attr_name|string|The name of a parent function's attribute.
 
 The properties ‘name’ and ‘type’ are required on all attributes, and ‘doc_string’ SHOULD be used on all attributes. An attribute MUST have only one of the value-carrying properties.
+
+In case ‘ref_attr_name’ is set, this attribute does not contain data, and instead it's a reference to the parent function's attribute of the given name. Can only be used within the function body.
 
 
 #### Variadic Inputs and Outputs

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -545,7 +545,23 @@ def make_attribute(
     return attr
 
 
+def make_attribute_ref(
+        name: str,
+        attr_type: AttributeProto.AttributeType,
+        doc_string: Optional[str] = None
+) -> AttributeProto:
+    """Make an AttributeProto holding a reference to the parent function's attribute of given name and type."""
+    attr = AttributeProto()
+    attr.name = name
+    attr.type = attr_type
+    if doc_string:
+        attr.doc_string = doc_string
+    return attr
+
+
 def get_attribute_value(attr: AttributeProto) -> Any:
+    if attr.ref_attr_name:
+        raise ValueError(f"Cannot get value of reference attribute: {attr}")
     if attr.type == AttributeProto.FLOAT:
         return attr.f
     if attr.type == AttributeProto.INT:


### PR DESCRIPTION
**Description**
- Adds `onnx.helper.make_attribute_ref` to create parent function attribute references.
- Explains the mechanism of passing attribute references in `IR.md`.

**Motivation and Context**
- When developing code generating ONNX models, supporting the function specification requires attribute references. This  PR helps clarify the expected method for doing this.
- Fixes #4374 
