### PR TITLE
Fix clang-tidy CI: use v0.12.3 to enable comment from forks

### DIFF
--- a/.github/workflows/clang_tidy_review.yml
+++ b/.github/workflows/clang_tidy_review.yml
@@ -22,11 +22,11 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       # Pleaes note that it won't cause any failure here; it will only post comments in PRs
       - name: clang-tidy review
-        uses: ZedThree/clang-tidy-review@4f11cae8aa5a0866738de40c1f6443b1a01d5642 # v0.12.2
+        uses: ZedThree/clang-tidy-review@fix-split-post-metadata
         with:
           apt_packages: "libprotobuf-dev,protobuf-compiler"
           cmake_command: "cmake -S . -B .setuptools-cmake-build -DCMAKE_EXPORT_COMPILE_COMMANDS=on -DONNX_USE_PROTOBUF_SHARED_LIBS=ON"
           build_dir: ".setuptools-cmake-build"
           exclude: "/third_party/*"
           split_workflow: true
-      - uses: ZedThree/clang-tidy-review/upload@4f11cae8aa5a0866738de40c1f6443b1a01d5642 # v0.12.2
+      - uses: ZedThree/clang-tidy-review/upload@fix-split-post-metadata

--- a/.github/workflows/clang_tidy_review.yml
+++ b/.github/workflows/clang_tidy_review.yml
@@ -22,11 +22,11 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       # Pleaes note that it won't cause any failure here; it will only post comments in PRs
       - name: clang-tidy review
-        uses: ZedThree/clang-tidy-review@fix-split-post-metadata
+        uses: ZedThree/clang-tidy-review@9b71ee90fecd94a7869a7812dadc3ef128c12e23 # v0.12.3
         with:
           apt_packages: "libprotobuf-dev,protobuf-compiler"
           cmake_command: "cmake -S . -B .setuptools-cmake-build -DCMAKE_EXPORT_COMPILE_COMMANDS=on -DONNX_USE_PROTOBUF_SHARED_LIBS=ON"
           build_dir: ".setuptools-cmake-build"
           exclude: "/third_party/*"
           split_workflow: true
-      - uses: ZedThree/clang-tidy-review/upload@fix-split-post-metadata
+      - uses: ZedThree/clang-tidy-review/upload@9b71ee90fecd94a7869a7812dadc3ef128c12e23 # v0.12.3

--- a/.github/workflows/clang_tidy_review_post.yml
+++ b/.github/workflows/clang_tidy_review_post.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: ZedThree/clang-tidy-review/post@4f11cae8aa5a0866738de40c1f6443b1a01d5642 # v0.12.2
+      - uses: ZedThree/clang-tidy-review/post@fix-split-post-metadata
         with:
           lgtm_comment_body: ""
           # Use annotations instead of comments

--- a/.github/workflows/clang_tidy_review_post.yml
+++ b/.github/workflows/clang_tidy_review_post.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: ZedThree/clang-tidy-review/post@fix-split-post-metadata
+      - uses: ZedThree/clang-tidy-review/post@9b71ee90fecd94a7869a7812dadc3ef128c12e23 # v0.12.3
         with:
           lgtm_comment_body: ""
           # Use annotations instead of comments


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Fix clang-tidy CI: use v0.12.3 to enable comment from forks

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Apply fix from https://github.com/ZedThree/clang-tidy-review/issues/82.