### PR TITLE
Fix missing page for ai.onnx.ml domain

### DIFF
--- a/docs/docsgen/source/onnx_sphinx.py
+++ b/docs/docsgen/source/onnx_sphinx.py
@@ -755,12 +755,11 @@ def is_last_schema(sch: OpSchema) -> bool:
     return last.since_version == sch.since_version
 
 
-def onnx_documentation_folder(folder, ops=None, title="ONNX Operators", flog=None, max_opsets=None):  # type: ignore
+def onnx_documentation_folder(folder, title="ONNX Operators", flog=None, max_opsets=None):  # type: ignore
     """
     Creates documentation in a folder for all known
     ONNX operators or a subset.
     :param folder: folder where to write the documentation
-    :param ops: None for all operators or a subset of them
     :param title: index title
     :param flog: logging function
     :param max_opsets: included operator definition up to this opsets
@@ -856,9 +855,6 @@ def onnx_documentation_folder(folder, ops=None, title="ONNX Operators", flog=Non
     pages = []
     tables = []
 
-    if ops is not None:
-        ops = set(ops)
-
     # loop on domains
     for dom in sorted(all_schemas):
         sdom = "ai.onnx" if dom == "" else dom
@@ -868,15 +864,7 @@ def onnx_documentation_folder(folder, ops=None, title="ONNX Operators", flog=Non
         if len(sub) == 0:
             raise RuntimeError(f"No operator for domain={dom!r}.")
         do = []  # type: ignore
-        if ops is None:
-            do.extend(sub)
-        else:
-            inter = set(sub).intersection(ops)
-            if len(inter) == 0:
-                raise RuntimeError(f"No operator for domain={dom!r}\nsub={set(sub)},\nops={ops}.")
-            do.extend(sorted(inter))
-        if len(do) == 0:
-            raise RuntimeError(f"No operator for domain={dom!r}, ops={ops}.")
+        do.extend(sub)
 
         # loop on operators
         for op in sorted(do):

--- a/docs/docsgen/source/onnx_sphinx.py
+++ b/docs/docsgen/source/onnx_sphinx.py
@@ -860,11 +860,9 @@ def onnx_documentation_folder(folder, title="ONNX Operators", flog=None, max_ops
         sdom = "ai.onnx" if dom == "" else dom
         dom_pages = []
 
-        sub = all_schemas[dom]
-        if len(sub) == 0:
+        do = all_schemas[dom]
+        if len(do) == 0:
             raise RuntimeError(f"No operator for domain={dom!r}.")
-        do = []  # type: ignore
-        do.extend(sub)
 
         # loop on operators
         for op in sorted(do):


### PR DESCRIPTION
Signed-off-by: xadupre <xadupre@microsoft.com>

### Description
ai.onnx.ml are missing from page: https://onnx.ai/onnx/operators/. It was broken by PR: https://github.com/onnx/onnx/pull/4753.

