### PR TITLE
Test onnxruntime 1.15 with opset 19/IR 9 and fix test source distribution

### DIFF
--- a/.github/workflows/release_linux_aarch64.yml
+++ b/.github/workflows/release_linux_aarch64.yml
@@ -80,7 +80,7 @@ jobs:
         name: wheels
         path: dist
 
-    - name: Upload wheel to TestPyPI/PyPI weekly
+    - name: Upload wheel to PyPI weekly
       if: (github.event_name == 'schedule') # Only triggered by weekly event
       run: |
         python -m pip install -q twine

--- a/.github/workflows/release_linux_aarch64.yml
+++ b/.github/workflows/release_linux_aarch64.yml
@@ -135,7 +135,6 @@ jobs:
           deactivate'
 
     - name: Verify ONNX with ONNX Runtime PyPI package
-      if: matrix.python-version != 'cp311-cp311'
       run: |
          docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
           ${{ env.img }} \
@@ -143,8 +142,8 @@ jobs:
           source .env/bin/activate && \
           python -m pip uninstall -y protobuf numpy && python -m pip install -q -r requirements-release.txt && \
           python -m pip install -q onnxruntime && \
-          export ORT_MAX_IR_SUPPORTED_VERSION=8 \
+          export ORT_MAX_IR_SUPPORTED_VERSION=9 \
           export ORT_MAX_ML_OPSET_SUPPORTED_VERSION=3 \
-          export ORT_MAX_ONNX_OPSET_SUPPORTED_VERSION=18 \
+          export ORT_MAX_ONNX_OPSET_SUPPORTED_VERSION=19 \
           pytest && \
           deactivate'

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -102,11 +102,10 @@ jobs:
         pytest
 
     - name: Verify ONNX with ONNX Runtime PyPI package
-      if: matrix.python-version != '3.11'
       run: |
         python -m pip uninstall -y protobuf numpy && python -m pip install -q -r requirements-release.txt
         python -m pip install -q onnxruntime
-        export ORT_MAX_IR_SUPPORTED_VERSION=8
+        export ORT_MAX_IR_SUPPORTED_VERSION=9
         export ORT_MAX_ML_OPSET_SUPPORTED_VERSION=3
-        export ORT_MAX_ONNX_OPSET_SUPPORTED_VERSION=18
+        export ORT_MAX_ONNX_OPSET_SUPPORTED_VERSION=19
         pytest

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -62,7 +62,7 @@ jobs:
         name: wheels
         path: dist
 
