### PR TITLE
Extend python API documentation

### DIFF
--- a/docs/docsgen/source/api/hub.rst
+++ b/docs/docsgen/source/api/hub.rst
@@ -9,17 +9,27 @@ ModelInfo
 .. autoclass:: onnx.hub.ModelInfo
     :members:
 
-list_models
-+++++++++++
+download_model_with_test_data
++++++++++++++++++++++++++++++
 
-.. autofunction:: onnx.hub.list_models
+.. autofunction:: onnx.hub.download_model_with_test_data
 
 get_model_info
 ++++++++++++++
 
 .. autofunction:: onnx.hub.get_model_info
 
+list_models
++++++++++++
+
+.. autofunction:: onnx.hub.list_models
+
 load
 ++++
 
 .. autofunction:: onnx.hub.load
+
+load_composite
+++++++++++++++
+
+.. autofunction:: onnx.hub.load_composite_model

--- a/docs/docsgen/source/api/hub.rst
+++ b/docs/docsgen/source/api/hub.rst
@@ -29,7 +29,7 @@ load
 
 .. autofunction:: onnx.hub.load
 
-load_composite
-++++++++++++++
+load_composite_model
+++++++++++++++++++++
 
 .. autofunction:: onnx.hub.load_composite_model


### PR DESCRIPTION
### Description
Document missing hub functions in Python documentation
