### PR TITLE
Dynamic reshape inference with inferred shape

### DIFF
--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -318,12 +318,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
           } else if (shapeInput) {
             targetShapeProto.CopyFrom(*shapeInput);
-          } else if (hasInputShape(ctx, 1) && getInputShape(ctx, 1).dim_size() > 0) {
-            // The shape parameter's rank can be used to inform the rank of the output shape.
-            int64_t output_rank = getInputShape(ctx, 1).dim(0).dim_value();
-            TensorShapeProto* outputShape = getOutputShape(ctx, 0);
-            for (size_t i = 0; i < output_rank; ++i) {
-              outputShape->add_dim();
+          } else if (hasInputShape(ctx, 1)) {
+            TensorShapeProto shape = getInputShape(ctx, 1);
+            if (shape.dim_size() > 0 && shape.dim(0).has_dim_value()) {
+              // The shape parameter's shape can be used to inform the rank of the output shape.
+              int64_t output_rank = getInputShape(ctx, 1).dim(0).dim_value();
+              TensorShapeProto* outputShape = getOutputShape(ctx, 0);
+              for (size_t i = 0; i < output_rank; ++i) {
+                outputShape->add_dim();
+              }
             }
             return;
           } else {

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -318,6 +318,14 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
           } else if (shapeInput) {
             targetShapeProto.CopyFrom(*shapeInput);
+          } else if (hasInputShape(ctx, 1) && getInputShape(ctx, 1).dim_size() > 0) {
+            // The shape parameter's rank can be used to inform the rank of the output shape.
+            int64_t output_rank = getInputShape(ctx, 1).dim(0).dim_value();
+            TensorShapeProto* outputShape = getOutputShape(ctx, 0);
+            for (size_t i = 0; i < output_rank; ++i) {
+              outputShape->add_dim();
+            }
+            return;
           } else {
             return;
           }

--- a/onnx/reference/reference_evaluator.py
+++ b/onnx/reference/reference_evaluator.py
@@ -7,10 +7,10 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 
-from onnx import load, numpy_helper
+from onnx import load
 from onnx.defs import onnx_opset_version
 from onnx.onnx_pb import FunctionProto, GraphProto, ModelProto, NodeProto, TypeProto
-from onnx.reference.op_run import OpRun, RuntimeContextError
+from onnx.reference.op_run import OpRun, RuntimeContextError, to_array_extended
 from onnx.reference.ops_optimized import optimized_operators
 
 
@@ -344,7 +344,7 @@ class ReferenceEvaluator:
         self.rt_inits_ = {}
         self.rt_nodes_ = []
         for init in self.inits_:
-            self.rt_inits_[init.name] = numpy_helper.to_array(init)  # type: ignore[union-attr,arg-type]
+            self.rt_inits_[init.name] = to_array_extended(init)  # type: ignore[union-attr,arg-type]
         run_params = {
             "log": lambda pattern, *args: self._log(10, pattern, *args),
             "opsets": self.opsets,

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -510,6 +510,16 @@ class TestShapeInference(TestShapeInferenceHelper):
             graph, [make_tensor_value_info("y", TensorProto.UINT8, (None, None))]
         )
 
+    def test_reshape_dynamic_shape_symbolic(self) -> None:
+        graph = self._make_graph(
+            [("x", TensorProto.UINT8, (2, 4, 3)), ("shape", TensorProto.INT64, ("M",))],
+            [make_node("Reshape", ["x", "shape"], ["y"])],
+            [],
+        )
+        self._assert_inferred(
+            graph, [make_tensor_value_info("y", TensorProto.UINT8, None)]
+        )
+
     def test_reshape_dynamic_unknown_rank(self) -> None:
         graph = self._make_graph(
             [("x", TensorProto.UINT8, (2, 4, 3)), ("shape", TensorProto.INT64, None)],


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
This PR should address https://github.com/onnx/onnx/issues/5324. In situations where the shape in a dynamic reshape operation itself has an inferred shape, this can be used to determine the rank of the output shape.

### Motivation and Context
Closes https://github.com/onnx/onnx/issues/5324
