### PR TITLE
Fix Windows x86 pipeline failure: handle NumPy behavior in reference

### DIFF
--- a/onnx/reference/ops/op_non_zero.py
+++ b/onnx/reference/ops/op_non_zero.py
@@ -8,5 +8,6 @@ from onnx.reference.op_run import OpRun
 
 class NonZero(OpRun):
     def _run(self, x):  # type: ignore
-        res = np.vstack(np.nonzero(x))
+        # Specify np.int64 for Windows x86 machines
+        res = np.array(np.vstack(np.nonzero(x)), dtype=np.int64)
         return (res,)

--- a/onnx/reference/ops/op_non_zero.py
+++ b/onnx/reference/ops/op_non_zero.py
@@ -9,5 +9,5 @@ from onnx.reference.op_run import OpRun
 class NonZero(OpRun):
     def _run(self, x):  # type: ignore
         # Specify np.int64 for Windows x86 machines
-        res = np.array(np.vstack(np.nonzero(x)), dtype=np.int64)
+        res = np.vstack(np.nonzero(x)).astype(np.int64)
         return (res,)

--- a/onnx/test/test_backend_reference.py
+++ b/onnx/test/test_backend_reference.py
@@ -102,6 +102,17 @@ backend_test.exclude(
 backend_test.exclude("(test_scatter_with_axis|test_scatter_without)")
 
 
+# The following tests are using types not supported by NumPy.
+# They could be if method to_array is extended to support custom
+# types the same as the reference implementation does
+# (see onnx.reference.op_run.to_array_extended).
+backend_test.exclude(
+    "(test_cast_FLOAT_to_BFLOAT16"
+    "|test_castlike_FLOAT_to_BFLOAT16"
+    "|test_castlike_FLOAT_to_BFLOAT16_expanded"
+    ")"
+)
+
 # The following tests are too slow with the reference implementation (Conv).
 backend_test.exclude(
     "(test_bvlc_alexnet"


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Fix Windows x86 pipeline failure: handle NumPy behavior in reference:
- Disable float_to_bfloat test cases
- Specify np.int64 for np.nonzero(x)

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Fix Windows x86 pipeline failure:
```
FAILED onnx/test/test_backend_reference.py::OnnxBackendNodeModelTest::test_cast_FLOAT_to_BFLOAT16_cpu - TypeError: ufunc 'isnan' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
FAILED onnx/test/test_backend_reference.py::OnnxBackendNodeModelTest::test_castlike_FLOAT_to_BFLOAT16_cpu - TypeError: ufunc 'isnan' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
FAILED onnx/test/test_backend_reference.py::OnnxBackendNodeModelTest::test_castlike_FLOAT_to_BFLOAT16_expanded_cpu - TypeError: ufunc 'isnan' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
FAILED onnx/test/test_backend_reference.py::OnnxBackendNodeModelTest::test_nonzero_example_cpu - AssertionError: 
Items are not equal:
 ACTUAL: dtype('int32')
 DESIRED: dtype('int64')
```