### PR TITLE
Fix default value of RoiAlign's attribute coordinate_transformation_mode.

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -22339,7 +22339,7 @@ Other versions of this operator: <a href="Changelog.md#RoiAlign-10">10</a>
 #### Attributes
 
 <dl>
-<dt><tt>coordinate_transformation_mode</tt> : string (default is half_pixel)</dt>
+<dt><tt>coordinate_transformation_mode</tt> : string (default is output_half_pixel)</dt>
 <dd>Allowed values are 'half_pixel' and 'output_half_pixel'. Use the value 'half_pixel' to pixel shift the input coordinates by -0.5 (the recommended behavior). Use the value 'output_half_pixel' to omit the pixel shift for the input (use this for a backward-compatible behavior).</dd>
 <dt><tt>mode</tt> : string (default is avg)</dt>
 <dd>The pooling method. Two modes are supported: 'avg' and 'max'. Default is 'avg'.</dd>


### PR DESCRIPTION
The default semenatics of RoiAlign's attrtibute coordinate_transformation_mode in opset16 is not same with opset10.

For opset10, other framework like pytorch will manual insert an operation to process half_pixel, so it treat coordinate_transformation_mode  as output_half_pixel, while in opset16, the default value for RoiAlign's  attrtibute coordinate_transformation_mode in Operators.md is half_pixel. And at the same time, onnxruntime treat this attribute as no half_pixel in its cpu providers, below is the link.

https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/providers/cpu/object_detection/roialign.h
