### PR TITLE
WIP, do not merge, REUSE compliance (Make licensing easy for everyone)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 ---
 name: Bug report
 about: Create a bug report to help improve the ONNX.

--- a/.github/ISSUE_TEMPLATE/operator.md
+++ b/.github/ISSUE_TEMPLATE/operator.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 ---
 name: New Operator
 about: Create a new operator that does not currently exist in the ONNX.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 ---
 name: Question
 about: Ask a question about the ONNX.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # For most projects, this workflow file will not need changing; you simply need
 # to commit it to your repository.
 #

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Generate and publish ONNX docs
 
 on:

--- a/.github/workflows/release_linux_aarch64.yml
+++ b/.github/workflows/release_linux_aarch64.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: LinuxRelease_aarch64
 
 on:

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: LinuxRelease_x86_64
 
 on:

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: MacRelease
 
 on:

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: WindowsRelease
 
 on:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2022 Free Software Foundation Europe e.V. <https://fsfe.org>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: REUSE Compliance Check
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: REUSE Compliance Check
+      uses: fsfe/reuse-action@v1

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: 2022 Free Software Foundation Europe e.V. <https://fsfe.org>
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
 #
+# SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: CC0-1.0
 
 name: REUSE Compliance Check

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # This workflow uses actions that are not certified by GitHub. They are provided
 # by a third-party and are governed by separate terms of service, privacy
 # policy, and support documentation.
@@ -27,8 +31,6 @@ jobs:
       # Needed to publish results and get a badge (see publish_results below).
       id-token: write
       # Uncomment the permissions below if installing in a private repository.
-      # contents: read
-      # actions: read
 
     steps:
       - name: "Checkout code"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
 #
 # You can adjust the behavior by modifying this file.

--- a/.github/workflows/weekly_mac_ci.yml
+++ b/.github/workflows/weekly_mac_ci.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Weekly ci workflow for model zoo.
 # Runs model checker/shape_inference/version_converter for all models
 name: Weekly CI with the latest ONNX and ONNX Model Zoo

--- a/.github/workflows/win_no_exception_ci.yml
+++ b/.github/workflows/win_no_exception_ci.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Windows_No_Exception_CI
 
 on:

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,8 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: Onnx
+Upstream-Contact: Jane Doe <jane@example.com>
+Source: https://github.com/onnx/onnx
+
+Files: onnx/backend/
+Copyright: ONNX Project Contributors
+License: Apache-2.0

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/onnx/backend/test/case/__init__.py
+++ b/onnx/backend/test/case/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import sys

--- a/onnx/backend/test/case/base.py
+++ b/onnx/backend/test/case/base.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import inspect

--- a/onnx/backend/test/case/model/__init__.py
+++ b/onnx/backend/test/case/model/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import sys

--- a/onnx/backend/test/case/model/expand.py
+++ b/onnx/backend/test/case/model/expand.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Sequence

--- a/onnx/backend/test/case/model/gradient.py
+++ b/onnx/backend/test/case/model/gradient.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/model/sequence.py
+++ b/onnx/backend/test/case/model/sequence.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/onnx/backend/test/case/model/shrink.py
+++ b/onnx/backend/test/case/model/shrink.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/model/sign.py
+++ b/onnx/backend/test/case/model/sign.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/model/single-relu.py
+++ b/onnx/backend/test/case/model/single-relu.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/model/stringnormalizer.py
+++ b/onnx/backend/test/case/model/stringnormalizer.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-
 
 from typing import Sequence
 

--- a/onnx/backend/test/case/node/__init__.py
+++ b/onnx/backend/test/case/node/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import sys

--- a/onnx/backend/test/case/node/abs.py
+++ b/onnx/backend/test/case/node/abs.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/acos.py
+++ b/onnx/backend/test/case/node/acos.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/acosh.py
+++ b/onnx/backend/test/case/node/acosh.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/adagrad.py
+++ b/onnx/backend/test/case/node/adagrad.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/adam.py
+++ b/onnx/backend/test/case/node/adam.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/add.py
+++ b/onnx/backend/test/case/node/add.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/and.py
+++ b/onnx/backend/test/case/node/and.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/argmax.py
+++ b/onnx/backend/test/case/node/argmax.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/argmin.py
+++ b/onnx/backend/test/case/node/argmin.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/asin.py
+++ b/onnx/backend/test/case/node/asin.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/asinh.py
+++ b/onnx/backend/test/case/node/asinh.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/atan.py
+++ b/onnx/backend/test/case/node/atan.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/atanh.py
+++ b/onnx/backend/test/case/node/atanh.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/averagepool.py
+++ b/onnx/backend/test/case/node/averagepool.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/batchnorm.py
+++ b/onnx/backend/test/case/node/batchnorm.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/bernoulli.py
+++ b/onnx/backend/test/case/node/bernoulli.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/bitshift.py
+++ b/onnx/backend/test/case/node/bitshift.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/bitwiseand.py
+++ b/onnx/backend/test/case/node/bitwiseand.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np  # type: ignore

--- a/onnx/backend/test/case/node/bitwisenot.py
+++ b/onnx/backend/test/case/node/bitwisenot.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np  # type: ignore

--- a/onnx/backend/test/case/node/bitwiseor.py
+++ b/onnx/backend/test/case/node/bitwiseor.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np  # type: ignore

--- a/onnx/backend/test/case/node/bitwisexor.py
+++ b/onnx/backend/test/case/node/bitwisexor.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np  # type: ignore

--- a/onnx/backend/test/case/node/blackmanwindow.py
+++ b/onnx/backend/test/case/node/blackmanwindow.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/cast.py
+++ b/onnx/backend/test/case/node/cast.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-
 
 import sys
 

--- a/onnx/backend/test/case/node/castlike.py
+++ b/onnx/backend/test/case/node/castlike.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-
 
 import sys
 

