### PR TITLE
cleanup in governance file

### DIFF
--- a/community/readme.md
+++ b/community/readme.md
@@ -57,7 +57,7 @@ Member Companies can request their logo be displayed on the website and other ma
 The ONNX community is organized in the following manner, with all governance and execution being planned and coordinated as follows:
 
 * **Steering Committee** is made up of a set number of people whose charter it is to define and iterate on the vision, goals, and governance process of the ONNX community.
-* **Special  Interest Groups (SIGs)** are persistent groups that are responsible for specific parts of the project. SIGs must have open and transparent proceedings. Anyone is welcome to participate and contribute provided they follow the Code of Conduct. The purpose of a SIG is to develop a set of goals to be achieved over a set period of time, and then to gather input, drive consensus and closure, implement code contributions, and other related activities to achieve the goal. SIGs are also responsible for ongoing maintenance of the code in their areas.
+* **Special Interest Groups (SIGs)** are persistent groups that are responsible for specific parts of the project. SIGs must have open and transparent proceedings. Anyone is welcome to participate and contribute provided they follow the Code of Conduct. The purpose of a SIG is to develop a set of goals to be achieved over a set period of time, and then to gather input, drive consensus and closure, implement code contributions, and other related activities to achieve the goal. SIGs are also responsible for ongoing maintenance of the code in their areas.
 * **Working Groups** are temporary groups that are formed to address issues that cross SIG boundaries. Working groups do not own any code ownership or other long term artifacts. Working groups can report back and act through involved SIGs.
 
 ### Steering Committee
@@ -142,12 +142,9 @@ Working Groups (WGs) are primarily used to facilitate topics of discussion that 
 * have a clear goal measured through specific deliverables
 * will be disbanded after the goal is achieved
 
-Working Groups can create specifications, recommendations, or implementations for submission to the relevant SIGs for approval and acceptance. At time of inception of this organizational structure, the following WGs will be present:
+Working Groups can create specifications, recommendations, or implementations for submission to the relevant SIGs for approval and acceptance.
 
-   * Edge / Mobile
-   * Training
-   * Quantization
-   * Data Processing
+A list of all active, inactive, and completed working groups can be found in the [working-groups repository](https://github.com/onnx/working-groups)
 
 Working Groups are formed by submitting a proposal via PR to the Steering Committee. The proposal should cover:
 
@@ -160,17 +157,10 @@ Working Groups are disbanded when there is no activity for more than *3 months* 
 
 ## Repository Guidelines
 
-All repositories under the ONNX github org:
 
-* Must adopt the ONNX Code of Conduct
-* All code projects use the Apache 2.0 license. Documentation repositories must use the Creative Commons License version 4.0.
-* Must adopt the DCO bot
-* All OWNERS must be members of standing as defined by ability to vote in ONNX steering committee elections
-* Repository must be approved by the Steering Committee
 
-Repositories can be removed when they are inactive by archiving them.
 
-(Code repositories previously used the MIT license and moved to Apache 2.0 in October 2020.)
+The current guidelines for all repos under ONNX github.org could be found [here](repo_guidelines.md).
 
 ## CLA / DCO
 

--- a/community/repo_guidelines.md
+++ b/community/repo_guidelines.md
@@ -6,12 +6,12 @@ The ONNX GitHub organization contains a number of repositories. Every repository
 
 ## Rules for all repos
 
-* Must be owned and managed by one of the ONNX SIGs
+* Must be owned and managed by one of the ONNX SIGs or the Steering Committee
 * Must be actively maintained
 * Must adopt the ONNX Code of Conduct
-* Must adopt the standard ONNX license(s)
+* Must adopt the standard ONNX license(s) [All code projects use the Apache 2.0 license. Documentation repositories must use the Creative Commons License version 4.0.]
 * Must adopt the ONNX DCO bot
-* Must adopt all ONNX automation (like LGTM)
+* Must adopt all ONNX automation (like static code analysis)
 * Must have CI or other automation in place for repos containing code to ensure quality
 * All OWNERS must be members of standing as defined by ability to vote in Steering Committee elections.
 


### PR DESCRIPTION
Signed-off-by: Andreas Fehlner <fehlner@arcor.de>

* Reduce redundancy
* Make it easier for new interest to find out which structure and working groups are currently active (rather than highlighting the historical structure) 
* Adapting to the circumstances. (e.g. the Steering Committee Repo should belong to the SC and not to a SIG).

PR as decided at the SC meeting of 1/18/2023.