### PR TITLE
Deprecate function with suffix _with_bfloat

### DIFF
--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -606,7 +606,7 @@ class OpSchema final {
     return numeric_types_for_math_reduction_ir4;
   }
 
-  // Deprecated function, use numeric_types_for_math_reduction_ir4 instread. It will be removed in onnx==1.15.0.
+  // Deprecated function, use numeric_types_for_math_reduction_ir4 instead. It will be removed in onnx==1.15.0.
   static const std::vector<std::string>& numeric_types_for_math_reduction_with_bfloat() {
     return numeric_types_for_math_reduction_ir4();
   }

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -661,7 +661,7 @@ class OpSchema final {
     return all_numeric_types_ir4;
   }
 
-  // Deprecated function, use all_numeric_types_ir4 instread. It will be removed in onnx==1.15.0.
+  // Deprecated function, use all_numeric_types_ir4 instead. It will be removed in onnx==1.15.0.
   static const std::vector<std::string>& all_numeric_types_with_bfloat() {
     return all_numeric_types_ir4();
   }

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -795,7 +795,7 @@ class OpSchema final {
     return all_tensor_sequence_types_ir4;
   }
 
-  // Deprecated function, use all_tensor_sequence_types_ir4 instread. It will be removed in onnx==1.15.0.
+  // Deprecated function, use all_tensor_sequence_types_ir4 instead. It will be removed in onnx==1.15.0.
   static const std::vector<std::string>& all_tensor_sequence_types_with_bfloat() {
     return all_tensor_sequence_types_ir4();
   }

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -739,7 +739,7 @@ class OpSchema final {
     return all_tensor_types_ir4;
   }
 
-  // Deprecated function, use all_tensor_types_ir4 instread. It will be removed in onnx==1.15.0.
+  // Deprecated function, use all_tensor_types_ir4 instead. It will be removed in onnx==1.15.0.
   static const std::vector<std::string>& all_tensor_types_with_bfloat() {
     return all_tensor_types_ir4();
   }

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -606,6 +606,11 @@ class OpSchema final {
     return numeric_types_for_math_reduction_ir4;
   }
 
+  // Deprecated function, use numeric_types_for_math_reduction_ir4 instread. It will be removed in onnx==1.15.0.
+  static const std::vector<std::string>& numeric_types_for_math_reduction_with_bfloat() {
+    return numeric_types_for_math_reduction_ir4();
+  }
+
   static const std::vector<std::string>& numeric_types_for_math_reduction() {
     static const std::vector<std::string> numeric_types_for_math_reduction = {
         "tensor(uint32)",
@@ -654,6 +659,11 @@ class OpSchema final {
         "tensor(double)",
         "tensor(bfloat16)"};
     return all_numeric_types_ir4;
+  }
+
+  // Deprecated function, use all_numeric_types_ir4 instread. It will be removed in onnx==1.15.0.
+  static const std::vector<std::string>& all_numeric_types_with_bfloat() {
+    return all_numeric_types_ir4();
   }
 
   static const std::vector<std::string>& all_numeric_types() {
@@ -729,6 +739,11 @@ class OpSchema final {
     return all_tensor_types_ir4;
   }
 
+  // Deprecated function, use all_tensor_types_ir4 instread. It will be removed in onnx==1.15.0.
+  static const std::vector<std::string>& all_tensor_types_with_bfloat() {
+    return all_tensor_types_ir4();
+  }
+
   static const std::vector<std::string>& all_tensor_types_ir9() {
     static const std::vector<std::string> all_tensor_types_ir9 = {
         "tensor(uint8)",        "tensor(uint16)",         "tensor(uint32)",     "tensor(uint64)",
@@ -780,6 +795,11 @@ class OpSchema final {
     return all_tensor_sequence_types_ir4;
   }
 
+  // Deprecated function, use all_tensor_sequence_types_ir4 instread. It will be removed in onnx==1.15.0.
+  static const std::vector<std::string>& all_tensor_sequence_types_with_bfloat() {
+    return all_tensor_sequence_types_ir4();
+  }
+
   static const std::vector<std::string>& all_tensor_sequence_types_ir9() {
     static const std::vector<std::string> all_tensor_sequence_types_ir4 = {
         "seq(tensor(uint8))",      "seq(tensor(uint16))",        "seq(tensor(uint32))",
@@ -823,6 +843,10 @@ class OpSchema final {
     return all_optional_types;
   }
 
+  // Deprecated function, use all_optional_types_ir4 instread. It will be removed in onnx==1.15.0.
+  static const std::vector<std::string>& all_optional_types_with_bfloat() {
+    return all_optional_types_ir4();
+  }
   static const std::vector<std::string>& all_optional_types_ir9() {
     static const std::vector<std::string> all_optional_types = {
         "optional(seq(tensor(uint8)))",      "optional(seq(tensor(uint16)))", "optional(seq(tensor(uint32)))",

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -843,7 +843,7 @@ class OpSchema final {
     return all_optional_types;
   }
 
-  // Deprecated function, use all_optional_types_ir4 instread. It will be removed in onnx==1.15.0.
+  // Deprecated function, use all_optional_types_ir4 instead. It will be removed in onnx==1.15.0.
   static const std::vector<std::string>& all_optional_types_with_bfloat() {
     return all_optional_types_ir4();
   }


### PR DESCRIPTION
### Description
Restore functions removed in PR #5123 as deprecated. That avoids breaking packages taking a dependency on the C++ API.
