### PR TITLE
Configure dependabot to update pip dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    # disable version updates for pip dependencies 
-    open-pull-requests-limit: 0    
-   
+
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
     # default location of `.github/workflows`


### PR DESCRIPTION
So that lintrunner and other dependencies are updated. We can simply ignore the PRs that will update requirements.txt.
