### PR TITLE
Update .lintrunner.toml to include a merge base

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -32,6 +32,7 @@
 # To read more about lintrunner, see [wiki](https://github.com/pytorch/pytorch/wiki/lintrunner).
 # To update an existing linting rule or create a new one, modify this file or create a
 # new adapter following examples in https://github.com/justinchuby/lintrunner-adapters.
+merge_base_with = 'main'
 
 [[linter]]
 code = 'RUFF'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,6 @@ jupyter
 setuptools
 twine
 # Dependencies for linting. Versions match those in setup.py.
-lintrunner
+lintrunner>=0.10.7
 lintrunner-adapters>=0.7
 # Edit additional linter dependencies in requirements-lintrunner.txt


### PR DESCRIPTION
### Motivation and Context

So running `lintrunner` now means `lintrunner -m main`, which is easier.

https://github.com/suo/lintrunner/commit/75ea9c09cd6904e6e53170af0661fd3dcb39c9e9#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fc

cc @jcwchen 