### PR TITLE
Unskip a backend test in the list supported by the reference implementation

### DIFF
--- a/onnx/test/reference_evaluator_backend_test.py
+++ b/onnx/test/reference_evaluator_backend_test.py
@@ -53,14 +53,13 @@ from onnx.reference import ReferenceEvaluator
 from onnx.reference.ops.op_cast import cast_to
 
 # Number of tests expected to pass without raising an exception.
-MIN_PASSING_TESTS = 1230
+MIN_PASSING_TESTS = 1231
 
 # Update this list if one new operator does not have any implementation.
 SKIP_TESTS = {
     # mismatches
     # shapes (10, 9, 3), (10, 8, 3) shape mismatch unexpected as the operator is inlined
     "test_center_crop_pad_crop_axes_hwc_expanded",
-    "test_col2im_pads",  # mismatch by one value, the onnx backend test is probably wrong
     # deprecated
     "test_scan_sum",  # deprecated, opset 8 -> not implemented
     "test_scatter_with_axis",  # deprecated, scatter is removed


### PR DESCRIPTION
Signed-off-by: xadupre <xadupre@microsoft.com>

### Description
A skipped backend test is now passing with the reference implementation after #4769 is merged.


### Motivation and Context
Increase test coverage.

