### PR TITLE
Remove `stderr` prints in `version_converter`

### DIFF
--- a/onnx/version_converter/convert.cc
+++ b/onnx/version_converter/convert.cc
@@ -73,13 +73,15 @@ void DefaultVersionConverter::convert_graph(
       debug(std::string("Finding schema for ") + std::string(cur_op->kind().toString()));
       const std::string op_name = cur_op->kind().toString();
       if (op_name == "ConstantFill") {
-        std::cerr
-            << "Warning: skipping schema search for experimental op 'ConstantFill' and keeping the op as is. "
-               "Please be advised the converted model may not be working properly if target runtime does not support this "
-               "experimental op."
-            << std::endl;
+        if (DEBUG)
+          std::cerr
+              << "Warning: skipping schema search for experimental op 'ConstantFill' and keeping the op as is. "
+                 "Please be advised the converted model may not be working properly if target runtime does not support this "
+                 "experimental op."
+              << std::endl;
       } else if (cur_op->domain() != "" && cur_op->domain() != "ai.onnx") {
-        std::cerr << "Warning: opset domain '" << cur_op->domain() << "' is not supported." << std::endl;
+        if (DEBUG)
+          std::cerr << "Warning: opset domain '" << cur_op->domain() << "' is not supported." << std::endl;
       } else if (op_name != "Undefined" && op_name != "Captured") {
         auto& op_domain_map = all_schemas.at(op_name);
         OpSetID curr_id(curr_version);

--- a/onnx/version_converter/convert.cc
+++ b/onnx/version_converter/convert.cc
@@ -73,15 +73,17 @@ void DefaultVersionConverter::convert_graph(
       debug(std::string("Finding schema for ") + std::string(cur_op->kind().toString()));
       const std::string op_name = cur_op->kind().toString();
       if (op_name == "ConstantFill") {
-        if (DEBUG)
+        if (DEBUG) {
           std::cerr
               << "Warning: skipping schema search for experimental op 'ConstantFill' and keeping the op as is. "
                  "Please be advised the converted model may not be working properly if target runtime does not support this "
                  "experimental op."
               << std::endl;
+        }
       } else if (cur_op->domain() != "" && cur_op->domain() != "ai.onnx") {
-        if (DEBUG)
+        if (DEBUG) {
           std::cerr << "Warning: opset domain '" << cur_op->domain() << "' is not supported." << std::endl;
+        }
       } else if (op_name != "Undefined" && op_name != "Captured") {
         auto& op_domain_map = all_schemas.at(op_name);
         OpSetID curr_id(curr_version);
@@ -91,8 +93,9 @@ void DefaultVersionConverter::convert_graph(
           auto& op_adapter = adapter_lookup(cur_op, curr_id, next_id);
           // If adapter_lookup returns null, no adapter is present.
           // Error thrown by adapter_lookup
-          if (DEBUG)
+          if (DEBUG) {
             std::cerr << "Applying adapter" << std::endl;
+          }
           // adapt should handle replacing node in graph
           cur_op = op_adapter.adapt(g, cur_op);
           it = graph_node_list_iterator(cur_op, kNextDirection);


### PR DESCRIPTION
### Description

Removes `std::cerr` prints directly into STDERR whenever `version_converter` encounters ops outside `ai.onnx`. 
For now, the prints are kept behind an `if (DEBUG)` similar to some other ones in the same function. This is to make this change as smooth as possible. They can be removed entirely in the future, as the function could be refactored anyway (what are "ConstantFill", "Undefined", "Captured" ops? I've never seen them)

### Motivation and Context

Though `version_converter` might usually be used in an interactive context, Spox uses it often programmatically. The current prints pollute the standard output log and the are confusing as they are not properly labelled with traceback. 

I would appreciate merging this before the code freeze a lot! 