### PR TITLE
Adding adapter to convert Sub from opset 13 to 12.

### DIFF
--- a/onnx/version_converter/convert.h
+++ b/onnx/version_converter/convert.h
@@ -476,6 +476,7 @@ class DefaultVersionConverter : public BaseVersionConverter {
     registerAdapter(make_unique<CompatibleAdapter>("Constant", OpSetID(13), OpSetID(12)));
     registerAdapter(make_unique<AxesInputToAttribute>("ReduceSum", OpSetID(13), OpSetID(12)));
     registerAdapter(make_unique<AxesInputToAttribute>("Squeeze", OpSetID(13), OpSetID(12)));
+    registerAdapter(make_unique<CompatibleAdapter>("Sub", OpSetID(13), OpSetID(12)));
     registerAdapter(make_unique<AxesInputToAttribute>("Unsqueeze", OpSetID(13), OpSetID(12)));
     registerAdapter(make_unique<Split_13_12>());
 


### PR DESCRIPTION
Need this for being able to down-convert resnext50 to an earlier opset.

### Description
<!-- - Describe your changes. -->
Add an adapter to convert Sub between opsets version 13 and 13

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
Running into an issue when converting between newer opset version of resnext50 from here for testing in MIGraphX:

https://zenodo.org/record/6617879/files/resnext50_32x4d_fpn.onnx

We require opset12 currently, but this model is in opset 13. I see there's an adapte to convert split from 13->12 but currently failing even when I add this adapter 

```
root@6b4c5c2b5d5e:/code# python3 AMDMIGraphX/tools/convert_onnx_version.py --model AMDMIGraphX/resnext50_32x4d_fpn.onnx --opset=12 --output AMDMIGraphX/resnext50_32x4d_fpn_opset12.onnx 
Traceback (most recent call last):
  File "AMDMIGraphX/tools/convert_onnx_version.py", line 82, in <module>
    main()
  File "AMDMIGraphX/tools/convert_onnx_version.py", line 71, in main
    converted_model = version_converter.convert_version(
  File "/usr/local/lib/python3.8/dist-packages/onnx/version_converter.py", line 166, in convert_version
    converted_model_str = C.convert_version(model_str, target_version)
RuntimeError: /github/workspace/onnx/version_converter/BaseConverter.h:63: adapter_lookup: Assertion `false` failed: No Adapter To Version $12 for Sub

```

<!-- - If it fixes an open issue, please link to the issue here. -->