--- a/onnx/backend/test/case/node/ceil.py
+++ b/onnx/backend/test/case/node/ceil.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/celu.py
+++ b/onnx/backend/test/case/node/celu.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/center_crop_pad.py
+++ b/onnx/backend/test/case/node/center_crop_pad.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/clip.py
+++ b/onnx/backend/test/case/node/clip.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/col2im.py
+++ b/onnx/backend/test/case/node/col2im.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import absolute_import, division, print_function, unicode_literals

--- a/onnx/backend/test/case/node/compress.py
+++ b/onnx/backend/test/case/node/compress.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/concat.py
+++ b/onnx/backend/test/case/node/concat.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, Sequence

--- a/onnx/backend/test/case/node/constant.py
+++ b/onnx/backend/test/case/node/constant.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/constantofshape.py
+++ b/onnx/backend/test/case/node/constantofshape.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/conv.py
+++ b/onnx/backend/test/case/node/conv.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/convinteger.py
+++ b/onnx/backend/test/case/node/convinteger.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/convtranspose.py
+++ b/onnx/backend/test/case/node/convtranspose.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/cos.py
+++ b/onnx/backend/test/case/node/cos.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/cosh.py
+++ b/onnx/backend/test/case/node/cosh.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/cumsum.py
+++ b/onnx/backend/test/case/node/cumsum.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/depthtospace.py
+++ b/onnx/backend/test/case/node/depthtospace.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/dequantizelinear.py
+++ b/onnx/backend/test/case/node/dequantizelinear.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/det.py
+++ b/onnx/backend/test/case/node/det.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/dft.py
+++ b/onnx/backend/test/case/node/dft.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/div.py
+++ b/onnx/backend/test/case/node/div.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/dropout.py
+++ b/onnx/backend/test/case/node/dropout.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/dynamicquantizelinear.py
+++ b/onnx/backend/test/case/node/dynamicquantizelinear.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/einsum.py
+++ b/onnx/backend/test/case/node/einsum.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-
 
 from typing import Tuple
 

--- a/onnx/backend/test/case/node/elu.py
+++ b/onnx/backend/test/case/node/elu.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/equal.py
+++ b/onnx/backend/test/case/node/equal.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/erf.py
+++ b/onnx/backend/test/case/node/erf.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/onnx/backend/test/case/node/exp.py
+++ b/onnx/backend/test/case/node/exp.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/expand.py
+++ b/onnx/backend/test/case/node/expand.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/eyelike.py
+++ b/onnx/backend/test/case/node/eyelike.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/flatten.py
+++ b/onnx/backend/test/case/node/flatten.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/floor.py
+++ b/onnx/backend/test/case/node/floor.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/gather.py
+++ b/onnx/backend/test/case/node/gather.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/gatherelements.py
+++ b/onnx/backend/test/case/node/gatherelements.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/gathernd.py
+++ b/onnx/backend/test/case/node/gathernd.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/gemm.py
+++ b/onnx/backend/test/case/node/gemm.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Optional

--- a/onnx/backend/test/case/node/globalaveragepool.py
+++ b/onnx/backend/test/case/node/globalaveragepool.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/globalmaxpool.py
+++ b/onnx/backend/test/case/node/globalmaxpool.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/greater.py
+++ b/onnx/backend/test/case/node/greater.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/greater_equal.py
+++ b/onnx/backend/test/case/node/greater_equal.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/gridsample.py
+++ b/onnx/backend/test/case/node/gridsample.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/groupnormalization.py
+++ b/onnx/backend/test/case/node/groupnormalization.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/gru.py
+++ b/onnx/backend/test/case/node/gru.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Tuple

--- a/onnx/backend/test/case/node/hammingwindow.py
+++ b/onnx/backend/test/case/node/hammingwindow.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/hannwindow.py
+++ b/onnx/backend/test/case/node/hannwindow.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/hardmax.py
+++ b/onnx/backend/test/case/node/hardmax.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/hardsigmoid.py
+++ b/onnx/backend/test/case/node/hardsigmoid.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/hardswish.py
+++ b/onnx/backend/test/case/node/hardswish.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/identity.py
+++ b/onnx/backend/test/case/node/identity.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/if.py
+++ b/onnx/backend/test/case/node/if.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/instancenorm.py
+++ b/onnx/backend/test/case/node/instancenorm.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/isinf.py
+++ b/onnx/backend/test/case/node/isinf.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/isnan.py
+++ b/onnx/backend/test/case/node/isnan.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/layernormalization.py
+++ b/onnx/backend/test/case/node/layernormalization.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/leakyrelu.py
+++ b/onnx/backend/test/case/node/leakyrelu.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/less.py
+++ b/onnx/backend/test/case/node/less.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/less_equal.py
+++ b/onnx/backend/test/case/node/less_equal.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/log.py
+++ b/onnx/backend/test/case/node/log.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/logsoftmax.py
+++ b/onnx/backend/test/case/node/logsoftmax.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/loop.py
+++ b/onnx/backend/test/case/node/loop.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, List

--- a/onnx/backend/test/case/node/lppool.py
+++ b/onnx/backend/test/case/node/lppool.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/lrn.py
+++ b/onnx/backend/test/case/node/lrn.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/onnx/backend/test/case/node/lstm.py
+++ b/onnx/backend/test/case/node/lstm.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Tuple

--- a/onnx/backend/test/case/node/matmul.py
+++ b/onnx/backend/test/case/node/matmul.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/matmulinteger.py
+++ b/onnx/backend/test/case/node/matmulinteger.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/max.py
+++ b/onnx/backend/test/case/node/max.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/maxpool.py
+++ b/onnx/backend/test/case/node/maxpool.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/maxunpool.py
+++ b/onnx/backend/test/case/node/maxunpool.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/mean.py
+++ b/onnx/backend/test/case/node/mean.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/meanvariancenormalization.py
+++ b/onnx/backend/test/case/node/meanvariancenormalization.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/melweightmatrix.py
+++ b/onnx/backend/test/case/node/melweightmatrix.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/min.py
+++ b/onnx/backend/test/case/node/min.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/mish.py
+++ b/onnx/backend/test/case/node/mish.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/mod.py
+++ b/onnx/backend/test/case/node/mod.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/momentum.py
+++ b/onnx/backend/test/case/node/momentum.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/mul.py
+++ b/onnx/backend/test/case/node/mul.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/neg.py
+++ b/onnx/backend/test/case/node/neg.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/negativeloglikelihoodloss.py
+++ b/onnx/backend/test/case/node/negativeloglikelihoodloss.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/nonmaxsuppression.py
+++ b/onnx/backend/test/case/node/nonmaxsuppression.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/nonzero.py
+++ b/onnx/backend/test/case/node/nonzero.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/not.py
+++ b/onnx/backend/test/case/node/not.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/onehot.py
+++ b/onnx/backend/test/case/node/onehot.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/optionalgetelement.py
+++ b/onnx/backend/test/case/node/optionalgetelement.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Optional

