### PR TITLE
Solve merge queue timeout issue: accelerate windows CI

### DIFF
--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -24,16 +24,16 @@ jobs:
         onnx_ml: 0
         onnx_verify_proto: 0
         protobuf_type: 'External'
+      py39_ml_internal_protobuf:
+        python.version: '3.9'
+        onnx_ml: 1
+        onnx_verify_proto: 0
+        protobuf_type: 'External'
       py38_internal_protobuf:
         python.version: '3.8'
         onnx_ml: 0
         onnx_verify_proto: 0
         protobuf_type: 'Internal'
-      py38_onnx_ml:
-        python.version: '3.8'
-        onnx_ml: 1
-        onnx_verify_proto: 0
-        protobuf_type: 'External'
     maxParallel: 4
 
   steps:

--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -34,7 +34,7 @@ jobs:
         onnx_ml: 0
         onnx_verify_proto: 0
         protobuf_type: 'Internal'
-    maxParallel: 4
+    maxParallel: 6
 
   steps:
   - task: UsePythonVersion@0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,10 @@ on:
 permissions:  # set top-level default permissions as security best practice
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/release_linux_aarch64.yml
+++ b/.github/workflows/release_linux_aarch64.yml
@@ -13,6 +13,10 @@ on:
 permissions:  # set top-level default permissions as security best practice
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
 jobs:
   build:
     if: github.event_name != 'pull_request' || startsWith( github.base_ref, 'rel-') || contains( github.event.pull_request.labels.*.name, 'run release CIs')

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -13,6 +13,10 @@ on:
 permissions:  # set top-level default permissions as security best practice
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
 jobs:
   build:
     if: github.event_name != 'pull_request' || startsWith( github.base_ref, 'rel-') || contains( github.event.pull_request.labels.*.name, 'run release CIs')

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -17,6 +17,9 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -13,6 +13,10 @@ on:
 permissions:  # set top-level default permissions as security best practice
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
 jobs:
   build:
     if: github.event_name != 'pull_request' || startsWith( github.base_ref, 'rel-') || contains( github.event.pull_request.labels.*.name, 'run release CIs')

--- a/.github/workflows/weekly_mac_ci.yml
+++ b/.github/workflows/weekly_mac_ci.yml
@@ -13,6 +13,10 @@ on:
 permissions:  # set top-level default permissions as security best practice
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
 jobs:
   build:
     if: github.event_name != 'pull_request' || contains( github.event.pull_request.labels.*.name, 'test ONNX Model Zoo')

--- a/.github/workflows/win_no_exception_ci.yml
+++ b/.github/workflows/win_no_exception_ci.yml
@@ -9,6 +9,10 @@ on:
 permissions:  # set top-level default permissions as security best practice
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
- I noticed typically py38_onnx_ml pipeline was very slowly created... Using newer version of Python 3.9 might help. If it is still too slow, we need to review the build time for build internal Protobuf and see whether we can make it faster.
- Set maxParallel as 6 to ensure every pipelines on Windows run at the same time.
- Make heavy release CIs cancel-in-progress.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Merge queue automatically removed PR, because some of pipelines (mainly py38_onnx_ml on Windows) are too slow and hit the timeout for merge queue. We should solve it in both ways:
- Increase the timeout for merge queue (just increased from 60 to 90 mins)
- Accelerate the slow Windows CI if possible

The PR is doing the later one. The former one needs to be done by the maintainer. cc @prasanthpul.