### PR TITLE
Add type inference for CategoryMapper & TreeEnsembleRegressor/Classifier

### DIFF
--- a/onnx/defs/traditionalml/defs.cc
+++ b/onnx/defs/traditionalml/defs.cc
@@ -2,8 +2,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "onnx/defs/schema.h"
 #include <stdio.h>
+#include "onnx/defs/schema.h"
 
 #ifdef ONNX_ML
 namespace ONNX_NAMESPACE {
@@ -854,7 +854,7 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
           // Second axis of Z - E (classes)
           std::vector<int64_t> class_ids;
           auto has_ids = getRepeatedAttribute(ctx, "class_ids", class_ids);
-          if(has_ids) {
+          if (has_ids) {
             snd_dim_z->set_dim_value(class_ids.size());
           }
         }));

--- a/onnx/defs/traditionalml/defs.cc
+++ b/onnx/defs/traditionalml/defs.cc
@@ -3,6 +3,7 @@
  */
 
 #include "onnx/defs/schema.h"
+#include <stdio.h>
 
 #ifdef ONNX_ML
 namespace ONNX_NAMESPACE {
@@ -809,6 +810,7 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
           } else {
             output_elem_type->set_elem_type(TensorProto::INT64);
           }
+          ctx.getOutputType(1)->mutable_tensor_type()->set_elem_type(TensorProto::FLOAT);
 
           auto* nodes_values = ctx.getAttribute("nodes_values");
           auto* nodes_values_as_tensor = ctx.getAttribute("nodes_values_as_tensor");
@@ -834,6 +836,26 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
           if (nullptr != base_values && nullptr != base_values_as_tensor) {
             fail_shape_inference(
                 "Only one of the attributes 'base_values', 'base_values_as_tensor' should be specified.");
+          }
+
+          // First axis of Y & Z - N (inputs)
+          auto fst_dim_y = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim();
+          auto fst_dim_z = ctx.getOutputType(1)->mutable_tensor_type()->mutable_shape()->add_dim();
+          auto snd_dim_z = ctx.getOutputType(1)->mutable_tensor_type()->mutable_shape()->add_dim();
+          if (nullptr != ctx.getInputType(0)) {
+            auto input_shape = ctx.getInputType(0)->tensor_type().shape();
+            if (input_shape.dim_size() != 2) {
+              fail_shape_inference("Input of TreeEnsembleRegressor is expected to be a matrix.");
+            }
+            *fst_dim_y = input_shape.dim(0);
+            *fst_dim_z = input_shape.dim(0);
+          }
+
+          // Second axis of Z - E (classes)
+          std::vector<int64_t> class_ids;
+          auto has_ids = getRepeatedAttribute(ctx, "class_ids", class_ids);
+          if(has_ids) {
+            snd_dim_z->set_dim_value(class_ids.size());
           }
         }));
 
@@ -955,8 +977,9 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
                 "Only one of the attributes 'base_values', 'base_values_as_tensor' should be specified.");
           }
 
-          // First axis for output - N (examples)
           auto fst_dim = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim();
+          auto snd_dim = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim();
+          // First axis for Y - N (inputs)
           if (nullptr != ctx.getInputType(0)) {
             auto input_shape = ctx.getInputType(0)->tensor_type().shape();
             if (input_shape.dim_size() != 2) {
@@ -965,8 +988,7 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
             *fst_dim = input_shape.dim(0);
           }
 
-          // Second axis for output
-          auto snd_dim = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim();
+          // Second axis for Y - E (targets)
           if (nullptr != ctx.getAttribute("n_targets")) {
             snd_dim->set_dim_value(ctx.getAttribute("n_targets")->i());
           }

--- a/onnx/defs/traditionalml/defs.cc
+++ b/onnx/defs/traditionalml/defs.cc
@@ -141,12 +141,16 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
             AttributeProto::INT,
             static_cast<int64_t>(-1))
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
+          if (nullptr == ctx.getInputType(0)) 
+            return;
           auto input_elem_type = ctx.getInputType(0)->tensor_type().elem_type();
