### PR TITLE
Sphinx type name rendering

### DIFF
--- a/docs/docsgen/source/onnx_sphinx.py
+++ b/docs/docsgen/source/onnx_sphinx.py
@@ -401,8 +401,9 @@ def get_rst_doc(  # type: ignore
             name = str(ii)
         name = f"**{name}** in ("
         if const.allowed_type_strs:
-            text = ",\n  ".join(sorted(const.allowed_type_strs))
-            name += "\n  " + text + "\n  )"
+            types = [f"``{type_str}``" for type_str in sorted(const.allowed_type_strs)]
+            text = ", ".join(types)
+            name += " " + text + " )"
         return name
 
     def getname(obj, i):


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->

Render types as inline code.

Before

<img width="741" alt="image" src="https://user-images.githubusercontent.com/11205048/221239427-4b09802c-6baa-42a1-9c86-74ac06d29aa9.png">

After

<img width="757" alt="image" src="https://user-images.githubusercontent.com/11205048/221241184-a05fcc46-8ea1-4f06-ac0b-f257c83aeaf1.png">

-----

<img width="788" alt="image" src="https://user-images.githubusercontent.com/11205048/221239528-cec043d0-6423-4fdc-b4ed-155d7887e58c.png">


### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->

Doc readability
