### PR TITLE
Fix permission and bump version as v0.13.0 for clang-tidy-review

### DIFF
--- a/.github/workflows/clang_tidy_review.yml
+++ b/.github/workflows/clang_tidy_review.yml
@@ -22,11 +22,11 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       # Pleaes note that it won't cause any failure here; it will only post comments in PRs
       - name: clang-tidy review
-        uses: ZedThree/clang-tidy-review@9b71ee90fecd94a7869a7812dadc3ef128c12e23 # v0.12.3
+        uses: ZedThree/clang-tidy-review@2c55ef8cfc9acb3715d433e58aea086dcec9b206 # v0.13.0
         with:
           apt_packages: "libprotobuf-dev,protobuf-compiler"
           cmake_command: "cmake -S . -B .setuptools-cmake-build -DCMAKE_EXPORT_COMPILE_COMMANDS=on -DONNX_USE_PROTOBUF_SHARED_LIBS=ON"
           build_dir: ".setuptools-cmake-build"
           exclude: "/third_party/*"
           split_workflow: true
-      - uses: ZedThree/clang-tidy-review/upload@9b71ee90fecd94a7869a7812dadc3ef128c12e23 # v0.12.3
+      - uses: ZedThree/clang-tidy-review/upload@2c55ef8cfc9acb3715d433e58aea086dcec9b206 # v0.13.0

--- a/.github/workflows/clang_tidy_review_post.yml
+++ b/.github/workflows/clang_tidy_review_post.yml
@@ -8,9 +8,6 @@ on:
     types:
       - completed
 
-permissions:  # set top-level default permissions as security best practice
-  contents: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -19,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: ZedThree/clang-tidy-review/post@9b71ee90fecd94a7869a7812dadc3ef128c12e23 # v0.12.3
+      - uses: ZedThree/clang-tidy-review/post@2c55ef8cfc9acb3715d433e58aea086dcec9b206 # v0.13.0
         with:
           lgtm_comment_body: ""
           # Use annotations instead of comments

--- a/.github/workflows/clang_tidy_review_post.yml
+++ b/.github/workflows/clang_tidy_review_post.yml
@@ -8,6 +8,9 @@ on:
     types:
       - completed
 
+permissions:
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
- Fix permission to enable write access for PRs
- Bump versionas  v0.13.0 for clang-tidy-review

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Try to fix https://github.com/onnx/onnx/issues/5093.