### PR TITLE
Pin Python Protobuf version as 3.20.2 for documentation generation CI

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           python -m pip install --quiet --upgrade pip setuptools wheel
           python -m pip install -r docs/docsgen/source/requirements.txt
+          python -m pip install protobuf==3.20.2
       - name: Uninstall onnx
         run: python -m pip uninstall -y onnx
       - name: Install onnx development version


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
To fix CI failure for doc generation, pin Python Protobuf version as 3.20.2 for now.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Fix CI failure for doc generation. The root cause is Protobuf compatibility issue. (protoc from apt-get is not compatible with Python Protobuf>=4.21)