--- a/onnx/backend/test/case/node/optionalhaselement.py
+++ b/onnx/backend/test/case/node/optionalhaselement.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Optional

--- a/onnx/backend/test/case/node/or.py
+++ b/onnx/backend/test/case/node/or.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/pad.py
+++ b/onnx/backend/test/case/node/pad.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/pool_op_common.py
+++ b/onnx/backend/test/case/node/pool_op_common.py
@@ -1,4 +1,7 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
+
 import itertools
 from typing import Sequence
 

--- a/onnx/backend/test/case/node/pow.py
+++ b/onnx/backend/test/case/node/pow.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/prelu.py
+++ b/onnx/backend/test/case/node/prelu.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/qlinearconv.py
+++ b/onnx/backend/test/case/node/qlinearconv.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/qlinearmatmul.py
+++ b/onnx/backend/test/case/node/qlinearmatmul.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/quantizelinear.py
+++ b/onnx/backend/test/case/node/quantizelinear.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/rangeop.py
+++ b/onnx/backend/test/case/node/rangeop.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/reciprocal.py
+++ b/onnx/backend/test/case/node/reciprocal.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/reduce_log_sum.py
+++ b/onnx/backend/test/case/node/reduce_log_sum.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/reduce_log_sum_exp.py
+++ b/onnx/backend/test/case/node/reduce_log_sum_exp.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/reducel1.py
+++ b/onnx/backend/test/case/node/reducel1.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/reducel2.py
+++ b/onnx/backend/test/case/node/reducel2.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/reducemax.py
+++ b/onnx/backend/test/case/node/reducemax.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/reducemean.py
+++ b/onnx/backend/test/case/node/reducemean.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/reducemin.py
+++ b/onnx/backend/test/case/node/reducemin.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/reduceprod.py
+++ b/onnx/backend/test/case/node/reduceprod.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/reducesum.py
+++ b/onnx/backend/test/case/node/reducesum.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/reducesumsquare.py
+++ b/onnx/backend/test/case/node/reducesumsquare.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/relu.py
+++ b/onnx/backend/test/case/node/relu.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/reshape.py
+++ b/onnx/backend/test/case/node/reshape.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/resize.py
+++ b/onnx/backend/test/case/node/resize.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/reversesequence.py
+++ b/onnx/backend/test/case/node/reversesequence.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/rnn.py
+++ b/onnx/backend/test/case/node/rnn.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Tuple

--- a/onnx/backend/test/case/node/roialign.py
+++ b/onnx/backend/test/case/node/roialign.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/round.py
+++ b/onnx/backend/test/case/node/round.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/scan.py
+++ b/onnx/backend/test/case/node/scan.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/scatter.py
+++ b/onnx/backend/test/case/node/scatter.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/scatterelements.py
+++ b/onnx/backend/test/case/node/scatterelements.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/scatternd.py
+++ b/onnx/backend/test/case/node/scatternd.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/selu.py
+++ b/onnx/backend/test/case/node/selu.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/sequence_map.py
+++ b/onnx/backend/test/case/node/sequence_map.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/sequenceinsert.py
+++ b/onnx/backend/test/case/node/sequenceinsert.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, List

--- a/onnx/backend/test/case/node/shape.py
+++ b/onnx/backend/test/case/node/shape.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/shrink.py
+++ b/onnx/backend/test/case/node/shrink.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/sigmoid.py
+++ b/onnx/backend/test/case/node/sigmoid.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/sign.py
+++ b/onnx/backend/test/case/node/sign.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/sin.py
+++ b/onnx/backend/test/case/node/sin.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/sinh.py
+++ b/onnx/backend/test/case/node/sinh.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/size.py
+++ b/onnx/backend/test/case/node/size.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/slice.py
+++ b/onnx/backend/test/case/node/slice.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/softmax.py
+++ b/onnx/backend/test/case/node/softmax.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/softmaxcrossentropy.py
+++ b/onnx/backend/test/case/node/softmaxcrossentropy.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/softplus.py
+++ b/onnx/backend/test/case/node/softplus.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/softsign.py
+++ b/onnx/backend/test/case/node/softsign.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/spacetodepth.py
+++ b/onnx/backend/test/case/node/spacetodepth.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 
 import onnx

--- a/onnx/backend/test/case/node/split.py
+++ b/onnx/backend/test/case/node/split.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/splittosequence.py
+++ b/onnx/backend/test/case/node/splittosequence.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/sqrt.py
+++ b/onnx/backend/test/case/node/sqrt.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/squeeze.py
+++ b/onnx/backend/test/case/node/squeeze.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/stft.py
+++ b/onnx/backend/test/case/node/stft.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/stringnormalizer.py
+++ b/onnx/backend/test/case/node/stringnormalizer.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/sub.py
+++ b/onnx/backend/test/case/node/sub.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/sum.py
+++ b/onnx/backend/test/case/node/sum.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/tan.py
+++ b/onnx/backend/test/case/node/tan.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/tanh.py
+++ b/onnx/backend/test/case/node/tanh.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/tfidfvectorizer.py
+++ b/onnx/backend/test/case/node/tfidfvectorizer.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any

