### PR TITLE
Upgrade macOS in azp due to upcoming deprecation

### DIFF
--- a/.azure-pipelines/MacOS-CI.yml
+++ b/.azure-pipelines/MacOS-CI.yml
@@ -4,7 +4,7 @@ trigger:
 jobs:
 - job: 'Test'
   pool:
-    vmImage: 'macOS-10.15'
+    vmImage: 'macOS-11'
   strategy:
     matrix:
       py39:

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   build:
     if: github.event_name != 'pull_request' || startsWith( github.base_ref, 'rel-') || contains( github.event.pull_request.labels.*.name, 'run release CIs')
-    runs-on: macos-11
+    runs-on: macos-latest
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']


### PR DESCRIPTION
### Description
- Upgrade macOS in azp due to upcoming deprecation.
- Make all release pipelines use the latest OS and let Azurepipelines use older OS to enhance test coverage.

### Motivation and Context
Upcoming deprecation:
```
This is a scheduled macOS-10.15 brownout. The macOS-10.15 environment is deprecated and will be removed on September 30th, 2022. For more details, see https://github.com/actions/virtual-environments/issues/5583
The remote provider was unable to process the request.
```
Currently it fails occasionally.


