### PR TITLE
fix light model input in backend test

### DIFF
--- a/onnx/backend/test/runner/__init__.py
+++ b/onnx/backend/test/runner/__init__.py
@@ -398,13 +398,13 @@ class Runner:
                     if onx.graph.input[i].name in inits:
                         continue
                     name = os.path.join(test_data_set, f"input_{n_input}.pb")
-                    inputs.append(name)
                     n_input += 1
                     x = onx.graph.input[i]
                     value = self.generate_random_data(
                         x, seed=0, name=model_test.model_name
                     )
                     feeds[x.name] = value
+                    inputs.append(value)
                     with open(name, "wb") as f:
                         f.write(onnx.numpy_helper.from_array(value).SerializeToString())
 


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
In backend test for light models, the input list to backend should not data paths - change it to actual data arrays.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
PR that introduced this issue: https://github.com/onnx/onnx/pull/4861
This should fix the current scoreboard pipeline failure caused by incorrect input type.