### PR TITLE
Fixed Typo in concepts.rst

### DIFF
--- a/docs/docsgen/source/intro/concepts.rst
+++ b/docs/docsgen/source/intro/concepts.rst
@@ -51,7 +51,7 @@ It is just a kind of pseudo-code to illustrate the model.
     Output: float[M, N] y
 
     r = onnx.MatMul(a, x)
-    y = onnx.Add(ax, c)
+    y = onnx.Add(r, c)
 
 This code implements a function `f(x, a, c) -> y = a @ x + c`.
 And *x*, *a*, *c* are the **inputs**, *y* is the **output**.


### PR DESCRIPTION
In line 54,
Changed y = onnx.Add(ax, c) to y = onnx.Add(r, c)

Signed-off-by: Anand Krishna <51157561+AnandKri@users.noreply.github.com>