### PR TITLE
Fix python setup.py install failure in weekly pipeline

### DIFF
--- a/.github/workflows/weekly_mac_ci.yml
+++ b/.github/workflows/weekly_mac_ci.yml
@@ -45,3 +45,11 @@ jobs:
         export CXX=clang++
         export ONNX_ML=1
         pip install -e .
+
+    - name: Test all models with onnx.checker, onnx.shape_inference, onnx.version_converter
+      run: |
+        cd ..
+        git clone https://github.com/onnx/models.git
+        cd models
+        python ../onnx/workflow_scripts/test_model_zoo.py
+

--- a/.github/workflows/weekly_mac_ci.yml
+++ b/.github/workflows/weekly_mac_ci.yml
@@ -1,8 +1,7 @@
 # Weekly ci workflow for model zoo.
-# Runs model checker for all models
-name: Weekly CI with latest onnx.checker
+# Runs model checker/shape_inference/version_converter for all models
+name: Weekly CI with the latest ONNX and ONNX Model Zoo
 
-# Triggers the workflow on push or pull request events but only for the main branch
 on:
   schedule:
     # run weekly on Sunday 23:59
@@ -45,11 +44,4 @@ jobs:
         export CC=clang
         export CXX=clang++
         export ONNX_ML=1
-        python setup.py --quiet install
-
-    - name: Test all models with onnx.checker and onnx.shape_inference
-      run: |
-        cd ..
-        git clone https://github.com/onnx/models.git
-        cd models
-        python ../onnx/workflow_scripts/test_model_zoo.py
+        pip install -e .


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Fix `python setup.py install` failure after this PR: https://github.com/onnx/onnx/pull/4772.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Error when `python setup.py install`:
```
/Users/runner/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/site-packages/pkg_resources/__init__.py:123: PkgResourcesDeprecationWarning:  is an invalid version and will not be supported in a future release
  warnings.warn(
No local packages or working download links found for onnx==1.14.0
error: Could not find suitable distribution for Requirement.parse('onnx==1.14.0')
Error: Process completed with exit code 1.
```