### PR TITLE
Fix parser bug in handling non-tensor types

### DIFF
--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -369,7 +369,17 @@ Status OnnxParser::Parse(TensorProto& tensorProto, const TypeProto& tensorTypePr
 bool OnnxParser::NextIsType() {
   std::string id("");
   (void)PeekIdentifier(id);
-  return (PrimitiveTypeNameMap::IsTypeName(id));
+  if (PrimitiveTypeNameMap::IsTypeName(id))
+    return true;
+  switch (KeyWordMap::Lookup(id)) {
+    case KeyWordMap::KeyWord::SEQ_TYPE:
+    case KeyWordMap::KeyWord::MAP_TYPE:
+    case KeyWordMap::KeyWord::OPTIONAL_TYPE:
+    case KeyWordMap::KeyWord::SPARSE_TENSOR_TYPE:
+      return true;
+    default:
+      return false;
+  }
 }
 
 Status OnnxParser::ParseSingleAttributeValue(AttributeProto& attr) {

--- a/onnx/test/cpp/parser_test.cc
+++ b/onnx/test/cpp/parser_test.cc
@@ -490,5 +490,33 @@ square (x) => (y) {
   CheckModel(code);
 }
 
+TEST(ParserTest, TypesModelTest1) {
+  const char* code = R"ONNX(
+    <
+    ir_version: 8,
+    opset_import: [ "" : 18 ]
+    >
+    agraph (seq(float[N]) seqX) => (float[M, N] X)
+    {
+        X = ConcatFromSequence < axis = 0, new_axis = 1 >(seqX)
+    }
+)ONNX";
+  CheckModel(code);
+}
+
+TEST(ParserTest, TypesModelTest2) {
+  const char* code = R"ONNX(
+    <
+    ir_version: 8,
+    opset_import: [ "" : 18 ]
+    >
+    agraph (float[N] tensorX, seq(float[N]) seqX, map(int32, float[N]) mapX, optional(float[N]) optionalX, sparse_tensor(float[N]) sparseX) => (float[N] X)
+    {
+        X = Identity (tensorX)
+    }
+)ONNX";
+  CheckModel(code);
+}
+
 } // namespace Test
 } // namespace ONNX_NAMESPACE


### PR DESCRIPTION
The parser does not handle non-tensor types used in graph input/outputs. Fix the bug.