### PR TITLE
Add security-events permission to the lint action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,6 +45,8 @@ jobs:
   enforce-style:
     name: Enforce style
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Setup Python


### PR DESCRIPTION
### Motivation and Context

So that it is able to post sarif code scan results.

cc @jcwchen 