### PR TITLE
Add vcpkg instruct step

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ pip install onnx
 onnx is in the maintenance list of [vcpkg](https://github.com/microsoft/vcpkg), you can easily use vcpkg to build and install it.
 ```
 git clone https://github.com/microsoft/vcpkg.git
+cd vcpkg
 ./bootstrap-vcpkg.bat # For powershell
 ./bootstrap-vcpkg.sh # For bash
 ./vcpkg install onnx

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ pip install onnx
 
 [Weekly packages](https://test.pypi.org/project/onnx-weekly/) are published in test pypi to enable experimentation and early testing.
 
+## vcpkg packages
+onnx is in the maintenance list of [vcpkg](https://github.com/microsoft/vcpkg), you can easily use vcpkg to build and install it.
+```
+git clone https://github.com/microsoft/vcpkg.git
+./bootstrap-vcpkg.bat # For powershell
+./bootstrap-vcpkg.sh # For bash
+./vcpkg install onnx
+```
 
 ## Conda packages
 A binary build of ONNX is available from [Conda](https://conda.io), in [conda-forge](https://conda-forge.org/):


### PR DESCRIPTION
Signed-off-by: JackBoosY <yuzaiyang@beyondsoft.com>

`onnx` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `onnx` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `onnx`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/onnx/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)