--- a/onnx/backend/test/case/node/thresholdedrelu.py
+++ b/onnx/backend/test/case/node/thresholdedrelu.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/tile.py
+++ b/onnx/backend/test/case/node/tile.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/topk.py
+++ b/onnx/backend/test/case/node/topk.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/transpose.py
+++ b/onnx/backend/test/case/node/transpose.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/onnx/backend/test/case/node/trilu.py
+++ b/onnx/backend/test/case/node/trilu.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/unique.py
+++ b/onnx/backend/test/case/node/unique.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/unsqueeze.py
+++ b/onnx/backend/test/case/node/unsqueeze.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/upsample.py
+++ b/onnx/backend/test/case/node/upsample.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/where.py
+++ b/onnx/backend/test/case/node/where.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/node/xor.py
+++ b/onnx/backend/test/case/node/xor.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/test_case.py
+++ b/onnx/backend/test/case/test_case.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass

--- a/onnx/backend/test/case/utils.py
+++ b/onnx/backend/test/case/utils.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib

--- a/onnx/reference/ops/__init__.py
+++ b/onnx/reference/ops/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 from onnx.reference.ops._op_list import load_op

--- a/onnx/reference/ops/_helpers.py
+++ b/onnx/reference/ops/_helpers.py
@@ -1,4 +1,7 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
+
 from typing import Any, Dict, Union
 
 from onnx.reference.op_run import OpRun, _split_class_name

--- a/onnx/reference/ops/_op.py
+++ b/onnx/reference/ops/_op.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict

--- a/onnx/reference/ops/_op_common_indices.py
+++ b/onnx/reference/ops/_op_common_indices.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/_op_common_pool.py
+++ b/onnx/reference/ops/_op_common_pool.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221,R0913,R0914
 
 import itertools
 from typing import Optional, Tuple

