### PR TITLE
Refactor shape inference test PR2: extend to Op versions <= 5

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -158,7 +158,7 @@ For an operator input/output's differentiability, it can be differentiable,
 |<a href="#Trilu">Trilu</a>|<a href="Changelog.md#Trilu-14">14</a>|
 |<a href="#Unique">Unique</a>|<a href="Changelog.md#Unique-11">11</a>|
 |<a href="#Unsqueeze">Unsqueeze</a>|<a href="Changelog.md#Unsqueeze-13">13</a>, <a href="Changelog.md#Unsqueeze-11">11</a>, <a href="Changelog.md#Unsqueeze-1">1</a>|
-|<a href="#Upsample">Upsample</a> (deprecated)|<a href="Changelog.md#Upsample-10">10</a>, <a href="Changelog.md#Upsample-9">9</a>, <a href="Changelog.md#Upsample-7">7</a>|
+|<a href="#Upsample">Upsample</a> (deprecated)|<a href="Changelog.md#Upsample-10">10</a>, <a href="Changelog.md#Upsample-9">9</a>, <a href="Changelog.md#Upsample-7">7</a>, <a href="Changelog.md#Upsample-1">1</a>|
 |<a href="#Where">Where</a>|<a href="Changelog.md#Where-16">16</a>, <a href="Changelog.md#Where-9">9</a>|
 |<a href="#Xor">Xor</a>|<a href="Changelog.md#Xor-7">7</a>, <a href="Changelog.md#Xor-1">1</a>|
 |**Function**|**Since version**|**Function version**|
@@ -32349,7 +32349,7 @@ expect(node, inputs=[x, axes], outputs=[y], name="test_unsqueeze_unsorted_axes")
 
 This version of the operator has been deprecated since version 10 of the default ONNX operator set.
 
-Other versions of this operator: <a href="Changelog.md#Upsample-7">7</a>, <a href="Changelog.md#Upsample-9">9</a>
+Other versions of this operator: <a href="Changelog.md#Upsample-1">1</a>, <a href="Changelog.md#Upsample-7">7</a>, <a href="Changelog.md#Upsample-9">9</a>, <a href="Changelog.md#Upsample-10">10</a>
 
 
 #### Examples

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -446,7 +446,7 @@ class TestShapeInference(TestShapeInferenceHelper):
             graph,
             [make_tensor_value_info("y", TensorProto.UINT8, (2, 4, 3))],
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
-            # Concat Version 1 does not have shape inference function.
+            # Cast Version 1 does not have shape inference function.
             has_inference_function=has_inference_function("Cast", version),
         )
 
@@ -615,6 +615,7 @@ class TestShapeInference(TestShapeInferenceHelper):
             graph,
             [make_tensor_value_info("z", TensorProto.FLOAT, (9, 4, 3))],
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
+            # Concat Version 1 does not have shape inference function.
             has_inference_function=has_inference_function("Concat", version),
         )
 
@@ -718,6 +719,7 @@ class TestShapeInference(TestShapeInferenceHelper):
             graph,
             [make_tensor_value_info("y", TensorProto.UINT8, None)],
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
+            # Reshape Version 1 does not have shape inference function.
             has_inference_function=has_inference_function("Reshape", version),
         )
 
@@ -881,6 +883,7 @@ class TestShapeInference(TestShapeInferenceHelper):
                 graph,
                 [make_tensor_value_info("y", TensorProto.INT32, (2, 4, 3, 9))],
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
+                # Upsample Version 1 does not have shape inference function.
                 has_inference_function=has_inference_function("Upsample", version),
             )
         else:


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Previous refactor PR https://github.com/onnx/onnx/pull/5263 only extend the test for Op Version > 5, because there are attribute change for Op "Reshape" which is used in `TestShapeInferenceHelper._make_graph` function. 
This PR does the following change:
1. Give a argument `reshape_version` to function `TestShapeInferenceHelper._make_graph`. Then, this function can use it to call different version of `make_node` for `Reshape` Op.
2. Give a keyword argument to function `TestShapeInferenceHelper._assert_inferred`, for some Ops' Version 1 implementation, it's SchemaOp's `has_type_and_shape_inference_function` is False.
3. Apply the new Scheme to more Ops.

After this PR, the tests with annotation `@parameterized.expand(all_versions_for("${OpName}"))` covers all Op Versions.
![image](https://github.com/onnx/onnx/assets/19584326/5007d24b-6e3b-4695-8188-7aa072529ea2)


### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Fix: https://github.com/onnx/onnx/issues/5289
Related Issue: https://github.com/onnx/onnx/issues/4160