### PR TITLE
Correct the description of BatchNormalization's training_mode

### DIFF
--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -1556,7 +1556,7 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Attr(
             "training_mode",
             "If set to true, it indicates BatchNormalization is being used for training, and outputs 1, "
-            "2, 3, and 4 would be populated.",
+            "2, and 3 would be populated.",
             AttributeProto::INT,
             static_cast<int64_t>(0))
         .Input(

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -1555,8 +1555,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             0.9f)
         .Attr(
             "training_mode",
-            "If set to true, it indicates BatchNormalization is being used for training, and outputs 1, "
-            "2, and 3 would be populated.",
+            "If set to true, it indicates BatchNormalization is being used for training, and outputs 1 and "
+            "2 would be populated.",
             AttributeProto::INT,
             static_cast<int64_t>(0))
         .Input(


### PR DESCRIPTION
The description of training_mode in BatchNormalization doesn't match the number of outputs