### PR TITLE
Supports float 8 initializers in ReferenceEvaluator

### DIFF
--- a/onnx/reference/ops/op_quantize_linear.py
+++ b/onnx/reference/ops/op_quantize_linear.py
@@ -130,4 +130,6 @@ class QuantizeLinear_10(_CommonQuantizeLinear):
 class QuantizeLinear_19(_CommonQuantizeLinear):
     def _run(self, *args, axis=None, saturate=None):  # type: ignore
         # args: x, y_scale, zero_point
+        print("-----------")
+        print(args)
         return self.common_run(*args, axis=axis, saturate=saturate)  # type: ignore

--- a/onnx/reference/ops/op_quantize_linear.py
+++ b/onnx/reference/ops/op_quantize_linear.py
@@ -130,6 +130,4 @@ class QuantizeLinear_10(_CommonQuantizeLinear):
 class QuantizeLinear_19(_CommonQuantizeLinear):
     def _run(self, *args, axis=None, saturate=None):  # type: ignore
         # args: x, y_scale, zero_point
-        print("-----------")
-        print(args)
         return self.common_run(*args, axis=axis, saturate=saturate)  # type: ignore

--- a/onnx/reference/reference_evaluator.py
+++ b/onnx/reference/reference_evaluator.py
@@ -10,7 +10,7 @@ import numpy as np
 from onnx import load, numpy_helper
 from onnx.defs import onnx_opset_version
 from onnx.onnx_pb import FunctionProto, GraphProto, ModelProto, NodeProto, TypeProto
-from onnx.reference.op_run import OpRun, RuntimeContextError
+from onnx.reference.op_run import OpRun, RuntimeContextError, to_array_extended
 from onnx.reference.ops_optimized import optimized_operators
 
 
@@ -344,7 +344,7 @@ class ReferenceEvaluator:
         self.rt_inits_ = {}
         self.rt_nodes_ = []
         for init in self.inits_:
-            self.rt_inits_[init.name] = numpy_helper.to_array(init)  # type: ignore[union-attr,arg-type]
+            self.rt_inits_[init.name] = to_array_extended(init)  # type: ignore[union-attr,arg-type]
         run_params = {
             "log": lambda pattern, *args: self._log(10, pattern, *args),
             "opsets": self.opsets,

--- a/onnx/reference/reference_evaluator.py
+++ b/onnx/reference/reference_evaluator.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
-from onnx import load, numpy_helper
+from onnx import load
 from onnx.defs import onnx_opset_version
 from onnx.onnx_pb import FunctionProto, GraphProto, ModelProto, NodeProto, TypeProto
 from onnx.reference.op_run import OpRun, RuntimeContextError, to_array_extended


### PR DESCRIPTION
### Description
The ReferenceEvaluator was only tested with float 8 constants (in node Constant), not in initializers. This fixes that issues.

### Motivation and Context
Fixes a bug.
