### PR TITLE
Fix errors reported by flake8 5.0.2

### DIFF
--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -1298,7 +1298,7 @@ class TestShapeInference(TestShapeInferenceHelper):
             [make_node('RNN', ['x', 'w', 'r'], ['all', 'last'], hidden_size=hiddensize,
                 layout=1, direction=direction)],
             [])
-        if(direction == 'bidirectional'):
+        if direction == 'bidirectional':
             num_directions = 2
         else:
             num_directions = 1

--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -117,9 +117,9 @@ class Extractor:
 
         initializer = [self.wmap[t] for t in self.wmap.keys() if t in all_tensors_name]
         value_info = [self.vimap[t] for t in self.vimap.keys() if t in all_tensors_name]
-        assert(len(self.graph.sparse_initializer) == 0)
-        assert(len(self.graph.quantization_annotation) == 0)
-        return (initializer, value_info)
+        assert len(self.graph.sparse_initializer) == 0
+        assert len(self.graph.quantization_annotation) == 0
+        return initializer, value_info
 
     def _make_model(
             self,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ pyzmq
 setuptools
 twine
 # Dependencies for linting. Versions match those in setup.py.
-flake8
+flake8==5.0.1
 clang-format==13.0.0
 mypy==0.782
 types-protobuf==3.18.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ pyzmq
 setuptools
 twine
 # Dependencies for linting. Versions match those in setup.py.
-flake8==5.0.1
+flake8==5.0.2
 clang-format==13.0.0
 mypy==0.782
 types-protobuf==3.18.4

--- a/setup.py
+++ b/setup.py
@@ -320,7 +320,7 @@ tests_require.append("tabulate")
 
 extras_require["lint"] = [
     "clang-format==13.0.0",
-    "flake8==5.0.1",
+    "flake8==5.0.2",
     "mypy==0.782",
     "types-protobuf==3.18.4",
 ]

--- a/setup.py
+++ b/setup.py
@@ -320,7 +320,7 @@ tests_require.append("tabulate")
 
 extras_require["lint"] = [
     "clang-format==13.0.0",
-    "flake8",
+    "flake8==5.0.1",
     "mypy==0.782",
     "types-protobuf==3.18.4",
 ]


### PR DESCRIPTION
**Description**
flake8 [released](https://pypi.org/project/flake8/#history) 5.0.0 and 5.0.1 these days, making the CI fail: https://github.com/onnx/onnx/pull/4385 https://github.com/onnx/onnx/pull/4395.

This PR fixes errors it reported, and uses flake8==5.0.1 instead of always using the latest version.
