### PR TITLE
Fix reference implementation for reduce operators and issue #4653

### DIFF
--- a/onnx/reference/ops/_op_list.py
+++ b/onnx/reference/ops/_op_list.py
@@ -144,16 +144,20 @@ from .op_random_uniform import RandomUniform
 from .op_random_uniform_like import RandomUniformLike
 from .op_range import Range
 from .op_reciprocal import Reciprocal
-from .op_reduce_l1 import ReduceL1
-from .op_reduce_l2 import ReduceL2
-from .op_reduce_log_sum import ReduceLogSum
-from .op_reduce_log_sum_exp import ReduceLogSumExp
-from .op_reduce_max import ReduceMax
-from .op_reduce_mean import ReduceMean
-from .op_reduce_min import ReduceMin
-from .op_reduce_prod import ReduceProd
-from .op_reduce_sum import ReduceSum, ReduceSum_1, ReduceSum_11, ReduceSum_13
-from .op_reduce_sum_square import ReduceSumSquare
+from .op_reduce_l1 import ReduceL1, ReduceL1_1, ReduceL1_18
+from .op_reduce_l2 import ReduceL2, ReduceL2_1, ReduceL2_18
+from .op_reduce_log_sum import ReduceLogSum, ReduceLogSum_1, ReduceLogSum_18
+from .op_reduce_log_sum_exp import (
+    ReduceLogSumExp,
+    ReduceLogSumExp_1,
+    ReduceLogSumExp_18,
+)
+from .op_reduce_max import ReduceMax, ReduceMax_1, ReduceMax_18
+from .op_reduce_mean import ReduceMean, ReduceMean_1, ReduceMean_18
+from .op_reduce_min import ReduceMin, ReduceMin_1, ReduceMin_18
+from .op_reduce_prod import ReduceProd, ReduceProd_1, ReduceProd_18
+from .op_reduce_sum import ReduceSum, ReduceSum_1, ReduceSum_13
+from .op_reduce_sum_square import ReduceSumSquare, ReduceSumSquare_1, ReduceSumSquare_18
 from .op_relu import Relu
 from .op_reshape import Reshape, Reshape_5, Reshape_14
 from .op_resize import Resize

--- a/onnx/reference/ops/op_reduce_l1.py
+++ b/onnx/reference/ops/op_reduce_l1.py
@@ -15,21 +15,8 @@ class ReduceL1_1(OpRunReduceNumpy):
         )
 
 
-class ReduceL1_11(ReduceL1_1):
-    pass
-
-
-class ReduceL1_13(ReduceL1_1):
-    pass
-
-
 class ReduceL1_18(OpRunReduceNumpy):
-    def run(self, data, axes=None, keepdims=None, noop_with_empty_axes=None):  # type: ignore
-        keepdims = keepdims or self.keepdims  # type: ignore
-        noop_with_empty_axes = noop_with_empty_axes or self.noop_with_empty_axes  # type: ignore
-        return self._run(data, axes, keepdims, noop_with_empty_axes)
-
-    def _run(self, data, axes, keepdims=1, noop_with_empty_axes=0):  # type: ignore
+    def _run(self, data, axes=None, keepdims=1, noop_with_empty_axes=0):  # type: ignore
         if self.is_axes_empty(axes) and noop_with_empty_axes:  # type: ignore
             return (data,)
 
@@ -42,9 +29,5 @@ class ReduceL1_18(OpRunReduceNumpy):
 
 if onnx_opset_version() >= 18:
     ReduceL1 = ReduceL1_18
-elif onnx_opset_version() >= 13:
-    ReduceL1 = ReduceL1_13  # type: ignore
-elif onnx_opset_version() >= 11:
-    ReduceL1 = ReduceL1_11  # type: ignore
 else:
     ReduceL1 = ReduceL1_1  # type: ignore

--- a/onnx/reference/ops/op_reduce_l2.py
+++ b/onnx/reference/ops/op_reduce_l2.py
@@ -17,20 +17,7 @@ class ReduceL2_1(OpRunReduceNumpy):
         )
 
 
-class ReduceL2_11(ReduceL2_1):
-    pass
-
-
-class ReduceL2_13(ReduceL2_1):
-    pass
-
-
 class ReduceL2_18(OpRunReduceNumpy):
