### PR TITLE
Fix some build errors with the latest protobuf version

### DIFF
--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -10,6 +10,7 @@
 #include <initializer_list>
 #include <iostream>
 #include <limits>
+#include <map>
 #include <memory>
 #include <ostream>
 #include <set>


### PR DESCRIPTION
### Description

onnx/defs/schema.h forgot to include <map> header file, but the file uses std::map


### Motivation and Context
Make it be compatible with the latest protobuf code.
