### PR TITLE
Use Python 3.10 in CI job CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,8 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.x'
+        # Update to Python 3.11 is released when PR #4490 is merged.
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Signed-off-by: xadupre <xadupre@microsoft.com>

### Description
Use Python 3.10 is CI job CodeQL.

### Motivation and Context
Job CodeQL Is using the latest python to check style. It recently became Python 3.11 but this needs PR #4490. 
