### PR TITLE
Fix typo in python.rst

### DIFF
--- a/docs/docsgen/source/intro/python.rst
+++ b/docs/docsgen/source/intro/python.rst
@@ -20,7 +20,7 @@ The linear regression is the most simple model
 in machine learning described by the following expression
 :math:`Y = XA + B`. We can see it as a function of three
 variables :math:`Y = f(X, A, B)` decomposed into
-`y = Add(MatMul(X, A), B))`. That what's we need to represent
+`y = Add(MatMul(X, A), B)`. That what's we need to represent
 with ONNX operators. The first thing is to implement a function
 with :ref:`ONNX operators <l-onnx-operators>`.
 ONNX is strongly typed. Shape and type must be defined for both


### PR DESCRIPTION
In line 23 there was an extra closing brace.
Signed-off-by: Ishan Singh <86545965+Ishan-cmd@users.noreply.github.com>