### PR TITLE
Add missing header in shape_inference.h

### DIFF
--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <functional>
 #include "onnx/defs/data_type_utils.h"
 #include "onnx/proto_utils.h"


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Add missing header: <algorithm> in shape_inference.h.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/onnx/onnx/issues/5346. If using shape_inference.h independently, it cannot use std::transform because `<algorithm>` is not included.