-          auto output_elem_type = ctx.getOutputType(0)->mutable_tensor_type();
           if (TensorProto::STRING == input_elem_type) {
-            output_elem_type->set_elem_type(TensorProto::INT64);
+            updateOutputElemType(ctx, 0, TensorProto::INT64);
           } else if (TensorProto::INT64 == input_elem_type) {
-            output_elem_type->set_elem_type(TensorProto::STRING);
+            updateOutputElemType(ctx, 0, TensorProto::STRING);
+          }
+          if (hasInputShape(ctx, 0)) {
+            propagateShapeFromInputToOutput(ctx, 0, 0);
           }
         }));
 

--- a/onnx/defs/traditionalml/defs.cc
+++ b/onnx/defs/traditionalml/defs.cc
@@ -844,7 +844,7 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
           if (nullptr != ctx.getInputType(0)) {
             auto input_shape = ctx.getInputType(0)->tensor_type().shape();
             if (input_shape.dim_size() != 2) {
-              fail_shape_inference("Input of TreeEnsembleRegressor is expected to be a matrix.");
+              fail_shape_inference("Input of TreeEnsembleClassifier is expected to be a matrix.");
             }
             *fst_dim_y = input_shape.dim(0);
             *fst_dim_z = input_shape.dim(0);

--- a/onnx/defs/traditionalml/defs.cc
+++ b/onnx/defs/traditionalml/defs.cc
@@ -2,7 +2,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stdio.h>
 #include "onnx/defs/schema.h"
 
 #ifdef ONNX_ML

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -8427,10 +8427,10 @@ class TestShapeInference(TestShapeInferenceHelper):
 
     def test_category_mapper(self) -> None:
         cat = make_node(
-            "CategoryMapper", 
+            "CategoryMapper",
             ["x"],
-            ["y"], 
-            domain=ONNX_ML_DOMAIN, 
+            ["y"],
+            domain=ONNX_ML_DOMAIN,
         )
         graph_int = self._make_graph(
             [("x", TensorProto.INT64, (30, 4, 5))],
@@ -8457,6 +8457,26 @@ class TestShapeInference(TestShapeInferenceHelper):
             ],
         )
 
