### PR TITLE
Dummy dco workflow to enable merge queue

### DIFF
--- a/.github/workflows/dco_merge_group.yml
+++ b/.github/workflows/dco_merge_group.yml
@@ -1,0 +1,10 @@
+name: dco
+on:
+  merge_group:
+
+jobs:
+  dco:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - run: echo "dummy DCO workflow (it won't run any check actually) to trigger by merge_group in order to enable merge queue"


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Create a dummy dco workflow to enable merge queue: it won't check anything, but it should make DCO pass in the merge queue. The PR itself has already checked DCO and there is no need to check it again in the merge queue. Ideally with this PR https://github.com/onnx/onnx/pull/4890, we should finally be able to use merge queue feature in onnx repo. I don't not sure whether it can really work, but it's worth a shot.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
A workaround to enable merge_queue for DCO workflow: https://github.com/onnx/onnx/issues/4884. Now onnx repo has more PRs to merge every day and having this merge queue feature can save a lot of time for merging multiple PRs.