### PR TITLE
Update Linux-CI.yml. Ubuntu18.04 deprecated (unsupported by 2023/04/01)

### DIFF
--- a/.azure-pipelines/Linux-CI.yml
+++ b/.azure-pipelines/Linux-CI.yml
@@ -4,7 +4,7 @@ trigger:
 jobs:
 - job: 'Test'
   pool:
-    vmImage: 'Ubuntu-18.04'
+    vmImage: 'Ubuntu-20.04'
   strategy:
     matrix:
       py39-ml-debug:


### PR DESCRIPTION
"The Ubuntu 18.04 Actions runner image will begin deprecation on 2022/08/08 and will be fully unsupported by 2023/04/01"
https://github.com/actions/runner-images/issues/6002

Does python 3.7 work with ubuntu 20.04 ? should not make a difference?

Signed-off-by: Andreas Fehlner <fehlner@arcor.de>

### Description
<!-- - Describe your changes. -->


### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
