### PR TITLE
Fix several issues regarding recent mapping update

### DIFF
--- a/docs/PythonAPIOverview.md
+++ b/docs/PythonAPIOverview.md
@@ -100,6 +100,7 @@ print('After saving and loading, new TensorProto:\n{}'.format(new_tensor))
 from onnx import TensorProto, helper
 
 # Conversion utilities for mapping attributes in ONNX IR
+# The functions below are available after ONNX 1.13
 np_dtype = helper.tensor_dtype_to_np_dtype(TensorProto.FLOAT)
 print(f"The converted numpy dtype for {helper.tensor_dtype_to_string(TensorProto.FLOAT)} is {np_dtype}.")
 storage_dtype = helper.tensor_dtype_to_storage_tensor_dtype(TensorProto.FLOAT)

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -1179,7 +1179,7 @@ def np_dtype_to_tensor_dtype(np_dtype: np.dtype) -> int:
     :param np_dtype: numpy's data_type
     :return: TensorsProto's data_type
     """
-    return cast(int, mapping.NP_TYPE_TO_TENSOR_TYPE[np_dtype])
+    return cast(int, mapping._NP_TYPE_TO_TENSOR_TYPE[np_dtype])
 
 
 def get_all_tensor_dtypes() -> KeysView[int]:

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -1167,12 +1167,9 @@ def tensor_dtype_to_field(tensor_dtype: int) -> str:
     :param tensor_dtype: TensorProto's data_type
     :return: field name
     """
