### PR TITLE
Modify OneHot operator explanation

### DIFF
--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -2623,9 +2623,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Input(
             1,
             "depth",
-            "Scalar specifying the number of classes in one-hot tensor. This is also the size "
-            "of the one-hot dimension (specified by 'axis' attribute) added on in the output "
-            "tensor. The values in the 'indices' input tensor are expected to be "
+            "Scalar or Rank 1 tensor containing exactly one element, specifying the number of classes " 
+            "in one-hot tensor. This is also the size of the one-hot dimension (specified by 'axis' attribute) "
+            "added on in the output tensor. The values in the 'indices' input tensor are expected to be "
             "in the range [-depth, depth-1]. "
             "In case 'depth' is of non-integer type, it will be casted to int64 before use.",
             "T2",

--- a/onnx/defs/tensor/old.cc
+++ b/onnx/defs/tensor/old.cc
@@ -4156,9 +4156,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Input(
             1,
             "depth",
-            "Scalar specifying the number of classes in one-hot tensor. This is also the size "
-            "of the one-hot dimension (specified by 'axis' attribute) added on in the output "
-            "tensor. The values in the 'indices' input tensor are expected to be "
+            "Scalar or rank 1 tensor containing exactly one element, specifying the number of classes "
+            "in one-hot tensor. This is also the size of the one-hot dimension (specified by 'axis' attribute) "
+            "added on in the output tensor. The values in the 'indices' input tensor are expected to be "
             "in the range [0, depth). "
             "In case 'depth' is of non-integer type, it will be casted to int64 before use.",
             "T2")


### PR DESCRIPTION

### Description
<!-- - Describe your changes. -->
referring to https://github.com/onnx/onnx/blob/main/onnx/defs/tensor/defs.cc#L2676-L2683

Onehot operator should support scalar and tensor with rank 1 both for depth input. 
### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
