### PR TITLE
Validate the generated number of input.pb and output.pb in CIs

### DIFF
--- a/.azure-pipelines/Linux-CI.yml
+++ b/.azure-pipelines/Linux-CI.yml
@@ -127,5 +127,10 @@ jobs:
         echo "git diff for test generation returned failures. Please check updated node test files"
         exit 1
       fi
+      git diff --exit-code --name-only -- . ':!onnx/onnx-data.proto' ':!onnx/onnx-data.proto3'
+      if [ $? -ne 0 ]; then
+        echo "Test generation returned failures. Please check the number of node test files (input_*.pb or output_*.pb)"
+        exit 1
+      fi
 
     displayName: Test backend test data

--- a/.azure-pipelines/MacOS-CI.yml
+++ b/.azure-pipelines/MacOS-CI.yml
@@ -109,5 +109,10 @@ jobs:
         echo "git diff for test generation returned failures. Please check updated node test files"
         exit 1
       fi
+      git diff --exit-code --name-only -- . ':!onnx/onnx-data.proto' ':!onnx/onnx-data.proto3'
+      if [ $? -ne 0 ]; then
+        echo "Test generation returned failures. Please check the number of node test files (input_*.pb or output_*.pb)"
+        exit 1
+      fi
 
     displayName: 'Run ONNX Tests'

--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -65,7 +65,7 @@ jobs:
       python onnx/gen_proto.py -l
       python onnx/gen_proto.py -l --ml
       
-      git diff --exit-code  -- . :(exclude)onnx/onnx-data.proto :(exclude)onnx/onnx-data.proto3
+      git diff --exit-code -- . :(exclude)onnx/onnx-data.proto :(exclude)onnx/onnx-data.proto3
       IF NOT %ERRORLEVEL% EQU 0 (
         @echo "git diff returned failures"
         EXIT 1
@@ -73,9 +73,14 @@ jobs:
 
       python onnx/backend/test/cmd_tools.py generate-data
       git status
-      git diff --exit-code  -- . :!onnx/onnx-data.proto :!onnx/onnx-data.proto3 :!*output_*.pb :!*input_*.pb
+      git diff --exit-code -- . :!onnx/onnx-data.proto :!onnx/onnx-data.proto3 :!*output_*.pb :!*input_*.pb
       IF NOT %ERRORLEVEL% EQU 0 (
         @echo "git diff for test generation returned failures. Please check updated node test files"
+        EXIT 1
+      )
+      git diff --exit-code --name-only -- . :!onnx/onnx-data.proto :!onnx/onnx-data.proto3
+      IF NOT %ERRORLEVEL% EQU 0 (
+        @echo "Test generation returned failures. Please check the number of node test files (input_*.pb or output_*.pb)."
         EXIT 1
       )
 


### PR DESCRIPTION
### Description
Validate the generated number of input.pb and output.pb in CIs

### Motivation and Context
Some validation will be missing after https://github.com/onnx/onnx/pull/4431. We should additionally handle the validation of generated number of input.pb and output.pb