-    return cast(
-        str,
-        mapping._STORAGE_TENSOR_TYPE_TO_FIELD[
-            mapping.TENSOR_TYPE_MAP[tensor_dtype].storage_dtype
-        ],
-    )
+    return mapping._STORAGE_TENSOR_TYPE_TO_FIELD[
+        mapping.TENSOR_TYPE_MAP[tensor_dtype].storage_dtype
+    ]
 
 
 def np_dtype_to_tensor_dtype(np_dtype: np.dtype) -> int:

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -902,7 +902,8 @@ def printable_attribute(
             content.append("<Tensor>")
         else:
             # special case to print scalars
-            content.append("<Scalar Tensor>")
+            field = tensor_dtype_to_field(attr.t.data_type)
+            content.append(f"<Scalar Tensor {str(getattr(attr.t, field))}>")
     elif attr.HasField("g"):
         content.append(f"<graph {attr.g.name}>")
         graphs.append(attr.g)
@@ -1136,7 +1137,7 @@ def tensor_dtype_to_np_dtype(tensor_dtype: int) -> np.dtype:
     :param tensor_dtype: TensorProto's data_type
     :return: numpy's data_type
     """
-    return mapping.TENSOR_TYPE_MAP[int(tensor_dtype)].np_dtype
+    return mapping.TENSOR_TYPE_MAP[tensor_dtype].np_dtype
 
 
 def tensor_dtype_to_storage_tensor_dtype(tensor_dtype: int) -> int:
@@ -1156,7 +1157,7 @@ def tensor_dtype_to_string(tensor_dtype: int) -> str:
     :param tensor_dtype: TensorProto's data_type
     :return: the name of data_type
     """
-    return mapping.TENSOR_TYPE_MAP[int(tensor_dtype)].name
+    return mapping.TENSOR_TYPE_MAP[tensor_dtype].name
 
 
 def tensor_dtype_to_field(tensor_dtype: int) -> str:
@@ -1168,8 +1169,8 @@ def tensor_dtype_to_field(tensor_dtype: int) -> str:
     """
     return cast(
         str,
-        mapping.STORAGE_TENSOR_TYPE_TO_FIELD[
-            mapping.TENSOR_TYPE_MAP[int(tensor_dtype)].storage_dtype
+        mapping._STORAGE_TENSOR_TYPE_TO_FIELD[
+            mapping.TENSOR_TYPE_MAP[tensor_dtype].storage_dtype
         ],
     )
 

--- a/onnx/mapping.py
+++ b/onnx/mapping.py
@@ -88,7 +88,7 @@ class DeprecatedWarningDict(dict):  # type: ignore
             warnings.warn(
                 str(
                     f"`mapping.{self._origin_function}` is now deprecated and will be removed in the next release or so."
-                    + "To silence this warning, please simply use if-else statement to check the type of the key."
+                    + "To silence this warning, please simply use if-else statement to get the corresponding value."
                 ),
                 DeprecationWarning,
                 stacklevel=2,
@@ -112,7 +112,7 @@ TENSOR_TYPE_TO_NP_TYPE = DeprecatedWarningDict(
     "tensor_dtype_to_np_dtype",
 )
 # This is only used to get keys into STORAGE_TENSOR_TYPE_TO_FIELD.
-# TODO(https://github.com/onnx/onnx/issues/4261): Remove this.
+# TODO(https://github.com/onnx/onnx/issues/4554): Move these variables into _mapping.py
 
 TENSOR_TYPE_TO_STORAGE_TENSOR_TYPE = DeprecatedWarningDict(
     {
@@ -131,22 +131,25 @@ NP_TYPE_TO_TENSOR_TYPE = DeprecatedWarningDict(
     "np_dtype_to_tensor_dtype",
 )
 
+_STORAGE_TENSOR_TYPE_TO_FIELD = {
+    int(TensorProto.FLOAT): "float_data",
+    int(TensorProto.INT32): "int32_data",
+    int(TensorProto.INT64): "int64_data",
+    int(TensorProto.UINT16): "int32_data",
+    int(TensorProto.DOUBLE): "double_data",
+    int(TensorProto.COMPLEX64): "float_data",
+    int(TensorProto.COMPLEX128): "double_data",
+    int(TensorProto.UINT32): "uint64_data",
+    int(TensorProto.UINT64): "uint64_data",
+    int(TensorProto.STRING): "string_data",
+    int(TensorProto.BOOL): "int32_data",
+}
+
+# STORAGE_TENSOR_TYPE_TO_FIELD will be eventually removed in the future
+# and _STORAGE_TENSOR_TYPE_TO_FIELD will only be used internally
 STORAGE_TENSOR_TYPE_TO_FIELD = DeprecatedWarningDict(
-    {
-        int(TensorProto.FLOAT): "float_data",
-        int(TensorProto.INT32): "int32_data",
-        int(TensorProto.INT64): "int64_data",
-        int(TensorProto.UINT16): "int32_data",
-        int(TensorProto.DOUBLE): "double_data",
-        int(TensorProto.COMPLEX64): "float_data",
-        int(TensorProto.COMPLEX128): "double_data",
-        int(TensorProto.UINT32): "uint64_data",
-        int(TensorProto.UINT64): "uint64_data",
-        int(TensorProto.STRING): "string_data",
-        int(TensorProto.BOOL): "int32_data",
-    },
+    _STORAGE_TENSOR_TYPE_TO_FIELD,
     "STORAGE_TENSOR_TYPE_TO_FIELD",
-    "tensor_dtype_to_field",
 )
 
 

--- a/onnx/mapping.py
+++ b/onnx/mapping.py
@@ -123,14 +123,22 @@ TENSOR_TYPE_TO_STORAGE_TENSOR_TYPE = DeprecatedWarningDict(
     "tensor_dtype_to_storage_tensor_dtype",
 )
 
+# NP_TYPE_TO_TENSOR_TYPE will be eventually removed in the future
+# and _NP_TYPE_TO_TENSOR_TYPE will only be used internally
+_NP_TYPE_TO_TENSOR_TYPE = {
+    v: k for k, v in TENSOR_TYPE_TO_NP_TYPE.items() if k != TensorProto.BFLOAT16
+}
+
 # Currently native numpy does not support bfloat16 so TensorProto.BFLOAT16 is ignored for now
 # Numpy float32 array is only reversed to TensorProto.FLOAT
 NP_TYPE_TO_TENSOR_TYPE = DeprecatedWarningDict(
-    {v: k for k, v in TENSOR_TYPE_TO_NP_TYPE.items() if k != TensorProto.BFLOAT16},
+    cast(Dict[int, Union[int, str, Any]], _NP_TYPE_TO_TENSOR_TYPE),
     "NP_TYPE_TO_TENSOR_TYPE",
     "np_dtype_to_tensor_dtype",
 )
 
+# STORAGE_TENSOR_TYPE_TO_FIELD will be eventually removed in the future
+# and _STORAGE_TENSOR_TYPE_TO_FIELD will only be used internally
 _STORAGE_TENSOR_TYPE_TO_FIELD = {
     int(TensorProto.FLOAT): "float_data",
     int(TensorProto.INT32): "int32_data",
@@ -145,8 +153,6 @@ _STORAGE_TENSOR_TYPE_TO_FIELD = {
     int(TensorProto.BOOL): "int32_data",
 }
 
-# STORAGE_TENSOR_TYPE_TO_FIELD will be eventually removed in the future
-# and _STORAGE_TENSOR_TYPE_TO_FIELD will only be used internally
 STORAGE_TENSOR_TYPE_TO_FIELD = DeprecatedWarningDict(
     cast(Dict[int, Union[int, str, Any]], _STORAGE_TENSOR_TYPE_TO_FIELD),
     "STORAGE_TENSOR_TYPE_TO_FIELD",

--- a/onnx/mapping.py
+++ b/onnx/mapping.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, Dict, NamedTuple, Union
+from typing import Any, Dict, NamedTuple, Union, cast
 
 import numpy as np
 
@@ -148,7 +148,7 @@ _STORAGE_TENSOR_TYPE_TO_FIELD = {
 # STORAGE_TENSOR_TYPE_TO_FIELD will be eventually removed in the future
 # and _STORAGE_TENSOR_TYPE_TO_FIELD will only be used internally
 STORAGE_TENSOR_TYPE_TO_FIELD = DeprecatedWarningDict(
-    _STORAGE_TENSOR_TYPE_TO_FIELD,
+    cast(Dict[int, Union[int, str, Any]], _STORAGE_TENSOR_TYPE_TO_FIELD),
     "STORAGE_TENSOR_TYPE_TO_FIELD",
 )
 

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -162,6 +162,8 @@ def to_list(sequence: SequenceProto) -> List[Any]:
         return [to_array(v) for v in sequence.sparse_tensor_values]
     if elem_type == SequenceProto.SEQUENCE:
         return [to_list(v) for v in sequence.sequence_values]
+    if elem_type == SequenceProto.MAP:
+        return [to_dict(v) for v in sequence.map_values]
     raise TypeError("The element type in the input sequence is not supported.")
 
 

--- a/onnx/onnx-ml.proto
+++ b/onnx/onnx-ml.proto
@@ -544,7 +544,7 @@ message TensorProto {
   // float16 values must be bit-wise converted to an uint16_t prior
   // to writing to the buffer.
   // When this field is present, the data_type field MUST be
-  // INT32, INT16, INT8, UINT16, UINT8, BOOL, or FLOAT16
+  // INT32, INT16, INT8, UINT16, UINT8, BOOL, FLOAT16 or BFLOAT16
   repeated int32 int32_data = 5 [packed = true];
 
   // For strings.

--- a/onnx/onnx-ml.proto3
+++ b/onnx/onnx-ml.proto3
@@ -544,7 +544,7 @@ message TensorProto {
   // float16 values must be bit-wise converted to an uint16_t prior
   // to writing to the buffer.
   // When this field is present, the data_type field MUST be
-  // INT32, INT16, INT8, UINT16, UINT8, BOOL, or FLOAT16
+  // INT32, INT16, INT8, UINT16, UINT8, BOOL, FLOAT16 or BFLOAT16
   repeated int32 int32_data = 5 [packed = true];
 
   // For strings.

--- a/onnx/onnx.in.proto
+++ b/onnx/onnx.in.proto
@@ -541,7 +541,7 @@ message TensorProto {
   // float16 values must be bit-wise converted to an uint16_t prior
   // to writing to the buffer.
   // When this field is present, the data_type field MUST be
-  // INT32, INT16, INT8, UINT16, UINT8, BOOL, or FLOAT16
+  // INT32, INT16, INT8, UINT16, UINT8, BOOL, FLOAT16 or BFLOAT16
   repeated int32 int32_data = 5 [packed = true];
 
   // For strings.

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -542,7 +542,7 @@ message TensorProto {
   // float16 values must be bit-wise converted to an uint16_t prior
   // to writing to the buffer.
   // When this field is present, the data_type field MUST be
-  // INT32, INT16, INT8, UINT16, UINT8, BOOL, or FLOAT16
+  // INT32, INT16, INT8, UINT16, UINT8, BOOL, FLOAT16 or BFLOAT16
   repeated int32 int32_data = 5 [packed = true];
 
   // For strings.

--- a/onnx/onnx.proto3
+++ b/onnx/onnx.proto3
@@ -542,7 +542,7 @@ message TensorProto {
   // float16 values must be bit-wise converted to an uint16_t prior
   // to writing to the buffer.
   // When this field is present, the data_type field MUST be
-  // INT32, INT16, INT8, UINT16, UINT8, BOOL, or FLOAT16
+  // INT32, INT16, INT8, UINT16, UINT8, BOOL, FLOAT16 or BFLOAT16
   repeated int32 int32_data = 5 [packed = true];
 
   // For strings.

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -743,6 +743,17 @@ class TestHelperMappingFunctions(unittest.TestCase):
     def test_np_dtype_to_tensor_dtype_not_throw_warning(self) -> None:
         _ = helper.np_dtype_to_tensor_dtype(np.dtype("float32"))
 
+    def test_tensor_dtype_to_np_dtype_bfloat16(self) -> None:
+        self.assertEqual(
+            helper.tensor_dtype_to_np_dtype(TensorProto.BFLOAT16), np.dtype("float32")
+        )
+
+    def test_tensor_dtype_to_storage_tensor_dtype_bfloat16(self) -> None:
+        self.assertEqual(
+            helper.tensor_dtype_to_storage_tensor_dtype(TensorProto.BFLOAT16),
+            TensorProto.UINT16,
+        )
+
     # BFloat16 tensor uses TensorProto.UINT16 as storage type;
     # And the field name for TensorProto.UINT16 is int32_data
     def test_tensor_dtype_to_field_bfloat16(self) -> None:

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -724,6 +724,26 @@ def test_make_tensor_raw(tensor_dtype: int) -> None:
     np.testing.assert_equal(np_array, numpy_helper.to_array(tensor))
 
 
+# TODO (#4554): remove this test after the deprecation period
+# Test these new functions should not raise any depreaction warnings
+class TestHelperMappingFunctions(unittest.TestCase):
+    @pytest.mark.filterwarnings("error::DeprecationWarning")
+    def test_tensor_dtype_to_np_dtype_not_throw_warning(self) -> None:
+        _ = helper.tensor_dtype_to_np_dtype(TensorProto.FLOAT)
+
+    @pytest.mark.filterwarnings("error::DeprecationWarning")
+    def test_tensor_dtype_to_storage_tensor_dtype_not_throw_warning(self) -> None:
+        _ = helper.tensor_dtype_to_storage_tensor_dtype(TensorProto.FLOAT)
+
+    @pytest.mark.filterwarnings("error::DeprecationWarning")
+    def test_tensor_dtype_to_field_not_throw_warning(self) -> None:
+        _ = helper.tensor_dtype_to_field(TensorProto.FLOAT)
+
+    @pytest.mark.filterwarnings("error::DeprecationWarning")
+    def test_np_dtype_to_tensor_dtype_not_throw_warning(self) -> None:
+        _ = helper.np_dtype_to_tensor_dtype(np.float32)
+
+
 if __name__ == "__main__":
     unittest.main()
     pytest.main([__file__])

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -724,9 +724,9 @@ def test_make_tensor_raw(tensor_dtype: int) -> None:
     np.testing.assert_equal(np_array, numpy_helper.to_array(tensor))
 
 
-# TODO (#4554): remove this test after the deprecation period
-# Test these new functions should not raise any depreaction warnings
 class TestHelperMappingFunctions(unittest.TestCase):
+    # TODO (#4554): remove these tests about catching warnings after the deprecation period
+    # Test these new functions should not raise any deprecation warnings
     @pytest.mark.filterwarnings("error::DeprecationWarning")
     def test_tensor_dtype_to_np_dtype_not_throw_warning(self) -> None:
         _ = helper.tensor_dtype_to_np_dtype(TensorProto.FLOAT)
@@ -741,7 +741,14 @@ class TestHelperMappingFunctions(unittest.TestCase):
 
     @pytest.mark.filterwarnings("error::DeprecationWarning")
     def test_np_dtype_to_tensor_dtype_not_throw_warning(self) -> None:
-        _ = helper.np_dtype_to_tensor_dtype(np.float32)
+        _ = helper.np_dtype_to_tensor_dtype(np.dtype("float32"))
+
+    # BFloat16 tensor uses TensorProto.UINT16 as storage type;
+    # And the field name for TensorProto.UINT16 is int32_data
+    def test_tensor_dtype_to_field_bfloat16(self) -> None:
+        self.assertEqual(
+            helper.tensor_dtype_to_field(TensorProto.BFLOAT16), "int32_data"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description
- Add missing case for SequenceProto.MAP in numpy_helper.to_list.
- Fix issue onnx/issues/4552, make `tensor_dtype_to_field` not throw deprecation warning by introducing a identical dictionary `_STORAGE_TENSOR_TYPE_TO_FIELD`. Same case for `NP_TYPE_TO_TENSOR_TYPE`.
- Partially fix https://github.com/onnx/onnx/issues/4549: enable `printable_attribute` to handle bfloat16.

### Motivation and Context
Recent https://github.com/onnx/onnx/pull/4270 refactored existing code, but I forgot to add the case for SequenceProto.MAP in to_list.

cc @gramalingam Please review this PR. Sorry that I should catch this in advance before my PR got merged. Thank you!
