### PR TITLE
Output missing last new line from coverage reporter

### DIFF
--- a/onnx/backend/test/report/coverage.py
+++ b/onnx/backend/test/report/coverage.py
@@ -133,6 +133,7 @@ class Coverage:
                 tablefmt="plain",
             )
         )
+        writer.write("\n")
         if os.environ.get("CSVDIR") is not None:
             self.report_csv(all_ops, passed, experimental)
 


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
`tabulate` function doesn't add new line to last row so it will be mixed up with next pytest summary

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->

Without this, the pytest summary would be broken like following:

```
...
Tanh                   No attributes
ThresholdedRelu        alpha: 1
Tile                   No attributes
TopK                   axis: 2
                       largest: 1
                       sorted: 1
Transpose              perm: 9
Trilu                  upper: 1
Xor                    No attributes
PRelu                  No attributes============================= 1100 passed, 985 skipped, 80 xfailed, 1400 warnings in 11.72s ==============================
```