### PR TITLE
Fix ModuleNotFoundError: No module named 'cmake'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -219,17 +219,15 @@ class CmakeBuild(setuptools.Command):
                 raise RuntimeError(
                     "-DONNX_DISABLE_EXCEPTIONS=ON option is only available for c++ builds. Python binding require exceptions to be enabled."
                 )
-            if "PYTHONPATH" in os.environ and sys.platform != "win32":
-                # To solve problem that the extra PYTHONPATH env variable added by pip.
-                segs = os.environ["PYTHONPATH"].split(":")
-                new_paths = []
-                for path in segs:
-                    if path not in sys.path:
-                        new_paths.append(path)
-                if len(new_paths) == 0:
-                    del os.environ["PYTHONPATH"]
-                else:
-                    os.environ["PYTHONPATH"] = ":".join(new_paths)
+            if "PYTHONPATH" in os.environ and "pip-build-env" in os.environ["PYTHONPATH"]:
+                # When the users use `pip install -e .` to install onnx and
+                # the cmake executable is a python entry script, there will be
+                # `Fix ModuleNotFoundError: No module named 'cmake'` from the cmake script.
+                # This is caused by the additional PYTHONPATH environment variable added by pip,
+                # which makes cmake python entry script not able to find correct python cmake packages.
+                # Actually, sys.path is well enough for `pip install -e .`.
+                # Therefore, we delete the PYTHONPATH variable.
+                del os.environ["PYTHONPATH"]
             subprocess.check_call(cmake_args)
 
             build_args = [CMAKE, "--build", os.curdir]

--- a/setup.py
+++ b/setup.py
@@ -219,6 +219,17 @@ class CmakeBuild(setuptools.Command):
                 raise RuntimeError(
                     "-DONNX_DISABLE_EXCEPTIONS=ON option is only available for c++ builds. Python binding require exceptions to be enabled."
                 )
+            if "PYTHONPATH" in os.environ:
+                # To solve problem that the extra PYTHONPATH env variable added by pip.
+                segs = os.environ["PYTHONPATH"].split(":")
+                new_paths = []
+                for path in segs:
+                    if path not in sys.path:
+                        new_paths.append(path)
+                if len(new_paths) == 0:
+                    del os.environ["PYTHONPATH"]
+                else:
+                    os.environ["PYTHONPATH"] = ":".join(new_paths)
             subprocess.check_call(cmake_args)
 
             build_args = [CMAKE, "--build", os.curdir]

--- a/setup.py
+++ b/setup.py
@@ -219,7 +219,7 @@ class CmakeBuild(setuptools.Command):
                 raise RuntimeError(
                     "-DONNX_DISABLE_EXCEPTIONS=ON option is only available for c++ builds. Python binding require exceptions to be enabled."
                 )
-            if "PYTHONPATH" in os.environ:
+            if "PYTHONPATH" in os.environ and sys.platform != "win32":
                 # To solve problem that the extra PYTHONPATH env variable added by pip.
                 segs = os.environ["PYTHONPATH"].split(":")
                 new_paths = []

--- a/setup.py
+++ b/setup.py
@@ -219,7 +219,10 @@ class CmakeBuild(setuptools.Command):
                 raise RuntimeError(
                     "-DONNX_DISABLE_EXCEPTIONS=ON option is only available for c++ builds. Python binding require exceptions to be enabled."
                 )
-            if "PYTHONPATH" in os.environ and "pip-build-env" in os.environ["PYTHONPATH"]:
+            if (
+                "PYTHONPATH" in os.environ
+                and "pip-build-env" in os.environ["PYTHONPATH"]
+            ):
                 # When the users use `pip install -e .` to install onnx and
                 # the cmake executable is a python entry script, there will be
                 # `Fix ModuleNotFoundError: No module named 'cmake'` from the cmake script.


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Described by https://github.com/onnx/onnx/issues/5194

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Since `python setup.py build` works fine, I compared the `os.environ` and found that `pip install -e .` add a strange `PYTHONPATH` to `os.environ`. Deleting it make the installation working fine.
