### PR TITLE
Build onnx in page creating CI

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,9 +11,9 @@ jobs:
     name: Lint Python
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v4.1.0
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       # Install onnx so that it is found by the linters

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,17 +30,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - name: Setup Pages
         uses: actions/configure-pages@v2
 
       - name: Install Dependencies
-        run: pip install -r docs/docsgen/source/requirements.txt
+        run: |
+          python -m pip install --quiet --upgrade pip setuptools wheel 
+          python -m pip install -r docs/docsgen/source/requirements.txt
 
       - name: Uninstall onnx
-        run: pip uninstall -y onnx
+        run: python -m pip uninstall -y onnx
 
       - name: Install onnx development version
-        run: python setup.py install
+        run: |
+          sudo apt-get install libprotobuf-dev protobuf-compiler
+          git submodule update --init --recursive
+          export CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=ON"
+          python setup.py install
 
       - name: Build Docs
         run: cd docs/docsgen && make html -j auto

--- a/.github/workflows/release_linux_aarch64.yml
+++ b/.github/workflows/release_linux_aarch64.yml
@@ -24,7 +24,7 @@ jobs:
       img: quay.io/pypa/manylinux2014_aarch64
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Checkout submodules
       shell: bash
       run: |

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -20,7 +20,7 @@ jobs:
         architecture: ['x64']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Checkout submodules
       shell: bash
       run: |

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -24,14 +24,13 @@ jobs:
         architecture: ['x64']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Checkout submodules
       shell: bash
       run: |
         auth_header="$(git config --local --get http.https://github.com/.extraheader)"
         git submodule sync --recursive
         git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -21,10 +21,9 @@ jobs:
         architecture: ['x64', 'x86']
     steps:        
     - name: Checkout ONNX
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
          path: ./onnx
-
     - name: Checkout ONNX submodules
       shell: bash
       run: |

--- a/.github/workflows/weekly_mac_ci.yml
+++ b/.github/workflows/weekly_mac_ci.yml
@@ -15,12 +15,8 @@ jobs:
   build:
     if: github.event_name != 'pull_request' || contains( github.event.pull_request.labels.*.name, 'test ONNX Model Zoo')
     runs-on: macos-latest
-    strategy:
-      matrix:
-        python-version: ['3.9']
-        architecture: ['x64']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout repo
     - name: Checkout submodules
       shell: bash
@@ -28,13 +24,10 @@ jobs:
         auth_header="$(git config --local --get http.https://github.com/.extraheader)"
         git submodule sync --recursive
         git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
-        architecture: ${{ matrix.architecture }}
-
+        python-version: '3.10'
     - name: Install dependencies
       shell: bash
       run: |


### PR DESCRIPTION
### Description
- Build onnx in page creating CI with the full prerequisite such as upgrading pip, installing shared protoc, setting config.
- All CIs use the same version of actions/checkout@v3

### Motivation and Context
The CI of Deploy static content to Pages is still failing because ONNX was not built successfully.