### PR TITLE
avoid modifying node when creating test cases

### DIFF
--- a/onnx/backend/test/case/node/__init__.py
+++ b/onnx/backend/test/case/node/__init__.py
@@ -130,16 +130,15 @@ def function_expand_helper(
 def function_testcase_helper(
     node: NodeProto, input_types: List[TypeProto], name: str
 ) -> Tuple[List[NodeProto], List[OperatorSetIdProto]]:
-    node_copy = deepcopy(node)
-    test_op = node_copy.op_type
+    test_op = node.op_type
     op_prefix = test_op + "_" + name + "_expanded_function_"
-    schema = onnx.defs.get_schema(test_op, node_copy.domain)
+    schema = onnx.defs.get_schema(test_op, node.domain)
 
     if schema.has_function:  # type: ignore
         function_proto = schema.function_body  # type: ignore
     elif schema.has_context_dependent_function:  # type: ignore
         function_proto_str = schema.get_context_dependent_function(  # type: ignore
-            node_copy.SerializeToString(), [t.SerializeToString() for t in input_types]
+            node.SerializeToString(), [t.SerializeToString() for t in input_types]
         )
         function_proto = FunctionProto()
         function_proto.ParseFromString(function_proto_str)
@@ -147,13 +146,13 @@ def function_testcase_helper(
         return [], []
 
     for attr in schema.attributes:
-        if attr in [a.name for a in node_copy.attribute]:
+        if attr in [a.name for a in node.attribute]:
             continue
         if schema.attributes[attr].default_value:
-            node_copy.attribute.extend([schema.attributes[attr].default_value])
+            node.attribute.extend([schema.attributes[attr].default_value])
 
     # function_proto.attributes
-    node_list = function_expand_helper(node_copy, function_proto, op_prefix)
+    node_list = function_expand_helper(node, function_proto, op_prefix)
     return node_list, function_proto.opset_import
 
 
@@ -208,26 +207,29 @@ def _make_test_model_gen_version(graph: GraphProto, **kwargs: Any) -> ModelProto
     return onnx.helper.make_model_gen_version(graph, **kwargs)
 
 
-# In the case of ops with optional inputs and outputs, node.input and node.output indicate
+# In the case of ops with optional inputs and outputs, node_op.input and node_op.output indicate
 # which inputs/outputs are present and which are omitted. However, the parameter inputs
 # and outputs of this function include values only for inputs/outputs that are present.
 # E.g., for an op with 3 inputs, if the second parameter is optional and we wish to omit it,
-# node.inputs would look like ["Param1", "", "Param3"], while inputs would look like
+# node_op.inputs would look like ["Param1", "", "Param3"], while inputs would look like
 # [input-1-value, input-3-value]
 # Instead of creating model with latest version, it now generates models for since_version by default.
 # Thus it can make every model uses the same opset version after every opset change.
 # Besides, user can specify "use_max_opset_version" to generate models for
 # the latest opset vesion that supports before targeted opset version
 def expect(
-    node: onnx.NodeProto,
+    node_op: onnx.NodeProto,
     inputs: Sequence[np.ndarray],
     outputs: Sequence[np.ndarray],
     name: str,
     **kwargs: Any,
 ) -> None:
-    # skip if the node's op_type is not same as the given one
+    # skip if the node_op's op_type is not same as the given one
     if _TargetOpType and node.op_type != _TargetOpType:
         return
+
+    # in case node_op is modified
+    node = deepcopy(node_op)
     present_inputs = [x for x in node.input if (x != "")]
     present_outputs = [x for x in node.output if (x != "")]
     input_type_protos = [None] * len(inputs)

--- a/onnx/backend/test/case/node/__init__.py
+++ b/onnx/backend/test/case/node/__init__.py
@@ -225,7 +225,7 @@ def expect(
     **kwargs: Any,
 ) -> None:
     # skip if the node_op's op_type is not same as the given one
-    if _TargetOpType and node.op_type != _TargetOpType:
+    if _TargetOpType and node_op.op_type != _TargetOpType:
         return
 
     # in case node_op is modified


### PR DESCRIPTION
Signed-off-by: Liqun Fu <liqfu@microsoft.com>

### Description
avoid modifying node when creating test cases


### Motivation and Context
An operator node is used to create test cases.  Sometimes a node is used to create multiple test cases. This requires that the node is immutable when creating a test case. This is especially true when a test with default attributes. In this PR, change is added to avoid default attributes being added to the original node which will cause subsequent test case creation failure.
This bug was detected when changing ReduceSumSquare to function op. When extended cases were created, a attribute of empty attribute was added to the original node which cause the next test case to fail.