### PR TITLE
Enable RUFF as a formatter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -73,9 +73,10 @@ jobs:
       - name: Run lintrunner on all files
         run: |
           set +e
-          if ! lintrunner --force-color --all-files --tee-json=lint.json; then
+          if ! lintrunner --force-color --all-files --tee-json=lint.json -v; then
               echo ""
-              echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner -m main\`.\e[0m"
+              echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner\`.\e[0m"
+              echo -e "\e[1m\e[36mSee https://github.com/onnx/onnx/blob/main/docs/CONTRIBUTING.md#code-style for setup instructions.\e[0m"
               exit 1
           fi
       - name: Produce SARIF

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -63,36 +63,6 @@ init_command = [
     '--dry-run={{DRYRUN}}',
     '--requirement=requirements-lintrunner.txt',
 ]
-
-[[linter]]
-code = 'RUFF-FIX'
-include_patterns = [
-    '**/*.py',
-    '**/*.pyi',
-]
-exclude_patterns = [
-    '*_pb2*',
-    '.setuptools-cmake-build/*',
-    'docs/**',
-]
-command = [
-    'python',
-    '-m',
-    'lintrunner_adapters',
-    'run',
-    'ruff_fix_linter',
-    '--config=pyproject.toml',
-    '@{{PATHSFILE}}'
-]
-init_command = [
-    'python',
-    '-m',
-    'lintrunner_adapters',
-    'run',
-    'pip_init',
-    '--dry-run={{DRYRUN}}',
-    '--requirement=requirements-lintrunner.txt',
-]
 is_formatter = true
 
 [[linter]]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,5 +11,5 @@ setuptools
 twine
 # Dependencies for linting. Versions match those in setup.py.
 lintrunner>=0.10.7
-lintrunner-adapters>=0.7
+lintrunner-adapters>=0.8
 # Edit additional linter dependencies in requirements-lintrunner.txt

--- a/requirements-lintrunner.txt
+++ b/requirements-lintrunner.txt
@@ -1,4 +1,5 @@
 # This file is auto updated by dependabot
+lintrunner-adapters>=0.8.0
 # RUFF, RUFF-FIX
 ruff==0.0.261
 # MYPY


### PR DESCRIPTION
RUFF can now format since lintrunner-adapters v0.8. Removed the RUFF-FIX linter