### PR TITLE
Refactor shape_inference_test for old Op versions PR1

### DIFF
--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -652,7 +652,9 @@ class TestShapeInference(TestShapeInferenceHelper):
     def test_concat_missing_shape(self) -> None:
         self._test_an_op("Concat", self.get_caller_function_name())
 
-    def _internal_test_concat_missing_shape_v11(self, op_name, version) -> None:
+    def _internal_test_concat_missing_shape_v11(
+        self, op_name, version  # pylint: disable=unused-argument
+    ) -> None:
         assert op_name == "Concat"
         graph = self._make_graph(
             [
@@ -1521,7 +1523,9 @@ class TestShapeInference(TestShapeInferenceHelper):
     def test_squeeze(self) -> None:
         self._test_an_op("Squeeze", self.get_caller_function_name())
 
-    def _internal_test_squeeze_v11(self, op_name, version) -> None:
+    def _internal_test_squeeze_v11(
+        self, op_name, version  # pylint: disable=unused-argument
+    ) -> None:
         assert op_name == "Squeeze"
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (1, 3, 1, 1, 2, 1))],
@@ -1534,7 +1538,9 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 11)],
         )
 
-    def _internal_test_squeeze_v13(self, op_name, version) -> None:
+    def _internal_test_squeeze_v13(
+        self, op_name, version  # pylint: disable=unused-argument
+    ) -> None:
         assert op_name == "Squeeze"
         graph = self._make_graph(
             [

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -31,6 +31,7 @@ from onnx.defs import (
     AI_ONNX_PREVIEW_TRAINING_DOMAIN,
     ONNX_DOMAIN,
     ONNX_ML_DOMAIN,
+    OpSchema,
     SchemaError,
 )
 from onnx.helper import (
@@ -44,7 +45,7 @@ from onnx.helper import (
 from onnx.parser import parse_graph
 
 
-def get_available_versions(schema):
+def get_available_versions(schema: OpSchema) -> set[int]:
     versions: set[int] = set()
     for version in range(schema.since_version, 0, -1):
         try:

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -1523,9 +1523,7 @@ class TestShapeInference(TestShapeInferenceHelper):
     def test_squeeze(self) -> None:
         self._test_an_op("Squeeze", self.get_caller_function_name())
 
-    def _internal_test_squeeze_v11(
-        self, op_name, version  # pylint: disable=unused-argument
-    ) -> None:
+    def _internal_test_squeeze_v11(self, op_name, version) -> None:
         assert op_name == "Squeeze"
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (1, 3, 1, 1, 2, 1))],
@@ -1535,12 +1533,10 @@ class TestShapeInference(TestShapeInferenceHelper):
         self._assert_inferred(
             graph,
             [make_tensor_value_info("y", TensorProto.FLOAT, (3, 2))],
-            opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 11)],
+            opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    def _internal_test_squeeze_v13(
-        self, op_name, version  # pylint: disable=unused-argument
-    ) -> None:
+    def _internal_test_squeeze_v13(self, op_name, version) -> None:
         assert op_name == "Squeeze"
         graph = self._make_graph(
             [
@@ -1554,7 +1550,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         self._assert_inferred(
             graph,
             [make_tensor_value_info("y", TensorProto.FLOAT, (3, 2))],
-            opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 13)],
+            opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
     def test_unsqueeze_regular(self) -> None:

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -186,7 +186,7 @@ class TestShapeInferenceHelper(unittest.TestCase):
             return []
 
         ret = []
-        name_pattern = re.compile("^{}_([0-9]+)$".format(op_name))
+        name_pattern = re.compile(f"^{op_name}_([0-9]+)$")
         for name in op_names:
             m = name_pattern.search(name)
             if m is not None:
@@ -202,7 +202,7 @@ class TestShapeInferenceHelper(unittest.TestCase):
         if len(versions) == 0:
             # Only one version found for this op.
             function_name = f"_internal_{test_function_middel_name}"
-            test_func = self.__getattribute__(function_name)
+            test_func = getattr(self, function_name)
             assert test_func is not None, "Cannot find test function {function_name}"
             test_func()
         for version in versions:
@@ -211,7 +211,7 @@ class TestShapeInferenceHelper(unittest.TestCase):
                 # Not sure how to fix the Reshape error in self._make_graph.
                 continue
             function_name = f"_internal_{test_function_middel_name}_v{version}"
-            test_func = self.__getattribute__(function_name)
+            test_func = getattr(self, function_name)
             assert test_func is not None, "Cannot find test function {function_name}"
             test_func()
 

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import inspect
-import re
 import unittest
 from typing import Any, Sequence
 
@@ -195,27 +194,6 @@ class TestShapeInferenceHelper(unittest.TestCase):
             raise NotImplementedError(
                 "Unrecognized value info type in _compare_value_infos: ", str(vi_type)
             )
-
-    def _get_op_version(self, op_name):
-        """This function returns a version str list for an op.
-        If op has only one version, [] is returned.
-        If op has many version, [versions] is returned.
-        If op is not in the opset, None is returned.
-        """
-        op_names = dir(op_list)
-        if op_name in op_names:
-            return []
-
-        ret = []
-        name_pattern = re.compile(f"^{op_name}_([0-9]+)$")
-        for name in op_names:
-            m = name_pattern.search(name)
-            if m is not None:
-                ret.append(m.group(1))
-        if op_name in op_names or len(ret) > 0:
-            return ret
-        else:
-            return None
 
     def _test_an_op(self, op_name, test_function_name) -> None:
         """Given an operator name and test_function_name, run tests for op versions > 5.

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import re
 import unittest
 from typing import Any, Sequence
 
@@ -175,10 +176,14 @@ class TestShapeInferenceHelper(unittest.TestCase):
             )
 
     def _get_op_version(self, op_name):
+        """This function returns a version str list for an op.
+        If op has only one version, [] is returned.
+        If op has many version, [versions] is returned.
+        If op is not in the opset, None is returned.
+        """
         op_names = dir(op_list)
         if op_name in op_names:
             return []
-        import re
 
         ret = []
         name_pattern = re.compile("^{}_([0-9]+)$".format(op_name))
@@ -195,18 +200,19 @@ class TestShapeInferenceHelper(unittest.TestCase):
         versions = self._get_op_version(op_name)
         assert versions is not None
         if len(versions) == 0:
-            # Only one version found.
+            # Only one version found for this op.
             function_name = f"_internal_{test_function_middel_name}"
             test_func = self.__getattribute__(function_name)
-            assert test_func is not None, "Cannot find {function_name}"
+            assert test_func is not None, "Cannot find test function {function_name}"
             test_func()
         for version in versions:
+            # Many versions found for this op.
             if int(version) <= 5:
-                # Not sure how to refactor the Reshape in self._make_graph.
+                # Not sure how to fix the Reshape error in self._make_graph.
                 continue
             function_name = f"_internal_{test_function_middel_name}_v{version}"
             test_func = self.__getattribute__(function_name)
-            assert test_func is not None, "Cannot find {function_name}"
+            assert test_func is not None, "Cannot find test function {function_name}"
             test_func()
 
 


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
https://github.com/onnx/onnx/issues/4160

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Shape inference tests for older opset versions are not supported before this PR. This refactor would help to test old-versioned ops.
This PR introduces a function `all_versions_for` to help generate test functions for all versions of one Op. The users can use `@parameterized.expand(all_versions_for("${op_name}"))` to annotate the test function to apply the test function to all op versions. The test function should have the arguments like `def test_op(self, version_name, op_version)`. `version_name` is usually unused but it's better to keep that to make the parameterized test name more readable. For example, with this `version_name`, the test name will have a version suffix showed as follows.
![image](https://github.com/onnx/onnx/assets/19584326/70ab74ec-5108-4c24-80bf-c04802858582)