### PR TITLE
numerical competition --> numerical computation

### DIFF
--- a/docs/docsgen/source/intro/concepts.rst
+++ b/docs/docsgen/source/intro/concepts.rst
@@ -163,7 +163,7 @@ supports any custom domains and operators
 Supported Types
 +++++++++++++++
 
-ONNX specifications are optimized for numerical competition with
+ONNX specifications are optimized for numerical computation with
 tensors. A *tensor* is a multidimensional array. It is defined
 by:
 


### PR DESCRIPTION
ONNX specifications are optimized for numerical *competition* with tensors.
-->
ONNX specifications are optimized for numerical *computation* with tensors.

### Description
<!-- - Describe your changes. -->


### Motivation and Context

This looks like a writing mistake. Not crucial.
