### PR TITLE
[Do not merge] Enable refurb checks with lintrunner

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -253,3 +253,29 @@ init_command = [
     '--dry-run={{DRYRUN}}',
     '--requirement=requirements-lintrunner.txt',
 ]
+
+[[linter]]
+code = 'REFURB'
+include_patterns = [
+    '**/*.py',
+]
+exclude_patterns = []
+command = [
+    'python',
+    '-m',
+    'lintrunner_adapters',
+    'run',
+    'refurb_linter',
+    '--config-file=pyproject.toml',
+    '--',
+    '@{{PATHSFILE}}',
+]
+init_command = [
+    'python',
+    '-m',
+    'lintrunner_adapters',
+    'run',
+    'pip_init',
+    '--dry-run={{DRYRUN}}',
+    '--requirement=requirements-lintrunner.txt',
+]

--- a/requirements-lintrunner.txt
+++ b/requirements-lintrunner.txt
@@ -14,3 +14,5 @@ clang-format==16.0.6
 pylint==2.17.4
 # EDITORCONFIG-CHECKER
 editorconfig-checker==2.7.2
+# REFURB
+refurb==1.17.0


### PR DESCRIPTION
@jcwchen So I enabled refurb here with lintrunner. There are some suggestions we may not want around pathlib, which we can turn off. The thing though with refurb is it is hard to ignore instances of the lint errors inline (like mypy or ruff); there are false positives like "Replace `3.144844` with `math.pi` ". Since ruff is catching up with some refurb checks, I think we can just wait for ruff to implement more checks.