-    def run(self, data, axes=None, keepdims=None, noop_with_empty_axes=None):  # type: ignore
-        keepdims = keepdims or self.keepdims  # type: ignore
-        noop_with_empty_axes = noop_with_empty_axes or self.noop_with_empty_axes  # type: ignore
-        return self._run(data, axes, keepdims, noop_with_empty_axes)
-
     def _run(self, data, axes, keepdims=1, noop_with_empty_axes=0):  # type: ignore
         if self.is_axes_empty(axes) and noop_with_empty_axes:  # type: ignore
             return (data,)
@@ -46,9 +33,5 @@ class ReduceL2_18(OpRunReduceNumpy):
 
 if onnx_opset_version() >= 18:
     ReduceL2 = ReduceL2_18
-elif onnx_opset_version() >= 13:
-    ReduceL2 = ReduceL2_13  # type: ignore
-elif onnx_opset_version() >= 11:
-    ReduceL2 = ReduceL2_11  # type: ignore
 else:
     ReduceL2 = ReduceL2_1  # type: ignore

--- a/onnx/reference/ops/op_reduce_log_sum.py
+++ b/onnx/reference/ops/op_reduce_log_sum.py
@@ -17,21 +17,8 @@ class ReduceLogSum_1(OpRunReduceNumpy):
         return (np.log(res),)
 
 
-class ReduceLogSum_11(ReduceLogSum_1):
-    pass
-
-
-class ReduceLogSum_13(ReduceLogSum_1):
-    pass
-
-
 class ReduceLogSum_18(OpRunReduceNumpy):
-    def run(self, data, axes=None, keepdims=None, noop_with_empty_axes=None):  # type: ignore
-        keepdims = keepdims or self.keepdims  # type: ignore
-        noop_with_empty_axes = noop_with_empty_axes or self.noop_with_empty_axes  # type: ignore
-        return self._run(data, axes, keepdims, noop_with_empty_axes)
-
-    def _run(self, data, axes, keepdims=1, noop_with_empty_axes=0):  # type: ignore
+    def _run(self, data, axes=None, keepdims=1, noop_with_empty_axes=0):  # type: ignore
         if self.is_axes_empty(axes) and noop_with_empty_axes:  # type: ignore
             return (data,)
 
@@ -46,9 +33,5 @@ class ReduceLogSum_18(OpRunReduceNumpy):
 
 if onnx_opset_version() >= 18:
     ReduceLogSum = ReduceLogSum_18
-elif onnx_opset_version() >= 13:
-    ReduceLogSum = ReduceLogSum_13  # type: ignore
-elif onnx_opset_version() >= 11:
-    ReduceLogSum = ReduceLogSum_11  # type: ignore
 else:
     ReduceLogSum = ReduceLogSum_1  # type: ignore

--- a/onnx/reference/ops/op_reduce_log_sum_exp.py
+++ b/onnx/reference/ops/op_reduce_log_sum_exp.py
@@ -28,21 +28,8 @@ class ReduceLogSumExp_1(OpRunReduceNumpy):
         return compute_log_sum_exp(data, tax, keepdims)
 
 
-class ReduceLogSumExp_11(ReduceLogSumExp_1):
-    pass
-
-
-class ReduceLogSumExp_13(ReduceLogSumExp_1):
-    pass
-
-
 class ReduceLogSumExp_18(OpRunReduceNumpy):
-    def run(self, data, axes=None, keepdims=None, noop_with_empty_axes=None):  # type: ignore
-        keepdims = keepdims or self.keepdims  # type: ignore
-        noop_with_empty_axes = noop_with_empty_axes or self.noop_with_empty_axes  # type: ignore
-        return self._run(data, axes, keepdims, noop_with_empty_axes)
-
-    def _run(self, data, axes, keepdims=1, noop_with_empty_axes=0):  # type: ignore
+    def _run(self, data, axes=None, keepdims=1, noop_with_empty_axes=0):  # type: ignore
         if self.is_axes_empty(axes) and noop_with_empty_axes:  # type: ignore
             return (data,)
 
@@ -54,9 +41,5 @@ class ReduceLogSumExp_18(OpRunReduceNumpy):
 
 if onnx_opset_version() >= 18:
     ReduceLogSumExp = ReduceLogSumExp_18
-elif onnx_opset_version() >= 13:
-    ReduceLogSumExp = ReduceLogSumExp_13  # type: ignore
-elif onnx_opset_version() >= 11:
-    ReduceLogSumExp = ReduceLogSumExp_11  # type: ignore
 else:
     ReduceLogSumExp = ReduceLogSumExp_1  # type: ignore

