### PR TITLE
Modify the annotation: fix the label serial number mistake

### DIFF
--- a/onnx/common/ir_pb_converter.cc
+++ b/onnx/common/ir_pb_converter.cc
@@ -231,7 +231,7 @@ std::unique_ptr<Graph> graphProtoToGraph(const ONNX_NAMESPACE::GraphProto& gp, b
   // 3) initialize inputs of all Nodes
   // 4) initialize inputs of the Return sentinel node
   // 5) fill in type info for graph outputs, and register them as outputs
-  // 5) fill in type info for Values from the value_info list in the graph
+  // 6) fill in type info for Values from the value_info list in the graph
 
   // In ONNX proto land, Values are just strings. We are going to make
   // objects out of them, and equal strings must be mapped to the same


### PR DESCRIPTION
**Description**
- Describe your changes.

origin annotation in onnx/onnx/common/ir_pb_converter.cc
https://github.com/onnx/onnx/blob/eb634addcbb23ec1baf4d548d826bf3932527533/onnx/common/ir_pb_converter.cc#L229-L234

this pull request replace the second label "5)" with "6)"


**Motivation and Context**
Fix annotation mistaken
