### PR TITLE
Fix Windows Release Python 3.10 CI failure when building NumPy from source

### DIFF
--- a/.github/workflows/release_linux_aarch64.yml
+++ b/.github/workflows/release_linux_aarch64.yml
@@ -112,7 +112,6 @@ jobs:
           deactivate'
 
     - name: Verify ONNX with ONNX Runtime PyPI package
-      if: matrix.python-version != 'cp310-cp310' # TODO update once onnxruntime has supported Python 3.10
       run: |
          docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
           ${{ env.img }} \

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -29,7 +29,7 @@ jobs:
         git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.architecture }}
@@ -87,7 +87,6 @@ jobs:
         pytest
 
     - name: Verify ONNX with ONNX Runtime PyPI package
-      if: matrix.python-version != '3.10' # TODO update once onnxruntime has supported Python 3.10
       run: |
         python -m pip install -q onnxruntime
         python onnx/test/test_with_ort.py

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -33,7 +33,7 @@ jobs:
         git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.architecture }}
@@ -98,7 +98,6 @@ jobs:
         pytest
 
     - name: Verify ONNX with ONNX Runtime PyPI package
-      if: matrix.python-version != '3.10' # TODO update once onnxruntime has supported Python 3.10
       run: |
         python -m pip install -q onnxruntime
         python onnx/test/test_with_ort.py

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -48,14 +48,6 @@ jobs:
         python -m pip install -q --upgrade pip
         cd onnx
         python -m pip install -q -r requirements-release.txt
-        python -m pip install numpy == 1.21.5
-protobuf == 3.16.0
-pytest
-nbval
-ipython
-wheel
-setuptools
-twine
 
     - name: Build ONNX wheel
       run: |

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     if: github.event_name != 'pull_request' || startsWith( github.base_ref, 'rel-') || contains( github.event.pull_request.labels.*.name, 'run release CIs')
-    runs-on: windows-2019
+    runs-on: windows-latest
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
@@ -36,7 +36,7 @@ jobs:
       uses: microsoft/setup-msbuild@v1.1
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.architecture }}    
@@ -117,7 +117,7 @@ jobs:
         pytest
 
     - name: Verify ONNX with ONNX Runtime PyPI package
-      if: matrix.python-version != '3.10' && matrix.architecture != 'x86' # TODO update once onnxruntime has supported Python 3.10
+      if:
       run: |
         python -m pip install -q onnxruntime
         python onnx\onnx\test\test_with_ort.py

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -33,7 +33,7 @@ jobs:
          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -32,15 +32,17 @@ jobs:
          git submodule sync --recursive
          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
 
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.architecture }}    
-          
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.1
+      with:
+        msbuild-architecture: ${{ matrix.architecture }}
+
     - name: Install Python dependencies
       run: |
         python -m pip install -q --upgrade pip
@@ -117,7 +119,6 @@ jobs:
         pytest
 
     - name: Verify ONNX with ONNX Runtime PyPI package
-      if:
       run: |
         python -m pip install -q onnxruntime
         python onnx\onnx\test\test_with_ort.py

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     if: github.event_name != 'pull_request' || startsWith( github.base_ref, 'rel-') || contains( github.event.pull_request.labels.*.name, 'run release CIs')
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10.5']
         architecture: ['x64', 'x86']
     steps:        
     - name: Checkout ONNX
@@ -48,6 +48,14 @@ jobs:
         python -m pip install -q --upgrade pip
         cd onnx
         python -m pip install -q -r requirements-release.txt
+        python -m pip install numpy == 1.21.5
+protobuf == 3.16.0
+pytest
+nbval
+ipython
+wheel
+setuptools
+twine
 
     - name: Build ONNX wheel
       run: |

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
+        # TODO: Freeze as 3.10.5 for now; Follow-up this issue by https://github.com/actions/setup-python/issues/481
         python-version: ['3.7', '3.8', '3.9', '3.10.5']
         architecture: ['x64', 'x86']
     steps:        

--- a/.github/workflows/weekly_mac_ci.yml
+++ b/.github/workflows/weekly_mac_ci.yml
@@ -30,7 +30,7 @@ jobs:
         git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.architecture }}

--- a/.github/workflows/win_no_exception_ci.yml
+++ b/.github/workflows/win_no_exception_ci.yml
@@ -27,14 +27,16 @@ jobs:
          git submodule sync --recursive
          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
 
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.architecture }}
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.1
+      with:
+        msbuild-architecture: ${{ matrix.architecture }}
 
     - name: Build and test ONNX binaries
       run: |

--- a/.github/workflows/win_no_exception_ci.yml
+++ b/.github/workflows/win_no_exception_ci.yml
@@ -31,7 +31,7 @@ jobs:
       uses: microsoft/setup-msbuild@v1.1
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.architecture }}

--- a/.github/workflows/win_no_exception_ci.yml
+++ b/.github/workflows/win_no_exception_ci.yml
@@ -28,7 +28,7 @@ jobs:
          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2


### PR DESCRIPTION
### Description
- In Windows CI, use the fixed Python version 3.10.5 as Python 3.10 for now because Python 3.10.6 is missing some compiler tools like BLAS/MKL for building NumPy from source
- Upgrade to setup-msbuild@v1.1
- Upgrade to setup-python@v4
- Remove if condition for skipping ORT with Python 3.10 because the latest ORT has supported Python 3.10.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/onnx/onnx/issues/4439.