--- a/onnx/reference/ops/op_reduce_max.py
+++ b/onnx/reference/ops/op_reduce_max.py
@@ -14,25 +14,8 @@ class ReduceMax_1(OpRunReduceNumpy):
         return (np.maximum.reduce(data, axis=axes, keepdims=keepdims == 1),)
 
 
-class ReduceMax_11(ReduceMax_1):
-    pass
-
-
-class ReduceMax_12(ReduceMax_1):
-    pass
-
-
-class ReduceMax_13(ReduceMax_1):
-    pass
-
-
 class ReduceMax_18(OpRunReduceNumpy):
-    def run(self, data, axes=None, keepdims=None, noop_with_empty_axes=None):  # type: ignore
-        keepdims = keepdims or self.keepdims  # type: ignore
-        noop_with_empty_axes = noop_with_empty_axes or self.noop_with_empty_axes  # type: ignore
-        return self._run(data, axes, keepdims, noop_with_empty_axes)
-
-    def _run(self, data, axes, keepdims=1, noop_with_empty_axes=0):  # type: ignore
+    def _run(self, data, axes=None, keepdims=1, noop_with_empty_axes=0):  # type: ignore
         if self.is_axes_empty(axes) and noop_with_empty_axes != 0:  # type: ignore
             return (data,)
 
@@ -43,11 +26,5 @@ class ReduceMax_18(OpRunReduceNumpy):
 
 if onnx_opset_version() >= 18:
     ReduceMax = ReduceMax_18
-elif onnx_opset_version() >= 13:
-    ReduceMax = ReduceMax_13  # type: ignore
-elif onnx_opset_version() >= 12:
-    ReduceMax = ReduceMax_12  # type: ignore
-elif onnx_opset_version() >= 11:
-    ReduceMax = ReduceMax_11  # type: ignore
 else:
     ReduceMax = ReduceMax_1  # type: ignore

--- a/onnx/reference/ops/op_reduce_mean.py
+++ b/onnx/reference/ops/op_reduce_mean.py
@@ -15,21 +15,8 @@ class ReduceMean_1(OpRunReduceNumpy):
         return (np.mean(data, axis=axes, keepdims=keepdims, dtype=data.dtype),)
 
 
-class ReduceMean_11(ReduceMean_1):
-    pass
-
-
-class ReduceMean_13(ReduceMean_1):
-    pass
-
-
 class ReduceMean_18(OpRunReduceNumpy):
-    def run(self, data, axes=None, keepdims=None, noop_with_empty_axes=None):  # type: ignore
-        keepdims = keepdims or self.keepdims  # type: ignore
-        noop_with_empty_axes = noop_with_empty_axes or self.noop_with_empty_axes  # type: ignore
-        return self._run(data, axes, keepdims, noop_with_empty_axes)
-
-    def _run(self, data, axes, keepdims=1, noop_with_empty_axes=0):  # type: ignore
+    def _run(self, data, axes=None, keepdims=1, noop_with_empty_axes=0):  # type: ignore
         if self.is_axes_empty(axes) and noop_with_empty_axes:  # type: ignore
             return (data,)
 
@@ -47,9 +34,5 @@ class ReduceMean_18(OpRunReduceNumpy):
 
 if onnx_opset_version() >= 18:
     ReduceMean = ReduceMean_18
-elif onnx_opset_version() >= 13:
-    ReduceMean = ReduceMean_13  # type: ignore
-elif onnx_opset_version() >= 11:
-    ReduceMean = ReduceMean_11  # type: ignore
 else:
     ReduceMean = ReduceMean_1  # type: ignore

--- a/onnx/reference/ops/op_reduce_min.py
+++ b/onnx/reference/ops/op_reduce_min.py
@@ -18,21 +18,8 @@ class ReduceMin_11(ReduceMin_1):
     pass
 
 
-class ReduceMin_12(ReduceMin_1):
-    pass
-
-
-class ReduceMin_13(ReduceMin_1):
-    pass
-
-
 class ReduceMin_18(OpRunReduceNumpy):