--- a/onnx/reference/ops/_op_common_random.py
+++ b/onnx/reference/ops/_op_common_random.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/_op_common_window.py
+++ b/onnx/reference/ops/_op_common_window.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0613,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/_op_list.py
+++ b/onnx/reference/ops/_op_list.py
@@ -1,5 +1,7 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=C0415,R0912,R0913,R0914,R0915,W0611,W0603
+
 """
 Every class imported in this module defines an implementation of
 an operator of the main domain. Any class name uses `_` to specify a

--- a/onnx/reference/ops/op_abs.py
+++ b/onnx/reference/ops/op_abs.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_acos.py
+++ b/onnx/reference/ops/op_acos.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_acosh.py
+++ b/onnx/reference/ops/op_acosh.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_add.py
+++ b/onnx/reference/ops/op_add.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_and.py
+++ b/onnx/reference/ops/op_and.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_argmax.py
+++ b/onnx/reference/ops/op_argmax.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_argmin.py
+++ b/onnx/reference/ops/op_argmin.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_asin.py
+++ b/onnx/reference/ops/op_asin.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_asinh.py
+++ b/onnx/reference/ops/op_asinh.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_atan.py
+++ b/onnx/reference/ops/op_atan.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_atanh.py
+++ b/onnx/reference/ops/op_atanh.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_attribute_has_value.py
+++ b/onnx/reference/ops/op_attribute_has_value.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221,W0613
 
 import numpy as np
 

--- a/onnx/reference/ops/op_average_pool.py
+++ b/onnx/reference/ops/op_average_pool.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221,R0913,R0914
 
 from onnx.reference.ops._op_common_pool import CommonPool
 

--- a/onnx/reference/ops/op_batch_normalization.py
+++ b/onnx/reference/ops/op_batch_normalization.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221,R0913,W0613
 
 import numpy as np
 

--- a/onnx/reference/ops/op_bernoulli.py
+++ b/onnx/reference/ops/op_bernoulli.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 from onnx.helper import np_dtype_to_tensor_dtype
 from onnx.reference.ops._op_common_random import _CommonRandom

--- a/onnx/reference/ops/op_bitshift.py
+++ b/onnx/reference/ops/op_bitshift.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_bitwise_and.py
+++ b/onnx/reference/ops/op_bitwise_and.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_bitwise_not.py
+++ b/onnx/reference/ops/op_bitwise_not.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_bitwise_or.py
+++ b/onnx/reference/ops/op_bitwise_or.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_bitwise_xor.py
+++ b/onnx/reference/ops/op_bitwise_xor.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_blackman_window.py
+++ b/onnx/reference/ops/op_blackman_window.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_cast.py
+++ b/onnx/reference/ops/op_cast.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_cast_like.py
+++ b/onnx/reference/ops/op_cast_like.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 from onnx.helper import np_dtype_to_tensor_dtype
 from onnx.onnx_pb import TensorProto

--- a/onnx/reference/ops/op_ceil.py
+++ b/onnx/reference/ops/op_ceil.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_celu.py
+++ b/onnx/reference/ops/op_celu.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_center_crop_pad.py
+++ b/onnx/reference/ops/op_center_crop_pad.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0914,R1702,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_clip.py
+++ b/onnx/reference/ops/op_clip.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0622,W0622,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_col2im.py
+++ b/onnx/reference/ops/op_col2im.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_compress.py
+++ b/onnx/reference/ops/op_compress.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_concat.py
+++ b/onnx/reference/ops/op_concat.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_concat_from_sequence.py
+++ b/onnx/reference/ops/op_concat_from_sequence.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 from typing import Any, List
 

--- a/onnx/reference/ops/op_constant.py
+++ b/onnx/reference/ops/op_constant.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_constant_of_shape.py
+++ b/onnx/reference/ops/op_constant_of_shape.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_conv.py
+++ b/onnx/reference/ops/op_conv.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,R0914,R0915,R1702,W0221
 
 from typing import Sequence, Tuple
 

--- a/onnx/reference/ops/op_conv_integer.py
+++ b/onnx/reference/ops/op_conv_integer.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_conv_transpose.py
+++ b/onnx/reference/ops/op_conv_transpose.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,R0914,R0915,R1702,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_cos.py
+++ b/onnx/reference/ops/op_cos.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_cosh.py
+++ b/onnx/reference/ops/op_cosh.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_cum_sum.py
+++ b/onnx/reference/ops/op_cum_sum.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_depth_to_space.py
+++ b/onnx/reference/ops/op_depth_to_space.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_dequantize_linear.py
+++ b/onnx/reference/ops/op_dequantize_linear.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_det.py
+++ b/onnx/reference/ops/op_det.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_dft.py
+++ b/onnx/reference/ops/op_dft.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
 
 from typing import Sequence
 

--- a/onnx/reference/ops/op_div.py
+++ b/onnx/reference/ops/op_div.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_dropout.py
+++ b/onnx/reference/ops/op_dropout.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 from typing import Optional, Tuple
 

--- a/onnx/reference/ops/op_dynamic_quantize_linear.py
+++ b/onnx/reference/ops/op_dynamic_quantize_linear.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_einsum.py
+++ b/onnx/reference/ops/op_einsum.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=E0203,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_elu.py
+++ b/onnx/reference/ops/op_elu.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_equal.py
+++ b/onnx/reference/ops/op_equal.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_erf.py
+++ b/onnx/reference/ops/op_erf.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 from math import erf
 

--- a/onnx/reference/ops/op_exp.py
+++ b/onnx/reference/ops/op_exp.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_expand.py
+++ b/onnx/reference/ops/op_expand.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_eyelike.py
+++ b/onnx/reference/ops/op_eyelike.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_flatten.py
+++ b/onnx/reference/ops/op_flatten.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_floor.py
+++ b/onnx/reference/ops/op_floor.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_gather.py
+++ b/onnx/reference/ops/op_gather.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_gather_elements.py
+++ b/onnx/reference/ops/op_gather_elements.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_gathernd.py
+++ b/onnx/reference/ops/op_gathernd.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 from typing import Tuple
 

--- a/onnx/reference/ops/op_gemm.py
+++ b/onnx/reference/ops/op_gemm.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_global_average_pool.py
+++ b/onnx/reference/ops/op_global_average_pool.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_global_max_pool.py
+++ b/onnx/reference/ops/op_global_max_pool.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_greater.py
+++ b/onnx/reference/ops/op_greater.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_greater_or_equal.py
+++ b/onnx/reference/ops/op_greater_or_equal.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_grid_sample.py
+++ b/onnx/reference/ops/op_grid_sample.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,R0914,R0915,R1702,R1716,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_gru.py
+++ b/onnx/reference/ops/op_gru.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221,W0613
 
 import numpy as np
 

--- a/onnx/reference/ops/op_hamming_window.py
+++ b/onnx/reference/ops/op_hamming_window.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_hann_window.py
+++ b/onnx/reference/ops/op_hann_window.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_hard_sigmoid.py
+++ b/onnx/reference/ops/op_hard_sigmoid.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_hardmax.py
+++ b/onnx/reference/ops/op_hardmax.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_identity.py
+++ b/onnx/reference/ops/op_identity.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 from onnx.reference.ops._op import OpRunUnaryNum
 

--- a/onnx/reference/ops/op_if.py
+++ b/onnx/reference/ops/op_if.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221,W0613
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/op_instance_normalization.py
+++ b/onnx/reference/ops/op_instance_normalization.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_isinf.py
+++ b/onnx/reference/ops/op_isinf.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_isnan.py
+++ b/onnx/reference/ops/op_isnan.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_layer_normalization.py
+++ b/onnx/reference/ops/op_layer_normalization.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221
 
 from typing import Tuple
 

--- a/onnx/reference/ops/op_leaky_relu.py
+++ b/onnx/reference/ops/op_leaky_relu.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_less.py
+++ b/onnx/reference/ops/op_less.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_less_or_equal.py
+++ b/onnx/reference/ops/op_less_or_equal.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_log.py
+++ b/onnx/reference/ops/op_log.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_log_softmax.py
+++ b/onnx/reference/ops/op_log_softmax.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_loop.py
+++ b/onnx/reference/ops/op_loop.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0914,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_lp_normalization.py
+++ b/onnx/reference/ops/op_lp_normalization.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_lp_pool.py
+++ b/onnx/reference/ops/op_lp_pool.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221,R0913,R0914
 
 import numpy as np
 

--- a/onnx/reference/ops/op_lrn.py
+++ b/onnx/reference/ops/op_lrn.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
 
 import math
 

--- a/onnx/reference/ops/op_lstm.py
+++ b/onnx/reference/ops/op_lstm.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221,W0613
 
 from typing import Tuple
 

--- a/onnx/reference/ops/op_matmul.py
+++ b/onnx/reference/ops/op_matmul.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_matmul_integer.py
+++ b/onnx/reference/ops/op_matmul_integer.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_max.py
+++ b/onnx/reference/ops/op_max.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_max_pool.py
+++ b/onnx/reference/ops/op_max_pool.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=C0200,R0912,R0913,R0914,R0915,R0916,R1702,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_max_unpool.py
+++ b/onnx/reference/ops/op_max_unpool.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=C0200,R0913,R0914,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_mean.py
+++ b/onnx/reference/ops/op_mean.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/op_mel_weight_matrix.py
+++ b/onnx/reference/ops/op_mel_weight_matrix.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_min.py
+++ b/onnx/reference/ops/op_min.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_mod.py
+++ b/onnx/reference/ops/op_mod.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_mul.py
+++ b/onnx/reference/ops/op_mul.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_neg.py
+++ b/onnx/reference/ops/op_neg.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_negative_log_likelihood_loss.py
+++ b/onnx/reference/ops/op_negative_log_likelihood_loss.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_non_max_suppression.py
+++ b/onnx/reference/ops/op_non_max_suppression.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0902,R0911,R0912,R0913,R0914,W0221
 
 import dataclasses
 from typing import Optional, Tuple

--- a/onnx/reference/ops/op_non_zero.py
+++ b/onnx/reference/ops/op_non_zero.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_not.py
+++ b/onnx/reference/ops/op_not.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_one_hot.py
+++ b/onnx/reference/ops/op_one_hot.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_optional.py
+++ b/onnx/reference/ops/op_optional.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221,W0622
 
 from onnx.helper import tensor_dtype_to_np_dtype
 from onnx.reference.op_run import OpRun

--- a/onnx/reference/ops/op_optional_get_element.py
+++ b/onnx/reference/ops/op_optional_get_element.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/op_optional_has_element.py
+++ b/onnx/reference/ops/op_optional_has_element.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_or.py
+++ b/onnx/reference/ops/op_or.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_pad.py
+++ b/onnx/reference/ops/op_pad.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_pow.py
+++ b/onnx/reference/ops/op_pow.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 from warnings import catch_warnings, simplefilter
 

--- a/onnx/reference/ops/op_prelu.py
+++ b/onnx/reference/ops/op_prelu.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_qlinear_conv.py
+++ b/onnx/reference/ops/op_qlinear_conv.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_qlinear_matmul.py
+++ b/onnx/reference/ops/op_qlinear_matmul.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_quantize_linear.py
+++ b/onnx/reference/ops/op_quantize_linear.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_random_normal.py
+++ b/onnx/reference/ops/op_random_normal.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
 
 from onnx.reference.ops._op_common_random import _CommonRandom
 

--- a/onnx/reference/ops/op_random_normal_like.py
+++ b/onnx/reference/ops/op_random_normal_like.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
 
 from onnx.helper import np_dtype_to_tensor_dtype
 from onnx.reference.ops._op_common_random import _CommonRandom

--- a/onnx/reference/ops/op_random_uniform.py
+++ b/onnx/reference/ops/op_random_uniform.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
 
 from onnx.reference.ops._op_common_random import _CommonRandom
 

--- a/onnx/reference/ops/op_random_uniform_like.py
+++ b/onnx/reference/ops/op_random_uniform_like.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
 
 from onnx.helper import np_dtype_to_tensor_dtype
 from onnx.reference.ops._op_common_random import _CommonRandom

--- a/onnx/reference/ops/op_range.py
+++ b/onnx/reference/ops/op_range.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reciprocal.py
+++ b/onnx/reference/ops/op_reciprocal.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reduce_l1.py
+++ b/onnx/reference/ops/op_reduce_l1.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reduce_l2.py
+++ b/onnx/reference/ops/op_reduce_l2.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reduce_log_sum.py
+++ b/onnx/reference/ops/op_reduce_log_sum.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reduce_log_sum_exp.py
+++ b/onnx/reference/ops/op_reduce_log_sum_exp.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reduce_max.py
+++ b/onnx/reference/ops/op_reduce_max.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=E1123,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reduce_mean.py
+++ b/onnx/reference/ops/op_reduce_mean.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reduce_min.py
+++ b/onnx/reference/ops/op_reduce_min.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=E1123,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reduce_prod.py
+++ b/onnx/reference/ops/op_reduce_prod.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reduce_sum.py
+++ b/onnx/reference/ops/op_reduce_sum.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reduce_sum_square.py
+++ b/onnx/reference/ops/op_reduce_sum_square.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_relu.py
+++ b/onnx/reference/ops/op_relu.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reshape.py
+++ b/onnx/reference/ops/op_reshape.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_resize.py
+++ b/onnx/reference/ops/op_resize.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=C0123,C3001,R0912,R0913,R0914,R1730,W0221,W0613
 
 from typing import Any, Callable, List, Optional, Tuple
 

--- a/onnx/reference/ops/op_reverse_sequence.py
+++ b/onnx/reference/ops/op_reverse_sequence.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=C0123,R0912,R0913,R0914,W0221
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/op_rnn.py
+++ b/onnx/reference/ops/op_rnn.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221,W0613
 
 import numpy as np
 

--- a/onnx/reference/ops/op_roi_align.py
+++ b/onnx/reference/ops/op_roi_align.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0902,R0912,R0913,R0914,R0915,R1702,W0221
 
 from typing import Tuple
 

--- a/onnx/reference/ops/op_round.py
+++ b/onnx/reference/ops/op_round.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_scan.py
+++ b/onnx/reference/ops/op_scan.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0914,W0221,W0613
 
 import numpy as np
 

--- a/onnx/reference/ops/op_scatter_elements.py
+++ b/onnx/reference/ops/op_scatter_elements.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=C3001,R0912,R0913,R0914,R0915,W0108,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_scatternd.py
+++ b/onnx/reference/ops/op_scatternd.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_selu.py
+++ b/onnx/reference/ops/op_selu.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_sequence_at.py
+++ b/onnx/reference/ops/op_sequence_at.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/op_sequence_construct.py
+++ b/onnx/reference/ops/op_sequence_construct.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/op_sequence_empty.py
+++ b/onnx/reference/ops/op_sequence_empty.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221,W0613
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/op_sequence_erase.py
+++ b/onnx/reference/ops/op_sequence_erase.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/op_sequence_insert.py
+++ b/onnx/reference/ops/op_sequence_insert.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 from typing import Any, List, Optional, Union
 

--- a/onnx/reference/ops/op_sequence_length.py
+++ b/onnx/reference/ops/op_sequence_length.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_sequence_map.py
+++ b/onnx/reference/ops/op_sequence_map.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/op_shape.py
+++ b/onnx/reference/ops/op_shape.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 from typing import Optional, Tuple
 

--- a/onnx/reference/ops/op_shrink.py
+++ b/onnx/reference/ops/op_shrink.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=E1130,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_sigmoid.py
+++ b/onnx/reference/ops/op_sigmoid.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_sign.py
+++ b/onnx/reference/ops/op_sign.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_sin.py
+++ b/onnx/reference/ops/op_sin.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_sinh.py
+++ b/onnx/reference/ops/op_sinh.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_size.py
+++ b/onnx/reference/ops/op_size.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_slice.py
+++ b/onnx/reference/ops/op_slice.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,W0221
 
 from typing import Optional
 

--- a/onnx/reference/ops/op_softmax.py
+++ b/onnx/reference/ops/op_softmax.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_softmax_cross_entropy_loss.py
+++ b/onnx/reference/ops/op_softmax_cross_entropy_loss.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,R0914,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_softplus.py
+++ b/onnx/reference/ops/op_softplus.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_softsign.py
+++ b/onnx/reference/ops/op_softsign.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_space_to_depth.py
+++ b/onnx/reference/ops/op_space_to_depth.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_split.py
+++ b/onnx/reference/ops/op_split.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/op_split_to_sequence.py
+++ b/onnx/reference/ops/op_split_to_sequence.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=C0200,W0221
 
 from typing import List, Optional, Tuple
 

--- a/onnx/reference/ops/op_sqrt.py
+++ b/onnx/reference/ops/op_sqrt.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 from warnings import catch_warnings, simplefilter
 

--- a/onnx/reference/ops/op_squeeze.py
+++ b/onnx/reference/ops/op_squeeze.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=E0203,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_stft.py
+++ b/onnx/reference/ops/op_stft.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,R0915,W0613,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_string_normalizer.py
+++ b/onnx/reference/ops/op_string_normalizer.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,W0221
 
 import locale as pylocale
 import unicodedata

--- a/onnx/reference/ops/op_sub.py
+++ b/onnx/reference/ops/op_sub.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_sum.py
+++ b/onnx/reference/ops/op_sum.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/op_tan.py
+++ b/onnx/reference/ops/op_tan.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_tanh.py
+++ b/onnx/reference/ops/op_tanh.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_tfidf_vectorizer.py
+++ b/onnx/reference/ops/op_tfidf_vectorizer.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=C0200,R0902,R0912,R0913,R0914,R0915,R1716,W0611,W0612,W0613,W0221
 
 from enum import IntEnum
 from typing import List

--- a/onnx/reference/ops/op_thresholded_relu.py
+++ b/onnx/reference/ops/op_thresholded_relu.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_tile.py
+++ b/onnx/reference/ops/op_tile.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_topk.py
+++ b/onnx/reference/ops/op_topk.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221,W0622
 
 import numpy as np
 

--- a/onnx/reference/ops/op_transpose.py
+++ b/onnx/reference/ops/op_transpose.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_trilu.py
+++ b/onnx/reference/ops/op_trilu.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_unique.py
+++ b/onnx/reference/ops/op_unique.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221,W0622
 
 import numpy as np
 

--- a/onnx/reference/ops/op_unsqueeze.py
+++ b/onnx/reference/ops/op_unsqueeze.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=E0203,W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_upsample.py
+++ b/onnx/reference/ops/op_upsample.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221,R0913
 
 import numpy as np
 

--- a/onnx/reference/ops/op_where.py
+++ b/onnx/reference/ops/op_where.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/reference/ops/op_xor.py
+++ b/onnx/reference/ops/op_xor.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
 
 import numpy as np
 

--- a/onnx/test/cpp/common_path_test.cc
+++ b/onnx/test/cpp/common_path_test.cc
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 #include <list>
 #include <utility>

--- a/onnx/test/cpp/data_propagation_test.cc
+++ b/onnx/test/cpp/data_propagation_test.cc
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 #include <iostream>
 #include "gtest/gtest.h"

--- a/onnx/test/cpp/function_context_test.cc
+++ b/onnx/test/cpp/function_context_test.cc
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 #include <iostream>
 #include "gtest/gtest.h"

--- a/onnx/test/cpp/function_get_test.cc
+++ b/onnx/test/cpp/function_get_test.cc
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 #include <iostream>
 #include "gtest/gtest.h"

--- a/onnx/test/cpp/function_verify_test.cc
+++ b/onnx/test/cpp/function_verify_test.cc
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 #include <iostream>
 #include <set>

--- a/onnx/test/cpp/op_reg_test.cc
+++ b/onnx/test/cpp/op_reg_test.cc
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 #include <iostream>
 #include "gtest/gtest.h"

--- a/onnx/test/cpp/parser_test.cc
+++ b/onnx/test/cpp/parser_test.cc
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 #include "gtest/gtest.h"
 

--- a/onnx/test/cpp/schema_registration_test.cc
+++ b/onnx/test/cpp/schema_registration_test.cc
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 #include <iostream>
 #include "gtest/gtest.h"

--- a/onnx/test/cpp/shape_inference_test.cc
+++ b/onnx/test/cpp/shape_inference_test.cc
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 #include <iostream>
 #include "gtest/gtest.h"

--- a/onnx/test/cpp/test_main.cc
+++ b/onnx/test/cpp/test_main.cc
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 #include <iostream>
 #include "gtest/gtest.h"

--- a/onnx/version_converter/BaseConverter.h
+++ b/onnx/version_converter/BaseConverter.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Version converter interface for ONNX models between different opset versions.
 

--- a/onnx/version_converter/adapters/adapter.h
+++ b/onnx/version_converter/adapters/adapter.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Interface for Op Version Adapters
 

--- a/onnx/version_converter/adapters/axes_attribute_to_input.h
+++ b/onnx/version_converter/adapters/axes_attribute_to_input.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for all ops that remove consumed_inputs
 

--- a/onnx/version_converter/adapters/axes_input_to_attribute.h
+++ b/onnx/version_converter/adapters/axes_input_to_attribute.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for all ops that remove consumed_inputs
 

--- a/onnx/version_converter/adapters/batch_normalization_13_14.h
+++ b/onnx/version_converter/adapters/batch_normalization_13_14.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for BatchNormalization in default domain from version 13 to 14
 

--- a/onnx/version_converter/adapters/broadcast_backward_compatibility.h
+++ b/onnx/version_converter/adapters/broadcast_backward_compatibility.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for broadcasting ops in default domain from version 7 to 6
 

--- a/onnx/version_converter/adapters/broadcast_forward_compatibility.h
+++ b/onnx/version_converter/adapters/broadcast_forward_compatibility.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for broadcasting ops in default domain from version 6 to 7
 

--- a/onnx/version_converter/adapters/cast_9_8.h
+++ b/onnx/version_converter/adapters/cast_9_8.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for Cast in default domain from version 9 to 8
 

--- a/onnx/version_converter/adapters/clip_10_11.h
+++ b/onnx/version_converter/adapters/clip_10_11.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for Clip in default domain from version 10 to 11
 

--- a/onnx/version_converter/adapters/compatible.h
+++ b/onnx/version_converter/adapters/compatible.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter indicating compatibility of op between opsets with separate
 // definitions

--- a/onnx/version_converter/adapters/dropout_11_12.h
+++ b/onnx/version_converter/adapters/dropout_11_12.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for Dropout in default domain from version 11 to 12
 

--- a/onnx/version_converter/adapters/extend_supported_types.h
+++ b/onnx/version_converter/adapters/extend_supported_types.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter indicating compatibility of op between opsets with separate
 // definitions

--- a/onnx/version_converter/adapters/gemm_6_7.h
+++ b/onnx/version_converter/adapters/gemm_6_7.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for Gemm in default domain from version 6 to 7
 

--- a/onnx/version_converter/adapters/gemm_7_6.h
+++ b/onnx/version_converter/adapters/gemm_7_6.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for Gemm in default domain from version 7 to 6
 

--- a/onnx/version_converter/adapters/maxpool_8_7.h
+++ b/onnx/version_converter/adapters/maxpool_8_7.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for MaxPool in default domain from version 8 to 7
 

--- a/onnx/version_converter/adapters/no_previous_version.h
+++ b/onnx/version_converter/adapters/no_previous_version.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter indicating lack of a previous version of some op before a given
 // opset version.

--- a/onnx/version_converter/adapters/pad_10_11.h
+++ b/onnx/version_converter/adapters/pad_10_11.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for Pad in default domain from version 10 to 11
 

--- a/onnx/version_converter/adapters/remove_consumed_inputs.h
+++ b/onnx/version_converter/adapters/remove_consumed_inputs.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for all ops that remove consumed_inputs
 

--- a/onnx/version_converter/adapters/reshape_4_5.h
+++ b/onnx/version_converter/adapters/reshape_4_5.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for Reshape in default domain from version 4 to 5
 

--- a/onnx/version_converter/adapters/reshape_5_4.h
+++ b/onnx/version_converter/adapters/reshape_5_4.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for Reshape in default domain from version 5 to 4
 

--- a/onnx/version_converter/adapters/resize_10_11.h
+++ b/onnx/version_converter/adapters/resize_10_11.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for Resize in default domain from version 10 to 11
 

--- a/onnx/version_converter/adapters/scan_8_9.h
+++ b/onnx/version_converter/adapters/scan_8_9.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for Scan in default domain from version 8 to 9
 

--- a/onnx/version_converter/adapters/scan_9_8.h
+++ b/onnx/version_converter/adapters/scan_9_8.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for Scan in default domain from version 9 to 8
 

--- a/onnx/version_converter/adapters/scatter_10_11.h
+++ b/onnx/version_converter/adapters/scatter_10_11.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for Scatter in default domain from version 10 to 11
 

--- a/onnx/version_converter/adapters/slice_9_10.h
+++ b/onnx/version_converter/adapters/slice_9_10.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for Slice in default domain from version 9 to 10
 

--- a/onnx/version_converter/adapters/softmax_12_13.h
+++ b/onnx/version_converter/adapters/softmax_12_13.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for Softmax amd LogSoftmax in default domain from version 12 to 13
 

--- a/onnx/version_converter/adapters/split_12_13.h
+++ b/onnx/version_converter/adapters/split_12_13.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for all ops that remove consumed_inputs
 

--- a/onnx/version_converter/adapters/split_13_12.h
+++ b/onnx/version_converter/adapters/split_13_12.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for all ops that remove consumed_inputs
 

--- a/onnx/version_converter/adapters/split_17_18.h
+++ b/onnx/version_converter/adapters/split_17_18.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for Split in default domain from version 17 to 18
 

--- a/onnx/version_converter/adapters/sum_8_7.h
+++ b/onnx/version_converter/adapters/sum_8_7.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for Sum in default domain from version 8 to 7
 

--- a/onnx/version_converter/adapters/topk_9_10.h
+++ b/onnx/version_converter/adapters/topk_9_10.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for TopK in default domain from version 9 to 10
 

--- a/onnx/version_converter/adapters/transformers.h
+++ b/onnx/version_converter/adapters/transformers.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/onnx/version_converter/adapters/type_restriction.h
+++ b/onnx/version_converter/adapters/type_restriction.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for Add in default domain from version 6 to 5
 

--- a/onnx/version_converter/adapters/upsample_6_7.h
+++ b/onnx/version_converter/adapters/upsample_6_7.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for Upsample in default domain from version 6 to 7
 

--- a/onnx/version_converter/adapters/upsample_8_9.h
+++ b/onnx/version_converter/adapters/upsample_8_9.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for Upsample in default domain from version 8 to 9
 

--- a/onnx/version_converter/adapters/upsample_9_10.h
+++ b/onnx/version_converter/adapters/upsample_9_10.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for Upsample in default domain from version 9 to 10
 

--- a/onnx/version_converter/adapters/upsample_9_8.h
+++ b/onnx/version_converter/adapters/upsample_9_8.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Adapter for Upsample in default domain from version 9 to 8
 

--- a/onnx/version_converter/convert.cc
+++ b/onnx/version_converter/convert.cc
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 #include "onnx/version_converter/convert.h"
 

--- a/onnx/version_converter/convert.h
+++ b/onnx/version_converter/convert.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Default converter for ONNX models between different opset versions
 // in the default domain ("" or "ai.onnx").

--- a/onnx/version_converter/helper.cc
+++ b/onnx/version_converter/helper.cc
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Helper Methods for Adapters
 

--- a/onnx/version_converter/helper.h
+++ b/onnx/version_converter/helper.h
@@ -1,6 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2023 ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // Helper Methods for Adapters
 


### PR DESCRIPTION
### Description
Starting adapting onnx to best practices suggested by https://reuse.software/ (but also from fossogly, the scanning tool also used by the Linux Foundation)

At the moment we have 9 files containing the following line:
"// Copyright (c) ONNX Project Contributors."

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
