### PR TITLE
Fix squeeze opset 11 reference runtime bug

### DIFF
--- a/onnx/reference/ops/op_squeeze.py
+++ b/onnx/reference/ops/op_squeeze.py
@@ -8,6 +8,8 @@ from onnx.reference.op_run import OpRun
 
 class Squeeze_1(OpRun):
     def _run(self, data, axes=None):  # type: ignore
+        if axes is None:
+            axes = getattr(self, "axes", axes)
         if isinstance(axes, np.ndarray):
             axes = tuple(axes)
         elif axes in [[], tuple()]:


### PR DESCRIPTION
squeeze in opset 11 should getattr(self, "axes"), or shape would be wrong. For example, [1, 5, 1, 5] with axes[2], will get wrong output shape.

Signed-off-by: pengchao.hu <pengchao.hu@sophgo.com>

### Description
For squeeze in opset 11, get axes by getattr.


### Motivation and Context
Many Onnx model use opset 11, and if it contains squeeze, shape inference is not correct as no axes.
