### PR TITLE
add missing copyright to various files

### DIFF
--- a/onnx/backend/test/case/model/__init__.py
+++ b/onnx/backend/test/case/model/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 
 import sys

--- a/onnx/backend/test/case/model/expand.py
+++ b/onnx/backend/test/case/model/expand.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Sequence

--- a/onnx/backend/test/case/model/gradient.py
+++ b/onnx/backend/test/case/model/gradient.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/model/sequence.py
+++ b/onnx/backend/test/case/model/sequence.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/onnx/backend/test/case/model/shrink.py
+++ b/onnx/backend/test/case/model/shrink.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/model/sign.py
+++ b/onnx/backend/test/case/model/sign.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/model/single-relu.py
+++ b/onnx/backend/test/case/model/single-relu.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/onnx/backend/test/case/model/stringnormalizer.py
+++ b/onnx/backend/test/case/model/stringnormalizer.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/onnx/reference/ops/__init__.py
+++ b/onnx/reference/ops/__init__.py
@@ -1,4 +1,6 @@
 # Copyright (c) ONNX Project Contributors
+
+# Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/onnx/reference/ops/_helpers.py
+++ b/onnx/reference/ops/_helpers.py
@@ -1,4 +1,6 @@
 # Copyright (c) ONNX Project Contributors
+
+# Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/onnx/reference/ops/_op.py
+++ b/onnx/reference/ops/_op.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict

--- a/onnx/reference/ops/_op_common_indices.py
+++ b/onnx/reference/ops/_op_common_indices.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/_op_common_pool.py
+++ b/onnx/reference/ops/_op_common_pool.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221,R0913,R0914
 

--- a/onnx/reference/ops/_op_common_random.py
+++ b/onnx/reference/ops/_op_common_random.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/_op_common_window.py
+++ b/onnx/reference/ops/_op_common_window.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0613,W0221
 