-    - name: Upload wheel to TestPyPI/PyPI weekly
+    - name: Upload wheel to PyPI weekly
       if: (github.event_name == 'schedule') # Only triggered by weekly event
       run: |
         twine upload --verbose dist/*.whl --repository-url https://upload.pypi.org/legacy/ -u ${{ secrets.ONNXWEEKLY_USERNAME }} -p ${{ secrets.ONNXWEEKLY_TOKEN }}

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -80,7 +80,7 @@ jobs:
         name: wheels
         path: dist
 
-    - name: Upload wheel to TestPyPI/PyPI weekly
+    - name: Upload wheel to PyPI weekly
       if: github.event_name == 'schedule' # Only triggered by weekly event
       run: |
         twine upload --verbose dist/*.whl --repository-url https://upload.pypi.org/legacy/ -u ${{ secrets.ONNXWEEKLY_USERNAME }} -p ${{ secrets.ONNXWEEKLY_TOKEN }}

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -128,17 +128,16 @@ jobs:
         twine upload dist/* --repository-url https://upload.pypi.org/legacy/ -u ${{ secrets.ONNXWEEKLY_USERNAME }} -p ${{ secrets.ONNXWEEKLY_TOKEN }}
 
         # Test weekly source distribution from PyPI
-        python -m pip uninstall -y onnx
+        python -m pip uninstall -y onnx-weekly
         python -m pip install setuptools
-        python -m pip install --index-url https://upload.pypi.org/legacy/ --use-deprecated=legacy-resolver --no-use-pep517 --no-binary onnx-weekly onnx-weekly
+        python -m pip install --use-deprecated=legacy-resolver --no-use-pep517 --no-binary onnx-weekly onnx-weekly
         pytest
 
     - name: Verify ONNX with ONNX Runtime PyPI package
-      if: matrix.python-version != '3.11'
       run: |
         python -m pip uninstall -y protobuf numpy && python -m pip install -q -r requirements-release.txt
         python -m pip install -q onnxruntime
-        export ORT_MAX_IR_SUPPORTED_VERSION=8
+        export ORT_MAX_IR_SUPPORTED_VERSION=9
         export ORT_MAX_ML_OPSET_SUPPORTED_VERSION=3
-        export ORT_MAX_ONNX_OPSET_SUPPORTED_VERSION=18
+        export ORT_MAX_ONNX_OPSET_SUPPORTED_VERSION=19
         pytest

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -66,7 +66,7 @@ jobs:
         $Env:CMAKE_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=OFF -DONNX_USE_LITE_PROTO=ON"
 
         if ('${{ github.event_name }}' -eq 'schedule') {
-          echo "Build weekly TestPyPI package"
+          echo "Build weekly PyPI package"
           python setup.py bdist_wheel --weekly_build
         } else {
           python setup.py bdist_wheel
@@ -83,7 +83,7 @@ jobs:
         name: wheels
         path: ./onnx/dist
 
-    - name: Upload onnx-weekly wheel to TestPyPI/PyPI weekly
+    - name: Upload onnx-weekly wheel to PyPI/PyPI weekly
       if: (github.event_name == 'schedule') # Only triggered by weekly event
       run: |
         twine upload --verbose onnx/dist/*.whl --repository-url https://upload.pypi.org/legacy/ -u ${{ secrets.ONNXWEEKLY_USERNAME }} -p ${{ secrets.ONNXWEEKLY_TOKEN }}

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -126,12 +126,11 @@ jobs:
         pytest
 
     - name: Verify ONNX with ONNX Runtime PyPI package
-      if: matrix.python-version != '3.11'
       run: |
         cd onnx
         python -m pip uninstall -y protobuf numpy && python -m pip install -q -r requirements-release.txt
         python -m pip install -q onnxruntime
-        $Env:ORT_MAX_IR_SUPPORTED_VERSION=8
+        $Env:ORT_MAX_IR_SUPPORTED_VERSION=9
         $Env:ORT_MAX_ML_OPSET_SUPPORTED_VERSION=3
-        $Env:ORT_MAX_ONNX_OPSET_SUPPORTED_VERSION=18
+        $Env:ORT_MAX_ONNX_OPSET_SUPPORTED_VERSION=19
         pytest

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@80e868c13c90f172d68d1f4501dee99e2479f7af # v2.1.3
+        uses: ossf/scorecard-action@08b4669551908b1024bb425080c797723083c031 # v2.2.0
         with:
           results_file: results.sarif
           results_format: sarif

--- a/docs/OnnxReleases.md
+++ b/docs/OnnxReleases.md
@@ -94,7 +94,7 @@ The ONNX project, going forward, will plan to release roughly on a four month ca
 **Source Distribution**
 * Follow the same process in TestPyPI to produce the source distribution.
 * Use ``twine upload --verbose dist/* --repository-url https://upload.pypi.org/legacy/`` instead to upload to the official PyPI.
-* Test with ``pip install --no-binary onnx onnx``
+* Test with ``pip install --use-deprecated=legacy-resolver --no-use-pep517 --no-binary onnx onnx``
 
 ## After PyPI Release
 


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
- Test onnxruntime 1.15 with opset 19/IR 9 in CI
- Fix test source distribution -- CI should first uninstall onnx-weekly instead of onnx to test `pip install` from PyPI's source distribution.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
onnxruntime 1.15.0 was out recently and the test version in ONNX should be bumped as 19 (IR as 9) to increase test coverage.