### PR TITLE
Remove sentences about deprecated onnx-docker in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,6 @@ We encourage you to open [Issues](https://github.com/onnx/onnx/issues), or use [
 Stay up to date with the latest ONNX news. [[Facebook](https://www.facebook.com/onnxai/)] [[Twitter](https://twitter.com/onnxai)]
 
 
-
-
-
-
 # Installation
 
 ## Official Python packages
@@ -65,8 +61,6 @@ A binary build of ONNX is available from [Conda](https://conda.io), in [conda-fo
 ```
 conda install -c conda-forge onnx
 ```
-
-You can also use the [onnx-dev docker image](https://hub.docker.com/r/onnx/onnx-dev) for a Linux-based installation without having to worry about dependency versioning.
 
 
 ## Build ONNX from Source

--- a/community/readme.md
+++ b/community/readme.md
@@ -103,7 +103,7 @@ The ONNX project is organized primarily into Special Interest Groups, or SIGs. E
 Our goal is to enable a distributed decision structure and code ownership, as well as providing focused forums for getting work done, making decisions, and on-boarding new contributors. Every identifiable part of the project (e.g., repository, subdirectory, API, test, issue, PR, Slack channel) is intended to be owned by some SIG. At the time of inception of this organizational structure, the following SIGs will be present:
 
 * Architecture & Infra
-    * This SIG is responsible for defining and maintaining the core ONNX format, the build and CI/CD systems for ONNX repositories, publishing release packages for ONNX, the onnx-docker repository, and creating tools to help integrate with and test against the ONNX standard. This SIG is also the defacto owner of files in the main ONNX repository unless explicitly owned by another SIG.
+    * This SIG is responsible for defining and maintaining the core ONNX format, the build and CI/CD systems for ONNX repositories, publishing release packages for ONNX, and creating tools to help integrate with and test against the ONNX standard. This SIG is also the defacto owner of files in the main ONNX repository unless explicitly owned by another SIG.
 * Operator Standardization
     * This SIG is responsible for determining the operators that are part of the ONNX spec (ONNX and ONNX-ML domains), ensuring high quality operator definitions and documentation, establishing criteria for adding new operators, managing ops domains and compliance tiers, and enforcing versioning mechanisms.
 * Converters

--- a/community/sigs.md
+++ b/community/sigs.md
@@ -14,7 +14,7 @@ You can find the schedule of SIG meetings on the [LF AI calendar](https://wiki.l
 
 | Name | Responsibilities |
 | ---- | ---------------- |
-| [Architecture & Infra](https://lfaifoundation.slack.com/archives/C018Y2QG7V2) | Defining and maintaining the core ONNX format, the build and CI/CD systems for ONNX repositories, publishing release packages for ONNX, the onnx-docker repository, and creating tools to help integrate with and test against the ONNX standard. This SIG is also the defacto owner of files in the main ONNX repository unless explicitly owned by another SIG. |
+| [Architecture & Infra](https://lfaifoundation.slack.com/archives/C018Y2QG7V2) | Defining and maintaining the core ONNX format, the build and CI/CD systems for ONNX repositories, publishing release packages for ONNX, and creating tools to help integrate with and test against the ONNX standard. This SIG is also the defacto owner of files in the main ONNX repository unless explicitly owned by another SIG. |
 | [Operators](https://lfaifoundation.slack.com/archives/C018Y2RAY4C) | Determining the operators that are part of the ONNX spec (ONNX and ONNX-ML domains), ensuring high quality operator definitions and documentation, establishing criteria for adding new operators, managing ops domains and compliance tiers, and enforcing versioning mechanisms. |
 | [Converters](https://lfaifoundation.slack.com/archives/C0171FSKZBN) | Developing and maintaining the various converter repositories under ONNX. |
 | [Models and tutorials](https://lfaifoundation.slack.com/archives/C018RE2BRBL) | Providing a comprehensive collection of state of the art ONNX models from a variety of sources and making it easy for users to get started with ONNX and the ecosystem around it. |


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Remove sentences about deprecated onnx-docker in docs.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
https://github.com/onnx/onnx-docker was just deprecated recently. Related sentences in the documents should be updated.