### PR TITLE
Fix enforce-style CI error: solve empty-body issue raised by mypy 0.990

### DIFF
--- a/onnx/backend/base.py
+++ b/onnx/backend/base.py
@@ -62,7 +62,7 @@ class BackendRep:
 
     def run(self, inputs: Any, **kwargs: Any) -> Tuple[Any, ...]:
         """Abstract function."""
-        return (None, )
+        return (None,)
 
 
 class Backend:

--- a/onnx/backend/base.py
+++ b/onnx/backend/base.py
@@ -61,7 +61,8 @@ class BackendRep:
     """
 
     def run(self, inputs: Any, **kwargs: Any) -> Tuple[Any, ...]:
-        pass
+        """Abstract function."""
+        return (None, )
 
 
 class Backend:


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Fix enforce-style CI error: solve empty-body issue raised by mypy 0.990


### Motivation and Context
Currently enforce-style CI failed due to the latest mypy 0.990