### PR TITLE
Make check_model with full_check always not modify the model in place

### DIFF
--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -962,8 +962,9 @@ void check_model(const ModelProto& model, bool full_check) {
   check_model(model, ctx);
   if (full_check) {
     ShapeInferenceOptions options{true, 1, false};
-    // Do not update the model in place by shape inference, because checker should not modify the original model
-    auto copy = model;
+    // Do not update the model in place by the check from shape inference
+    // because checker should not modify the original model
+    ModelProto copy = model;
     ONNX_NAMESPACE::shape_inference::InferShapes(copy, ctx.get_schema_registry(), options);
   }
 }

--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -957,18 +957,14 @@ void check_model(const std::string& model_path, bool full_check) {
   }
 }
 
-void check_model(const ModelProto& model) {
+void check_model(const ModelProto& model, bool full_check) {
   CheckerContext ctx;
   check_model(model, ctx);
-}
-
-void check_model(ModelProto& model, bool full_check) {
-  CheckerContext ctx;
-  check_model(model, ctx);
-
   if (full_check) {
     ShapeInferenceOptions options{true, 1, false};
-    ONNX_NAMESPACE::shape_inference::InferShapes(model, ctx.get_schema_registry(), options);
+    // Do not update the model in place by shape inference, because checker should not modify the original model
+    auto copy = model;
+    ONNX_NAMESPACE::shape_inference::InferShapes(copy, ctx.get_schema_registry(), options);
   }
 }
 

--- a/onnx/checker.h
+++ b/onnx/checker.h
@@ -142,7 +142,7 @@ void check_model_local_functions(
     const CheckerContext& ctx,
     const LexicalScopeContext& parent_lex);
 
-void check_model(const ModelProto& model, bool full_check);
+void check_model(const ModelProto& model, bool full_check = false);
 void check_model(const std::string& model_path, bool full_check = false);
 
 bool check_is_experimental_op(std::string node_op_type);

--- a/onnx/checker.h
+++ b/onnx/checker.h
@@ -142,8 +142,7 @@ void check_model_local_functions(
     const CheckerContext& ctx,
     const LexicalScopeContext& parent_lex);
 
-void check_model(const ModelProto& model);
-void check_model(ModelProto& model, bool full_check);
+void check_model(const ModelProto& model, bool full_check);
 void check_model(const std::string& model_path, bool full_check = false);
 
 bool check_is_experimental_op(std::string node_op_type);

--- a/onnx/shape_inference/implementation.cc
+++ b/onnx/shape_inference/implementation.cc
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <list>
 #include "onnx/checker.h"
+#include "onnx/common/file_utils.h"
 #include "onnx/defs/data_type_utils.h"
 #include "onnx/string_utils.h"
 
@@ -691,15 +692,7 @@ void InferShapes(
     const ShapeInferenceOptions& options,
     std::unordered_map<std::string, TensorShapeProto>* generated_shape_data_by_name) {
   ModelProto model;
-  std::fstream model_stream(model_path, std::ios::in | std::ios::binary);
-  if (!model_stream.good()) {
-    fail_check("Unable to open model file:", model_path, ". Please check if it is a valid file.");
-  }
-  std::string data{std::istreambuf_iterator<char>{model_stream}, std::istreambuf_iterator<char>{}};
-  if (!ParseProtoFromBytes(&model, data.c_str(), data.size())) {
-    fail_check(
-        "Unable to parse model from file:", model_path, ". Please check if it is a valid protobuf file of model.");
-  }
+  LoadProtoFromPath(model_path, model);
   InferShapes(model, schema_registry, options, generated_shape_data_by_name);
   // Save the inferred model to the original model path
   // Use SerializeToString instead of SerializeToOstream due to LITE_PROTO


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
- To prevent confusion, make check_model always not modify the model.
- Use `LoadProtoFromPath` to simplify duplicate code.

After this PR, all check_model with full_check Python/C++ APIs won't update the model in place. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/onnx/onnx/issues/4422. Follow-up work for https://github.com/onnx/onnx/pull/4386.
