### PR TITLE
Reference implementation inconsistently handles optionals

### DIFF
--- a/onnx/reference/ops/op_optional_has_element.py
+++ b/onnx/reference/ops/op_optional_has_element.py
@@ -11,9 +11,8 @@ class OptionalHasElement(OpRun):
         if x is None:
             return ([],)
         if isinstance(x, list):
-            if len(x) > 0:
-                return (np.array([e is not None for e in x]),)
+            (e,) = x
+            return (np.array(e is not None),)
         elif isinstance(x, np.ndarray):
-            if len(x.shape) > 0 and x.shape[0] > 0:
-                return (np.array([e is not None for e in x]),)
+            return (np.array(True),)
         return ([],)


### PR DESCRIPTION
### Description

Attempt to fix the `OptionalHasElement` reference implementation. 

Currently, any call to it returns a `list` - `[array([False])]`, as if it was a single-element vector wrapped in an `optional(tensor(bool))`, rather than a scalar `tensor(bool)` - `array(False)` - as would be expected. 

This also remains somewhat inconsistent with how ONNX Runtime handles optionals (it doesn't wrap them, a missing optional is just returned to Python as `None`). Maybe changing the representation would be useful to make this more clear?

@xadupre What was your idea for representing optional? From what I gathered I understand you wanted to use singleton lists to indicate optionals, i.e. `[None]` is a `Nothing`, and otherwise `[x]` is `Some x` (where `x` is a tensor)? Doesn't this intersect with `[x]` being a single-element sequence of `x`?
I'm also not sure what the meaning of an empty-list result `[]` in e.g. `OptionalGetElement` and some branches of `OptionalHasElement`?

### Motivation and Context

`OptionalHasElement` currently is not standard-consistent, the `output` in the docs [for optionals] is described as `A scalar boolean tensor.`, while an optional-wrapped single-element vector is returned instead. This is because the reference implementation doesn't differentiate sequences and optionals.