+    def test_tree_ensemble_regressor(self) -> None:
+        tree = make_node(
+            "TreeEnsembleRegressor",
+            ["x"],
+            ["y"],
+            domain=ONNX_ML_DOMAIN,
+            n_targets=5,
+        )
+        graph = self._make_graph(
+            [("x", TensorProto.DOUBLE, (30, 3))],
+            [tree],
+            [],
+        )
+        self._assert_inferred(
+            graph, [make_tensor_value_info("y", TensorProto.FLOAT, (30, 5))],
+            opset_imports=[
+                make_opsetid(ONNX_ML_DOMAIN, 3),
+                make_opsetid(ONNX_DOMAIN, 11),
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -8426,85 +8426,88 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
 
     def test_category_mapper(self) -> None:
-        cat = make_node(
-            "CategoryMapper",
-            ["x"],
-            ["y"],
-            domain=ONNX_ML_DOMAIN,
-        )
-        graph_int = self._make_graph(
-            [("x", TensorProto.INT64, (30, 4, 5))],
-            [cat],
-            [],
-        )
-        self._assert_inferred(
-            graph_int,
-            [make_tensor_value_info("y", TensorProto.STRING, (30, 4, 5))],
-            opset_imports=[
-                make_opsetid(ONNX_ML_DOMAIN, 1),
-                make_opsetid(ONNX_DOMAIN, 11),
-            ],
-        )
-        graph_str = self._make_graph(
-            [("x", TensorProto.STRING, (30, 5, 4))],
-            [cat],
-            [],
-        )
-        self._assert_inferred(
-            graph_str,
-            [make_tensor_value_info("y", TensorProto.INT64, (30, 5, 4))],
-            opset_imports=[
-                make_opsetid(ONNX_ML_DOMAIN, 1),
-                make_opsetid(ONNX_DOMAIN, 11),
-            ],
-        )
+        if ONNX_ML:
+            cat = make_node(
+                "CategoryMapper",
+                ["x"],
+                ["y"],
+                domain=ONNX_ML_DOMAIN,
+            )
+            graph_int = self._make_graph(
+                [("x", TensorProto.INT64, (30, 4, 5))],
+                [cat],
+                [],
+            )
+            self._assert_inferred(
+                graph_int,
+                [make_tensor_value_info("y", TensorProto.STRING, (30, 4, 5))],
+                opset_imports=[
+                    make_opsetid(ONNX_ML_DOMAIN, 1),
+                    make_opsetid(ONNX_DOMAIN, 11),
+                ],
+            )
+            graph_str = self._make_graph(
+                [("x", TensorProto.STRING, (30, 5, 4))],
+                [cat],
+                [],
+            )
+            self._assert_inferred(
+                graph_str,
+                [make_tensor_value_info("y", TensorProto.INT64, (30, 5, 4))],
+                opset_imports=[
+                    make_opsetid(ONNX_ML_DOMAIN, 1),
+                    make_opsetid(ONNX_DOMAIN, 11),
+                ],
+            )
 
     def test_tree_ensemble_regressor(self) -> None:
-        tree = make_node(
-            "TreeEnsembleRegressor",
-            ["x"],
-            ["y"],
-            domain=ONNX_ML_DOMAIN,
-            n_targets=5,
-        )
-        graph = self._make_graph(
-            [("x", TensorProto.DOUBLE, (30, 3))],
-            [tree],
-            [],
-        )
-        self._assert_inferred(
-            graph,
-            [make_tensor_value_info("y", TensorProto.FLOAT, (30, 5))],
-            opset_imports=[
-                make_opsetid(ONNX_ML_DOMAIN, 3),
-                make_opsetid(ONNX_DOMAIN, 11),
-            ],
-        )
+        if ONNX_ML:
+            tree = make_node(
+                "TreeEnsembleRegressor",
+                ["x"],
+                ["y"],
+                domain=ONNX_ML_DOMAIN,
+                n_targets=5,
+            )
+            graph = self._make_graph(
+                [("x", TensorProto.DOUBLE, (30, 3))],
+                [tree],
+                [],
+            )
+            self._assert_inferred(
+                graph,
+                [make_tensor_value_info("y", TensorProto.FLOAT, (30, 5))],
+                opset_imports=[
+                    make_opsetid(ONNX_ML_DOMAIN, 3),
+                    make_opsetid(ONNX_DOMAIN, 11),
+                ],
+            )
 
     def test_tree_ensemble_classifier(self) -> None:
-        tree = make_node(
-            "TreeEnsembleClassifier",
-            ["x"],
-            ["y", "z"],
-            class_ids=[0, 1, 2, 3, 4],
-            domain=ONNX_ML_DOMAIN,
-        )
-        graph = self._make_graph(
-            [("x", TensorProto.DOUBLE, (30, 3))],
-            [tree],
-            [],
-        )
-        self._assert_inferred(
-            graph,
-            [
-                make_tensor_value_info("y", TensorProto.INT64, (30,)),
-                make_tensor_value_info("z", TensorProto.FLOAT, (30, 5)),
-            ],
-            opset_imports=[
-                make_opsetid(ONNX_ML_DOMAIN, 3),
-                make_opsetid(ONNX_DOMAIN, 11),
-            ],
-        )
+        if ONNX_ML:
+            tree = make_node(
+                "TreeEnsembleClassifier",
+                ["x"],
+                ["y", "z"],
+                class_ids=[0, 1, 2, 3, 4],
+                domain=ONNX_ML_DOMAIN,
+            )
+            graph = self._make_graph(
+                [("x", TensorProto.DOUBLE, (30, 3))],
+                [tree],
+                [],
+            )
+            self._assert_inferred(
+                graph,
+                [
+                    make_tensor_value_info("y", TensorProto.INT64, (30,)),
+                    make_tensor_value_info("z", TensorProto.FLOAT, (30, 5)),
+                ],
+                opset_imports=[
+                    make_opsetid(ONNX_ML_DOMAIN, 3),
+                    make_opsetid(ONNX_DOMAIN, 11),
+                ],
+            )
 
 
 if __name__ == "__main__":

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -8481,6 +8481,31 @@ class TestShapeInference(TestShapeInferenceHelper):
             ],
         )
 
