### PR TITLE
Update `OnnxReleases.md`

### DIFF
--- a/docs/OnnxReleases.md
+++ b/docs/OnnxReleases.md
@@ -74,12 +74,10 @@ The ONNX project, going forward, will plan to release roughly on a four month ca
 
  * Test with ONNX converters: Create GitHub issues in converters repos to provide them the package links and have them test the TestPyPI packages.
    * https://github.com/pytorch/pytorch
-   * https://github.com/onnx/onnx-tensorflow
    * https://github.com/onnx/tensorflow-onnx
    * https://github.com/onnx/sklearn-onnx
    * https://github.com/onnx/onnxmltools
    * https://github.com/onnx/onnx-tensorrt
-   * https://github.com/onnx/onnx-coreml
 
 
 **Source distribution verification**

--- a/docs/OnnxReleases.md
+++ b/docs/OnnxReleases.md
@@ -59,11 +59,11 @@ The ONNX project, going forward, will plan to release roughly on a four month ca
   * Protobuf versions : Latest protobuf version at the time of the release + protobuf version used for previous release
   * Utilize the following matrix to check:
 
-    |   | 3.7 | 3.8 | 3.9 | 3.10 |
-    -- | -- | -- | -- | -- |
-    Linux |   |   |   |   |
-    Windows |   |   |   |   |
-    Mac |   |   |   |   |
+    |   | 3.7 | 3.8 | 3.9 | 3.10 | 3.11 |
+    -- | -- | -- | -- | -- | -- |
+    Linux |   |   |   |   |   |
+    Windows |   |   |   |   |   |
+    Mac |   |   |   |   |   |
 
 
 * After installing the PyPI package, run `pytest` in the release branch.
@@ -78,7 +78,6 @@ The ONNX project, going forward, will plan to release roughly on a four month ca
    * https://github.com/onnx/tensorflow-onnx
    * https://github.com/onnx/sklearn-onnx
    * https://github.com/onnx/onnxmltools
-   * https://github.com/onnx/keras-onnx
    * https://github.com/onnx/onnx-tensorrt
    * https://github.com/onnx/onnx-coreml
 

--- a/docs/OnnxReleases.md
+++ b/docs/OnnxReleases.md
@@ -121,4 +121,4 @@ The ONNX project, going forward, will plan to release roughly on a four month ca
 * Steps: Login and go [here](https://test.pypi.org/manage/project/onnx-weekly/releases/) -> Choose target package -> Options -> Delete.
 
 **Bump opset version for ai.onnx**
-* Bump opset version for ai.onnx domain in `onnx/defs/operator_sets.h` and `onnx/defs/schema.h` for use by future operator additions and changes. For example, this [demo PR](https://github.com/onnx/onnx/pull/4134/files).
+* Bump opset version for ai.onnx domain in `onnx/defs/operator_sets.h` and `onnx/defs/schema.h` for use by future operator additions and changes. For example, this [demo PR](https://github.com/onnx/onnx/pull/4701).


### PR DESCRIPTION
Signed-off-by: p-wysocki <przemyslaw.wysocki@intel.com>

### Description
- add Python 3.11 to validation table
- remove link to `keras2onnx`, which is archived and frozen to `onnx==1.10`: https://github.com/onnx/keras-onnx
