### PR TITLE
[WIP] Reference implementation for onnx operators (python runtime for onnx)

### DIFF
--- a/onnx/runtime/__init__.py
+++ b/onnx/runtime/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from .inference import Inference

--- a/onnx/runtime/aionnx/__init__.py
+++ b/onnx/runtime/aionnx/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from ._op_list import load_op

--- a/onnx/runtime/aionnx/_op.py
+++ b/onnx/runtime/aionnx/_op.py
@@ -1,0 +1,476 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pprint
+import numpy as np
+from onnx import TensorProto, GraphProto
+from onnx.defs import get_all_schemas_with_history
+
+
+def _build_schemas():
+    res = {}
+    for schema in get_all_schemas_with_history():
+        # Multiple version can coexist. The last one is kept.
+        if schema.name in res:
+            if schema.since_version > res[schema.name].since_version:
+                # We keep the most recent one.
+                res[schema.name] = schema
+        else:
+            res[schema.name] = schema
+        res[schema.name + '_' + str(schema.since_version)] = schema
+    return res
+
+
+_schemas = _build_schemas()
+
+
+class RuntimeTypeError(RuntimeError):
+    """
+    Raised when a type of a variable is unexpected.
+    """
+    pass
+
+
+class DefaultNone:
+    """
+    Default value for parameters when the parameter is not set
+    but the operator has a default behaviour for it.
+    """
+    pass
+
+
+class RefAttrName:
+    """
+    Implements a link between a parameter of a function
+    and an attribute in node.
+
+    :param name: name of the input
+    """
+
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        "usual"
+        return f"{self.__class__.__name__}({self.name!r})"
+
+
+class OpRun:
+    """
+    Ancestor to all operators in this subfolder.
+    The runtime for every node can checked into
+    `ONNX unit tests
+    <https://github.com/onnx/onnx/tree/master/onnx/backend/test/case/node>`_.
+
+    :param onnx_node: :epkg:`onnx` node
+    :param log_function: function used to log information while
+        executing the onnx graph
+    """
+    _attribute_conversion_functions = {
+        TensorProto.FLOAT: lambda att: np.float32(att.f),
+        TensorProto.INT64: lambda att: np.float32(att.i),
+    }
+
+    def __init__(self, onnx_node, log_function):
+        self.onnx_node = onnx_node
+        self.log_function = log_function
+        self._schema = _schemas[onnx_node.op_type]
+        self._load_attributes()
+
+    def _extract_attribute_value(self, att):
+        """
+        Converts an attribute value into a python value.
+        """
+        if att.type in OpRun._attribute_conversion_functions:
+            return OpRun._attribute_conversion_functions[att.type](att)
+        raise NotImplementedError(
+            f"Unable to convert attribute {att.name!r} type {att.type!r} "
+            f"from node type {self.onnx_node.op_type!r}, "
+            f"domain {self.onnx_node.domain!r}.")
+
+    def _load_attributes(self):
+        "Checks and loads attributes."
+        for att in self.onnx_node.attribute:
+            name = att.name
+            value = self._extract_attribute_value(att)
+            setattr(self, name, value)
+
+        if self.onnx_node.op_type not in {'Constant'}:
+            for k, v in self._schema.attributes.items():
+                if not hasattr(self, k) and getattr(v, 'required', True):
+                    raise RuntimeError(
+                        "Attribute '{}' is expected based on ONNX specifications "
+                        "for node '{}' and options {}.".format(
+                            k, onnx_node.op_type, pprint.pformat(options)))
+
+    @staticmethod
+    def local_inputs(graph):
+        """
+        Returns all varibles not registered as inputs and not produced by
+        an node inside the graph. This inputs are part of the context
+        existing in the graph calling this one.
+        """
+        if not isinstance(graph, GraphProto):
+            raise TypeError(
+                f"Unexpected type {type(graph)!r}.")
+        local = set()
+        known = set()
+        for init in graph.initializer:
+            known.add(init.name)
+        for init in graph.input:
+            known.add(init.name)
+        for node in graph.node:
+            for o in node.output:
+                known.add(o)
+            for i in node.input:
+                if i not in known:
+                    local.add(i)
+        return list(local)
+
+    @property
+    def input(self):
+        "Returns node attribute `input`."
+        return self.onnx_node.input
+
+    @property
+    def output(self):
+        "Returns node attribute `output`."
+        return self.onnx_node.output
+
+    @property
+    def op_type(self):
+        "Returns node attribute `op_type`."
+        return self.onnx_node.op_type
+
+    @property
+    def domain(self):
+        "Returns node attribute `domain`."
+        return self.onnx_node.domain
+
+    def need_context(self):
+        """
+        Tells the runtime if this node needs the context
+        (all the results produced so far) as it may silently access
+        one of them (operator Scan, If, Loop).
+        The default answer is `False`.
+        """
+        return False
+
+    def __str__(self):
+        atts = [self.__class__.__name__ + '(',
+                f"    op_type={self.onnx_node.op_type}"]
+        for k, v in sorted(self.__dict__.items()):
+            if k in {'desc', 'onnx_node'}:
+                continue
+            if 'a' <= k[0] <= 'z' and k[-1] != '_':
+                atts.append(f'    {k}={v},')
+        atts.append(')')
+        return "\n".join(atts)
+
+    def _run(self, *args, attributes=None, **kwargs):
+        """
+        Should be overwritten.
+        Parameter *attributes* is used by functions.
+        """
+        raise NotImplementedError(
+            "Method '_run' or 'to_python' should be overwritten for operator %s."
+            "" % self.__class__.__name__)
+
+    def run(self, *args, **kwargs):  # pylint: disable=E0202
+        """
+        Calls method ``_run``, catches exceptions,
+        displays a longer error message.
+        """
+        try:
+            res = self._run(*args, **kwargs)
+        except TypeError as e:
+            raise TypeError(
+                "Issues with types {} (operator {}).".format(
+                    ", ".join(str(type(_)) for _ in args),
+                    self.__class__.__name__)) from e
+        except AttributeError as e:
+            raise AttributeError(
+                "Issues with types {} (operator {}).".format(
+                    ", ".join(str(type(_)) for _ in args),
+                    self.__class__.__name__)) from e
+        return res
+
+    @property
+    def args_default(self):
+        """
+        Returns the list of arguments as well as
+        the list of parameters with the default values
+        (close to the signature).
+        """
+        inps = []
+        if hasattr(self, 'atts'):
+            for k, v in self.atts.items():  # pylint: disable=E1101
+                if isinstance(v, (list, tuple, dict)) and len(v) == 0:
+                    v = None
+                inps.append(f'{k}={v!r}')
+        return inps
+
+    @property
+    def args_default_modified(self):
+        """
+        Returns the list of modified parameters.
+        """
+        if not hasattr(self, 'atts'):
+            return None
+
+        inps = []
+        for k, v in self.atts.items():  # pylint: disable=E1101
+            val = getattr(self, k, None)
+            if isinstance(val, np.ndarray) and isinstance(v, list):
+                val = list(val)
+            try:
+                if val != v:
+                    inps.append(f'{k}={val!r}')
+            except ValueError as e:
+                raise ValueError(
+                    f"Unexpected value for v={v!r} and val={val!r}.") from e
+        return inps
+
+    @property
+    def args_optional(self):
+        """
+        Returns the list of optional arguments.
+        """
+        inps = []
+        if hasattr(self, 'optional_inputs'):
+            for k, v in self.optional_inputs.items():  # pylint: disable=E1101
+                inps.append(f'{k}={v!r}')
+        return inps
+
+    @property
+    def args_mandatory(self):
+        """
+        Returns the list of optional arguments.
+        """
+        if hasattr(self, 'mandatory_inputs'):
+            return self.mandatory_inputs  # pylint:  disable=E1101
+        return None
+
+    @property
+    def atts_value(self):
+        "Returns all parameters in a dictionary."
+        if hasattr(self, 'atts'):
+            return {k: getattr(self, k)
+                    for k in self.atts}  # pylint: disable=E1101
+        return None
+
+
+class OpRunUnary(OpRun):
+    """
+    Ancestor to all unary operators in this subfolder.
+    Checks that inputs type are the same.
+    """
+
+    def __init__(self, onnx_node, logging_function):
+        OpRun.__init__(self, onnx_node, logging_function)
+
+    def run(self, x, attributes=None):  # pylint: disable=E0202,W0221
+        """
+        Calls method ``_run``, catches exceptions,
+        displays a longer error message.
+        Supports only unary operators.
+        """
+        try:
+            res = self._run(x, attributes=attributes)
+        except TypeError as e:
+            raise TypeError(
+                "Issues with types {} (binary operator {}).".format(
+                    ", ".join(str(type(_)) for _ in [x]),
+                    self.__class__.__name__)) from e
+        return res
+
+
+class OpRunArg(OpRunUnary):
+    """
+    Ancestor to all unary operators in this subfolder
+    and which produces position of extremas (ArgMax, ...).
+    Checks that inputs type are the same.
+    The class must have attributes *axis*, *keepdim*.
+    """
+
+    def __init__(self, onnx_node, logging_function):
+        OpRunUnary.__init__(self, onnx_node, logging_function)
+        if not hasattr(self, 'keepdims'):
+            raise AttributeError(
+                "Attribute 'keepdims' is missing.")
+        if not hasattr(self, 'axis'):
+            raise AttributeError(
+                "Attribute 'axis' is missing.")
+
+    def run(self, x, attributes=None):  # pylint: disable=E0202
+        """
+        Calls method ``OpRunUnary.run``, catches exceptions,
+        displays a longer error message.
+        """
+        res = OpRunUnary.run(self, x, attributes=attributes)
+        if res[0].dtype != np.int64:
+            raise RuntimeTypeError(
+                "Output type mismatch: should be '{}' != output '{}' "
+                "(operator '{}')".format(
+                    np.int64, res[0].dtype, self.__class__.__name__))
+        return res
+
+    def _run_no_checks_(self, x, attributes=None):  # pylint: disable=W0221
+        return OpRunUnary.run(self, x, attributes=attributes)
+
+
+class OpRunUnaryNum(OpRunUnary):
+    """
+    Ancestor to all unary and numerical operators
+    in this subfolder. Checks that inputs type
+    are the same.
+    """
+
+    def __init__(self, onnx_node, logging_function):
+        OpRunUnary.__init__(self, onnx_node, logging_function)
+
+    def run(self, x, attributes=None):  # pylint: disable=E0202
+        """
+        Calls method ``OpRunUnary.run``, catches exceptions,
+        displays a longer error message.
+        Checks that the result is not empty.
+        """
+        res = OpRunUnary.run(self, x, attributes=attributes)
+        if len(res) == 0 or res[0] is None:
+            return res
+        if not isinstance(res[0], list) and res[0].dtype != x.dtype:
+            raise RuntimeTypeError(
+                "Output type mismatch: input '{}' != output '{}' "
+                "(operator '{}')".format(
+                    x.dtype, res[0].dtype, self.__class__.__name__))
+        return res
+
+    def _run_no_checks_(self, x, attributes=None):  # pylint: disable=W0221
+        return OpRunUnary.run(self, x, attributes=attributes)
+
+
+class OpRunBinary(OpRun):
+    """
+    Ancestor to all binary operators in this subfolder.
+    Checks that inputs type are the same.
+    """
+
+    def __init__(self, onnx_node, logging_function):
+        OpRun.__init__(self, onnx_node, logging_function)
+
+    def run(self, x, y, attributes=None):  # pylint: disable=E0202,W0221
+        """
+        Calls method ``_run``, catches exceptions,
+        displays a longer error message.
+        Supports only binary operators.
+        """
+        if x is None or y is None:
+            raise RuntimeError(
+                f"x and y have different dtype: {type(x)} != {type(y)} ({type(self)})")
+        if x.dtype != y.dtype:
+            raise RuntimeTypeError(
+                "Input type mismatch: {} != {} (operator '{}', shapes {}, {})".format(
+                    x.dtype, y.dtype, self.__class__.__name__,
+                    x.shape, y.shape))
+        try:
+            res = self._run(x, y, attributes=attributes)
+        except (TypeError, ValueError) as e:
+            raise TypeError(
+                "Issues with types {} (binary operator {}).".format(
+                    ", ".join(str(type(_)) for _ in [x, y]),
+                    self.__class__.__name__)) from e
+        return res
+
+    def _run_no_checks_(self, x, y, attributes=None):  # pylint: disable=W0221
+        """
+        Calls method ``_run``.
+        """
+        try:
+            res = self._run(x, y, attributes=attributes)
+        except TypeError as e:
+            raise TypeError(
+                "Issues with types {} (binary operator {}).".format(
+                    ", ".join(str(type(_)) for _ in [x, y]),
+                    self.__class__.__name__)) from e
+        return res
+
+
+class OpRunBinaryComparison(OpRunBinary):
+    """
+    Ancestor to all binary operators in this subfolder
+    comparing tensors.
+    """
+
+    def __init__(self, onnx_node, logging_function):
+        OpRunBinary.__init__(self, onnx_node, logging_function)
+
+
+class OpRunBinaryNum(OpRunBinary):
+    """
+    Ancestor to all binary operators in this subfolder.
+    Checks that inputs type are the same.
+    """
+
+    def __init__(self, onnx_node, logging_function):
+        OpRunBinary.__init__(self, onnx_node, logging_function)
+
+    def run(self, x, y, attributes=None):  # pylint: disable=E0202
+        """
+        Calls method ``OpRunBinary.run``, catches exceptions,
+        displays a longer error message.
+        """
+        res = OpRunBinary.run(self, x, y, attributes=attributes)
+        if res[0].dtype != x.dtype:
+            raise RuntimeTypeError(
+                "Output type mismatch: {} != {} or {} (operator '{}')"
+                " type(x)={} type(y)={}".format(
+                    x.dtype, res[0].dtype, y.dtype,
+                    self.__class__.__name__, type(x), type(y)))
+        return res
+
+    def _run_no_checks_(self, x, y, attributes=None):  # pylint: disable=W0221
+        return OpRunBinary._run_no_checks_(self, x, y, attributes=attributes)
+
+
+class OpRunBinaryNumpy(OpRunBinaryNum):
+    """
+    *numpy_fct* is a binary numpy function which
+    takes two matrices.
+    """
+
+    def __init__(self, numpy_fct, onnx_node, logging_function):
+        OpRunBinaryNum.__init__(self, onnx_node, logging_function)
+        self.numpy_fct = numpy_fct
+
+    def _run(self, a, b, attributes=None):  # pylint: disable=W0221
+        return (self.numpy_fct(a, b), )
+
+
+class OpRunReduceNumpy(OpRunUnaryNum):
+    """
+    Implements the reduce logic.
+    It must have a parameter *axes*.
+    """
+
+    def __init__(self, onnx_node, logging_function):
+        if ('noop_with_empty_axes' not in expected_attributes and
+                'axes' not in expected_attributes):
+            raise RuntimeError(
+                "Parameter 'axes' is expected but not found in {} "
+                "from class {}".format(expected_attributes, type(self)))
+        if (expected_attributes.get('noop_with_empty_axes', 0) and
+                (expected_attributes['axes'] is None or
+                    len(expected_attributes['axes']) == 0)):
+            raise RuntimeError(
+                "Parameter 'axes' cannot be empty as {} (noop_with_empty_axes=1) "
+                "from class {}".format(expected_attributes, type(self)))
+        OpRunUnaryNum.__init__(self, onnx_node, logging_function)
+        if isinstance(self.axes, np.ndarray):  # pylint: disable=E0203
+            if (len(self.axes.shape) == 0 or  # pylint: disable=E0203,E1101
+                    self.axes.shape[0] == 0):  # pylint: disable=E0203,E1101
+                self.axes = None
+            else:
+                self.axes = tuple(self.axes)
+        elif self.axes in [[], tuple()]:  # pylint: disable=E0203
+            self.axes = None
+        elif isinstance(self.axes, list):  # pylint: disable=E0203
+            self.axes = tuple(self.axes)

