### PR TITLE
Fix weekly mac release CI: only submit source distribution in one CI

### DIFF
--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -106,18 +106,17 @@ jobs:
       run: |
         python -m pip install -q onnxruntime
         python onnx/test/test_with_ort.py
-
+  
+    # Only triggered by weekly event on certain CI
     - name: Build and upload source distribution to TestPyPI weekly
-      if: github.event_name == 'schedule' && matrix.python-version == '3.10' # Only triggered by weekly event on Python 3.10
+      if: github.event_name == 'schedule' && matrix.python-version == '3.10' && matrix.target-architecture == 'x86_64'
       run: |
         # Build and upload source distribution to TestPyPI
         git clean -xdf
         python setup.py sdist --weekly_build
         twine upload dist/* --repository-url https://test.pypi.org/legacy/ -u ${{ secrets.TESTPYPI_USERNAME }} -p ${{ secrets.TESTPYPI_PASSWORD }}
-
-    - name: Test source distribution from TestPyPI
-      if: github.event_name == 'schedule' && matrix.python-version == '3.10'
-      run: |
+        
+        # Test source distribution from TestPyPI
         python -m pip uninstall -y onnx
         python -m pip install setuptools
         python -m pip install --index-url https://test.pypi.org/simple --use-deprecated=legacy-resolver --no-use-pep517 --no-binary onnx-weekly onnx-weekly


### PR DESCRIPTION
### Description
Only submit source distribution in one CI (Python 3.10 + x86_64)


### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Only "one" CI will submit source distribution weekly to TestPyPI. After adding universal2 support, we should filter it out for the action of source distribution.
