### PR TITLE
remove onnx internal ir code

### DIFF
--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -804,20 +804,20 @@ struct Node : public Attributes<Node> {
 
 // A class with the same properties as OperatorSetIdProto, but without protobuf
 // overhead, resulting in a simpler and more readable workflow.
-class OpSetID final {
+class OpSetIDIR final {
  private:
   OperatorSetIdProto opset_id_proto_;
 
  public:
-  explicit OpSetID(const OperatorSetIdProto& proto) : opset_id_proto_(proto) {}
+  explicit OpSetIDIR(const OperatorSetIdProto& proto) : opset_id_proto_(proto) {}
 
   // Default Domain Constructor
-  explicit OpSetID(const int64_t version) {
+  explicit OpSetIDIR(const int64_t version) {
     opset_id_proto_.set_domain("");
     opset_id_proto_.set_version(version);
   }
 
-  explicit OpSetID(const std::string& domain, int64_t version) {
+  explicit OpSetIDIR(const std::string& domain, int64_t version) {
     opset_id_proto_.set_domain(domain);
     opset_id_proto_.set_version(version);
   }
@@ -828,11 +828,11 @@ class OpSetID final {
   }
 
   // target must be in the form "<domain>&<version>"
-  static OpSetID fromString(const std::string& target) {
+  static OpSetIDIR fromString(const std::string& target) {
     ONNX_TRY {
       std::string new_domain = target.substr(0, target.find("$"));
       int new_version = ONNX_NAMESPACE::stoi(target.substr(target.find("$") + 1, target.length()).c_str());
-      return OpSetID(new_domain, new_version);
+      return OpSetIDIR(new_domain, new_version);
     }
     ONNX_CATCH(const std::runtime_error& e) {
       ONNX_HANDLE_EXCEPTION([&]() { ONNX_ASSERTM(false, "Error in fromString: %s", e.what()); });
@@ -844,7 +844,7 @@ class OpSetID final {
     // In case of "no exception build" the code aborts at the site of first exception.
     // Adding this to appease the warning "control may reach end of non-void function"
     // as the mac build fails when ONNX_WERROR==ON
-    return OpSetID("", 0);
+    return OpSetIDIR("", 0);
   }
 
   const std::string& domain() const {
@@ -1005,7 +1005,7 @@ struct Graph final {
     return const_graph_node_list(output_, kNextDirection);
   }
 
-  std::vector<OpSetID>& opset_versions_mutable() {
+  std::vector<OpSetIDIR>& opset_versions_mutable() {
     return opset_versions_;
   }
 

--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -67,10 +67,10 @@ class ResourceGuard final {
   }
 };
 
-struct Dimension final {
-  Dimension() : is_unknown(true), is_int(false), dim(-1) {}
-  Dimension(std::string param) : is_unknown(false), is_int(false), dim(-1), param(std::move(param)) {} // NOLINT
-  Dimension(int64_t dim) : is_unknown(false), is_int(true), dim(dim) {} // NOLINT
+struct DimensionIR final {
+  DimensionIR() : is_unknown(true), is_int(false), dim(-1) {}
+  DimensionIR(std::string param) : is_unknown(false), is_int(false), dim(-1), param(std::move(param)) {} // NOLINT
+  DimensionIR(int64_t dim) : is_unknown(false), is_int(true), dim(dim) {} // NOLINT
 
   bool is_unknown;
   bool is_int;
@@ -306,7 +306,7 @@ struct Value final {
   std::string unique_name_;
   int32_t elem_type_;
   bool has_sizes_;
-  std::vector<Dimension> sizes_;
+  std::vector<DimensionIR> sizes_;
 
  public:
   Value* setElemType(int32_t elem_type) {
@@ -319,17 +319,17 @@ struct Value final {
   bool has_sizes() const {
     return has_sizes_;
   }
-  Value* setSizes(std::vector<Dimension> sizes) {
+  Value* setSizes(std::vector<DimensionIR> sizes) {
     has_sizes_ = true;
     sizes_ = std::move(sizes);
     return this;
   }
   Value* wipeSizes() {
     has_sizes_ = false;
-    sizes_ = std::vector<Dimension>();
+    sizes_ = std::vector<DimensionIR>();
     return this;
   }
-  const std::vector<Dimension>& sizes() const {
+  const std::vector<DimensionIR>& sizes() const {
     return sizes_;
   }
   size_t unique() const {
@@ -941,7 +941,7 @@ struct Graph final {
   Value* addInitializerAndCreateValue(Tensor& initializer) {
     addInitializer(initializer);
     auto* init_value = initializer_node_->addOutput();
-    std::vector<Dimension> dim_sizes{initializer.sizes().cbegin(), initializer.sizes().cend()};
+    std::vector<DimensionIR> dim_sizes{initializer.sizes().cbegin(), initializer.sizes().cend()};
     init_value->setUniqueName(initializer.name());
     init_value->setSizes(dim_sizes);
     init_value->setElemType(initializer.elem_type());
@@ -1111,7 +1111,7 @@ struct Graph final {
   // Create an initializer whose value is stored in input
   Value* addInitializerAndInput(const Tensor& initializer, const std::string& name) {
     Tensor initializerCopy = initializer;
-    std::vector<Dimension> dim_sizes{initializerCopy.sizes().cbegin(), initializerCopy.sizes().cend()};
+    std::vector<DimensionIR> dim_sizes{initializerCopy.sizes().cbegin(), initializerCopy.sizes().cend()};
     Value* new_init = addInput();
     initializerCopy.setName(name);
     new_init->setUniqueName(name);

--- a/onnx/common/ir_pb_converter.cc
+++ b/onnx/common/ir_pb_converter.cc
@@ -185,8 +185,8 @@ void convertAttributes(ONNX_NAMESPACE::NodeProto& np, Node* n, const int ir_vers
   }
 }
 
-std::vector<Dimension> tensorShapeProtoToDimensions(const ONNX_NAMESPACE::TensorShapeProto& tsp) {
-  std::vector<Dimension> dims;
+std::vector<DimensionIR> tensorShapeProtoToDimensions(const ONNX_NAMESPACE::TensorShapeProto& tsp) {
+  std::vector<DimensionIR> dims;
   dims.reserve(tsp.dim_size());
   for (int i = 0; i < tsp.dim_size(); i++) {
     if (tsp.dim(i).has_dim_value()) {
@@ -540,7 +540,7 @@ void encodeTypeProtoTensorType(ONNX_NAMESPACE::TypeProto_Tensor* tensor_type, Va
   }
   if (n->has_sizes()) {
     ONNX_NAMESPACE::TensorShapeProto* shape = tensor_type->mutable_shape();
-    for (const Dimension& d : n->sizes()) {
+    for (const DimensionIR& d : n->sizes()) {
       auto dim = shape->add_dim();
       if (!d.is_unknown) {
         if (d.is_int) {
@@ -692,7 +692,7 @@ ModelProto PrepareOutput(const ModelProto& mp_in) {
   return mp_out;
 }
 
-void assertNonNull(const std::shared_ptr<Graph>& g) {
+void assertNonNull(const std::shared_ptr<GraphProto>& g) {
   ONNX_ASSERTM(
       g.get() != nullptr,
       "Warning: onnx version converter is unable to parse input model. "

--- a/onnx/common/ir_pb_converter.cc
+++ b/onnx/common/ir_pb_converter.cc
@@ -692,9 +692,9 @@ ModelProto PrepareOutput(const ModelProto& mp_in) {
   return mp_out;
 }
 
-void assertNonNull(const std::shared_ptr<GraphProto>& g) {
+void assertNonNull(const GraphProto* g) {
   ONNX_ASSERTM(
-      g.get() != nullptr,
+      g != nullptr,
       "Warning: onnx version converter is unable to parse input model. "
       "(The IR version of the ONNX model may be too old.)");
 }

--- a/onnx/common/ir_pb_converter.h
+++ b/onnx/common/ir_pb_converter.h
@@ -41,5 +41,5 @@ std::unique_ptr<Graph> ImportModelProto(const ModelProto& mp);
 
 ModelProto PrepareOutput(const ModelProto& mp_in);
 
-void assertNonNull(const std::shared_ptr<Graph>& g);
+void assertNonNull(const std::shared_ptr<GraphProto>& g);
 } // namespace ONNX_NAMESPACE

--- a/onnx/common/ir_pb_converter.h
+++ b/onnx/common/ir_pb_converter.h
@@ -41,5 +41,5 @@ std::unique_ptr<Graph> ImportModelProto(const ModelProto& mp);
 
 ModelProto PrepareOutput(const ModelProto& mp_in);
 
-void assertNonNull(const std::shared_ptr<GraphProto>& g);
+void assertNonNull(const GraphProto* g);
 } // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/BaseConverter.h
+++ b/onnx/version_converter/BaseConverter.h
@@ -10,8 +10,7 @@
 #include <iostream>
 #include <string>
 #include <utility>
-#include "onnx/common/ir.h"
-#include "onnx/common/ir_pb_converter.h"
+#include "onnx/common/assertions.h"
 #include "onnx/common/stl_backports.h"
 #include "onnx/defs/schema.h"
 #include "onnx/proto_utils.h"

--- a/onnx/version_converter/adapters/adapter.h
+++ b/onnx/version_converter/adapters/adapter.h
@@ -14,45 +14,51 @@
 namespace ONNX_NAMESPACE {
 namespace version_conversion {
 
+OperatorSetIdProto make_opset_proto(int64_t version, const std::string& domain = "") {
+  OperatorSetIdProto opset_proto;
+  opset_proto.set_domain("");
+  opset_proto.set_version(version);
+  return opset_proto;
+}
 class Adapter {
  private:
   std::string name_;
-  OpSetID initial_version_;
-  OpSetID target_version_;
+  OperatorSetIdProto initial_version_;
+  OperatorSetIdProto target_version_;
 
  public:
   virtual ~Adapter() noexcept = default;
 
-  explicit Adapter(const std::string& name, const OpSetID& initial_version, const OpSetID& target_version)
+  explicit Adapter(const std::string& name, const OperatorSetIdProto& initial_version, const OperatorSetIdProto& target_version)
       : name_(name), initial_version_(initial_version), target_version_(target_version) {}
 
   // This will almost always return its own node argument after modifying it in place.
   // The only exception are adapters for deprecated operators: in this case the input
   // node must be destroyed and a new one must be created and returned. See e.g.
   // upsample_9_10.h
-  virtual Node* adapt(std::shared_ptr<Graph> /*graph*/, Node* node) const = 0;
+  virtual NodeProto* adapt(std::shared_ptr<GraphProto> /*graph*/, NodeProto* node) const = 0;
 
   const std::string& name() const {
     return name_;
   }
 
-  const OpSetID& initial_version() const {
+  const OperatorSetIdProto& initial_version() const {
     return initial_version_;
   }
 
-  const OpSetID& target_version() const {
+  const OperatorSetIdProto& target_version() const {
     return target_version_;
   }
 };
 
-using NodeTransformerFunction = std::function<Node*(std::shared_ptr<Graph>, Node* node)>;
+using NodeTransformerFunction = std::function<NodeProto*(std::shared_ptr<GraphProto>, NodeProto* node)>;
 
 class GenericAdapter final : public Adapter {
  public:
   GenericAdapter(const char* op, int64_t from, int64_t to, NodeTransformerFunction transformer)
-      : Adapter(op, OpSetID(from), OpSetID(to)), transformer_(transformer) {}
+      : Adapter(op, OperatorSetIdProto(make_opset_proto(from)), OperatorSetIdProto(make_opset_proto(to))), transformer_(transformer) {}
 
-  Node* adapt(std::shared_ptr<Graph> graph, Node* node) const override {
+  NodeProto* adapt(std::shared_ptr<GraphProto> graph, NodeProto* node) const override {
     return transformer_(graph, node);
   }
 

--- a/onnx/version_converter/adapters/adapter.h
+++ b/onnx/version_converter/adapters/adapter.h
@@ -36,7 +36,7 @@ class Adapter {
   // The only exception are adapters for deprecated operators: in this case the input
   // node must be destroyed and a new one must be created and returned. See e.g.
   // upsample_9_10.h
-  virtual NodeProto* adapt(std::shared_ptr<GraphProto> /*graph*/, NodeProto* node) const = 0;
+  virtual NodeProto* adapt(GraphProto* /*graph*/, NodeProto* node) const = 0;
 
   const std::string& name() const {
     return name_;
@@ -51,14 +51,14 @@ class Adapter {
   }
 };
 
-using NodeTransformerFunction = std::function<NodeProto*(std::shared_ptr<GraphProto>, NodeProto* node)>;
+using NodeTransformerFunction = std::function<NodeProto*(GraphProto*, NodeProto* node)>;
 
 class GenericAdapter final : public Adapter {
  public:
   GenericAdapter(const char* op, int64_t from, int64_t to, NodeTransformerFunction transformer)
       : Adapter(op, OperatorSetIdProto(make_opset_proto(from)), OperatorSetIdProto(make_opset_proto(to))), transformer_(transformer) {}
 
-  NodeProto* adapt(std::shared_ptr<GraphProto> graph, NodeProto* node) const override {
+  NodeProto* adapt(GraphProto* graph, NodeProto* node) const override {
     return transformer_(graph, node);
   }
 

--- a/onnx/version_converter/adapters/axes_attribute_to_input.h
+++ b/onnx/version_converter/adapters/axes_attribute_to_input.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "onnx/version_converter/adapters/adapter.h"
+#include "onnx/defs/attr_proto_util.h"
 
 namespace ONNX_NAMESPACE {
 namespace version_conversion {
@@ -16,27 +17,28 @@ class AxesAttributeToInput : public Adapter {
   explicit AxesAttributeToInput(const std::string& op_name, const OpSetID& initial, const OpSetID& target)
       : Adapter(op_name, initial, target) {}
 
-  void attrToInput(std::shared_ptr<Graph> graph, Node* node, std::vector<int64_t> axes) const {
-    Tensor t;
-    t.elem_type() = TensorProto_DataType_INT64;
-    t.sizes() = std::vector<int64_t>{static_cast<int64_t>(axes.size())};
-    auto& data = t.int64s();
-    for (auto a : axes) {
-      data.emplace_back(a);
-    }
-
-    Node* constant = graph->create(kConstant);
-    constant->insertBefore(node);
-    constant->t_(kvalue, t);
-    node->addInput(constant->output());
+  void attrToInput(GraphProto* graph_proto, NodeProto* node_proto, std::vector<int64_t>& axes) const {
+    node_proto->attribute();
+    const std::string constant_node_name("aaa");
+    NodeProto* constant_node_proto = graph_proto->add_node();
+    constant_node_proto->set_op_type("Constant");
+    constant_node_proto->set_name(constant_node_name);
+    TensorProto tensor_proto = ToTensor(axes);
+    *constant_node_proto->add_attribute() = MakeAttribute("attr_name", tensor_proto);
+    node_proto->add_input(constant_node_name);
   }
 
-  Node* adapt(std::shared_ptr<Graph> graph, Node* node) const override {
-    if (node->hasAttribute(kaxes)) {
-      attrToInput(graph, node, node->is(kaxes));
-      node->removeAttribute(kaxes);
+  NodeProto* adapt(GraphProto* graph_proto, NodeProto* node_proto) const override {
+    auto it = std::find_if(node_proto->attribute().begin(), node_proto->attribute().end(), [](AttributeProto& attr) {
+      return attr.name() == "axes";
+    });
+    if (it != node_proto->attribute().end()) {
+      std::vector<int64_t> axes(it->ints().begin(), it->ints().end());
+      attrToInput(graph_proto, node_proto, axes);
+      std::remove_if(node_proto->mutable_attribute()->begin(), node_proto->mutable_attribute()->end(), [](AttributeProto& attr){
+        attr.name() == "axes";});
     }
-    return node;
+    return node_proto;
   }
 };
 

--- a/onnx/version_converter/adapters/batch_normalization_13_14.h
+++ b/onnx/version_converter/adapters/batch_normalization_13_14.h
@@ -15,14 +15,14 @@ class BatchNormalization_13_14 final : public Adapter {
  public:
   explicit BatchNormalization_13_14() : Adapter("BatchNormalization", OpSetID(13), OpSetID(14)) {}
 
-  void adapt_batch_normalization_13_14(Node* node) const {
+  void adapt_batch_normalization_13_14(NodeProto* node) const {
     ONNX_ASSERTM(
         node->outputs().size() < 4,
         "BatchNormalization outputs 4 and 5 are not "
         "supported in Opset 14.");
   }
 
-  Node* adapt(std::shared_ptr<Graph>, Node* node) const override {
+  NodeProto* adapt(GraphProto*, NodeProto* node) const override {
     adapt_batch_normalization_13_14(node);
     return node;
   }

--- a/onnx/version_converter/adapters/broadcast_forward_compatibility.h
+++ b/onnx/version_converter/adapters/broadcast_forward_compatibility.h
@@ -16,10 +16,10 @@ class BroadcastForwardCompatibility final : public Adapter {
   explicit BroadcastForwardCompatibility(const std::string& op_name, const OpSetID& initial, const OpSetID& target)
       : Adapter(op_name, initial, target) {}
 
-  void adapt_broadcast_forward_compatibility(std::shared_ptr<Graph> graph, Node* node) const {
+  void adapt_broadcast_forward_compatibility(GraphProto* graph, NodeProto* node) const {
     // Remove axis and broadcast attributes
     // Assess whether axis requires reshaping
-    if (node->hasAttribute(kbroadcast)) {
+    if (HasAttribute(node, "broadcast")) {
       const ArrayRef<Value*>& inputs = node->inputs();
       assertInputsAvailable(inputs, name().c_str(), 2);
       const std::vector<Dimension>& A_sizes = inputs[0]->sizes();
@@ -70,7 +70,7 @@ class BroadcastForwardCompatibility final : public Adapter {
     assert_numpy_multibroadcastable(inputs[0]->sizes(), inputs[1]->sizes());
   }
 
-  Node* adapt(std::shared_ptr<Graph> graph, Node* node) const override {
+  NodeProto* adapt(GraphProto* graph, NodeProto* node) const override {
     adapt_broadcast_forward_compatibility(graph, node);
     return node;
   }

--- a/onnx/version_converter/adapters/broadcast_forward_compatibility.h
+++ b/onnx/version_converter/adapters/broadcast_forward_compatibility.h
@@ -22,8 +22,8 @@ class BroadcastForwardCompatibility final : public Adapter {
     if (HasAttribute(node, "broadcast")) {
       const ArrayRef<Value*>& inputs = node->inputs();
       assertInputsAvailable(inputs, name().c_str(), 2);
-      const std::vector<Dimension>& A_sizes = inputs[0]->sizes();
-      const std::vector<Dimension>& B_sizes = inputs[1]->sizes();
+      const std::vector<DimensionIR>& A_sizes = inputs[0]->sizes();
+      const std::vector<DimensionIR>& B_sizes = inputs[1]->sizes();
       // Also assert that broadcasting syntax are correct if axis is not present
       if (node->hasAttribute(kaxis)) {
         if (node->i(kaxis) != (int)(A_sizes.size() - B_sizes.size())) {
@@ -31,13 +31,13 @@ class BroadcastForwardCompatibility final : public Adapter {
           Node* n = graph->create(kUnsqueeze);
           n->addInput(inputs[1]);
           std::vector<int64_t> axes;
-          std::vector<Dimension> new_sizes = B_sizes;
+          std::vector<DimensionIR> new_sizes = B_sizes;
           auto size = A_sizes.size() > B_sizes.size() ? A_sizes.size() - B_sizes.size() : 0;
           axes.reserve(size);
           new_sizes.reserve(new_sizes.size() + size);
           for (size_t i = 0; i < size; i++) {
             axes.emplace_back(B_sizes.size() + i);
-            new_sizes.emplace_back(Dimension(1));
+            new_sizes.emplace_back(DimensionIR(1));
           }
           if (target_version().version() >= 13) { // Unsqueeze takes 'axes' input
             Tensor t;

--- a/onnx/version_converter/adapters/compatible.h
+++ b/onnx/version_converter/adapters/compatible.h
@@ -16,7 +16,7 @@ struct CompatibleAdapter final : public Adapter {
   explicit CompatibleAdapter(const std::string& op_name, const OperatorSetIdProto& initial, const OperatorSetIdProto& target)
       : Adapter(op_name, initial, target) {}
 
-  NodeProto* adapt(std::shared_ptr<GraphProto>, NodeProto* node) const override {
+  NodeProto* adapt(GraphProto*, NodeProto* node) const override {
     return node;
   }
 };

--- a/onnx/version_converter/adapters/compatible.h
+++ b/onnx/version_converter/adapters/compatible.h
@@ -13,10 +13,10 @@ namespace ONNX_NAMESPACE {
 namespace version_conversion {
 
 struct CompatibleAdapter final : public Adapter {
-  explicit CompatibleAdapter(const std::string& op_name, const OpSetID& initial, const OpSetID& target)
+  explicit CompatibleAdapter(const std::string& op_name, const OperatorSetIdProto& initial, const OperatorSetIdProto& target)
       : Adapter(op_name, initial, target) {}
 
-  Node* adapt(std::shared_ptr<Graph>, Node* node) const override {
+  NodeProto* adapt(std::shared_ptr<GraphProto>, NodeProto* node) const override {
     return node;
   }
 };

--- a/onnx/version_converter/adapters/extend_supported_types.h
+++ b/onnx/version_converter/adapters/extend_supported_types.h
@@ -20,7 +20,7 @@ struct ExtendSupportedTypes final : public Adapter {
       std::shared_ptr<Graph> graph,
       ArrayRef<Value*> inputs,
       const int to_type,
-      const std::vector<Dimension>& output_shape,
+      const std::vector<DimensionIR>& output_shape,
       const std::string& name) const {
     Node* node = graph->create(kCast, inputs);
     node->i_(kto, to_type);

--- a/onnx/version_converter/adapters/gemm_6_7.h
+++ b/onnx/version_converter/adapters/gemm_6_7.h
@@ -23,7 +23,7 @@ class Gemm_6_7 final : public Adapter {
     // Determine if C is broadcastable
     const auto& C_shape = inputs[2]->sizes();
     // Create (M, N) to input to numpy_unibroadcastable
-    std::vector<Dimension> MN;
+    std::vector<DimensionIR> MN;
     if (node->hasAttribute(ktransA) && node->i(ktransA) == 1) {
       MN.emplace_back(A_shape[1]);
     } else {

--- a/onnx/version_converter/adapters/gemm_7_6.h
+++ b/onnx/version_converter/adapters/gemm_7_6.h
@@ -24,7 +24,7 @@ class Gemm_7_6 final : public Adapter {
     const auto& C_shape = inputs[2]->sizes();
     // Create (M, N) to input to numpy_unibroadcastable
     // TODO: Reconcile fact that shapes aren't determined for 1st 2 inputs
-    std::vector<Dimension> MN;
+    std::vector<DimensionIR> MN;
     if (node->hasAttribute(ktransA) && node->i(ktransA) == 1) {
       MN.emplace_back(A_shape[1]);
     } else {

--- a/onnx/version_converter/adapters/scan_8_9.h
+++ b/onnx/version_converter/adapters/scan_8_9.h
@@ -36,7 +36,7 @@ struct Scan_8_9 final : public Adapter {
 
     for (Value* input : inputs) {
       if (!input->sizes().empty()) {
-        std::vector<Dimension> new_sizes(input->sizes().begin() + 1, input->sizes().end());
+        std::vector<DimensionIR> new_sizes(input->sizes().begin() + 1, input->sizes().end());
         input->setSizes(new_sizes);
         node->addInput(input);
       }
@@ -44,7 +44,7 @@ struct Scan_8_9 final : public Adapter {
 
     for (Value* output : outputs) {
       if (!output->sizes().empty()) {
-        std::vector<Dimension> new_sizes(output->sizes().begin() + 1, output->sizes().end());
+        std::vector<DimensionIR> new_sizes(output->sizes().begin() + 1, output->sizes().end());
         output->setSizes(new_sizes);
       }
     }

--- a/onnx/version_converter/adapters/scan_9_8.h
+++ b/onnx/version_converter/adapters/scan_9_8.h
@@ -64,14 +64,14 @@ struct Scan_9_8 final : public Adapter {
     node->addInput(v);
 
     for (Value* input : inputs) {
-      std::vector<Dimension> new_sizes{Dimension(1)};
+      std::vector<DimensionIR> new_sizes{DimensionIR(1)};
       new_sizes.insert(new_sizes.end(), input->sizes().begin(), input->sizes().end());
       input->setSizes(new_sizes);
       node->addInput(input);
     }
 
     for (Value* output : outputs) {
-      std::vector<Dimension> new_sizes{Dimension(1)};
+      std::vector<DimensionIR> new_sizes{DimensionIR(1)};
       new_sizes.insert(new_sizes.end(), output->sizes().begin(), output->sizes().end());
       output->setSizes(new_sizes);
     }

--- a/onnx/version_converter/adapters/softmax_12_13.h
+++ b/onnx/version_converter/adapters/softmax_12_13.h
@@ -48,7 +48,7 @@ class Softmax_12_13 final : public Adapter {
       reshape->insertAfter(node);
 
       // Set shape input of Reshape
-      const std::vector<Dimension>& target_shape = flatten->inputs()[0]->sizes();
+      const std::vector<DimensionIR>& target_shape = flatten->inputs()[0]->sizes();
 
       ONNX_ASSERTM(
           target_shape.size() != 0,
@@ -59,7 +59,7 @@ class Softmax_12_13 final : public Adapter {
       t.elem_type() = TensorProto_DataType_INT64;
       t.sizes() = std::vector<int64_t>{static_cast<int64_t>(target_shape.size())};
       auto& data = t.int64s();
-      for (Dimension dim : target_shape) {
+      for (DimensionIR dim : target_shape) {
         data.emplace_back(dim.dim);
       }
       Node* constant = graph->create(kConstant);

--- a/onnx/version_converter/adapters/sum_8_7.h
+++ b/onnx/version_converter/adapters/sum_8_7.h
@@ -20,8 +20,8 @@ class Sum_8_7 final : public Adapter {
     const ArrayRef<Value*>& inputs = node->inputs();
     // Determine if inputs are of different sizes
     for (int i = 1; i < (int)inputs.size(); i++) {
-      std::vector<Dimension> A_sizes = inputs[i - 1]->sizes();
-      std::vector<Dimension> B_sizes = inputs[i]->sizes();
+      std::vector<DimensionIR> A_sizes = inputs[i - 1]->sizes();
+      std::vector<DimensionIR> B_sizes = inputs[i]->sizes();
       assert_numpy_multibroadcastable(A_sizes, B_sizes);
     }
   }

--- a/onnx/version_converter/convert.h
+++ b/onnx/version_converter/convert.h
@@ -90,7 +90,7 @@ class DefaultVersionConverter : public BaseVersionConverter {
     ONNX_ASSERTM(initial_domain == target_domain, "initial_version and target_version must have the same domains");
   }
 
-  void convert_graph(std::shared_ptr<GraphProto> g, std::vector<OperatorSetIdProto>& opset_imports,
+  void convert_graph(GraphProto* g, std::vector<OperatorSetIdProto>& opset_imports,
     const OperatorSetIdProto& initial_version, const OperatorSetIdProto& target_version) const;
 
  public:

--- a/onnx/version_converter/convert.h
+++ b/onnx/version_converter/convert.h
@@ -47,6 +47,11 @@
 namespace ONNX_NAMESPACE {
 namespace version_conversion {
 
+OperatorSetIdProto OpSetID(int64_t version) {
+  OperatorSetIdProto opset_proto;
+  opset_proto.set_version(version);
+  return opset_proto;
+}
 class DefaultVersionConverter : public BaseVersionConverter {
  private:
   bool DEBUG = false;
@@ -85,7 +90,8 @@ class DefaultVersionConverter : public BaseVersionConverter {
     ONNX_ASSERTM(initial_domain == target_domain, "initial_version and target_version must have the same domains");
   }
 
-  void convert_graph(std::shared_ptr<Graph> g, const OpSetID& initial_version, const OpSetID& target_version) const;
+  void convert_graph(std::shared_ptr<GraphProto> g, std::vector<OperatorSetIdProto>& opset_imports,
+    const OperatorSetIdProto& initial_version, const OperatorSetIdProto& target_version) const;
 
  public:
   DefaultVersionConverter() {
@@ -543,7 +549,7 @@ class DefaultVersionConverter : public BaseVersionConverter {
     registerAdapter(make_unique<CompatibleAdapter>("Resize", OpSetID(18), OpSetID(19)));
   }
 
-  ModelProto convert_version(const ModelProto& mp_in, const OpSetID& initial_version, const OpSetID& target_version)
+  ModelProto convert_version(const ModelProto& mp_in, const OperatorSetIdProto& initial_version, const OperatorSetIdProto& target_version)
       const override;
 };
 

--- a/onnx/version_converter/helper.cc
+++ b/onnx/version_converter/helper.cc
@@ -5,12 +5,13 @@
 // Helper Methods for Adapters
 
 #include "onnx/version_converter/helper.h"
+#include "onnx/common/assertions.h"
 
 namespace ONNX_NAMESPACE {
 namespace version_conversion {
 
 bool HasAttribute(NodeProto* node_proto, const std::string& name) {
-  return std::find_if(node_proto->attribute().begin(), node_proto->attribute().end(), [name](AttributeProto& attr) {
+  return std::find_if(node_proto->attribute().begin(), node_proto->attribute().end(), [name](const AttributeProto& attr) {
            return attr.name() == name;
          }) != node_proto->attribute().end();
 }
@@ -83,17 +84,5 @@ void assertNotParams(const std::vector<TensorShapeProto::Dimension>& sizes) {
   }
 }
 
-void assertInputsAvailable(const std::vector<std::shapred_ptr<Value>>& inputs, const char* name, uint64_t num_inputs) {
-  ONNX_ASSERTM(
-      inputs.size() == num_inputs,
-      "%s in opset version 6 can only broadcast"
-      " between %d inputs",
-      name,
-      num_inputs);
-  for (int i = 0; i < (int)num_inputs; i++) {
-    ONNX_ASSERTM(inputs[i]->has_sizes(), "Shape of input %d is not available.", num_inputs);
-    assertNotParams(inputs[i]->sizes());
-  }
-}
 } // namespace version_conversion
 } // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/helper.cc
+++ b/onnx/version_converter/helper.cc
@@ -22,30 +22,8 @@ std::vector<T> protobuf_repeated_fields_to_vector(google::protobuf::RepeatedPtrF
 }
 
 int check_numpy_unibroadcastable_and_require_broadcast(
-    const std::vector<Dimension>& input1_sizes,
-    const std::vector<Dimension>& input2_sizes) {
-  // Check that input1 is larger
-  if (input1_sizes.size() < input2_sizes.size())
-    return -1;
-  // Check that axis is input1_sizes.size()-input2_sizes.size()
-  bool broadcast = false;
-  int axis = (int)(input1_sizes.size() - input2_sizes.size());
-  for (int i = 0; i < (int)input2_sizes.size(); i++) {
-    if (input2_sizes[i].dim != input1_sizes[axis + i].dim && input2_sizes[i].dim != 1)
-      return -1;
-    if (input2_sizes[i].dim != input1_sizes[axis + i].dim)
-      broadcast = true;
-  }
-  // Return true if broadcasting is required
-  if (input1_sizes.size() > input2_sizes.size() || broadcast)
-    return 1;
-  else
-    return 0;
-}
-
-int check_numpy_unibroadcastable_and_require_broadcast(
-    std::vector<TensorShapeProto_Dimension>& dim1,
-    std::vector<TensorShapeProto_Dimension>& dim2) {
+    std::vector<TensorShapeProto::Dimension>& dim1,
+    std::vector<TensorShapeProto::Dimension>& dim2) {
   if (dim1.size() < dim2.size())
     return -1;
   // Check that axis is input1_sizes.size()-input2_sizes.size()
@@ -66,11 +44,11 @@ int check_numpy_unibroadcastable_and_require_broadcast(
   
 
 void assert_numpy_multibroadcastable(
-    const std::vector<Dimension>& input1_sizes,
-    const std::vector<Dimension>& input2_sizes) {
+    const std::vector<TensorShapeProto::Dimension>& input1_sizes,
+    const std::vector<TensorShapeProto::Dimension>& input2_sizes) {
   // Generalize above for multibroadcastable case
-  const std::vector<Dimension>* A_ptr;
-  const std::vector<Dimension>* B_ptr;
+  const std::vector<TensorShapeProto::Dimension>* A_ptr;
+  const std::vector<TensorShapeProto::Dimension>* B_ptr;
   int A;
   int B;
   if (input1_sizes.size() < input2_sizes.size()) {
@@ -84,12 +62,12 @@ void assert_numpy_multibroadcastable(
     A = 1;
     B = 2;
   }
-  const std::vector<Dimension>& A_sizes = *A_ptr;
-  const std::vector<Dimension>& B_sizes = *B_ptr;
+  const std::vector<TensorShapeProto::Dimension>& A_sizes = *A_ptr;
+  const std::vector<TensorShapeProto::Dimension>& B_sizes = *B_ptr;
   int axis = (int)(A_sizes.size() - B_sizes.size());
   for (int i = 0; i < (int)B_sizes.size(); i++) {
     ONNX_ASSERTM(
-        B_sizes[i].dim == A_sizes[axis + i].dim || B_sizes[i].dim == 1 || A_sizes[axis + i].dim == 1,
+        B_sizes[i].dim_value() == A_sizes[axis + i].dim_value() || B_sizes[i].dim_value() == 1 || A_sizes[axis + i].dim_value() == 1,
         "Dimension %d of input %d does not match "
         "dimension %d of input %d, and neither's value is 1",
         i,
@@ -99,13 +77,13 @@ void assert_numpy_multibroadcastable(
   }
 }
 
-void assertNotParams(const std::vector<Dimension>& sizes) {
-  for (const Dimension& dim : sizes) {
-    ONNX_ASSERTM(dim.is_int, "%s Dimension is a param instead of an int.", dim.param.c_str());
+void assertNotParams(const std::vector<TensorShapeProto::Dimension>& sizes) {
+  for (const TensorShapeProto::Dimension& dim : sizes) {
+    ONNX_ASSERTM(dim.has_dim_value(), "%s Dimension is a param instead of an int.", dim.dim_param().c_str());
   }
 }
 
-void assertInputsAvailable(const ArrayRef<Value*>& inputs, const char* name, uint64_t num_inputs) {
+void assertInputsAvailable(const std::vector<std::shapred_ptr<Value>>& inputs, const char* name, uint64_t num_inputs) {
   ONNX_ASSERTM(
       inputs.size() == num_inputs,
       "%s in opset version 6 can only broadcast"

--- a/onnx/version_converter/helper.h
+++ b/onnx/version_converter/helper.h
@@ -17,17 +17,17 @@ template <typename T>
 std::vector<T> protobuf_repeated_fields_to_vector(const google::protobuf::RepeatedPtrField<T>& repeated);
 
 int check_numpy_unibroadcastable_and_require_broadcast(
-    const std::vector<Dimension>& input1_sizes,
-    const std::vector<Dimension>& input2_sizes);
+    const std::vector<DimensionIR>& input1_sizes,
+    const std::vector<DimensionIR>& input2_sizes);
 int check_numpy_unibroadcastable_and_require_broadcast(
     std::vector<TensorShapeProto_Dimension>& dim1,
     std::vector<TensorShapeProto_Dimension>& dim2);
 
 void assert_numpy_multibroadcastable(
-    const std::vector<Dimension>& input1_sizes,
-    const std::vector<Dimension>& input2_sizes);
+    const std::vector<DimensionIR>& input1_sizes,
+    const std::vector<DimensionIR>& input2_sizes);
 
-void assertNotParams(const std::vector<Dimension>& sizes);
+void assertNotParams(const std::vector<DimensionIR>& sizes);
 
 void assertInputsAvailable(const ArrayRef<Value*>& inputs, const char* name, uint64_t num_inputs);
 } // namespace version_conversion

--- a/onnx/version_converter/helper.h
+++ b/onnx/version_converter/helper.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include "onnx/common/ir.h"
 #include "onnx/onnx_pb.h"
 
 namespace ONNX_NAMESPACE {
@@ -17,18 +16,8 @@ template <typename T>
 std::vector<T> protobuf_repeated_fields_to_vector(const google::protobuf::RepeatedPtrField<T>& repeated);
 
 int check_numpy_unibroadcastable_and_require_broadcast(
-    const std::vector<DimensionIR>& input1_sizes,
-    const std::vector<DimensionIR>& input2_sizes);
-int check_numpy_unibroadcastable_and_require_broadcast(
     std::vector<TensorShapeProto_Dimension>& dim1,
     std::vector<TensorShapeProto_Dimension>& dim2);
 
-void assert_numpy_multibroadcastable(
-    const std::vector<DimensionIR>& input1_sizes,
-    const std::vector<DimensionIR>& input2_sizes);
-
-void assertNotParams(const std::vector<DimensionIR>& sizes);
-
-void assertInputsAvailable(const ArrayRef<Value*>& inputs, const char* name, uint64_t num_inputs);
 } // namespace version_conversion
 } // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/helper.h
+++ b/onnx/version_converter/helper.h
@@ -7,12 +7,21 @@
 #pragma once
 
 #include "onnx/common/ir.h"
+#include "onnx/onnx_pb.h"
 
 namespace ONNX_NAMESPACE {
 namespace version_conversion {
+bool HasAttribute(NodeProto* node_proto, const std::string& name);
+
+template <typename T>
+std::vector<T> protobuf_repeated_fields_to_vector(const google::protobuf::RepeatedPtrField<T>& repeated);
+
 int check_numpy_unibroadcastable_and_require_broadcast(
     const std::vector<Dimension>& input1_sizes,
     const std::vector<Dimension>& input2_sizes);
+int check_numpy_unibroadcastable_and_require_broadcast(
+    std::vector<TensorShapeProto_Dimension>& dim1,
+    std::vector<TensorShapeProto_Dimension>& dim2);
 
 void assert_numpy_multibroadcastable(
     const std::vector<Dimension>& input1_sizes,


### PR DESCRIPTION
### Description
initial code to remove onnx internal ir code.


### Motivation and Context
internal IR code is only used by version converter. I hope by removing it, version converter will become simpler.