### PR TITLE
Display math in docs

### DIFF
--- a/docs/docsgen/source/conf.py
+++ b/docs/docsgen/source/conf.py
@@ -48,8 +48,8 @@ extensions = [
     "sphinx.ext.githubpages",
     "sphinx.ext.graphviz",
     "sphinx.ext.ifconfig",
-    "sphinx.ext.imgmath",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
 ]


### PR DESCRIPTION
### Description

Display math in docs with mathjax

| Before | After |
| - | - |
| <img width="778" alt="image" src="https://user-images.githubusercontent.com/11205048/232920682-a13811a4-28f8-4985-86c8-b57be6d134ad.png"> | <img width="788" alt="image" src="https://user-images.githubusercontent.com/11205048/232920636-dc7fcc96-9657-4606-b416-23f89c77082d.png"> |

cc @jcwchen @xadupre 