### PR TITLE
Only manually trigger page deployment and remove duplicate style check in Linux-CI

### DIFF
--- a/.azure-pipelines/Linux-CI.yml
+++ b/.azure-pipelines/Linux-CI.yml
@@ -67,16 +67,6 @@ jobs:
   - script: |
       source venv/bin/activate
 
-      # style check (flake8, mypy, and clang-format)
-      python -m pip install -q -r requirements-dev.txt
-      if [ '$(documentation)' == '0' ]; then
-        bash tools/style.sh
-        if [ $? -ne 0 ]; then
-          echo "style check failed"
-          exit 1
-        fi
-      fi
-
       # check line endings to be UNIX
       find . -type f -regextype posix-extended -regex '.*\.(py|cpp|md|h|cc|proto|proto3|in)' | xargs dos2unix --quiet
       git status

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,9 +2,6 @@
 name: Deploy static content to Pages
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: ["main"]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/docs/OnnxReleases.md
+++ b/docs/OnnxReleases.md
@@ -109,6 +109,10 @@ The ONNX project, going forward, will plan to release roughly on a four month ca
 * Notify ONNX partners like converter team and runtime team.
 * Create a news by updating `js/news.json` to announce ONNX release under [onnx/onnx.github.io](https://github.com/onnx/onnx.github.io) repo. For instance: https://github.com/onnx/onnx.github.io/pull/83.
 
+**Deploy released content to document website**
+* To update the website https://onnx.ai/onnx/ with the released content, manually deploy released content to document website by running [pages.yml](https://github.com/onnx/onnx/blob/main/.github/workflows/pages.yml).
+* Steps: start [actions](https://github.com/onnx/onnx/actions) -> Workflows -> Deploy static content to Pages -> Run workflow -> Use workflow from "rel-*" -> Run workflow.
+
 **Update conda-forge package with the new ONNX version**
 * Conda builds of ONNX are done via conda-forge, which runs infrastructure for building packages and uploading them to conda-forge. If it does not happen automatically, you need to submit a PR to https://github.com/conda-forge/onnx-feedstock (see https://github.com/conda-forge/onnx-feedstock/pull/1/files or https://github.com/conda-forge/onnx-feedstock/pull/50/files for example PRs) You will need to have uploaded to PyPI already, and update the version number and tarball hash of the PyPI uploaded tarball.
 


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
- Only manually trigger page deployment
- Update release document to let release manager manually deploy it after every release
- Remove duplicate code style check in Linux-CI. Going forward it will be done by another required CI: https://github.com/onnx/onnx/blob/4637098e881d0d2f63caa5e945a9fdc620e11e06/.github/workflows/lint.yaml#L83.

### Motivation and Context
- Currently the website will be updated after every main branch push. For now we only want to trigger it manually with the stable released content.
- https://github.com/onnx/onnx/blob/4637098e881d0d2f63caa5e945a9fdc620e11e06/.github/workflows/lint.yaml#L83 now enforce-style is required. Remove the same check in Linux-CI.