### PR TITLE
Use github-pr-review to enable manual resolution

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           # Change reviewdog reporter if you need [github-pr-check, github-check, github-pr-review].
-          reporter: github-pr-check
+          reporter: github-pr-review
           # Change reporter level if you need.
           # GitHub Status Check won't become failure with a warning.
           level: error
@@ -49,7 +49,7 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           locale: "US"
-          reporter: github-pr-check
+          reporter: github-pr-review
           level: info
           filter_mode: diff_context
           exclude: |
@@ -58,14 +58,14 @@ jobs:
         uses: reviewdog/action-shellcheck@v1
         with:
           github_token: ${{ secrets.github_token }}
-          reporter: github-pr-check
+          reporter: github-pr-review
           level: info
           filter_mode: diff_context
       - name: pylint
         uses: dciborow/action-pylint@0.0.7
         with:
           github_token: ${{ secrets.github_token }}
-          reporter: github-pr-check
+          reporter: github-pr-review
           level: warning
           filter_mode: diff_context
           glob_pattern: "**/*.py"
@@ -76,7 +76,7 @@ jobs:
         uses: tsuyoshicho/action-mypy@v3
         with:
           github_token: ${{ secrets.github_token }}
-          reporter: github-pr-check
+          reporter: github-pr-review
           level: warning
           filter_mode: diff_context
 


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Use github-pr-review instead of github-pr-check to enable manual resolution.

### Motivation and Context
We cannot manually resolve a warning from reviewdog with current github-pr-check. See discussion: https://github.com/reviewdog/reviewdog/issues/568. The drawback is old warnings won't be automatically resolved with new commits for correction so you will need to resolve each of them manually. It's a trade-off.