### PR TITLE
Manually catch build succeeded for page creating CI

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,7 +5,6 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
-  pull_request:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -53,27 +52,26 @@ jobs:
           python setup.py install
 
       - name: Build Docs
-        id: build_docs
-        if: ${{ always() }}
+        # TODO: fix warnings from "make html -j auto" so it can normally succeed without errors
+        continue-on-error: true
         run: |
           cd docs/docsgen
-          make html -j auto > stdout_stderr.log
+          make html -j auto > stdout_stderror.log 2>&1
       - name: Check whether previous build docs succeeded
         run: |
-          if grep -Fxq "build succeeded" stdout_stderr.log
+          cat docs/docsgen/stdout_stderror.log
+          if grep -F "build succeeded" docs/docsgen/stdout_stderror.log
           then
+            echo "Build succeeded."
+          else
             echo "Build failed."
             exit 1
-          else
-            echo "Build succeeded."
           fi
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
-        if: github.event_name == 'push'
         with:
           path: 'docs/docsgen/build/html'
       - name: Deploy to GitHub Pages
-        if: github.event_name == 'push'
         id: deployment
         uses: actions/deploy-pages@v1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,8 +4,8 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main", "add-docs"]
-
+    branches: ["main"]
+  pull_request:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -53,12 +53,27 @@ jobs:
           python setup.py install
 
       - name: Build Docs
-        run: cd docs/docsgen && make html -j auto
-      
+        id: build_docs
+        if: ${{ always() }}
+        run: |
+          cd docs/docsgen
+          make html -j auto > stdout_stderr.log
+      - name: Check whether previous build docs succeeded
+        run: |
+          if grep -Fxq "build succeeded" stdout_stderr.log
+          then
+            echo "Build failed."
+            exit 1
+          else
+            echo "Build succeeded."
+          fi
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
+        if: github.event_name == 'push'
         with:
           path: 'docs/docsgen/build/html'
       - name: Deploy to GitHub Pages
+        if: github.event_name == 'push'
         id: deployment
         uses: actions/deploy-pages@v1


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Manually catch build succeeded for page creating CI.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
pages.yml still failed because it cannot detect build succeeded with warnings. See more details [here](https://github.com/onnx/onnx/pull/4570#issuecomment-1268809300).