### PR TITLE
use correct package name onnx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ TOP_DIR = os.path.realpath(os.path.dirname(__file__))
 SRC_DIR = os.path.join(TOP_DIR, "onnx")
 TP_DIR = os.path.join(TOP_DIR, "third_party")
 CMAKE_BUILD_DIR = os.path.join(TOP_DIR, ".setuptools-cmake-build")
-PACKAGE_NAME = "onnx-test-protobufv21"
+PACKAGE_NAME = "onnx"
 
 WINDOWS = os.name == "nt"
 


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
use correct package name onnx instead of onnx-test-protobufv21.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
