### PR TITLE
move set up python steps after docker run because it is for steps after docker run

### DIFF
--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -31,6 +31,12 @@ jobs:
         git submodule sync --recursive
         git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
 
+    - name: Build manylinux2014_x86_64
+      uses: docker://quay.io/pypa/manylinux2014_x86_64:latest@sha256:085b7c2c1bcb45b936e5478fe24a5142b0519e242a0104142fd50d569d6cb922
+      with:
+        entrypoint: bash
+        args: .github/workflows/manylinux/entrypoint.sh ${{ matrix.python-version }} manylinux2014_x86_64 ${{ github.event_name }}
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b 
       with:
@@ -41,12 +47,6 @@ jobs:
       run: |
         python -m pip install -q --upgrade pip
         python -m pip install -q -r requirements-release.txt
-
-    - name: Build manylinux2014_x86_64
-      uses: docker://quay.io/pypa/manylinux2014_x86_64:latest@sha256:085b7c2c1bcb45b936e5478fe24a5142b0519e242a0104142fd50d569d6cb922
-      with:
-        entrypoint: bash
-        args: .github/workflows/manylinux/entrypoint.sh ${{ matrix.python-version }} manylinux2014_x86_64 ${{ github.event_name }}
 
     - name: Install protobuf in the GitHub Action environment for testing the wheel
       run: |


### PR DESCRIPTION
### Description
to make release manylinux x86_64 a bit clearer by moving docker run step before host python set up. https://github.com/onnx/onnx/actions/runs/4854762349/jobs/8652515453

### Motivation and Context
code refactor to improve readibility