### PR TITLE
[WIP] experimentation with bfloat16

### DIFF
--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -363,15 +363,19 @@ def make_tensor(
     # Check number of vals specified equals tensor size
     expected_size = 1
     if raw:
-        # NumPy doesn't have BFLOAT16. TENSOR_TYPE_TO_NP_TYPE maps it to float32,
-        # which has the wrong itemsize.
-        if data_type == TensorProto.BFLOAT16:
-            expected_size = 2
-        else:
-            expected_size = np_dtype.itemsize
+        expected_size = np_dtype.itemsize
 
-    if type(vals) is np.ndarray and len(vals.shape) > 1:
+    if isinstance(vals, np.ndarray) and len(vals.shape) > 1:
         vals = vals.flatten()
+
+    if not raw and np_dtype.itemsize < 4:
+        raw = True
+        expected_size = np_dtype.itemsize
+        if isinstance(vals, np.ndarray):
+            vals = vals.tobytes()
+        else:
+            vals = np.array(vals).astype(np_dtype).tobytes()
+
     for d in dims:
         expected_size *= d
 

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -387,17 +387,6 @@ def make_tensor(
     else:
         if data_type == TensorProto.COMPLEX64 or data_type == TensorProto.COMPLEX128:
             vals = split_complex_to_pairs(vals)
-        elif data_type == TensorProto.FLOAT16:
-            vals = (
-                np.array(vals).astype(np_dtype).view(dtype=np.uint16).flatten().tolist()
-            )
-        elif data_type == TensorProto.BFLOAT16:
-            vals = list(
-                map(
-                    float32_to_bfloat16,
-                    np.array(vals).astype(np_dtype).flatten().tolist(),
-                )
-            )
         field = mapping.STORAGE_TENSOR_TYPE_TO_FIELD[
             mapping.TENSOR_TYPE_TO_STORAGE_TENSOR_TYPE[data_type]
         ]

--- a/onnx/mapping.py
+++ b/onnx/mapping.py
@@ -27,9 +27,7 @@ TENSOR_TYPE_TO_NP_TYPE = {
 
 # Currently native numpy does not support bfloat16 so TensorProto.BFLOAT16 is ignored for now
 # Numpy float32 array is only reversed to TensorProto.FLOAT
-NP_TYPE_TO_TENSOR_TYPE = {
-    v: k for k, v in TENSOR_TYPE_TO_NP_TYPE.items()
-}
+NP_TYPE_TO_TENSOR_TYPE = {v: k for k, v in TENSOR_TYPE_TO_NP_TYPE.items()}
 
 # This is only used to get keys into STORAGE_TENSOR_TYPE_TO_FIELD.
 # TODO(https://github.com/onnx/onnx/issues/4261): Remove this.

--- a/onnx/mapping.py
+++ b/onnx/mapping.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np  # type: ignore
-from bfloat16 import bfloat16  # type: ignore
+from paddle_bfloat import bfloat16  # type: ignore
 
 from onnx import OptionalProto, SequenceProto, TensorProto
 

--- a/onnx/mapping.py
+++ b/onnx/mapping.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np  # type: ignore
-from bfloat16 import bfloat16
+from bfloat16 import bfloat16  # type: ignore
 
 from onnx import OptionalProto, SequenceProto, TensorProto
 

--- a/onnx/mapping.py
+++ b/onnx/mapping.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np  # type: ignore
+from bfloat16 import bfloat16
 
 from onnx import OptionalProto, SequenceProto, TensorProto
 
@@ -15,9 +16,7 @@ TENSOR_TYPE_TO_NP_TYPE = {
     int(TensorProto.INT64): np.dtype("int64"),
     int(TensorProto.BOOL): np.dtype("bool"),
     int(TensorProto.FLOAT16): np.dtype("float16"),
-    int(TensorProto.BFLOAT16): np.dtype(
-        "float32"
-    ),  # Native numpy does not support bfloat16 so now use float32 for bf16 values
+    int(TensorProto.BFLOAT16): np.dtype(bfloat16),
     int(TensorProto.DOUBLE): np.dtype("float64"),
     int(TensorProto.COMPLEX64): np.dtype("complex64"),
     int(TensorProto.COMPLEX128): np.dtype("complex128"),
@@ -29,7 +28,7 @@ TENSOR_TYPE_TO_NP_TYPE = {
 # Currently native numpy does not support bfloat16 so TensorProto.BFLOAT16 is ignored for now
 # Numpy float32 array is only reversed to TensorProto.FLOAT
 NP_TYPE_TO_TENSOR_TYPE = {
-    v: k for k, v in TENSOR_TYPE_TO_NP_TYPE.items() if k != TensorProto.BFLOAT16
+    v: k for k, v in TENSOR_TYPE_TO_NP_TYPE.items()
 }
 
 # This is only used to get keys into STORAGE_TENSOR_TYPE_TO_FIELD.

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -13,7 +13,7 @@ def combine_pairs_to_complex(fa: Sequence[int]) -> List[complex]:
     return [complex(fa[i * 2], fa[i * 2 + 1]) for i in range(len(fa) // 2)]
 
 
-def bfloat16_to_float32(
+def bfloat16uint32_to_float32(
     data: np.ndarray, dims: Union[int, Sequence[int]]
 ) -> np.ndarray:
     """Converts ndarray of bf16 (as uint32) to f32 (as uint32)."""
@@ -57,11 +57,6 @@ def to_array(tensor: TensorProto, base_dir: str = "") -> np.ndarray:
             # Convert endian from little to big
             convert_endian(tensor)
 
-        # manually convert bf16 since there's no numpy support
-        if tensor_dtype == TensorProto.BFLOAT16:
-            data = np.frombuffer(tensor.raw_data, dtype=np.int16)
-            return bfloat16_to_float32(data, dims)
-
         return np.frombuffer(tensor.raw_data, dtype=np_dtype).reshape(dims)
     else:
         # float16 is stored as int32 (uint16 type); Need view to get the original value
@@ -71,11 +66,6 @@ def to_array(tensor: TensorProto, base_dir: str = "") -> np.ndarray:
                 .reshape(dims)
                 .view(np.float16)
             )
-
-        # bfloat16 is stored as int32 (uint16 type); no numpy support for bf16
-        if tensor_dtype == TensorProto.BFLOAT16:
-            data = np.asarray(tensor.int32_data, dtype=np.int32)
-            return bfloat16_to_float32(data, dims)
 
         data = getattr(tensor, storage_field)
         if (

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -60,13 +60,6 @@ def to_array(tensor: TensorProto, base_dir: str = "") -> np.ndarray:
         return np.frombuffer(tensor.raw_data, dtype=np_dtype).reshape(dims)
     else:
         # float16 is stored as int32 (uint16 type); Need view to get the original value
-        if tensor_dtype == TensorProto.FLOAT16:
-            return (
-                np.asarray(tensor.int32_data, dtype=np.uint16)
-                .reshape(dims)
-                .view(np.float16)
-            )
-
         data = getattr(tensor, storage_field)
         if (
             tensor_dtype == TensorProto.COMPLEX64

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -6,7 +6,7 @@ import unittest
 from typing import Any, List, Tuple
 
 import numpy as np  # type: ignore
-from paddle_bfloat import bfloat16
+from paddle_bfloat import bfloat16  # type: ignore
 
 from onnx import (
     AttributeProto,

--- a/onnx/test/mapping_test.py
+++ b/onnx/test/mapping_test.py
@@ -1,8 +1,8 @@
 import unittest
 
 import numpy as np  # type: ignore
-from paddle_bfloat import bfloat16  # type: ignore
 from numpy.testing import assert_almost_equal  # type: ignore
+from paddle_bfloat import bfloat16  # type: ignore
 
 from onnx.mapping import TENSOR_TYPE_TO_NP_TYPE
 from onnx.numpy_helper import from_array, to_array

--- a/onnx/test/mapping_test.py
+++ b/onnx/test/mapping_test.py
@@ -1,7 +1,7 @@
 import unittest
 
 import numpy as np  # type: ignore
-from bfloat16 import bfloat16  # type: ignore
+from paddle_bfloat import bfloat16  # type: ignore
 from numpy.testing import assert_almost_equal  # type: ignore
 
 from onnx.mapping import TENSOR_TYPE_TO_NP_TYPE

--- a/onnx/test/mapping_test.py
+++ b/onnx/test/mapping_test.py
@@ -1,0 +1,34 @@
+import unittest
+
+import numpy as np
+from numpy.testing import assert_almost_equal
+from bfloat16 import bfloat16
+
+from onnx.mapping import TENSOR_TYPE_TO_NP_TYPE
+from onnx.numpy_helper import from_array, to_array
+
+class TestBasicFunctions(unittest.TestCase):
+
+    def test_numeric_types(self):
+        dtypes = [
+            np.float16, np.float32, np.float64,
+            bfloat16,
+            np.int8, np.int16, np.int32, np.int64,
+            np.uint8,np.uint16,np.uint32,np.uint64,
+            np.complex64, np.complex128,
+        ]
+        for dt in dtypes:
+            with self.subTest(dtype=dt):
+                t = np.array([0, 1, 2], dtype=dt)
+                ot = from_array(t)
+                u = to_array(ot)
+                self.assertEqual(t.dtype, u.dtype)
+                if t.dtype == bfloat16:
+                    # assert_almost_equal does not work is this case
+                    assert_almost_equal(t.astype(np.float32), u.astype(np.float32))
+                else:
+                    assert_almost_equal(t, u)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/onnx/test/mapping_test.py
+++ b/onnx/test/mapping_test.py
@@ -1,21 +1,30 @@
 import unittest
 
-import numpy as np
-from numpy.testing import assert_almost_equal
-from bfloat16 import bfloat16
+import numpy as np  # type: ignore
+from bfloat16 import bfloat16  # type: ignore
+from numpy.testing import assert_almost_equal  # type: ignore
 
 from onnx.mapping import TENSOR_TYPE_TO_NP_TYPE
 from onnx.numpy_helper import from_array, to_array
 
-class TestBasicFunctions(unittest.TestCase):
 
-    def test_numeric_types(self):
+class TestBasicFunctions(unittest.TestCase):
+    def test_numeric_types(self):  # type: ignore
         dtypes = [
-            np.float16, np.float32, np.float64,
+            np.float16,
+            np.float32,
+            np.float64,
             bfloat16,
-            np.int8, np.int16, np.int32, np.int64,
-            np.uint8,np.uint16,np.uint32,np.uint64,
-            np.complex64, np.complex128,
+            np.int8,
+            np.int16,
+            np.int32,
+            np.int64,
+            np.uint8,
+            np.uint16,
+            np.uint32,
+            np.uint64,
+            np.complex64,
+            np.complex128,
         ]
         for dt in dtypes:
             with self.subTest(dtype=dt):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 numpy
 protobuf
 typing-extensions
+paddle-bfloat
 pytest
 pytest-cov
 nbval

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-numpy
+numpy>=1.22
 protobuf
 typing-extensions
 paddle-bfloat

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -3,6 +3,7 @@ protobuf == 3.16.0
 pytest
 nbval
 ipython
+paddle-bfloat
 wheel
 setuptools
 twine

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,4 +1,4 @@
-numpy == 1.21.5
+numpy>=1.22
 protobuf == 3.16.0
 pytest
 nbval

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy >= 1.16.6 # TODO: update once TensorFlow 2.6 is end of life
+numpy>=1.22
 paddle-bfloat
 protobuf >= 3.12.2, <= 3.20.1
 typing-extensions >= 3.6.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bfloat16
 numpy >= 1.16.6 # TODO: update once TensorFlow 2.6 is end of life
+paddle-bfloat
 protobuf >= 3.12.2, <= 3.20.1
 typing-extensions >= 3.6.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+bfloat16
 numpy >= 1.16.6 # TODO: update once TensorFlow 2.6 is end of life
 protobuf >= 3.12.2, <= 3.20.1
 typing-extensions >= 3.6.2.1


### PR DESCRIPTION
Signed-off-by: sdpython <xavier.dupre@gmail.com>

### Description

bfloat16 is not supported by numpy. Package bfloat16 extends numpy with this type. This PR uses it to convert a tensor to a numpy array.


### Motivation and Context

onnx silently converts bfloat16 to float32 when converting the array to python.