-    def run(self, data, axes=None, keepdims=None, noop_with_empty_axes=None):  # type: ignore
-        keepdims = keepdims or self.keepdims  # type: ignore
-        noop_with_empty_axes = noop_with_empty_axes or self.noop_with_empty_axes  # type: ignore
-        return self._run(data, axes, keepdims, noop_with_empty_axes)
-
-    def _run(self, data, axes, keepdims=1, noop_with_empty_axes=0):  # type: ignore
+    def _run(self, data, axes=None, keepdims=1, noop_with_empty_axes=0):  # type: ignore
         if self.is_axes_empty(axes) and noop_with_empty_axes != 0:  # type: ignore
             return (data,)
 
@@ -43,11 +30,5 @@ class ReduceMin_18(OpRunReduceNumpy):
 
 if onnx_opset_version() >= 18:
     ReduceMin = ReduceMin_18
-elif onnx_opset_version() >= 13:
-    ReduceMin = ReduceMin_13  # type: ignore
-elif onnx_opset_version() >= 12:
-    ReduceMin = ReduceMin_12  # type: ignore
-elif onnx_opset_version() >= 11:
-    ReduceMin = ReduceMin_11  # type: ignore
 else:
     ReduceMin = ReduceMin_1  # type: ignore

--- a/onnx/reference/ops/op_reduce_prod.py
+++ b/onnx/reference/ops/op_reduce_prod.py
@@ -13,21 +13,8 @@ class ReduceProd_1(OpRunReduceNumpy):
         return (np.prod(data, axis=axes, keepdims=keepdims, dtype=data.dtype),)
 
 
-class ReduceProd_11(ReduceProd_1):
-    pass
-
-
-class ReduceProd_13(ReduceProd_1):
-    pass
-
-
 class ReduceProd_18(OpRunReduceNumpy):
-    def run(self, data, axes=None, keepdims=None, noop_with_empty_axes=None):  # type: ignore
-        keepdims = keepdims or self.keepdims  # type: ignore
-        noop_with_empty_axes = noop_with_empty_axes or self.noop_with_empty_axes  # type: ignore
-        return self._run(data, axes, keepdims, noop_with_empty_axes)
-
-    def _run(self, data, axes, keepdims=1, noop_with_empty_axes=0):  # type: ignore
+    def _run(self, data, axes=None, keepdims=1, noop_with_empty_axes=0):  # type: ignore
         if self.is_axes_empty(axes) and noop_with_empty_axes:  # type: ignore
             return (data,)
 
@@ -38,9 +25,5 @@ class ReduceProd_18(OpRunReduceNumpy):
 
 if onnx_opset_version() >= 18:
     ReduceProd = ReduceProd_18
-elif onnx_opset_version() >= 13:
-    ReduceProd = ReduceProd_13  # type: ignore
-elif onnx_opset_version() >= 11:
-    ReduceProd = ReduceProd_11  # type: ignore
 else:
     ReduceProd = ReduceProd_1  # type: ignore

--- a/onnx/reference/ops/op_reduce_sum.py
+++ b/onnx/reference/ops/op_reduce_sum.py
@@ -14,10 +14,6 @@ class ReduceSum_1(OpRunReduceNumpy):
         return (np.sum(x, axis=axes, keepdims=keepdims, dtype=x.dtype),)
 
 
-class ReduceSum_11(ReduceSum_1):
-    pass
-
-
 class ReduceSum_13(OpRunReduceNumpy):
     def run(self, x, axes=None, keepdims=None):  # type: ignore
         keepdims = keepdims or self.keepdims  # type: ignore
@@ -57,7 +53,5 @@ class ReduceSum_13(OpRunReduceNumpy):
 
 if onnx_opset_version() >= 13:
     ReduceSum = ReduceSum_13
-elif onnx_opset_version() >= 11:
-    ReduceSum = ReduceSum_11  # type: ignore
 else:
     ReduceSum = ReduceSum_1  # type: ignore

--- a/onnx/reference/ops/op_reduce_sum_square.py
+++ b/onnx/reference/ops/op_reduce_sum_square.py
@@ -13,21 +13,8 @@ class ReduceSumSquare_1(OpRunReduceNumpy):
         return (np.sum(np.square(data), axis=axes, keepdims=keepdims),)
 
 
-class ReduceSumSquare_11(ReduceSumSquare_1):
-    pass
-
-
-class ReduceSumSquare_13(ReduceSumSquare_1):
-    pass
-
-
 class ReduceSumSquare_18(OpRunReduceNumpy):
