### PR TITLE
add quantization annotation to merge_graphs

### DIFF
--- a/onnx/compose.py
+++ b/onnx/compose.py
@@ -244,6 +244,13 @@ def merge_graphs(
 
     g.value_info.extend(g1.value_info)
     g.value_info.extend([vi for vi in g2.value_info if vi.name not in io_map_g2_ins])
+    
+    g.quantization_annotation.extend(g1.quantization_annotation)
+    g.quantization_annotation.extend(
+        [
+            qa for qa in g2.quantization_annotation if qa.tensor_name not in io_map_g2_ins
+        ]
+    )
 
     g.name = name if name is not None else "_".join([g1.name, g2.name])
 


### PR DESCRIPTION
### Description
Pass along quantization annotation when merging graphs.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
I'm currently working with quantized graphs and wish to merge graphs together while preserving this quantization information. I'm doing it manually right now but it would be better if this just worked here.

<!-- - If it fixes an open issue, please link to the issue here. -->
