### PR TITLE
fix version_conversion error of Pad-2 to Pad-11 caused by missing value attribu…

### DIFF
--- a/onnx/test/version_converter_test.py
+++ b/onnx/test/version_converter_test.py
@@ -1835,6 +1835,22 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.opset_import[0].version == to_opset
         assert len(converted_model.graph.node[0].attribute) == 1
 
+    # Test Pad Adapter: 10 -> 11
+    def test_pad_10_11(self) -> None:
+        pads = (0, 1, 2, 0, 2, 1)
+        nodes = [helper.make_node("Pad", ["X"], ["Y"], pads=pads)]
+        graph = helper.make_graph(
+            nodes,
+            "test",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (1, 2, 2))],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, (1, 5, 5))],
+        )
+        converted_model = self._converted(graph, helper.make_operatorsetid("", 10), 11)
+
+        # Assert equality of graph and converted_model
+        assert converted_model.graph.node[1].op_type == "Pad"
+        assert converted_model.opset_import[0].version == 11
+
     # Test that subgraphs are converted
     def test_if_subgraph_10_11(self) -> None:
         from_opset = 10

--- a/onnx/test/version_converter_test.py
+++ b/onnx/test/version_converter_test.py
@@ -1853,7 +1853,7 @@ class TestVersionConverter(unittest.TestCase):
 
     def test_pad_with_value_10_11(self) -> None:
         pads = (0, 1, 2, 0, 2, 1)
-        nodes = [helper.make_node("Pad", ["X"], ["Y"], pads=pads, value=1.)]
+        nodes = [helper.make_node("Pad", ["X"], ["Y"], pads=pads, value=1.0)]
         graph = helper.make_graph(
             nodes,
             "test",

--- a/onnx/test/version_converter_test.py
+++ b/onnx/test/version_converter_test.py
@@ -1851,6 +1851,21 @@ class TestVersionConverter(unittest.TestCase):
         assert converted_model.graph.node[1].op_type == "Pad"
         assert converted_model.opset_import[0].version == 11
 
+    def test_pad_with_value_10_11(self) -> None:
+        pads = (0, 1, 2, 0, 2, 1)
+        nodes = [helper.make_node("Pad", ["X"], ["Y"], pads=pads, value=1.)]
+        graph = helper.make_graph(
+            nodes,
+            "test",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (1, 2, 2))],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, (1, 5, 5))],
+        )
+        converted_model = self._converted(graph, helper.make_operatorsetid("", 10), 11)
+
+        # Assert equality of graph and converted_model
+        assert converted_model.graph.node[1].op_type == "Pad"
+        assert converted_model.opset_import[0].version == 11
+
     # Test that subgraphs are converted
     def test_if_subgraph_10_11(self) -> None:
         from_opset = 10

--- a/onnx/version_converter/adapters/pad_10_11.h
+++ b/onnx/version_converter/adapters/pad_10_11.h
@@ -27,6 +27,8 @@ class Pad_10_11 final : public Adapter {
     node->removeAttribute(kpads);
     // Turn value attribute into input
     if (!node->hasAttribute(kmode) || node->s(kmode) == "constant") {
+      if (!node->hasAttribute(kvalue))
+        node->f_(kvalue, 0.);
       Tensor t_value;
       t_value.elem_type() = TensorProto_DataType_FLOAT;
       auto& data_value = t_value.floats();


### PR DESCRIPTION
…te which is not mandatory

### Description
<!-- - Describe your changes. -->
not to fail version_conversion, create `value` attribute with default value 0.f when `value` attribute is not present for `Pad-2` operator.


### Motivation and Context
`value` of `Pad-2` is optional, so missing `value` attribute is not a problem but if `value` attribute is not present, version conversion from 2 to 10 is failing.

<!-- - Why is this change required? What problem does it solve? -->

test code is here:

```
import onnx

from onnx import version_converter
from onnx.helper import make_tensor, make_tensor_value_info
from onnx.helper import make_model, make_graph, make_node


input_shape = (1, 3, 2, 4)
output_shape = (1, 3, 5, 7)

input_type = onnx.TensorProto.FLOAT
output_type = onnx.TensorProto.FLOAT

input_tensors = [make_tensor_value_info('A', input_type, input_shape)]
output_tensors = [make_tensor_value_info('B', output_type, output_shape)]

node = make_node('Pad',  inputs=['A'], outputs=['B'], pads=(0, 0, 2, 1, 0, 0, 1, 2))

graph = make_graph([node], 'graph', input_tensors, output_tensors)

model = make_model(graph)
model.opset_import[0].version = 2

new_model = convert_version(model, 11)
onnx.checker.check_model(new_model)
```
 
<!-- - If it fixes an open issue, please link to the issue here. -->