--- a/onnx/runtime/aionnx/_op_list.py
+++ b/onnx/runtime/aionnx/_op_list.py
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Every class imported in this module defines an implementation of
+an operator of the main domain. Any class name uses `_` to specify a
+version defined in a specific opset. The class name without `_`
+defines the current implementation. If an operator has no class
+with `_`, it means the implementation is valid for every opset.
+The operator may have been updated to support more types but that
+did not change the implementation.
+"""
+import textwrap
+from ._op import OpRun
+# from .op_abs import Abs
+# from .op_acos import Acos
+# from .op_acosh import Acosh
+# from .op_adagrad import Adagrad
+# from .op_adam import Adam
+from .op_add import Add
+# from .op_and import And
+# from .op_argmax import ArgMax
+# from .op_argmin import ArgMin
+# from .op_asin import Asin
+# from .op_asinh import Asinh
+# from .op_atan import Atan
+# from .op_atanh import Atanh
+# from .op_average_pool import AveragePool
+# from .op_batch_normalization import BatchNormalization, BatchNormalization_14
+# from .op_binarizer import Binarizer
+# from .op_bitshift import BitShift
+# from .op_broadcast_gradient_args import BroadcastGradientArgs
+# from .op_cast import Cast, CastLike
+# from .op_cdist import CDist
+# from .op_ceil import Ceil
+# from .op_celu import Celu
+from .op_clip import Clip_6, Clip_11, Clip
+# from .op_compress import Compress
+# from .op_concat import Concat
+# from .op_concat_from_sequence import ConcatFromSequence
+# from .op_conv import Conv
+# from .op_conv_transpose import ConvTranspose
+# from .op_constant import Constant, Constant_12, Constant_11, Constant_9
+# from .op_constant_of_shape import ConstantOfShape
+# from .op_cos import Cos
+# from .op_cosh import Cosh
+# from .op_cum_sum import CumSum
+# from .op_det import Det
+# from .op_depth_to_space import DepthToSpace, SpaceToDepth
+# from .op_dequantize_linear import DequantizeLinear
+# from .op_dft import DFT
+# from .op_dict_vectorizer import DictVectorizer
+# from .op_div import Div
+# from .op_dropout import Dropout, Dropout_7, Dropout_12
+# from .op_einsum import Einsum
+# from .op_elu import Elu
+# from .op_equal import Equal
+# from .op_erf import Erf
+# from .op_exp import Exp
+# from .op_expand import Expand, Expand_13
+# from .op_expression import Expression
+# from .op_eyelike import EyeLike
+# from .op_feature_vectorizer import FeatureVectorizer
+# from .op_flatten import Flatten
+# from .op_gather import Gather
+# from .op_gathernd import GatherND
+# from .op_gather_elements import GatherElements
+# from .op_gemm import Gemm
+# from .op_global_average_pool import GlobalAveragePool, GlobalMaxPool
+# from .op_greater import Greater, GreaterOrEqual
+# from .op_grid_sample import GridSample
+# from .op_gru import GRU
+# from .op_hardmax import Hardmax
+# from .op_hard_sigmoid import HardSigmoid
+# from .op_floor import Floor
+# from .op_identity import Identity
+# from .op_if import If
+# from .op_imputer import Imputer
+# from .op_inverse import Inverse
+# from .op_isinf import IsInf
+# from .op_isnan import IsNaN
+# from .op_layer_normalization import LayerNormalization
+# from .op_leaky_relu import LeakyRelu
+# from .op_less import Less, LessOrEqual
+# from .op_log import Log
+# from .op_log_softmax import LogSoftmax
+# from .op_loop import Loop
+# from .op_lp_normalization import LpNormalization
+# from .op_lrn import LRN
+# from .op_lstm import LSTM
+from .op_matmul import MatMul
+# from .op_max import Max
+# from .op_max_pool import MaxPool
+# from .op_mean import Mean
+# from .op_min import Min
+# from .op_mod import Mod
+# from .op_momentum import Momentum
+from .op_mul import Mul
+# from .op_neg import Neg
+# from .op_negative_log_likelihood_loss import NegativeLogLikelihoodLoss
+# from .op_normalizer import Normalizer
+# from .op_non_max_suppression import NonMaxSuppression
+# from .op_non_zero import NonZero
+# from .op_not import Not
+# from .op_one_hot import OneHot
+# from .op_optional import OptionalGetElement, OptionalHasElement
+# from .op_or import Or
+# from .op_pad import Pad
+# from .op_pow import Pow
+# from .op_prelu import PRelu
+# from .op_quantize_linear import QuantizeLinear, DynamicQuantizeLinear
+# from .op_qlinear_conv import QLinearConv
+# from .op_random import (
+#     Bernoulli, RandomNormal, RandomUniform,
+#     RandomUniformLike, RandomNormalLike)
+# from .op_range import Range
+# from .op_reciprocal import Reciprocal
+# from .op_reduce_log_sum import ReduceLogSum
+# from .op_reduce_log_sum_exp import ReduceLogSumExp
+# from .op_reduce_l1 import ReduceL1
+# from .op_reduce_l2 import ReduceL2
+# from .op_reduce_min import ReduceMin
+# from .op_reduce_max import ReduceMax
+# from .op_reduce_mean import ReduceMean
+# from .op_reduce_prod import ReduceProd
+# from .op_reduce_sum import (
+#     ReduceSum_1, ReduceSum_11, ReduceSum_13, ReduceSum)
+# from .op_reduce_sum_square import ReduceSumSquare
+# from .op_relu import Relu, ThresholdedRelu
+# from .op_reshape import Reshape, Reshape_5, Reshape_13, Reshape_14
+# from .op_resize import Resize
+# from .op_roi_align import RoiAlign
+# from .op_round import Round
+# from .op_rnn import RNN
+# from .op_scaler import Scaler
+# from .op_scan import Scan
+# from .op_scatter_elements import ScatterElements
+# from .op_scatternd import ScatterND
+# from .op_softmax_cross_entropy_loss import SoftmaxCrossEntropyLoss
+# from .op_selu import Selu
+# from .op_sequence_at import SequenceAt
+# from .op_sequence_construct import SequenceConstruct
+# from .op_sequence_empty import SequenceEmpty
+# from .op_sequence_insert import SequenceInsert
+# from .op_shape import Shape
+# from .op_shrink import Shrink
+# from .op_sigmoid import Sigmoid
+# from .op_sign import Sign
+# from .op_sin import Sin
+# from .op_sinh import Sinh
+# from .op_size import Size
+# from .op_slice import Slice, Slice_1, Slice_10
+# from .op_split import Split, Split_2, Split_11, Split_13
+# from .op_softmax import Softmax, SoftmaxGrad, SoftmaxGrad_13
+# from .op_softplus import Softplus
+# from .op_softsign import Softsign
+# from .op_solve import Solve
+# from .op_sqrt import Sqrt
+# from .op_squeeze import Squeeze, Squeeze_1, Squeeze_11, Squeeze_13
+# from .op_stft import STFT
+# from .op_string_normalizer import StringNormalizer
+from .op_sub import Sub
+# from .op_sum import Sum
+# from .op_tan import Tan
+# from .op_tanh import Tanh
+# from .op_tfidfvectorizer import TfIdfVectorizer
+# from .op_tokenizer import Tokenizer
+# from .op_topk import TopK_10, TopK_11, TopK_1, TopK
+# from .op_transpose import Transpose
+# from .op_trilu import Trilu
+# from .op_unique import Unique
+# from .op_unsqueeze import Unsqueeze, Unsqueeze_1, Unsqueeze_11, Unsqueeze_13
+# from .op_where import Where
+# from .op_window import BlackmanWindow, HannWindow, HammingWindow
+# from .op_xor import Xor
+# from .op_zipmap import ZipMap
+
+
+def _split_name(name):
+    if '_' in name:
+        prefix, vers = name.rsplit('_', maxsplit=1)
+        try:
+            v = int(vers)
+        except ValueError:
+            return name, None
+        return prefix, v
+    return name, None
+
+
+_registered_operators = {}
+clo = locals().copy()
+for name, cl in clo.items():
+    if name[0] == '_' or name in {
+            'cl', 'clo', 'name', 'textwrap'}:
+        continue  # pragma: no cover
+    if issubclass(cl, OpRun):
+        op, v = _split_name(name)
+        if op not in _registered_operators:
+            _registered_operators[op] = {}
+        _registered_operators[op][v] = cl
+
+
+def load_op(domain, op_type, version):
+    """
+    Loads the implemented for a specified operator.
+
+    :param domain: domain
+    :param op_type: oprator type
+    :param version: requested version
+    :return: class
+    """
+    if domain != '':
+        raise ValueError(f"Domain must be '' not {domain!r}.")
+    if op_type not in _registered_operators:
+        available = '\n'.join(textwrap.wrap(', '.join(
+            sorted(_registered_operators))))
+        raise ValueError(
+            f"Not registered implemented for operator {op_type!r} "
+            f"and domain {domain!r} in\n{available}")
+    impl = _registered_operators[op_type]
+    if None not in impl:
+        raise RuntimeError(
+            f"No default implementation for operator {op_type!r} "
+            f"and domain {domain!r}, found "
+            f"{', '.join(map(str, impl))}.")
+    if version is None or len(impl) == 1:
+        return impl[None]
+    best = -1
+    for v, cl in impl.items():
+        if v is None:
+            continue
+        if v > best and v <= version:
+            best = v
+    if best == -1:
+        raise RuntimeError(
+            f"No implementation for operator {op_type!r} "
+            f"domain {node.domain!r} and version {version!r}, found "
+            f"{', '.join(map(str, impl))}.")
+    return impl[best]

--- a/onnx/runtime/aionnx/_op_numpy_helper.py
+++ b/onnx/runtime/aionnx/_op_numpy_helper.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+from scipy.sparse import coo_matrix
+
+
+def numpy_matmul(a, b):
+    """
+    Implements a matmul product. See :func:`numpy.matmul`.
+    Handles sparse matrices.
+    """
+    try:
+        if isinstance(a, coo_matrix) or isinstance(b, coo_matrix):
+            return np.dot(a, b)
+        if len(a.shape) <= 2 and len(b.shape) <= 2:
+            return np.dot(a, b)
+        return np.matmul(a, b)
+    except ValueError as e:
+        raise ValueError(
+            f"Unable to multiply shapes {a.shape!r}, {b.shape!r}.") from e

--- a/onnx/runtime/aionnx/op_add.py
+++ b/onnx/runtime/aionnx/op_add.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy
+from ._op import OpRunBinaryNumpy
+
+
+class Add(OpRunBinaryNumpy):
+
+    def __init__(self, onnx_node, log_function):
+        OpRunBinaryNumpy.__init__(self, numpy.add, onnx_node, log_function)

--- a/onnx/runtime/aionnx/op_clip.py
+++ b/onnx/runtime/aionnx/op_clip.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from collections import OrderedDict
+import numpy as np
+from onnx.defs import onnx_opset_version
+from ._op import OpRunUnaryNum, OpRun
+
+
+class Clip_6(OpRunUnaryNum):
+
+    def __init__(self, onnx_node, log_function):
+        OpRunUnaryNum.__init__(self, onnx_node, log_function)
+
+    def _run(self, data, attributes=None):
+        res = np.clip(data, getattr(self, 'min', None), getattr(self, 'max', None))
+        return (res, ) if res.dtype == data.dtype else (res.astype(data.dtype), )
+
+
+class Clip_11(OpRun):
+
+    def __init__(self, onnx_node, log_function):
+        OpRunUnaryNum.__init__(self, onnx_node, log_function)
+
+    def _run(self, data, *minmax, attributes=None):
+        le = len(minmax)
+        amin = minmax[0] if le > 0 else None
+        amax = minmax[1] if le > 1 else None
+        res = np.clip(data, amin, amax)
+        return (res, ) if res.dtype == data.dtype else (res.astype(data.dtype), )
+
+
+if onnx_opset_version() >= 11:
+    Clip = Clip_11
+else:
+    Clip = Clip_6

--- a/onnx/runtime/aionnx/op_identity.py
+++ b/onnx/runtime/aionnx/op_identity.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from ._op import OpRunUnaryNum
+
+
+class Identity(OpRunUnaryNum):
+
+    def __init__(self, onnx_node, log_function):
+        OpRunUnaryNum.__init__(self, onnx_node, log_function)
+
+    def _run(self, a, attributes=None):
+        if a is None:
+            return (None, )
+        return (a.copy(), )

--- a/onnx/runtime/aionnx/op_matmul.py
+++ b/onnx/runtime/aionnx/op_matmul.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from ._op import OpRunBinaryNum
+from ._op_numpy_helper import numpy_matmul
+
+
+class MatMul(OpRunBinaryNum):
+
+    def __init__(self, onnx_node, log_function):
+        OpRunBinaryNum.__init__(self, onnx_node, log_function)
+
+    def _run(self, a, b, attributes=None):
+        return (numpy_matmul(a, b), )

--- a/onnx/runtime/aionnx/op_mul.py
+++ b/onnx/runtime/aionnx/op_mul.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy
+from ._op import OpRunBinaryNumpy
+
+
+class Mul(OpRunBinaryNumpy):
+
+    def __init__(self, onnx_node, log_function):
+        OpRunBinaryNumpy.__init__(self, numpy.multiply, onnx_node, log_function)

--- a/onnx/runtime/aionnx/op_sub.py
+++ b/onnx/runtime/aionnx/op_sub.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy
+from ._op import OpRunBinaryNumpy
+
+
+class Sub(OpRunBinaryNumpy):
+
+    def __init__(self, onnx_node, log_function):
+        OpRunBinaryNumpy.__init__(self, numpy.subtract, onnx_node, log_function)

--- a/onnx/runtime/inference.py
+++ b/onnx/runtime/inference.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+from io import BytesIO
+from onnx import load, ModelProto, GraphProto, FunctionProto, numpy_helper
+from onnx.defs import onnx_opset_version
+
+
+class Inference:
+    """
+    Executes an onnx model. The implementation relies on numpy
+    for the most past and C++ through pybind11.
+
+    :param proto: onnx model or file name
+    :param verbose: display intermediate results
+        on the standard output during the execution
+    :param opsets: if 
+
+    The class maps every node to its associated implementation.
+    When a subgraph of a function is met,
+    it uses this class to execute the subgraph or the function.
+    """
+
+    def __init__(self, proto, verbose=0, opsets=None):
+        if isinstance(proto, str):
+            with open(proto, "rb") as f:
+                proto = load(f)
+        elif isinstance(proto, bytes):
+            with open(BytesIO(proto), "rb") as f:
+                proto = load(f)
+        self.proto_ = proto
+        if isinstance(proto, ModelProto):
+            self.onnx_graph_ = proto.graph
+            self.opsets_ = {d.domain: d.version for d in proto.opset_import}
+            if opsets is not None:
+                raise ValueError("opsets must be None if proto is ModelProto.")
+        elif isinstance(proto, GraphProto):
+            self.onnx_graph_ = proto
+            if not isinstance(opsets, dict):
+                raise ValueError("opsets must be a dictionary if proto is GraphProto.")
+            self.opsets_ = opsets
+        elif isinstance(proto, FunctionProto):
+            self.onnx_graph_ = None
+            self.opsets_ = {d.domain: d.version for d in proto.opset_import}
+            if opsets is not None:
+                raise ValueError("opsets must be None if proto is FunctionProto.")
+        else:
+            raise TypeError(f"Unexpected type {type(proto)} for proto.")
+        if self.onnx_graph_:
+            self.input_names_ = [i.name for i in self.onnx_graph_.input]
+            self.output_names_ = [o.name for o in self.onnx_graph_.output]
+            self.inits_ = (list(self.onnx_graph_.initializer) +
+                           list(self.onnx_graph_.sparse_initializer))
+            self.nodes_ = self.onnx_graph_.node
+        else:
+            self.input_names_ = list(proto.input)
+            self.output_names_ = list(proto.output)
+            self.inits_ = []
+            self.nodes_ = proto.node
+        if '' not in self.opsets:
+            self.opsets[''] = onnx_opset_version()
+        self.verbose = verbose
+        self._init()
+
+    def _log(self, pattern, *args):
+        if self.verbose:
+            print(pattern % tuple(args))
+
+    @property
+    def input_names(self):
+        "Returns the input names."
+        return self.input_names_
+
+    @property
+    def output_names(self):
+        "Returns the output names."
+        return self.output_names_
+
+    @property
+    def opsets(self):
+        "Returns the opsets."
+        return self.opsets_
+
+    def _init(self):
+        """
+        Loads the implementation for every node in the graph.
+        """
+        self.rt_inits_ = {}
+        self.rt_nodes_ = []
+        for init in self.inits_:
+            self.rt_inits_[init.name] = numpy_helper.to_array(init)
+        for node in self.nodes_:
+            cl = self._load_impl(node)
+            self.rt_nodes_.append(cl(node, self._log))
+
+    def _load_impl(self, node):
+        """
+        Loads the implemented for a specified runtime.
+        """
+        if node.domain not in self.opsets:
+            raise RuntimeError(
+                f"Domain {node.domain!r} (node type: {node.op_type!r}) "
+                f"is not specified. Known opsets: {self.opsets!r}.")
+        version = self.opsets[node.domain]
+        if node.domain == '':
+            from .aionnx import load_op
+            return load_op(node.domain, node.op_type, version)
+
+    def run(self, output_names, feed_inputs):
+        """
+        Executes the onnx model.
+
+        :param output_names: requested outputs by names,
+            None for all
+        :param feed_inputs: dictionary `{ input name: input value }`
+        :return: list of requested outputs
+        """
+        if output_names is None:
+            output_names = self.output_names
+
+        # step 1: inputs and initalizers
+        results = {'': None}  # optional input
+        results.update(self.rt_inits_)
+        results.update(feed_inputs)
+
+        # step 2: execute nodes
+        for node in self.rt_nodes_:
+            inputs = [results[i] for i in node.input]
+            outputs = node.run(*inputs)
+            for name, value in zip(node.output, outputs):
+                results[name] = value
+
+        # return the results
+        return [results[name] for name in self.output_names]


### PR DESCRIPTION
### Description and Motivation

This PR addresses issue #4432. It proposes a reference implementation for onnx operators. This runtime can also be used to test function body. Currently, there is no way to check the body of a function validates the backend tests. This can also be used to validate other runtime or add more backend tests.

This work comes from a python runtime I wrote to easily check the onnx model built with a converter. onnxruntime is a fast runtime but it cannot be easily use to debug a model, like display intermediate results. This is another goal of this runtime.
When this PR is complete the runtime should validate 93% of the backend test.

