### PR TITLE
Corrected a typo in concept.rst

### DIFF
--- a/docs/docsgen/source/intro/concepts.rst
+++ b/docs/docsgen/source/intro/concepts.rst
@@ -51,7 +51,7 @@ It is just a kind of pseudo-code to illustrate the model.
     Output: float[M, N] y
 
     r = onnx.MatMul(a, x)
-    y = onnx.Add(ax, c)
+    y = onnx.Add(r, c)
 
 This code implements a function `f(x, a, c) -> y = a @ x + c`.
 And *x*, *a*, *c* are the **inputs**, *y* is the **output**.


### PR DESCRIPTION
In line 54, it should be y = onnx.Add(r, c) instead of y = onnx.Add(ax, c)

### Description
<!-- - Describe your changes. -->
In line 54,
Changed `y = onnx.Add(ax, c)` to `y = onnx.Add(r, c)`

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
Further description of the above code in Documentation was not matching the previous code. Below is the snippet.
`This code implements a function f(x, a, c) -> y = a @ x + c. And x, a, c are the inputs, y is the output. r is an intermediate result.`

<!-- - If it fixes an open issue, please link to the issue here. -->