--- a/onnx/reference/ops/_op_list.py
+++ b/onnx/reference/ops/_op_list.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=C0415,R0912,R0913,R0914,R0915,W0611,W0603
 """

--- a/onnx/reference/ops/op_abs.py
+++ b/onnx/reference/ops/op_abs.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_acos.py
+++ b/onnx/reference/ops/op_acos.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_acosh.py
+++ b/onnx/reference/ops/op_acosh.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_add.py
+++ b/onnx/reference/ops/op_add.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_and.py
+++ b/onnx/reference/ops/op_and.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_argmax.py
+++ b/onnx/reference/ops/op_argmax.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_argmin.py
+++ b/onnx/reference/ops/op_argmin.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_asin.py
+++ b/onnx/reference/ops/op_asin.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_asinh.py
+++ b/onnx/reference/ops/op_asinh.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_atan.py
+++ b/onnx/reference/ops/op_atan.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_atanh.py
+++ b/onnx/reference/ops/op_atanh.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_attribute_has_value.py
+++ b/onnx/reference/ops/op_attribute_has_value.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0913,R0914,W0221,W0613
 

--- a/onnx/reference/ops/op_average_pool.py
+++ b/onnx/reference/ops/op_average_pool.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221,R0913,R0914
 

--- a/onnx/reference/ops/op_batch_normalization.py
+++ b/onnx/reference/ops/op_batch_normalization.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221,R0913,W0613
 

--- a/onnx/reference/ops/op_bernoulli.py
+++ b/onnx/reference/ops/op_bernoulli.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_bitshift.py
+++ b/onnx/reference/ops/op_bitshift.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_bitwise_and.py
+++ b/onnx/reference/ops/op_bitwise_and.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_bitwise_not.py
+++ b/onnx/reference/ops/op_bitwise_not.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_bitwise_or.py
+++ b/onnx/reference/ops/op_bitwise_or.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_bitwise_xor.py
+++ b/onnx/reference/ops/op_bitwise_xor.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_blackman_window.py
+++ b/onnx/reference/ops/op_blackman_window.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_cast.py
+++ b/onnx/reference/ops/op_cast.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_cast_like.py
+++ b/onnx/reference/ops/op_cast_like.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_ceil.py
+++ b/onnx/reference/ops/op_ceil.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_celu.py
+++ b/onnx/reference/ops/op_celu.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_center_crop_pad.py
+++ b/onnx/reference/ops/op_center_crop_pad.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0912,R0914,R1702,W0221
 

--- a/onnx/reference/ops/op_clip.py
+++ b/onnx/reference/ops/op_clip.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0622,W0622,W0221
 

--- a/onnx/reference/ops/op_col2im.py
+++ b/onnx/reference/ops/op_col2im.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0913,R0914,W0221
 

--- a/onnx/reference/ops/op_compress.py
+++ b/onnx/reference/ops/op_compress.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_concat.py
+++ b/onnx/reference/ops/op_concat.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_concat_from_sequence.py
+++ b/onnx/reference/ops/op_concat_from_sequence.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_constant.py
+++ b/onnx/reference/ops/op_constant.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_constant_of_shape.py
+++ b/onnx/reference/ops/op_constant_of_shape.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_conv.py
+++ b/onnx/reference/ops/op_conv.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0912,R0913,R0914,R0915,R1702,W0221
 

--- a/onnx/reference/ops/op_conv_integer.py
+++ b/onnx/reference/ops/op_conv_integer.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0913,W0221
 

--- a/onnx/reference/ops/op_conv_transpose.py
+++ b/onnx/reference/ops/op_conv_transpose.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0912,R0913,R0914,R0915,R1702,W0221
 

--- a/onnx/reference/ops/op_cos.py
+++ b/onnx/reference/ops/op_cos.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_cosh.py
+++ b/onnx/reference/ops/op_cosh.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_cum_sum.py
+++ b/onnx/reference/ops/op_cum_sum.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_depth_to_space.py
+++ b/onnx/reference/ops/op_depth_to_space.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_dequantize_linear.py
+++ b/onnx/reference/ops/op_dequantize_linear.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_det.py
+++ b/onnx/reference/ops/op_det.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_dft.py
+++ b/onnx/reference/ops/op_dft.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0913,W0221
 

--- a/onnx/reference/ops/op_div.py
+++ b/onnx/reference/ops/op_div.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_dropout.py
+++ b/onnx/reference/ops/op_dropout.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_dynamic_quantize_linear.py
+++ b/onnx/reference/ops/op_dynamic_quantize_linear.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_einsum.py
+++ b/onnx/reference/ops/op_einsum.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=E0203,W0221
 

--- a/onnx/reference/ops/op_elu.py
+++ b/onnx/reference/ops/op_elu.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_equal.py
+++ b/onnx/reference/ops/op_equal.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_erf.py
+++ b/onnx/reference/ops/op_erf.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_exp.py
+++ b/onnx/reference/ops/op_exp.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_expand.py
+++ b/onnx/reference/ops/op_expand.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_eyelike.py
+++ b/onnx/reference/ops/op_eyelike.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_flatten.py
+++ b/onnx/reference/ops/op_flatten.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_floor.py
+++ b/onnx/reference/ops/op_floor.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_gather.py
+++ b/onnx/reference/ops/op_gather.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_gather_elements.py
+++ b/onnx/reference/ops/op_gather_elements.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_gathernd.py
+++ b/onnx/reference/ops/op_gathernd.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_gemm.py
+++ b/onnx/reference/ops/op_gemm.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0913,W0221
 

--- a/onnx/reference/ops/op_global_average_pool.py
+++ b/onnx/reference/ops/op_global_average_pool.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_global_max_pool.py
+++ b/onnx/reference/ops/op_global_max_pool.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_greater.py
+++ b/onnx/reference/ops/op_greater.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_greater_or_equal.py
+++ b/onnx/reference/ops/op_greater_or_equal.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_grid_sample.py
+++ b/onnx/reference/ops/op_grid_sample.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0912,R0913,R0914,R0915,R1702,R1716,W0221
 

--- a/onnx/reference/ops/op_gru.py
+++ b/onnx/reference/ops/op_gru.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0913,R0914,W0221,W0613
 

--- a/onnx/reference/ops/op_hamming_window.py
+++ b/onnx/reference/ops/op_hamming_window.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_hann_window.py
+++ b/onnx/reference/ops/op_hann_window.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_hard_sigmoid.py
+++ b/onnx/reference/ops/op_hard_sigmoid.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_hardmax.py
+++ b/onnx/reference/ops/op_hardmax.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_identity.py
+++ b/onnx/reference/ops/op_identity.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_if.py
+++ b/onnx/reference/ops/op_if.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0913,R0914,W0221,W0613
 

--- a/onnx/reference/ops/op_instance_normalization.py
+++ b/onnx/reference/ops/op_instance_normalization.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0913,R0914,W0221
 

--- a/onnx/reference/ops/op_isinf.py
+++ b/onnx/reference/ops/op_isinf.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_isnan.py
+++ b/onnx/reference/ops/op_isnan.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_layer_normalization.py
+++ b/onnx/reference/ops/op_layer_normalization.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0913,R0914,W0221
 

--- a/onnx/reference/ops/op_leaky_relu.py
+++ b/onnx/reference/ops/op_leaky_relu.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_less.py
+++ b/onnx/reference/ops/op_less.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_less_or_equal.py
+++ b/onnx/reference/ops/op_less_or_equal.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_log.py
+++ b/onnx/reference/ops/op_log.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_log_softmax.py
+++ b/onnx/reference/ops/op_log_softmax.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_loop.py
+++ b/onnx/reference/ops/op_loop.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0912,R0914,W0221
 

--- a/onnx/reference/ops/op_lp_normalization.py
+++ b/onnx/reference/ops/op_lp_normalization.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_lp_pool.py
+++ b/onnx/reference/ops/op_lp_pool.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221,R0913,R0914
 

--- a/onnx/reference/ops/op_lrn.py
+++ b/onnx/reference/ops/op_lrn.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0913,W0221
 

--- a/onnx/reference/ops/op_lstm.py
+++ b/onnx/reference/ops/op_lstm.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0913,R0914,W0221,W0613
 

--- a/onnx/reference/ops/op_matmul.py
+++ b/onnx/reference/ops/op_matmul.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_matmul_integer.py
+++ b/onnx/reference/ops/op_matmul_integer.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_max.py
+++ b/onnx/reference/ops/op_max.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_max_pool.py
+++ b/onnx/reference/ops/op_max_pool.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=C0200,R0912,R0913,R0914,R0915,R0916,R1702,W0221
 

--- a/onnx/reference/ops/op_max_unpool.py
+++ b/onnx/reference/ops/op_max_unpool.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=C0200,R0913,R0914,W0221
 

--- a/onnx/reference/ops/op_mean.py
+++ b/onnx/reference/ops/op_mean.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_mel_weight_matrix.py
+++ b/onnx/reference/ops/op_mel_weight_matrix.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0913,R0914,W0221
 

--- a/onnx/reference/ops/op_min.py
+++ b/onnx/reference/ops/op_min.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_mod.py
+++ b/onnx/reference/ops/op_mod.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_mul.py
+++ b/onnx/reference/ops/op_mul.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_neg.py
+++ b/onnx/reference/ops/op_neg.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_negative_log_likelihood_loss.py
+++ b/onnx/reference/ops/op_negative_log_likelihood_loss.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0912,R0913,W0221
 

--- a/onnx/reference/ops/op_non_max_suppression.py
+++ b/onnx/reference/ops/op_non_max_suppression.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0902,R0911,R0912,R0913,R0914,W0221
 

--- a/onnx/reference/ops/op_non_zero.py
+++ b/onnx/reference/ops/op_non_zero.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_not.py
+++ b/onnx/reference/ops/op_not.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_one_hot.py
+++ b/onnx/reference/ops/op_one_hot.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_optional.py
+++ b/onnx/reference/ops/op_optional.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221,W0622
 

--- a/onnx/reference/ops/op_optional_get_element.py
+++ b/onnx/reference/ops/op_optional_get_element.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_optional_has_element.py
+++ b/onnx/reference/ops/op_optional_has_element.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_or.py
+++ b/onnx/reference/ops/op_or.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_pad.py
+++ b/onnx/reference/ops/op_pad.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0913,W0221
 

--- a/onnx/reference/ops/op_pow.py
+++ b/onnx/reference/ops/op_pow.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_prelu.py
+++ b/onnx/reference/ops/op_prelu.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_qlinear_conv.py
+++ b/onnx/reference/ops/op_qlinear_conv.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0913,R0914,W0221
 

--- a/onnx/reference/ops/op_qlinear_matmul.py
+++ b/onnx/reference/ops/op_qlinear_matmul.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0913,W0221
 

--- a/onnx/reference/ops/op_quantize_linear.py
+++ b/onnx/reference/ops/op_quantize_linear.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_random_normal.py
+++ b/onnx/reference/ops/op_random_normal.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0913,W0221
 

--- a/onnx/reference/ops/op_random_normal_like.py
+++ b/onnx/reference/ops/op_random_normal_like.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0913,W0221
 

--- a/onnx/reference/ops/op_random_uniform.py
+++ b/onnx/reference/ops/op_random_uniform.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0913,W0221
 

--- a/onnx/reference/ops/op_random_uniform_like.py
+++ b/onnx/reference/ops/op_random_uniform_like.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0913,W0221
 

--- a/onnx/reference/ops/op_range.py
+++ b/onnx/reference/ops/op_range.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_reciprocal.py
+++ b/onnx/reference/ops/op_reciprocal.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_reduce_l1.py
+++ b/onnx/reference/ops/op_reduce_l1.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_reduce_l2.py
+++ b/onnx/reference/ops/op_reduce_l2.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_reduce_log_sum.py
+++ b/onnx/reference/ops/op_reduce_log_sum.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_reduce_log_sum_exp.py
+++ b/onnx/reference/ops/op_reduce_log_sum_exp.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_reduce_max.py
+++ b/onnx/reference/ops/op_reduce_max.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=E1123,W0221
 

--- a/onnx/reference/ops/op_reduce_mean.py
+++ b/onnx/reference/ops/op_reduce_mean.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_reduce_min.py
+++ b/onnx/reference/ops/op_reduce_min.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=E1123,W0221
 

--- a/onnx/reference/ops/op_reduce_prod.py
+++ b/onnx/reference/ops/op_reduce_prod.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_reduce_sum.py
+++ b/onnx/reference/ops/op_reduce_sum.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_reduce_sum_square.py
+++ b/onnx/reference/ops/op_reduce_sum_square.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_relu.py
+++ b/onnx/reference/ops/op_relu.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_reshape.py
+++ b/onnx/reference/ops/op_reshape.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_resize.py
+++ b/onnx/reference/ops/op_resize.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=C0123,C3001,R0912,R0913,R0914,R1730,W0221,W0613
 

--- a/onnx/reference/ops/op_reverse_sequence.py
+++ b/onnx/reference/ops/op_reverse_sequence.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=C0123,R0912,R0913,R0914,W0221
 

--- a/onnx/reference/ops/op_rnn.py
+++ b/onnx/reference/ops/op_rnn.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0913,R0914,W0221,W0613
 

--- a/onnx/reference/ops/op_roi_align.py
+++ b/onnx/reference/ops/op_roi_align.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0902,R0912,R0913,R0914,R0915,R1702,W0221
 

--- a/onnx/reference/ops/op_round.py
+++ b/onnx/reference/ops/op_round.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_scan.py
+++ b/onnx/reference/ops/op_scan.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0912,R0914,W0221,W0613
 

--- a/onnx/reference/ops/op_scatter_elements.py
+++ b/onnx/reference/ops/op_scatter_elements.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=C3001,R0912,R0913,R0914,R0915,W0108,W0221
 

--- a/onnx/reference/ops/op_scatternd.py
+++ b/onnx/reference/ops/op_scatternd.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_selu.py
+++ b/onnx/reference/ops/op_selu.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_sequence_at.py
+++ b/onnx/reference/ops/op_sequence_at.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_sequence_construct.py
+++ b/onnx/reference/ops/op_sequence_construct.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_sequence_empty.py
+++ b/onnx/reference/ops/op_sequence_empty.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221,W0613
 

--- a/onnx/reference/ops/op_sequence_erase.py
+++ b/onnx/reference/ops/op_sequence_erase.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_sequence_insert.py
+++ b/onnx/reference/ops/op_sequence_insert.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_sequence_length.py
+++ b/onnx/reference/ops/op_sequence_length.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_sequence_map.py
+++ b/onnx/reference/ops/op_sequence_map.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_shape.py
+++ b/onnx/reference/ops/op_shape.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_shrink.py
+++ b/onnx/reference/ops/op_shrink.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=E1130,W0221
 

--- a/onnx/reference/ops/op_sigmoid.py
+++ b/onnx/reference/ops/op_sigmoid.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_sign.py
+++ b/onnx/reference/ops/op_sign.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_sin.py
+++ b/onnx/reference/ops/op_sin.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_sinh.py
+++ b/onnx/reference/ops/op_sinh.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_size.py
+++ b/onnx/reference/ops/op_size.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_slice.py
+++ b/onnx/reference/ops/op_slice.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0912,R0913,W0221
 

--- a/onnx/reference/ops/op_softmax.py
+++ b/onnx/reference/ops/op_softmax.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_softmax_cross_entropy_loss.py
+++ b/onnx/reference/ops/op_softmax_cross_entropy_loss.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0912,R0913,R0914,W0221
 

--- a/onnx/reference/ops/op_softplus.py
+++ b/onnx/reference/ops/op_softplus.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_softsign.py
+++ b/onnx/reference/ops/op_softsign.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_space_to_depth.py
+++ b/onnx/reference/ops/op_space_to_depth.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_split.py
+++ b/onnx/reference/ops/op_split.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_split_to_sequence.py
+++ b/onnx/reference/ops/op_split_to_sequence.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=C0200,W0221
 

--- a/onnx/reference/ops/op_sqrt.py
+++ b/onnx/reference/ops/op_sqrt.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_squeeze.py
+++ b/onnx/reference/ops/op_squeeze.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=E0203,W0221
 

--- a/onnx/reference/ops/op_stft.py
+++ b/onnx/reference/ops/op_stft.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0913,R0914,R0915,W0613,W0221
 

--- a/onnx/reference/ops/op_string_normalizer.py
+++ b/onnx/reference/ops/op_string_normalizer.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0912,R0913,W0221
 

--- a/onnx/reference/ops/op_sub.py
+++ b/onnx/reference/ops/op_sub.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_sum.py
+++ b/onnx/reference/ops/op_sum.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_tan.py
+++ b/onnx/reference/ops/op_tan.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_tanh.py
+++ b/onnx/reference/ops/op_tanh.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_tfidf_vectorizer.py
+++ b/onnx/reference/ops/op_tfidf_vectorizer.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=C0200,R0902,R0912,R0913,R0914,R0915,R1716,W0611,W0612,W0613,W0221
 

--- a/onnx/reference/ops/op_thresholded_relu.py
+++ b/onnx/reference/ops/op_thresholded_relu.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_tile.py
+++ b/onnx/reference/ops/op_tile.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_topk.py
+++ b/onnx/reference/ops/op_topk.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=R0913,W0221,W0622
 

--- a/onnx/reference/ops/op_transpose.py
+++ b/onnx/reference/ops/op_transpose.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_trilu.py
+++ b/onnx/reference/ops/op_trilu.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_unique.py
+++ b/onnx/reference/ops/op_unique.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221,W0622
 

--- a/onnx/reference/ops/op_unsqueeze.py
+++ b/onnx/reference/ops/op_unsqueeze.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=E0203,W0221
 

--- a/onnx/reference/ops/op_upsample.py
+++ b/onnx/reference/ops/op_upsample.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221,R0913
 

--- a/onnx/reference/ops/op_where.py
+++ b/onnx/reference/ops/op_where.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/reference/ops/op_xor.py
+++ b/onnx/reference/ops/op_xor.py
@@ -1,3 +1,5 @@
+# Copyright (c) ONNX Project Contributors
+
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=W0221
 

--- a/onnx/version_converter/adapters/adapter.h
+++ b/onnx/version_converter/adapters/adapter.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/axes_attribute_to_input.h
+++ b/onnx/version_converter/adapters/axes_attribute_to_input.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/axes_input_to_attribute.h
+++ b/onnx/version_converter/adapters/axes_input_to_attribute.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/batch_normalization_13_14.h
+++ b/onnx/version_converter/adapters/batch_normalization_13_14.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/broadcast_backward_compatibility.h
+++ b/onnx/version_converter/adapters/broadcast_backward_compatibility.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/broadcast_forward_compatibility.h
+++ b/onnx/version_converter/adapters/broadcast_forward_compatibility.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/cast_9_8.h
+++ b/onnx/version_converter/adapters/cast_9_8.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/clip_10_11.h
+++ b/onnx/version_converter/adapters/clip_10_11.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/compatible.h
+++ b/onnx/version_converter/adapters/compatible.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/dropout_11_12.h
+++ b/onnx/version_converter/adapters/dropout_11_12.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/extend_supported_types.h
+++ b/onnx/version_converter/adapters/extend_supported_types.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/gemm_6_7.h
+++ b/onnx/version_converter/adapters/gemm_6_7.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/gemm_7_6.h
+++ b/onnx/version_converter/adapters/gemm_7_6.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/maxpool_8_7.h
+++ b/onnx/version_converter/adapters/maxpool_8_7.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/no_previous_version.h
+++ b/onnx/version_converter/adapters/no_previous_version.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/pad_10_11.h
+++ b/onnx/version_converter/adapters/pad_10_11.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/remove_consumed_inputs.h
+++ b/onnx/version_converter/adapters/remove_consumed_inputs.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/reshape_4_5.h
+++ b/onnx/version_converter/adapters/reshape_4_5.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/reshape_5_4.h
+++ b/onnx/version_converter/adapters/reshape_5_4.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/resize_10_11.h
+++ b/onnx/version_converter/adapters/resize_10_11.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/scan_8_9.h
+++ b/onnx/version_converter/adapters/scan_8_9.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/scan_9_8.h
+++ b/onnx/version_converter/adapters/scan_9_8.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/scatter_10_11.h
+++ b/onnx/version_converter/adapters/scatter_10_11.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/slice_9_10.h
+++ b/onnx/version_converter/adapters/slice_9_10.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/softmax_12_13.h
+++ b/onnx/version_converter/adapters/softmax_12_13.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/split_12_13.h
+++ b/onnx/version_converter/adapters/split_12_13.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/split_13_12.h
+++ b/onnx/version_converter/adapters/split_13_12.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/split_17_18.h
+++ b/onnx/version_converter/adapters/split_17_18.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/sum_8_7.h
+++ b/onnx/version_converter/adapters/sum_8_7.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/topk_9_10.h
+++ b/onnx/version_converter/adapters/topk_9_10.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/transformers.h
+++ b/onnx/version_converter/adapters/transformers.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/type_restriction.h
+++ b/onnx/version_converter/adapters/type_restriction.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/upsample_6_7.h
+++ b/onnx/version_converter/adapters/upsample_6_7.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/upsample_8_9.h
+++ b/onnx/version_converter/adapters/upsample_8_9.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/upsample_9_10.h
+++ b/onnx/version_converter/adapters/upsample_9_10.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/onnx/version_converter/adapters/upsample_9_8.h
+++ b/onnx/version_converter/adapters/upsample_9_8.h
@@ -1,3 +1,5 @@
+// Copyright (c) ONNX Project Contributors
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  */


### PR DESCRIPTION
### Description

add missing copyright to various files

used command:
reuse annotate --no-replace --copyright="Copyright (c) ONNX Project Contributors" 

#### Motivation and Context
Purpose: Make onnx https://reuse.software/ compliant
