### PR TITLE
Do not set minimum required NumPy version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy >= 1.16.6 # TODO: update once TensorFlow 2.6 is end of life
+numpy
 protobuf >= 3.20.2
 typing-extensions >= 3.6.2.1


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Do not set minimum required NumPy version in requirements.txt to grant the most flexibility for NumPy versions. For release onnx package, higher and safer NumPy version are using now: https://github.com/onnx/onnx/blob/main/requirements-release.txt.

An alternative is just bumping minimum required NumPy version, but it's possible that in the future another user complains onnx cannot work with an old version of NumPy. Actually unlike Protobuf, onnx itself does not have "hard requirement" about NumPy version, it seems fine to me we can provide more flexibility for required NumPy version with ONNX and let users decide which NumPy version they want to use with onnx. From ONNX official package perspective, the wheel will still be built with a higher version of NumPy, which is safer and more reliable.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Previously ONNX set minimum required NumPy version as 1.16.6: https://github.com/onnx/onnx/pull/4059 to let onnx compatible with older versions of TensorFlow. For instance, old TensorFlow needs older NumPy version<1.20: https://github.com/tensorflow/models/issues/9200. Currently the minimum required NumPy version 1.16.6 has vulnerability issues: https://github.com/onnx/onnx/security/code-scanning/5005. Upgrade the version is recommended. Or, we can just remove minimum required NumPy version in requirements.txt.

cc @andife 