+    def test_tree_ensemble_classifier(self) -> None:
+        tree = make_node(
+            "TreeEnsembleClassifier",
+            ["x"],
+            ["y", "z"],
+            class_ids=[0, 1, 2, 3, 4],
+            domain=ONNX_ML_DOMAIN
+        )
+        graph = self._make_graph(
+            [("x", TensorProto.DOUBLE, (30, 3))],
+            [tree],
+            [],
+        )
+        self._assert_inferred(
+            graph,
+            [
+                make_tensor_value_info("y", TensorProto.INT64, (30,)),
+                make_tensor_value_info("z", TensorProto.FLOAT, (30, 5)),
+            ],
+            opset_imports=[
+                make_opsetid(ONNX_ML_DOMAIN, 3),
+                make_opsetid(ONNX_DOMAIN, 11),
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -8438,7 +8438,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             [],
         )
         self._assert_inferred(
-            graph_int, [make_tensor_value_info("y", TensorProto.STRING, (30, 4, 5))],
+            graph_int,
+            [make_tensor_value_info("y", TensorProto.STRING, (30, 4, 5))],
             opset_imports=[
                 make_opsetid(ONNX_ML_DOMAIN, 1),
                 make_opsetid(ONNX_DOMAIN, 11),
@@ -8450,7 +8451,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             [],
         )
         self._assert_inferred(
-            graph_str, [make_tensor_value_info("y", TensorProto.INT64, (30, 5, 4))],
+            graph_str,
+            [make_tensor_value_info("y", TensorProto.INT64, (30, 5, 4))],
             opset_imports=[
                 make_opsetid(ONNX_ML_DOMAIN, 1),
                 make_opsetid(ONNX_DOMAIN, 11),
@@ -8471,7 +8473,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             [],
         )
         self._assert_inferred(
-            graph, [make_tensor_value_info("y", TensorProto.FLOAT, (30, 5))],
+            graph,
+            [make_tensor_value_info("y", TensorProto.FLOAT, (30, 5))],
             opset_imports=[
                 make_opsetid(ONNX_ML_DOMAIN, 3),
                 make_opsetid(ONNX_DOMAIN, 11),

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -8425,6 +8425,39 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 18)],
         )
 
+    def test_category_mapper(self) -> None:
+        cat = make_node(
+            "CategoryMapper", 
+            ["x"],
+            ["y"], 
+            domain=ONNX_ML_DOMAIN, 
+        )
+        graph_int = self._make_graph(
+            [("x", TensorProto.INT64, (30, 4, 5))],
+            [cat],
+            [],
+        )
+        self._assert_inferred(
+            graph_int, [make_tensor_value_info("y", TensorProto.STRING, (30, 4, 5))],
+            opset_imports=[
+                make_opsetid(ONNX_ML_DOMAIN, 1),
+                make_opsetid(ONNX_DOMAIN, 11),
+            ],
+        )
+        graph_str = self._make_graph(
+            [("x", TensorProto.STRING, (30, 5, 4))],
+            [cat],
+            [],
+        )
+        self._assert_inferred(
+            graph_str, [make_tensor_value_info("y", TensorProto.INT64, (30, 5, 4))],
+            opset_imports=[
+                make_opsetid(ONNX_ML_DOMAIN, 1),
+                make_opsetid(ONNX_DOMAIN, 11),
+            ],
+        )
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -8487,7 +8487,7 @@ class TestShapeInference(TestShapeInferenceHelper):
             ["x"],
             ["y", "z"],
             class_ids=[0, 1, 2, 3, 4],
-            domain=ONNX_ML_DOMAIN
+            domain=ONNX_ML_DOMAIN,
         )
         graph = self._make_graph(
             [("x", TensorProto.DOUBLE, (30, 3))],


### PR DESCRIPTION
### Description

Adds/extends type & shape inference for operators in `ai.onnx.ml`:
- `CategoryMapper`
- `TreeEnsembleRegressor`
- `TreeEnsembleClassifier`

### Motivation and Context

Traditional ML operators under `ai.onnx.ml` tend to be lacking in type and shape inference.

There is still a need for improving documentation for these operators and extending inference for other operators. They also generally lack sanity-checking whether they are properly specified - for example for the tree ensemble family, where there's a lot of attributes and almost no checking is done.

As a general note, adding new inference/verify functions is a bit of a pain. There's a lot of somewhat generic patterns (attributes of equal length, only one of attribute group is set, make dimensions equal to given shape list) that seem to be done really inefficiently, involving a lot of mutation. 

Adding inference functions is currently not an open issue but there probably should be one opened. Existence of operators like these causes total failure of the shape inference routines (as all succeeding operators fail their inference).

Related to #4572, which makes a similar improvement by implementing another inference function.