### PR TITLE
Remove non-required pyzmq due to different license

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,6 @@ parameterized
 nbval
 wheel
 jupyter
-pyzmq
 setuptools
 twine
 # Dependencies for linting. Versions match those in setup.py.


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Remove non-required pyzmq due to different license

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
The license for pyzmq may not be compatible with our ONNX license