### PR TITLE
[1.12.1] Solve vulnerability issue while loading external tensors

### DIFF
--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10.5']
         architecture: ['x64', 'x86']
     steps:        
     - name: Checkout ONNX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,10 +58,13 @@ else()
   set(Protobuf_USE_STATIC_LIBS ON)
 endif()
 
-# Set C++11 as standard for the whole project
+# Required to use /std:c++17 or higher on Windows
+# For other platforms, set C++11 as standard for the whole project
 if(NOT MSVC)
   set(CMAKE_CXX_STANDARD 11)
-endif(NOT MSVC)
+else()
+  string(APPEND CMAKE_CXX_FLAGS " /std:c++17")
+endif()
 
 set(ONNX_ROOT ${PROJECT_SOURCE_DIR})
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ You can also use the [onnx-dev docker image](https://hub.docker.com/r/onnx/onnx-
 ## Build ONNX from Source
 Before building from source uninstall any existing versions of onnx `pip uninstall onnx`.
 
+c++17 or higher C++ compiler version is required to build ONNX from source on Windows. For other platforms, please use C++11 or higher versions.
+
 Generally speaking, you need to install [protobuf C/C++ libraries and tools](https://github.com/protocolbuffers/protobuf) before proceeding forward. Then depending on how you installed protobuf, you need to set environment variable CMAKE_ARGS to "-DONNX_USE_PROTOBUF_SHARED_LIBS=ON" or "-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF".  For example, you may need to run the following command:
 
 Linux:

--- a/onnx/common/path.cc
+++ b/onnx/common/path.cc
@@ -9,11 +9,99 @@
 
 namespace ONNX_NAMESPACE {
 
+bool is_path_separator(char c) {
+  // Windows accept / as path separator.
+  if (k_preferred_path_separator == "\\") {
+    return c == '\\' || c == '/';
+  }
+
+  return c == k_preferred_path_separator[0];
+}
+
+void normalize_separator(std::string& path) {
+  char preferred_sep = k_preferred_path_separator[0];
+  if (preferred_sep == '/') {
+    // Do nothing on linux.
+    return;
+  }
+
+  for (size_t i = 0; i < path.size(); i++) {
+    if (is_path_separator(path[i]) && path[i] != preferred_sep) {
+      path[i] = preferred_sep;
+    }
+  }
+}
+
 std::string path_join(const std::string& origin, const std::string& append) {
   if (origin.find_last_of(k_preferred_path_separator) != origin.length() - k_preferred_path_separator.length()) {
     return origin + k_preferred_path_separator + append;
   }
   return origin + append;
+}
+
+std::string clean_relative_path(const std::string& path) {
+  if (path.empty()) {
+    return ".";
+  }
+
+  std::string out;
+
+  char sep = k_preferred_path_separator[0];
+  size_t n = path.size();
+
+  size_t r = 0;
+  size_t dotdot = 0;
+
+  while (r < n) {
+    if (is_path_separator(path[r])) {
+      r++;
+      continue;
+    }
+
+    if (path[r] == '.' && (r + 1 == n || is_path_separator(path[r + 1]))) {
+      r++;
+      continue;
+    }
+
+    if (path[r] == '.' && path[r + 1] == '.' && (r + 2 == n || is_path_separator(path[r + 2]))) {
+      r += 2;
+
+      if (out.size() > dotdot) {
+        while (out.size() > dotdot && !is_path_separator(out.back())) {
+          out.pop_back();
+        }
+        if (!out.empty())
+          out.pop_back();
+      } else {
+        if (!out.empty()) {
+          out.push_back(sep);
+        }
+
+        out.push_back('.');
+        out.push_back('.');
+        dotdot = out.size();
+      }
+
+      continue;
+    }
+
+    if (!out.empty() && out.back() != sep) {
+      out.push_back(sep);
+    }
+
+    for (; r < n && !is_path_separator(path[r]); r++) {
+      out.push_back(path[r]);
+    }
+  }
+
+  if (out.empty()) {
+    out.push_back('.');
+  }
+
+  // Use 1 separator in path.
+  normalize_separator(out);
+
+  return out;
 }
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/common/path.h
+++ b/onnx/common/path.h
@@ -18,5 +18,7 @@ const std::string k_preferred_path_separator = "/";
 #endif
 
 std::string path_join(const std::string& origin, const std::string& append);
+void normalize_separator(std::string& path);
+std::string clean_relative_path(const std::string& path);
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/common/path.h
+++ b/onnx/common/path.h
@@ -8,17 +8,40 @@
 #pragma once
 
 #include <string>
+#ifdef _WIN32
+#include <windows.h>
+#include <filesystem>
+#include "onnx/checker.h"
+#endif
 
 namespace ONNX_NAMESPACE {
 
 #ifdef _WIN32
-const std::string k_preferred_path_separator = "\\";
+constexpr const char k_preferred_path_separator = '\\';
 #else // POSIX
-const std::string k_preferred_path_separator = "/";
+constexpr const char k_preferred_path_separator = '/';
 #endif
 
+#ifdef _WIN32
+inline std::wstring path_join(const std::wstring& origin, const std::wstring& append) {
+  return (std::filesystem::path(origin) / std::filesystem::path(append)).wstring();
+}
+inline std::wstring utf8str_to_wstring(const std::string& utf8str) {
+  if (utf8str.size() > INT_MAX) {
+    fail_check("utf8str_to_wstring: string is too long for converting to wstring.");
+  }
+  int size_required = MultiByteToWideChar(CP_UTF8, 0, utf8str.c_str(), (int)utf8str.size(), NULL, 0);
+  std::wstring ws_str(size_required, 0);
+  MultiByteToWideChar(CP_UTF8, 0, utf8str.c_str(), (int)utf8str.size(), &ws_str[0], size_required);
+  return ws_str;
+}
+
+#else
 std::string path_join(const std::string& origin, const std::string& append);
-void normalize_separator(std::string& path);
+// TODO: also use std::filesystem::path for clean_relative_path after ONNX has supported C++17 for POSIX
+// Clean up relative path when there is ".." in the path, e.g.: a/b/../c -> a/c
+// It cannot work with absolute path
 std::string clean_relative_path(const std::string& path);
+#endif
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/test/cpp/common_path_test.cc
+++ b/onnx/test/cpp/common_path_test.cc
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <list>
+#include <utility>
+#include "gtest/gtest.h"
+
+#include "onnx/common/path.h"
+
+using namespace ONNX_NAMESPACE;
+
+namespace ONNX_NAMESPACE {
+namespace Test {
+namespace {
+std::string fix_sep(std::string path) {
+  std::string out = path;
+  normalize_separator(out);
+  return out;
+}
+} // namespace
+
+TEST(PathTest, CleanRelativePathTest) {
+  // Already normal.
+  EXPECT_EQ(clean_relative_path("abc"), fix_sep("abc"));
+  EXPECT_EQ(clean_relative_path("abc/def"), fix_sep("abc/def"));
+  EXPECT_EQ(clean_relative_path("a/b/c"), fix_sep("a/b/c"));
+  EXPECT_EQ(clean_relative_path("."), fix_sep("."));
+  EXPECT_EQ(clean_relative_path(".."), fix_sep(".."));
+  EXPECT_EQ(clean_relative_path("../.."), fix_sep("../.."));
+  EXPECT_EQ(clean_relative_path("../../abc"), fix_sep("../../abc"));
+  // Remove leading slash
+  EXPECT_EQ(clean_relative_path("/abc"), fix_sep("abc"));
+  EXPECT_EQ(clean_relative_path("/"), fix_sep("."));
+  // Remove trailing slash
+  EXPECT_EQ(clean_relative_path("abc/"), fix_sep("abc"));
+  EXPECT_EQ(clean_relative_path("abc/def/"), fix_sep("abc/def"));
+  EXPECT_EQ(clean_relative_path("a/b/c/"), fix_sep("a/b/c"));
+  EXPECT_EQ(clean_relative_path("./"), fix_sep("."));
+  EXPECT_EQ(clean_relative_path("../"), fix_sep(".."));
+  EXPECT_EQ(clean_relative_path("../../"), fix_sep("../.."));
+  EXPECT_EQ(clean_relative_path("/abc/"), fix_sep("abc"));
+  // Remove doubled slash
+  EXPECT_EQ(clean_relative_path("abc//def//ghi"), fix_sep("abc/def/ghi"));
+  EXPECT_EQ(clean_relative_path("//abc"), fix_sep("abc"));
+  EXPECT_EQ(clean_relative_path("///abc"), fix_sep("abc"));
+  EXPECT_EQ(clean_relative_path("//abc//"), fix_sep("abc"));
+  EXPECT_EQ(clean_relative_path("abc//"), fix_sep("abc"));
+  // Remove . elements
+  EXPECT_EQ(clean_relative_path("abc/./def"), fix_sep("abc/def"));
+  EXPECT_EQ(clean_relative_path("/./abc/def"), fix_sep("abc/def"));
+  EXPECT_EQ(clean_relative_path("abc/."), fix_sep("abc"));
+  // Remove .. elements
+  EXPECT_EQ(clean_relative_path("abc/def/ghi/../jkl"), fix_sep("abc/def/jkl"));
+  EXPECT_EQ(clean_relative_path("abc/def/../ghi/../jkl"), fix_sep("abc/jkl"));
+  EXPECT_EQ(clean_relative_path("abc/def/.."), fix_sep("abc"));
+  EXPECT_EQ(clean_relative_path("abc/def/../.."), fix_sep("."));
+  EXPECT_EQ(clean_relative_path("/abc/def/../.."), fix_sep("."));
+  EXPECT_EQ(clean_relative_path("abc/def/../../.."), fix_sep(".."));
+  EXPECT_EQ(clean_relative_path("/abc/def/../../.."), fix_sep(".."));
+  EXPECT_EQ(clean_relative_path("abc/def/../../../ghi/jkl/../../../mno"), fix_sep("../../mno"));
+  EXPECT_EQ(clean_relative_path("/../abc"), fix_sep("../abc"));
+  // Combinations
+  EXPECT_EQ(clean_relative_path("abc/./../def"), fix_sep("def"));
+  EXPECT_EQ(clean_relative_path("abc//./../def"), fix_sep("def"));
+  EXPECT_EQ(clean_relative_path("abc/../../././../def"), fix_sep("../../def"));
+}
+
+} // namespace Test
+} // namespace ONNX_NAMESPACE

--- a/onnx/test/cpp/common_path_test.cc
+++ b/onnx/test/cpp/common_path_test.cc
@@ -8,63 +8,51 @@
 
 #include "onnx/common/path.h"
 
+#ifdef _WIN32
+// Only test clean_relative_path and normalize_separator on non-Windows
+// because Windows has its own implementation for them from std::filesystem::path.
+#else
 using namespace ONNX_NAMESPACE;
-
 namespace ONNX_NAMESPACE {
 namespace Test {
-namespace {
-std::string fix_sep(std::string path) {
-  std::string out = path;
-  normalize_separator(out);
-  return out;
-}
-} // namespace
 
 TEST(PathTest, CleanRelativePathTest) {
   // Already normal.
-  EXPECT_EQ(clean_relative_path("abc"), fix_sep("abc"));
-  EXPECT_EQ(clean_relative_path("abc/def"), fix_sep("abc/def"));
-  EXPECT_EQ(clean_relative_path("a/b/c"), fix_sep("a/b/c"));
-  EXPECT_EQ(clean_relative_path("."), fix_sep("."));
-  EXPECT_EQ(clean_relative_path(".."), fix_sep(".."));
-  EXPECT_EQ(clean_relative_path("../.."), fix_sep("../.."));
-  EXPECT_EQ(clean_relative_path("../../abc"), fix_sep("../../abc"));
-  // Remove leading slash
-  EXPECT_EQ(clean_relative_path("/abc"), fix_sep("abc"));
-  EXPECT_EQ(clean_relative_path("/"), fix_sep("."));
+  EXPECT_EQ(clean_relative_path("abc"), "abc");
+  EXPECT_EQ(clean_relative_path("abc/def"), "abc/def");
+  EXPECT_EQ(clean_relative_path("a/b/c"), "a/b/c");
+  EXPECT_EQ(clean_relative_path("."), ".");
+  EXPECT_EQ(clean_relative_path(".."), "..");
+  EXPECT_EQ(clean_relative_path("../.."), "../..");
+  EXPECT_EQ(clean_relative_path("../../abc"), "../../abc");
   // Remove trailing slash
-  EXPECT_EQ(clean_relative_path("abc/"), fix_sep("abc"));
-  EXPECT_EQ(clean_relative_path("abc/def/"), fix_sep("abc/def"));
-  EXPECT_EQ(clean_relative_path("a/b/c/"), fix_sep("a/b/c"));
-  EXPECT_EQ(clean_relative_path("./"), fix_sep("."));
-  EXPECT_EQ(clean_relative_path("../"), fix_sep(".."));
-  EXPECT_EQ(clean_relative_path("../../"), fix_sep("../.."));
-  EXPECT_EQ(clean_relative_path("/abc/"), fix_sep("abc"));
+  EXPECT_EQ(clean_relative_path("abc/"), "abc");
+  EXPECT_EQ(clean_relative_path("abc/def/"), "abc/def");
+  EXPECT_EQ(clean_relative_path("a/b/c/"), "a/b/c");
+  EXPECT_EQ(clean_relative_path("./"), ".");
+  EXPECT_EQ(clean_relative_path("../"), "..");
+  EXPECT_EQ(clean_relative_path("../../"), "../..");
   // Remove doubled slash
-  EXPECT_EQ(clean_relative_path("abc//def//ghi"), fix_sep("abc/def/ghi"));
-  EXPECT_EQ(clean_relative_path("//abc"), fix_sep("abc"));
-  EXPECT_EQ(clean_relative_path("///abc"), fix_sep("abc"));
-  EXPECT_EQ(clean_relative_path("//abc//"), fix_sep("abc"));
-  EXPECT_EQ(clean_relative_path("abc//"), fix_sep("abc"));
+  EXPECT_EQ(clean_relative_path("abc//def//ghi"), "abc/def/ghi");
+  EXPECT_EQ(clean_relative_path("abc///"), "abc");
+  EXPECT_EQ(clean_relative_path("abc//"), "abc");
   // Remove . elements
-  EXPECT_EQ(clean_relative_path("abc/./def"), fix_sep("abc/def"));
-  EXPECT_EQ(clean_relative_path("/./abc/def"), fix_sep("abc/def"));
-  EXPECT_EQ(clean_relative_path("abc/."), fix_sep("abc"));
+  EXPECT_EQ(clean_relative_path("abc/./def"), "abc/def");
+  EXPECT_EQ(clean_relative_path("./abc/def"), "abc/def");
+  EXPECT_EQ(clean_relative_path("abc/."), "abc");
   // Remove .. elements
-  EXPECT_EQ(clean_relative_path("abc/def/ghi/../jkl"), fix_sep("abc/def/jkl"));
-  EXPECT_EQ(clean_relative_path("abc/def/../ghi/../jkl"), fix_sep("abc/jkl"));
-  EXPECT_EQ(clean_relative_path("abc/def/.."), fix_sep("abc"));
-  EXPECT_EQ(clean_relative_path("abc/def/../.."), fix_sep("."));
-  EXPECT_EQ(clean_relative_path("/abc/def/../.."), fix_sep("."));
-  EXPECT_EQ(clean_relative_path("abc/def/../../.."), fix_sep(".."));
-  EXPECT_EQ(clean_relative_path("/abc/def/../../.."), fix_sep(".."));
-  EXPECT_EQ(clean_relative_path("abc/def/../../../ghi/jkl/../../../mno"), fix_sep("../../mno"));
-  EXPECT_EQ(clean_relative_path("/../abc"), fix_sep("../abc"));
+  EXPECT_EQ(clean_relative_path("abc/def/ghi/../jkl"), "abc/def/jkl");
+  EXPECT_EQ(clean_relative_path("abc/def/../ghi/../jkl"), "abc/jkl");
+  EXPECT_EQ(clean_relative_path("abc/def/.."), "abc");
+  EXPECT_EQ(clean_relative_path("abc/def/../.."), ".");
+  EXPECT_EQ(clean_relative_path("abc/def/../../.."), "..");
+  EXPECT_EQ(clean_relative_path("abc/def/../../../ghi/jkl/../../../mno"), "../../mno");
+  EXPECT_EQ(clean_relative_path("../abc"), "../abc");
   // Combinations
-  EXPECT_EQ(clean_relative_path("abc/./../def"), fix_sep("def"));
-  EXPECT_EQ(clean_relative_path("abc//./../def"), fix_sep("def"));
-  EXPECT_EQ(clean_relative_path("abc/../../././../def"), fix_sep("../../def"));
+  EXPECT_EQ(clean_relative_path("abc/./../def"), "def");
+  EXPECT_EQ(clean_relative_path("abc//./../def"), "def");
+  EXPECT_EQ(clean_relative_path("abc/../../././../def"), "../../def");
 }
-
 } // namespace Test
 } // namespace ONNX_NAMESPACE
+#endif

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -1212,7 +1212,7 @@ class TestShapeInference(unittest.TestCase):
             [make_node('RNN', ['x', 'w', 'r'], ['all', 'last'], hidden_size=hiddensize,
                 layout=1, direction=direction)],
             [])
-        if(direction == 'bidirectional'):
+        if direction == 'bidirectional':
             num_directions = 2
         else:
             num_directions = 1

--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -116,8 +116,8 @@ class Extractor:
 
         initializer = [self.wmap[t] for t in self.wmap.keys() if t in all_tensors_name]
         value_info = [self.vimap[t] for t in self.vimap.keys() if t in all_tensors_name]
-        assert(len(self.graph.sparse_initializer) == 0)
-        assert(len(self.graph.quantization_annotation) == 0)
+        assert len(self.graph.sparse_initializer) == 0
+        assert len(self.graph.quantization_annotation) == 0
         return (initializer, value_info)
 
     def _make_model(


### PR DESCRIPTION
### Description
Cherry-pick https://github.com/onnx/onnx/pull/4400 and https://github.com/onnx/onnx/pull/4470 for 1.12.1. It will be used for updating ONNX commit in ONNX Runtime to solve vulnerability issue while loading external tensors from files outside the directory.


### Motivation and Context
With the base of rel-1.12.0, cherry-pick https://github.com/onnx/onnx/pull/4400 and https://github.com/onnx/onnx/pull/4470 to solve vulnerability issue while loading external tensors from files outside the directory.
