### PR TITLE
Bump CMAKE_CXX_STANDARD version as 14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,9 +56,9 @@ else()
 endif()
 
 # Required to use /std:c++17 or higher on Windows
-# For other platforms, set C++11 as standard for the whole project
+# For other platforms, set C++14 as standard for the whole project
 if(NOT MSVC)
-  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD 14)
 else()
   string(APPEND CMAKE_CXX_FLAGS " /std:c++17")
 endif()

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ conda install -c conda-forge onnx
 
 Before building from source uninstall any existing versions of onnx `pip uninstall onnx`.
 
-c++17 or higher C++ compiler version is required to build ONNX from source on Windows. For other platforms, please use C++11 or higher versions.
+c++17 or higher C++ compiler version is required to build ONNX from source on Windows. For other platforms, please use C++14 or higher versions.
 
 Generally speaking, you need to install [protobuf C/C++ libraries and tools](https://github.com/protocolbuffers/protobuf) before proceeding forward. Then depending on how you installed protobuf, you need to set environment variable CMAKE_ARGS to "-DONNX_USE_PROTOBUF_SHARED_LIBS=ON" or "-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF".  For example, you may need to run the following command:
 


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Bump CMAKE_CXX_STANDARD version as 14.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Close https://github.com/onnx/onnx/issues/4992. New Protobuf will only supports C++14 and newer. 11 is quite old and thus it seems fair for ONNX updates its required C++ version for better comparability with other packages.