### PR TITLE
Allow to override cmake options from cmd options, external projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,12 +55,15 @@ else()
   set(Protobuf_USE_STATIC_LIBS ON)
 endif()
 
-# Required to use /std:c++17 or higher on Windows
+# Required to use C++17 or higher on Windows
 # For other platforms, set C++14 as standard for the whole project
-if(NOT MSVC)
+if(NOT DEFINED CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
-else()
-  string(APPEND CMAKE_CXX_FLAGS " /std:c++17")
+endif()
+if(MSVC AND CMAKE_CXX_STANDARD LESS 17)
+  set(CMAKE_CXX_STANDARD 17)
+elseif(CMAKE_CXX_STANDARD LESS 14)
+  set(CMAKE_CXX_STANDARD 14)
 endif()
 
 include(GNUInstallDirs)
@@ -116,7 +119,9 @@ if(CMAKE_SYSTEM_NAME STREQUAL "AIX")
 endif()
 
 # Build the libraries with -fPIC including the protobuf lib.
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+if(NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif()
 
 if(ONNX_BUILD_TESTS)
   list(APPEND CMAKE_MODULE_PATH ${ONNX_ROOT}/cmake/external)


### PR DESCRIPTION
### Description
- Allow to override CMAKE_CXX_STANDARD and CMAKE_POSITION_INDEPENDENT_CODE

### Motivation and Context
- CMAKE_POSITION_INDEPENDENT_CODE is not required for cases when static library is compiled into executable. So, we need to a way to disable `CMAKE_POSITION_INDEPENDENT_CODE=ON`
- Protobuf depends on ABSL library, which requires CXX17. So, when we compile against latest versions of protobuf and ABSL, we need to set CXX17, but ONNX overrides these values to CXX14. So, we need an option to override the project default values.
