### PR TITLE
Also use `has_context_dependent_function` in sphinx document

### DIFF
--- a/docs/docsgen/source/onnx_sphinx.py
+++ b/docs/docsgen/source/onnx_sphinx.py
@@ -111,7 +111,7 @@ def _get_ops_template():  # type: ignore
         * **name**: `{{sch.name}} (GitHub) <{{build_doc_url(sch)}}{{sch.name}}>`_
         * **domain**: **{% if sch.domain == '' %}main{% else %}{{sch.domain}}{% endif %}**
         * **since_version**: **{{sch.since_version}}**
-        * **function**: {{sch.has_function}}
+        * **function**: {{sch.has_function or sch.has_context_dependent_function}}
         * **support_level**: {{sch.support_level}}
         * **shape inference**: {{sch.has_type_and_shape_inference_function}}
 


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
LayerNormalization has context dependent function but it's documented as non function in sphinx generated doc: https://onnx.ai/onnx/operators/onnx__LayerNormalization.html

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
