### PR TITLE
replace MIT with Apache-2.0

### DIFF
--- a/onnx/common/path.cc
+++ b/onnx/common/path.cc
@@ -3,7 +3,6 @@
  */
 
 // Copyright (c) ONNX Project Contributors.
-// Licensed under the MIT license.
 
 #include "onnx/common/path.h"
 

--- a/onnx/common/path.h
+++ b/onnx/common/path.h
@@ -3,7 +3,6 @@
  */
 
 // Copyright (c) ONNX Project Contributors.
-// Licensed under the MIT license.
 
 #pragma once
 

--- a/onnx/onnx-operators-ml.proto
+++ b/onnx/onnx-operators-ml.proto
@@ -4,7 +4,7 @@
 
 
 // Copyright (c) ONNX Project Contributors.
-// Licensed under the MIT license.
+// Licensed under the Apache-2.0 license.
 
 syntax = "proto2";
 

--- a/onnx/onnx-operators-ml.proto3
+++ b/onnx/onnx-operators-ml.proto3
@@ -4,7 +4,7 @@
 
 
 // Copyright (c) ONNX Project Contributors.
-// Licensed under the MIT license.
+// Licensed under the Apache-2.0 license.
 
 syntax = "proto3";
 

--- a/onnx/onnx-operators.in.proto
+++ b/onnx/onnx-operators.in.proto
@@ -1,5 +1,5 @@
 // Copyright (c) ONNX Project Contributors.
-// Licensed under the MIT license.
+// Licensed under the Apache-2.0 license.
 
 syntax = "proto2";
 

--- a/onnx/onnx-operators.proto
+++ b/onnx/onnx-operators.proto
@@ -4,7 +4,7 @@
 
 
 // Copyright (c) ONNX Project Contributors.
-// Licensed under the MIT license.
+// Licensed under the Apache-2.0 license.
 
 syntax = "proto2";
 

--- a/onnx/onnx-operators.proto3
+++ b/onnx/onnx-operators.proto3
@@ -4,7 +4,7 @@
 
 
 // Copyright (c) ONNX Project Contributors.
-// Licensed under the MIT license.
+// Licensed under the Apache-2.0 license.
 
 syntax = "proto3";
 


### PR DESCRIPTION
### Description
* correct license information in built proto files (original onnx.in.proto already had the correct license information)
* Add spdx license to cc / h files


### Motivation and Context
These files where also highlighted at the fossology scan from the linux foundation. (mail could be found at https://lists.lfaidata.foundation/g/onnx-technical-discuss/topic/96811486)
