### PR TITLE
Ignore B905 flake8 errors

### DIFF
--- a/tools/style.sh
+++ b/tools/style.sh
@@ -13,7 +13,7 @@ err=0
 trap 'err=1' ERR
 
 echo -e "\n::group:: ===> check flake8..."
-flake8 onnx tools workflow_scripts
+flake8 --ignore=B905 onnx tools workflow_scripts
 echo -e "::endgroup::"
 
 echo -e "\n::group:: ===> check isort..."


### PR DESCRIPTION
Newly introduced flake8 B905 error (https://github.com/PyCQA/flake8-bugbear/releases/tag/22.12.6) requires all zip() functions to have an explicit strict boolean parameter (https://peps.python.org/pep-0618/).

Since it has been introduced in Python 3.10 and ONNX supports lower Python versions I suggest ignoring it.

Backport to release branch: https://github.com/onnx/onnx/pull/4697