### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,8 @@
 * @onnx/sig-archinfra-approvers
 /community  @onnx/steering-committee
 /onnx/defs  @onnx/sig-operators-approvers
+/onnx/defs/parser.* @onnx/sig-archinfra-approvers
+/onnx/defs/printer.* @onnx/sig-archinfra-approvers
 /onnx/backend/test  @onnx/sig-operators-approvers
 /onnx/reference/ops @onnx/sig-operators-approvers
 /docs/AddNewOp.md @onnx/sig-operators-approvers


### PR DESCRIPTION
### Description
Update CODEOWNERS. The printer/parser utilities should not require operator SIG approval.