-    def run(self, data, axes=None, keepdims=None, noop_with_empty_axes=None):  # type: ignore
-        keepdims = keepdims or self.keepdims  # type: ignore
-        noop_with_empty_axes = noop_with_empty_axes or self.noop_with_empty_axes  # type: ignore
-        return self._run(data, axes, keepdims, noop_with_empty_axes)
-
-    def _run(self, data, axes, keepdims=1, noop_with_empty_axes=0):  # type: ignore
+    def _run(self, data, axes=None, keepdims=1, noop_with_empty_axes=0):  # type: ignore
         if self.is_axes_empty(axes) and noop_with_empty_axes != 0:  # type: ignore
             return (np.square(data),)
 
@@ -38,9 +25,5 @@ class ReduceSumSquare_18(OpRunReduceNumpy):
 
 if onnx_opset_version() >= 18:
     ReduceSumSquare = ReduceSumSquare_18
-elif onnx_opset_version() >= 13:
-    ReduceSumSquare = ReduceSumSquare_13  # type: ignore
-elif onnx_opset_version() >= 11:
-    ReduceSumSquare = ReduceSumSquare_11  # type: ignore
 else:
     ReduceSumSquare = ReduceSumSquare_1  # type: ignore

--- a/onnx/test/reference_evaluator_backend_test.py
+++ b/onnx/test/reference_evaluator_backend_test.py
@@ -51,7 +51,7 @@ from onnx.reference import ReferenceEvaluator
 from onnx.reference.ops.op_cast import cast_to
 
 # Number of tests expected to pass without raising an exception.
-MIN_PASSING_TESTS = 1211
+MIN_PASSING_TESTS = 1237
 
 # Update this list if one new operator does not have any implementation.
 SKIP_TESTS = {
@@ -66,25 +66,6 @@ SKIP_TESTS = {
     # not implemented
     "test__simple_gradient_of_add",  # gradient not implemented
     "test__simple_gradient_of_add_and_mul",  # gradient not implemented
-    "test_layer_normalization_2d_axis1_expanded",  # https://github.com/onnx/onnx/issues/4653
-    "test_layer_normalization_2d_axis_negative_1_expanded",  # https://github.com/onnx/onnx/issues/4653
-    "test_layer_normalization_3d_axis1_epsilon_expanded",  # https://github.com/onnx/onnx/issues/4653
-    "test_layer_normalization_3d_axis2_epsilon_expanded",  # https://github.com/onnx/onnx/issues/4653
-    "test_layer_normalization_3d_axis_negative_1_epsilon_expanded",  # https://github.com/onnx/onnx/issues/4653
-    "test_layer_normalization_3d_axis_negative_2_epsilon_expanded",  # https://github.com/onnx/onnx/issues/4653
-    "test_layer_normalization_4d_axis1_expanded",  # https://github.com/onnx/onnx/issues/4653
-    "test_layer_normalization_4d_axis2_expanded",  # https://github.com/onnx/onnx/issues/4653
-    "test_layer_normalization_4d_axis3_expanded",  # https://github.com/onnx/onnx/issues/4653
-    "test_layer_normalization_4d_axis_negative_1_expanded",  # https://github.com/onnx/onnx/issues/4653
-    "test_layer_normalization_4d_axis_negative_2_expanded",  # https://github.com/onnx/onnx/issues/4653
-    "test_layer_normalization_4d_axis_negative_3_expanded",  # https://github.com/onnx/onnx/issues/4653
-    "test_layer_normalization_default_axis_expanded",  # https://github.com/onnx/onnx/issues/4653
-    "test_mvn",  # https://github.com/onnx/onnx/issues/4653
-    "test_mvn_expanded",  # https://github.com/onnx/onnx/issues/4653
-    "test_softmax_large_number_expanded",  # https://github.com/onnx/onnx/issues/4653
-    "test_logsoftmax_large_number_expanded",  # https://github.com/onnx/onnx/issues/4653
-    "test__pytorch_operator_operator_reduced_mean_keepdim",  # https://github.com/onnx/onnx/issues/4653
-    "test__pytorch_operator_operator_reduced_mean",  # https://github.com/onnx/onnx/issues/4653
 }
 
 if version(npver) < version("1.21.5"):


### PR DESCRIPTION
Signed-off-by: xadupre <xadupre@microsoft.com>

### Description

The implementation for the reduce operators introduced in opset 18 were not registered in file `_op_list.py` and could not be used by the reference implementation.


### Motivation and Context

Extend the list of supported backend tests.
