### PR TITLE
Add future annotations

### DIFF
--- a/docs/docsgen/source/conf.py
+++ b/docs/docsgen/source/conf.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 # pylint: disable=W0622
 # type: ignore

--- a/docs/docsgen/source/onnx_sphinx.py
+++ b/docs/docsgen/source/onnx_sphinx.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 """Automates the generation of ONNX operators."""
 import difflib
 import importlib

--- a/onnx/__init__.py
+++ b/onnx/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from __future__ import annotations
 

--- a/onnx/__init__.py
+++ b/onnx/__init__.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from __future__ import annotations
-
 __all__ = [
     # Constants
     "ONNX_ML",

--- a/onnx/backend/__init__.py
+++ b/onnx/backend/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations

--- a/onnx/backend/base.py
+++ b/onnx/backend/base.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0613
 
 from collections import namedtuple

--- a/onnx/backend/base.py
+++ b/onnx/backend/base.py
@@ -2,16 +2,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0613
 
 from collections import namedtuple
-from typing import Any, Dict, NewType, Optional, Sequence, Tuple, Type
+from typing import Any, NewType, Sequence
 
 import numpy
 
 import onnx.checker
 import onnx.onnx_cpp2py_export.checker as c_checker
 from onnx import IR_VERSION, ModelProto, NodeProto
+
+# pylint: disable=W0613
 
 
 class DeviceType:
@@ -41,7 +42,7 @@ class Device:
 
 def namedtupledict(
     typename: str, field_names: Sequence[str], *args: Any, **kwargs: Any
-) -> Type[Tuple[Any, ...]]:
+) -> type[tuple[Any, ...]]:
     field_names_map = {n: i for i, n in enumerate(field_names)}
     # Some output names are invalid python identifier, e.g. "0"
     kwargs.setdefault("rename", True)
@@ -63,7 +64,7 @@ class BackendRep:
     BackendRep to retrieve the corresponding results.
     """
 
-    def run(self, inputs: Any, **kwargs: Any) -> Tuple[Any, ...]:
+    def run(self, inputs: Any, **kwargs: Any) -> tuple[Any, ...]:
         """Abstract function."""
         return (None,)
 
@@ -90,7 +91,7 @@ class Backend:
     @classmethod
     def prepare(
         cls, model: ModelProto, device: str = "CPU", **kwargs: Any
-    ) -> Optional[BackendRep]:
+    ) -> BackendRep | None:
         # TODO Remove Optional from return type
         onnx.checker.check_model(model)
         return None
@@ -98,7 +99,7 @@ class Backend:
     @classmethod
     def run_model(
         cls, model: ModelProto, inputs: Any, device: str = "CPU", **kwargs: Any
-    ) -> Tuple[Any, ...]:
+    ) -> tuple[Any, ...]:
         backend = cls.prepare(model, device, **kwargs)
         assert backend is not None
         return backend.run(inputs)
@@ -109,9 +110,9 @@ class Backend:
         node: NodeProto,
         inputs: Any,
         device: str = "CPU",
-        outputs_info: Optional[Sequence[Tuple[numpy.dtype, Tuple[int, ...]]]] = None,
-        **kwargs: Dict[str, Any],
-    ) -> Optional[Tuple[Any, ...]]:
+        outputs_info: Sequence[tuple[numpy.dtype, tuple[int, ...]]] | None = None,
+        **kwargs: dict[str, Any],
+    ) -> tuple[Any, ...] | None:
         """Simple run one operator and return the results.
         Args:
             outputs_info: a list of tuples, which contains the element type and

--- a/onnx/backend/test/__init__.py
+++ b/onnx/backend/test/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 __all__ = ["BackendTest"]
 # for backward compatibility

--- a/onnx/backend/test/case/base.py
+++ b/onnx/backend/test/case/base.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import inspect
 from collections import defaultdict

--- a/onnx/backend/test/case/base.py
+++ b/onnx/backend/test/case/base.py
@@ -6,12 +6,12 @@ from __future__ import annotations
 import inspect
 from collections import defaultdict
 from textwrap import dedent
-from typing import Any, ClassVar, Dict, List, Tuple, Type
+from typing import Any, ClassVar
 
 import numpy as np
 
 
-def process_snippet(op_name: str, name: str, export: Any) -> Tuple[str, str]:
+def process_snippet(op_name: str, name: str, export: Any) -> tuple[str, str]:
     snippet_name = name[len("export_") :] or op_name.lower()
     source_code = dedent(inspect.getsource(export))
     # remove the function signature line
@@ -21,14 +21,14 @@ def process_snippet(op_name: str, name: str, export: Any) -> Tuple[str, str]:
     return snippet_name, dedent("\n".join(lines[2:]))
 
 
-Snippets: Dict[str, List[Tuple[str, str]]] = defaultdict(list)
+Snippets: dict[str, list[tuple[str, str]]] = defaultdict(list)
 
 
 class _Exporter(type):
-    exports: ClassVar[Dict[str, List[Tuple[str, str]]]] = defaultdict(list)
+    exports: ClassVar[dict[str, list[tuple[str, str]]]] = defaultdict(list)
 
     def __init__(
-        cls, name: str, bases: Tuple[Type[Any], ...], dct: Dict[str, Any]
+        cls, name: str, bases: tuple[type[Any], ...], dct: dict[str, Any]
     ) -> None:
         for k, v in dct.items():
             if k.startswith("export"):

--- a/onnx/backend/test/case/model/expand.py
+++ b/onnx/backend/test/case/model/expand.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from typing import Sequence
 

--- a/onnx/backend/test/case/model/gradient.py
+++ b/onnx/backend/test/case/model/gradient.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/model/sequence.py
+++ b/onnx/backend/test/case/model/sequence.py
@@ -1,7 +1,6 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
-
 from __future__ import annotations
 
 import typing

--- a/onnx/backend/test/case/model/shrink.py
+++ b/onnx/backend/test/case/model/shrink.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/model/sign.py
+++ b/onnx/backend/test/case/model/sign.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/model/single-relu.py
+++ b/onnx/backend/test/case/model/single-relu.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/model/stringnormalizer.py
+++ b/onnx/backend/test/case/model/stringnormalizer.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-
 from typing import Sequence
 
 import numpy as np

--- a/onnx/backend/test/case/model/stringnormalizer.py
+++ b/onnx/backend/test/case/model/stringnormalizer.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 
 from typing import Sequence

--- a/onnx/backend/test/case/node/__init__.py
+++ b/onnx/backend/test/case/node/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import sys
 from copy import deepcopy

--- a/onnx/backend/test/case/node/__init__.py
+++ b/onnx/backend/test/case/node/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import sys
 from copy import deepcopy
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Sequence
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/__init__.py
+++ b/onnx/backend/test/case/node/__init__.py
@@ -29,7 +29,7 @@ _TargetOpType = None
 def _rename_edges_helper(
     internal_node: NodeProto,
     rename_helper: Callable[[str], str],
-    attribute_map: Dict[str, AttributeProto],
+    attribute_map: dict[str, AttributeProto],
     prefix: str,
 ) -> NodeProto:
     new_node = NodeProto()
@@ -93,7 +93,7 @@ def _rename_edges_helper(
 # FIXME(TMVector): Any reason we can't get rid of this and use the C++ helper directly?
 def function_expand_helper(
     node: NodeProto, function_proto: FunctionProto, op_prefix: str
-) -> List[NodeProto]:
+) -> list[NodeProto]:
     io_names_map = {}
     attribute_map = {a.name: a for a in node.attribute}
 
@@ -127,8 +127,8 @@ def function_expand_helper(
 
 
 def function_testcase_helper(
-    node: NodeProto, input_types: List[TypeProto], name: str
-) -> Tuple[List[Tuple[List[NodeProto], Any]], int]:
+    node: NodeProto, input_types: list[TypeProto], name: str
+) -> tuple[list[tuple[list[NodeProto], Any]], int]:
     test_op = node.op_type
     op_prefix = test_op + "_" + name + "_expanded_function_"
     schema = onnx.defs.get_schema(test_op, domain=node.domain)
@@ -168,9 +168,9 @@ def function_testcase_helper(
 
 
 def _extract_value_info(
-    input: Union[List[Any], np.ndarray, None],
+    input: list[Any] | np.ndarray | None,
     name: str,
-    type_proto: Optional[TypeProto] = None,
+    type_proto: TypeProto | None = None,
 ) -> onnx.ValueInfoProto:
     if type_proto is None:
         if input is None:
@@ -234,8 +234,8 @@ def _make_test_model_gen_version(graph: GraphProto, **kwargs: Any) -> ModelProto
 # the latest opset vesion that supports before targeted opset version
 def expect(
     node_op: onnx.NodeProto,
-    inputs: Sequence[Union[np.ndarray, TensorProto]],
-    outputs: Sequence[Union[np.ndarray, TensorProto]],
+    inputs: Sequence[np.ndarray | TensorProto],
+    outputs: Sequence[np.ndarray | TensorProto],
     name: str,
     **kwargs: Any,
 ) -> None:
@@ -299,8 +299,8 @@ def expect(
     # Create list of types for node.input, filling a default TypeProto for missing inputs:
     # E.g. merge(["x", "", "y"], [x-value-info, y-value-info]) will return [x-type, default-type, y-type]
     def merge(
-        node_inputs: List[str], present_value_info: List[onnx.ValueInfoProto]
-    ) -> List[TypeProto]:
+        node_inputs: list[str], present_value_info: list[onnx.ValueInfoProto]
+    ) -> list[TypeProto]:
         if node_inputs:
             if node_inputs[0] != "":
                 return [
@@ -368,7 +368,7 @@ def expect(
         )
 
 
-def collect_testcases(op_type: str) -> List[TestCase]:
+def collect_testcases(op_type: str) -> list[TestCase]:
     """Collect node test cases"""
     # only keep those tests related to this operator
     global _TargetOpType

--- a/onnx/backend/test/case/node/abs.py
+++ b/onnx/backend/test/case/node/abs.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/acos.py
+++ b/onnx/backend/test/case/node/acos.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/acosh.py
+++ b/onnx/backend/test/case/node/acosh.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/adagrad.py
+++ b/onnx/backend/test/case/node/adagrad.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/adam.py
+++ b/onnx/backend/test/case/node/adam.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/add.py
+++ b/onnx/backend/test/case/node/add.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/affinegrid.py
+++ b/onnx/backend/test/case/node/affinegrid.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/ai_onnx_ml/array_feature_extractor.py
+++ b/onnx/backend/test/case/node/ai_onnx_ml/array_feature_extractor.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/ai_onnx_ml/binarizer.py
+++ b/onnx/backend/test/case/node/ai_onnx_ml/binarizer.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/and.py
+++ b/onnx/backend/test/case/node/and.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/argmax.py
+++ b/onnx/backend/test/case/node/argmax.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/argmin.py
+++ b/onnx/backend/test/case/node/argmin.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/asin.py
+++ b/onnx/backend/test/case/node/asin.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/asinh.py
+++ b/onnx/backend/test/case/node/asinh.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/atan.py
+++ b/onnx/backend/test/case/node/atan.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/atanh.py
+++ b/onnx/backend/test/case/node/atanh.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/averagepool.py
+++ b/onnx/backend/test/case/node/averagepool.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/batchnorm.py
+++ b/onnx/backend/test/case/node/batchnorm.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/bernoulli.py
+++ b/onnx/backend/test/case/node/bernoulli.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/bitshift.py
+++ b/onnx/backend/test/case/node/bitshift.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/bitwiseand.py
+++ b/onnx/backend/test/case/node/bitwiseand.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np  # type: ignore
 

--- a/onnx/backend/test/case/node/bitwisenot.py
+++ b/onnx/backend/test/case/node/bitwisenot.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np  # type: ignore
 

--- a/onnx/backend/test/case/node/bitwiseor.py
+++ b/onnx/backend/test/case/node/bitwiseor.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np  # type: ignore
 

--- a/onnx/backend/test/case/node/bitwisexor.py
+++ b/onnx/backend/test/case/node/bitwisexor.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np  # type: ignore
 

--- a/onnx/backend/test/case/node/blackmanwindow.py
+++ b/onnx/backend/test/case/node/blackmanwindow.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-
 import numpy as np
 
 import onnx

--- a/onnx/backend/test/case/node/blackmanwindow.py
+++ b/onnx/backend/test/case/node/blackmanwindow.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 
 import numpy as np

--- a/onnx/backend/test/case/node/cast.py
+++ b/onnx/backend/test/case/node/cast.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import sys
 

--- a/onnx/backend/test/case/node/castlike.py
+++ b/onnx/backend/test/case/node/castlike.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import sys
 

--- a/onnx/backend/test/case/node/ceil.py
+++ b/onnx/backend/test/case/node/ceil.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/celu.py
+++ b/onnx/backend/test/case/node/celu.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/center_crop_pad.py
+++ b/onnx/backend/test/case/node/center_crop_pad.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/clip.py
+++ b/onnx/backend/test/case/node/clip.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/col2im.py
+++ b/onnx/backend/test/case/node/col2im.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-
 import numpy as np
 
 import onnx

--- a/onnx/backend/test/case/node/col2im.py
+++ b/onnx/backend/test/case/node/col2im.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 
 import numpy as np

--- a/onnx/backend/test/case/node/compress.py
+++ b/onnx/backend/test/case/node/compress.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/concat.py
+++ b/onnx/backend/test/case/node/concat.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from typing import Any, Dict, Sequence
 

--- a/onnx/backend/test/case/node/concat.py
+++ b/onnx/backend/test/case/node/concat.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import Any, Dict, Sequence
+from typing import Any, Sequence
 
 import numpy as np
 
@@ -15,7 +15,7 @@ from onnx.backend.test.case.node import expect
 class Concat(Base):
     @staticmethod
     def export() -> None:
-        test_cases: Dict[str, Sequence[Any]] = {
+        test_cases: dict[str, Sequence[Any]] = {
             "1d": ([1, 2], [3, 4]),
             "2d": ([[1, 2], [3, 4]], [[5, 6], [7, 8]]),
             "3d": (

--- a/onnx/backend/test/case/node/constant.py
+++ b/onnx/backend/test/case/node/constant.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/constantofshape.py
+++ b/onnx/backend/test/case/node/constantofshape.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/conv.py
+++ b/onnx/backend/test/case/node/conv.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/convinteger.py
+++ b/onnx/backend/test/case/node/convinteger.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/convtranspose.py
+++ b/onnx/backend/test/case/node/convtranspose.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/cos.py
+++ b/onnx/backend/test/case/node/cos.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/cosh.py
+++ b/onnx/backend/test/case/node/cosh.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/cumsum.py
+++ b/onnx/backend/test/case/node/cumsum.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/deformconv.py
+++ b/onnx/backend/test/case/node/deformconv.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/depthtospace.py
+++ b/onnx/backend/test/case/node/depthtospace.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/dequantizelinear.py
+++ b/onnx/backend/test/case/node/dequantizelinear.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/det.py
+++ b/onnx/backend/test/case/node/det.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/dft.py
+++ b/onnx/backend/test/case/node/dft.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/div.py
+++ b/onnx/backend/test/case/node/div.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/dropout.py
+++ b/onnx/backend/test/case/node/dropout.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/dynamicquantizelinear.py
+++ b/onnx/backend/test/case/node/dynamicquantizelinear.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/einsum.py
+++ b/onnx/backend/test/case/node/einsum.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from typing import Tuple
 

--- a/onnx/backend/test/case/node/einsum.py
+++ b/onnx/backend/test/case/node/einsum.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import Tuple
-
 import numpy as np
 
 import onnx
@@ -13,7 +11,7 @@ from onnx.backend.test.case.node import expect
 
 
 def einsum_reference_implementation(
-    Eqn: str, Operands: Tuple[np.ndarray, ...]
+    Eqn: str, Operands: tuple[np.ndarray, ...]
 ) -> np.ndarray:
     Z = np.einsum(Eqn, *Operands)
     return Z

--- a/onnx/backend/test/case/node/elu.py
+++ b/onnx/backend/test/case/node/elu.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/equal.py
+++ b/onnx/backend/test/case/node/equal.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/erf.py
+++ b/onnx/backend/test/case/node/erf.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import math
 

--- a/onnx/backend/test/case/node/exp.py
+++ b/onnx/backend/test/case/node/exp.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/expand.py
+++ b/onnx/backend/test/case/node/expand.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/eyelike.py
+++ b/onnx/backend/test/case/node/eyelike.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/flatten.py
+++ b/onnx/backend/test/case/node/flatten.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/floor.py
+++ b/onnx/backend/test/case/node/floor.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/gather.py
+++ b/onnx/backend/test/case/node/gather.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/gatherelements.py
+++ b/onnx/backend/test/case/node/gatherelements.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/gathernd.py
+++ b/onnx/backend/test/case/node/gathernd.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/gelu.py
+++ b/onnx/backend/test/case/node/gelu.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import math
 

--- a/onnx/backend/test/case/node/gemm.py
+++ b/onnx/backend/test/case/node/gemm.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import Optional
-
 import numpy as np
 
 import onnx
@@ -15,7 +13,7 @@ from onnx.backend.test.case.node import expect
 def gemm_reference_implementation(
     A: np.ndarray,
     B: np.ndarray,
-    C: Optional[np.ndarray] = None,
+    C: np.ndarray | None = None,
     alpha: float = 1.0,
     beta: float = 1.0,
     transA: int = 0,

--- a/onnx/backend/test/case/node/gemm.py
+++ b/onnx/backend/test/case/node/gemm.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from typing import Optional
 

--- a/onnx/backend/test/case/node/globalaveragepool.py
+++ b/onnx/backend/test/case/node/globalaveragepool.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/globalmaxpool.py
+++ b/onnx/backend/test/case/node/globalmaxpool.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/greater.py
+++ b/onnx/backend/test/case/node/greater.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/greater_equal.py
+++ b/onnx/backend/test/case/node/greater_equal.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/gridsample.py
+++ b/onnx/backend/test/case/node/gridsample.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/groupnormalization.py
+++ b/onnx/backend/test/case/node/groupnormalization.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/gru.py
+++ b/onnx/backend/test/case/node/gru.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import Any, Tuple
+from typing import Any
 
 import numpy as np
 
@@ -66,7 +66,7 @@ class GRUHelper:
     def g(self, x: np.ndarray) -> np.ndarray:
         return np.tanh(x)
 
-    def step(self) -> Tuple[np.ndarray, np.ndarray]:
+    def step(self) -> tuple[np.ndarray, np.ndarray]:
         seq_length = self.X.shape[0]
         hidden_size = self.H_0.shape[-1]
         batch_size = self.X.shape[1]

--- a/onnx/backend/test/case/node/gru.py
+++ b/onnx/backend/test/case/node/gru.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from typing import Any, Tuple
 

--- a/onnx/backend/test/case/node/hammingwindow.py
+++ b/onnx/backend/test/case/node/hammingwindow.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/hannwindow.py
+++ b/onnx/backend/test/case/node/hannwindow.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/hardmax.py
+++ b/onnx/backend/test/case/node/hardmax.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/hardsigmoid.py
+++ b/onnx/backend/test/case/node/hardsigmoid.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/hardswish.py
+++ b/onnx/backend/test/case/node/hardswish.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/identity.py
+++ b/onnx/backend/test/case/node/identity.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/if.py
+++ b/onnx/backend/test/case/node/if.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/instancenorm.py
+++ b/onnx/backend/test/case/node/instancenorm.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/isinf.py
+++ b/onnx/backend/test/case/node/isinf.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/isnan.py
+++ b/onnx/backend/test/case/node/isnan.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/layernormalization.py
+++ b/onnx/backend/test/case/node/layernormalization.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/leakyrelu.py
+++ b/onnx/backend/test/case/node/leakyrelu.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/less.py
+++ b/onnx/backend/test/case/node/less.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/less_equal.py
+++ b/onnx/backend/test/case/node/less_equal.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/log.py
+++ b/onnx/backend/test/case/node/log.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/logsoftmax.py
+++ b/onnx/backend/test/case/node/logsoftmax.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/loop.py
+++ b/onnx/backend/test/case/node/loop.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from typing import Any, List
 

--- a/onnx/backend/test/case/node/loop.py
+++ b/onnx/backend/test/case/node/loop.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import Any, List
+from typing import Any
 
 import numpy as np
 
@@ -251,7 +251,7 @@ class Loop(Base):
         )
 
         trip_count = np.array(5).astype(np.int64)
-        seq_empty: List[Any] = []
+        seq_empty: list[Any] = []
         seq_res = [x[: int(i)] for i in x]
         cond = np.array(1).astype(bool)
         expect(
@@ -442,7 +442,7 @@ class Loop(Base):
         trip_count = np.array(5).astype(np.int64)
         cond = np.array(1).astype(bool)
         seq_res = compute_loop_outputs(x, [x0], trip_count)
-        opt_seq_in: List[Any] = [x0]
+        opt_seq_in: list[Any] = [x0]
         expect(
             node,
             inputs=[trip_count, cond, opt_seq_in],

--- a/onnx/backend/test/case/node/lppool.py
+++ b/onnx/backend/test/case/node/lppool.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/lrn.py
+++ b/onnx/backend/test/case/node/lrn.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import math
 

--- a/onnx/backend/test/case/node/lstm.py
+++ b/onnx/backend/test/case/node/lstm.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import Any, Tuple
+from typing import Any
 
 import numpy as np
 
@@ -85,7 +85,7 @@ class LSTMHelper:
     def h(self, x: np.ndarray) -> np.ndarray:
         return np.tanh(x)
 
-    def step(self) -> Tuple[np.ndarray, np.ndarray]:
+    def step(self) -> tuple[np.ndarray, np.ndarray]:
         seq_length = self.X.shape[0]
         hidden_size = self.H_0.shape[-1]
         batch_size = self.X.shape[1]

--- a/onnx/backend/test/case/node/lstm.py
+++ b/onnx/backend/test/case/node/lstm.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from typing import Any, Tuple
 

--- a/onnx/backend/test/case/node/matmul.py
+++ b/onnx/backend/test/case/node/matmul.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/matmulinteger.py
+++ b/onnx/backend/test/case/node/matmulinteger.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/max.py
+++ b/onnx/backend/test/case/node/max.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/maxpool.py
+++ b/onnx/backend/test/case/node/maxpool.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/maxunpool.py
+++ b/onnx/backend/test/case/node/maxunpool.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/mean.py
+++ b/onnx/backend/test/case/node/mean.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/meanvariancenormalization.py
+++ b/onnx/backend/test/case/node/meanvariancenormalization.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/melweightmatrix.py
+++ b/onnx/backend/test/case/node/melweightmatrix.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/min.py
+++ b/onnx/backend/test/case/node/min.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/mish.py
+++ b/onnx/backend/test/case/node/mish.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/mod.py
+++ b/onnx/backend/test/case/node/mod.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/momentum.py
+++ b/onnx/backend/test/case/node/momentum.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/mul.py
+++ b/onnx/backend/test/case/node/mul.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/neg.py
+++ b/onnx/backend/test/case/node/neg.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/negativeloglikelihoodloss.py
+++ b/onnx/backend/test/case/node/negativeloglikelihoodloss.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/nonmaxsuppression.py
+++ b/onnx/backend/test/case/node/nonmaxsuppression.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/nonzero.py
+++ b/onnx/backend/test/case/node/nonzero.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/not.py
+++ b/onnx/backend/test/case/node/not.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/onehot.py
+++ b/onnx/backend/test/case/node/onehot.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/optionalgetelement.py
+++ b/onnx/backend/test/case/node/optionalgetelement.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 
@@ -12,7 +12,7 @@ from onnx.backend.test.case.base import Base
 from onnx.backend.test.case.node import expect
 
 
-def optional_get_element_reference_implementation(optional: Optional[Any]) -> Any:
+def optional_get_element_reference_implementation(optional: Any | None) -> Any:
     assert optional is not None
     return optional
 

--- a/onnx/backend/test/case/node/optionalgetelement.py
+++ b/onnx/backend/test/case/node/optionalgetelement.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from typing import Any, Optional
 

--- a/onnx/backend/test/case/node/optionalhaselement.py
+++ b/onnx/backend/test/case/node/optionalhaselement.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from typing import Optional
 

--- a/onnx/backend/test/case/node/optionalhaselement.py
+++ b/onnx/backend/test/case/node/optionalhaselement.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import Optional
-
 import numpy as np
 
 import onnx
@@ -13,7 +11,7 @@ from onnx.backend.test.case.node import expect
 
 
 def optional_has_element_reference_implementation(
-    optional: Optional[np.ndarray],
+    optional: np.ndarray | None,
 ) -> np.ndarray:
     if optional is None:
         return np.array(False)

--- a/onnx/backend/test/case/node/or.py
+++ b/onnx/backend/test/case/node/or.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/pad.py
+++ b/onnx/backend/test/case/node/pad.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/pow.py
+++ b/onnx/backend/test/case/node/pow.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/prelu.py
+++ b/onnx/backend/test/case/node/prelu.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/qlinearconv.py
+++ b/onnx/backend/test/case/node/qlinearconv.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/qlinearmatmul.py
+++ b/onnx/backend/test/case/node/qlinearmatmul.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/quantizelinear.py
+++ b/onnx/backend/test/case/node/quantizelinear.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/rangeop.py
+++ b/onnx/backend/test/case/node/rangeop.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/reciprocal.py
+++ b/onnx/backend/test/case/node/reciprocal.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/reduce_log_sum.py
+++ b/onnx/backend/test/case/node/reduce_log_sum.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/reduce_log_sum_exp.py
+++ b/onnx/backend/test/case/node/reduce_log_sum_exp.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/reducel1.py
+++ b/onnx/backend/test/case/node/reducel1.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/reducel2.py
+++ b/onnx/backend/test/case/node/reducel2.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/reducemax.py
+++ b/onnx/backend/test/case/node/reducemax.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/reducemean.py
+++ b/onnx/backend/test/case/node/reducemean.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/reducemin.py
+++ b/onnx/backend/test/case/node/reducemin.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/reduceprod.py
+++ b/onnx/backend/test/case/node/reduceprod.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/reducesum.py
+++ b/onnx/backend/test/case/node/reducesum.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/reducesumsquare.py
+++ b/onnx/backend/test/case/node/reducesumsquare.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/regex_full_match.py
+++ b/onnx/backend/test/case/node/regex_full_match.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/relu.py
+++ b/onnx/backend/test/case/node/relu.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/reshape.py
+++ b/onnx/backend/test/case/node/reshape.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/resize.py
+++ b/onnx/backend/test/case/node/resize.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/reversesequence.py
+++ b/onnx/backend/test/case/node/reversesequence.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/rnn.py
+++ b/onnx/backend/test/case/node/rnn.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from typing import Any, Tuple
 

--- a/onnx/backend/test/case/node/rnn.py
+++ b/onnx/backend/test/case/node/rnn.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import Any, Tuple
+from typing import Any
 
 import numpy as np
 
@@ -63,7 +63,7 @@ class RNNHelper:
     def f(self, x: np.ndarray) -> np.ndarray:
         return np.tanh(x)
 
-    def step(self) -> Tuple[np.ndarray, np.ndarray]:
+    def step(self) -> tuple[np.ndarray, np.ndarray]:
         seq_length = self.X.shape[0]
         hidden_size = self.H_0.shape[-1]
         batch_size = self.X.shape[1]

--- a/onnx/backend/test/case/node/roialign.py
+++ b/onnx/backend/test/case/node/roialign.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/round.py
+++ b/onnx/backend/test/case/node/round.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/scan.py
+++ b/onnx/backend/test/case/node/scan.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/scatter.py
+++ b/onnx/backend/test/case/node/scatter.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/scatterelements.py
+++ b/onnx/backend/test/case/node/scatterelements.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/scatternd.py
+++ b/onnx/backend/test/case/node/scatternd.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/selu.py
+++ b/onnx/backend/test/case/node/selu.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/sequence_map.py
+++ b/onnx/backend/test/case/node/sequence_map.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/sequenceinsert.py
+++ b/onnx/backend/test/case/node/sequenceinsert.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import Any, List
+from typing import Any
 
 import numpy as np
 
@@ -13,8 +13,8 @@ from onnx.backend.test.case.node import expect
 
 
 def sequence_insert_reference_implementation(
-    sequence: List[Any], tensor: np.ndarray, position: np.ndarray = None
-) -> List[Any]:
+    sequence: list[Any], tensor: np.ndarray, position: np.ndarray = None
+) -> list[Any]:
     # make a copy of input sequence
     seq = list(sequence)
     if position is not None:

--- a/onnx/backend/test/case/node/sequenceinsert.py
+++ b/onnx/backend/test/case/node/sequenceinsert.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from typing import Any, List
 

--- a/onnx/backend/test/case/node/shape.py
+++ b/onnx/backend/test/case/node/shape.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/shrink.py
+++ b/onnx/backend/test/case/node/shrink.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/sigmoid.py
+++ b/onnx/backend/test/case/node/sigmoid.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/sign.py
+++ b/onnx/backend/test/case/node/sign.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/sin.py
+++ b/onnx/backend/test/case/node/sin.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/sinh.py
+++ b/onnx/backend/test/case/node/sinh.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/size.py
+++ b/onnx/backend/test/case/node/size.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/slice.py
+++ b/onnx/backend/test/case/node/slice.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/softmax.py
+++ b/onnx/backend/test/case/node/softmax.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/softmaxcrossentropy.py
+++ b/onnx/backend/test/case/node/softmaxcrossentropy.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/softplus.py
+++ b/onnx/backend/test/case/node/softplus.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/softsign.py
+++ b/onnx/backend/test/case/node/softsign.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/spacetodepth.py
+++ b/onnx/backend/test/case/node/spacetodepth.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/split.py
+++ b/onnx/backend/test/case/node/split.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/splittosequence.py
+++ b/onnx/backend/test/case/node/splittosequence.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/sqrt.py
+++ b/onnx/backend/test/case/node/sqrt.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/squeeze.py
+++ b/onnx/backend/test/case/node/squeeze.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/stft.py
+++ b/onnx/backend/test/case/node/stft.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-
 import numpy as np
 
 import onnx

--- a/onnx/backend/test/case/node/stft.py
+++ b/onnx/backend/test/case/node/stft.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 
 import numpy as np

--- a/onnx/backend/test/case/node/string_concat.py
+++ b/onnx/backend/test/case/node/string_concat.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/string_split.py
+++ b/onnx/backend/test/case/node/string_split.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/stringnormalizer.py
+++ b/onnx/backend/test/case/node/stringnormalizer.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/sub.py
+++ b/onnx/backend/test/case/node/sub.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/sum.py
+++ b/onnx/backend/test/case/node/sum.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/tan.py
+++ b/onnx/backend/test/case/node/tan.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/tanh.py
+++ b/onnx/backend/test/case/node/tanh.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/tfidfvectorizer.py
+++ b/onnx/backend/test/case/node/tfidfvectorizer.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from typing import Any
 

--- a/onnx/backend/test/case/node/thresholdedrelu.py
+++ b/onnx/backend/test/case/node/thresholdedrelu.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/tile.py
+++ b/onnx/backend/test/case/node/tile.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/topk.py
+++ b/onnx/backend/test/case/node/topk.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/transpose.py
+++ b/onnx/backend/test/case/node/transpose.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import itertools
 

--- a/onnx/backend/test/case/node/trilu.py
+++ b/onnx/backend/test/case/node/trilu.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/unique.py
+++ b/onnx/backend/test/case/node/unique.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/unsqueeze.py
+++ b/onnx/backend/test/case/node/unsqueeze.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/upsample.py
+++ b/onnx/backend/test/case/node/upsample.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/where.py
+++ b/onnx/backend/test/case/node/where.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/node/xor.py
+++ b/onnx/backend/test/case/node/xor.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/backend/test/case/test_case.py
+++ b/onnx/backend/test/case/test_case.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Sequence, Tuple
+from typing import Sequence
 
 import numpy as np
 
@@ -15,10 +15,10 @@ import onnx
 class TestCase:
     name: str
     model_name: str
-    url: Optional[str]
-    model_dir: Optional[str]
-    model: Optional[onnx.ModelProto]
-    data_sets: Optional[Sequence[Tuple[Sequence[np.ndarray], Sequence[np.ndarray]]]]
+    url: str | None
+    model_dir: str | None
+    model: onnx.ModelProto | None
+    data_sets: Sequence[tuple[Sequence[np.ndarray], Sequence[np.ndarray]]] | None
     kind: str
     rtol: float
     atol: float

--- a/onnx/backend/test/case/test_case.py
+++ b/onnx/backend/test/case/test_case.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Optional, Sequence, Tuple

--- a/onnx/backend/test/case/utils.py
+++ b/onnx/backend/test/case/utils.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import importlib
 import pkgutil
 from types import ModuleType
-from typing import List, Optional
 
 import numpy as np
 
@@ -31,7 +30,7 @@ def import_recursive(package: ModuleType) -> None:
     """
     Takes a package and imports all modules underneath it
     """
-    pkg_dir: Optional[List[str]] = None
+    pkg_dir: list[str] | None = None
     pkg_dir = package.__path__  # type: ignore
     module_location = package.__name__
     for _module_loader, name, ispkg in pkgutil.iter_modules(pkg_dir):

--- a/onnx/backend/test/case/utils.py
+++ b/onnx/backend/test/case/utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import importlib
 import pkgutil

--- a/onnx/backend/test/cmd_tools.py
+++ b/onnx/backend/test/cmd_tools.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import argparse
 import json

--- a/onnx/backend/test/report/base.py
+++ b/onnx/backend/test/report/base.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 
 class ReporterBase:

--- a/onnx/backend/test/report/coverage.py
+++ b/onnx/backend/test/report/coverage.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import csv
 import datetime

--- a/onnx/backend/test/report/coverage.py
+++ b/onnx/backend/test/report/coverage.py
@@ -7,7 +7,7 @@ import csv
 import datetime
 import os
 from collections import OrderedDict, defaultdict
-from typing import IO, Any, Dict, List, Optional, Set
+from typing import IO, Any
 
 from tabulate import tabulate
 
@@ -19,8 +19,8 @@ _all_schemas = defs.get_all_schemas()
 
 class AttrCoverage:
     def __init__(self) -> None:
-        self.name: Optional[str] = None
-        self.values: Set[str] = set()
+        self.name: str | None = None
+        self.values: set[str] = set()
 
     def add(self, attr: onnx.AttributeProto) -> None:
         assert self.name in {None, attr.name}
@@ -36,8 +36,8 @@ class AttrCoverage:
 
 class NodeCoverage:
     def __init__(self) -> None:
-        self.op_type: Optional[str] = None
-        self.attr_coverages: Dict[str, AttrCoverage] = defaultdict(AttrCoverage)
+        self.op_type: str | None = None
+        self.attr_coverages: dict[str, AttrCoverage] = defaultdict(AttrCoverage)
 
     def add(self, node: onnx.NodeProto) -> None:
         assert self.op_type in [None, node.op_type]
@@ -53,9 +53,9 @@ class NodeCoverage:
 
 class ModelCoverage:
     def __init__(self) -> None:
-        self.name: Optional[str] = None
-        self.graph: Optional[GraphProto] = None
-        self.node_coverages: Dict[str, NodeCoverage] = defaultdict(NodeCoverage)
+        self.name: str | None = None
+        self.graph: GraphProto | None = None
+        self.node_coverages: dict[str, NodeCoverage] = defaultdict(NodeCoverage)
 
     def add(self, model: onnx.ModelProto) -> None:
         assert self.name in [None, model.graph.name]
@@ -71,11 +71,11 @@ class ModelCoverage:
 
 class Coverage:
     def __init__(self) -> None:
-        self.buckets: Dict[str, Dict[str, NodeCoverage]] = {
+        self.buckets: dict[str, dict[str, NodeCoverage]] = {
             "loaded": defaultdict(NodeCoverage),
             "passed": defaultdict(NodeCoverage),
         }
-        self.models: Dict[str, Dict[str, ModelCoverage]] = {
+        self.models: dict[str, dict[str, ModelCoverage]] = {
             "loaded": defaultdict(ModelCoverage),
             "passed": defaultdict(ModelCoverage),
         }
@@ -106,8 +106,8 @@ class Coverage:
 
         rows = []
         passed = []
-        all_ops: List[str] = []
-        experimental: List[str] = []
+        all_ops: list[str] = []
+        experimental: list[str] = []
         for op_cov in self.buckets["passed"].values():
             covered_attrs = [
                 f"{attr_cov.name}: {len(attr_cov.values)}"
@@ -145,7 +145,7 @@ class Coverage:
     # backend with indications of whether the tests passed or failed for
     # each row.
     def report_csv(
-        self, all_ops: List[str], passed: List[Optional[str]], experimental: List[str]
+        self, all_ops: list[str], passed: list[str | None], experimental: list[str]
     ) -> None:
         for schema in _all_schemas:
             if schema.domain == "" or schema.domain == "ai.onnx":
@@ -159,9 +159,9 @@ class Coverage:
         models_path = os.path.join(
             str(os.environ.get("CSVDIR")), "models.csv"  # type: ignore
         )  # type: ignore
-        existing_nodes: OrderedDict[str, Dict[str, str]] = OrderedDict()
-        existing_models: OrderedDict[str, Dict[str, str]] = OrderedDict()
-        frameworks: List[str] = []
+        existing_nodes: OrderedDict[str, dict[str, str]] = OrderedDict()
+        existing_models: OrderedDict[str, dict[str, str]] = OrderedDict()
+        frameworks: list[str] = []
         if os.path.isfile(nodes_path):
             with open(nodes_path) as nodes_file:
                 reader = csv.DictReader(nodes_file)
@@ -202,7 +202,7 @@ class Coverage:
                     existing_nodes[node_name][str(backend)] = "Passed!"
                 else:
                     existing_nodes[node_name][str(backend)] = "Failed!"
-            summaries: Dict[Any, Any] = {}
+            summaries: dict[Any, Any] = {}
             if "Summary" in existing_nodes:
                 summaries = existing_nodes["Summary"]
                 del existing_nodes["Summary"]

--- a/onnx/backend/test/runner/__init__.py
+++ b/onnx/backend/test/runner/__init__.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from __future__ import annotations
-
 import functools
 import glob
 import os

--- a/onnx/backend/test/runner/__init__.py
+++ b/onnx/backend/test/runner/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from __future__ import annotations
 

--- a/onnx/backend/test/runner/item.py
+++ b/onnx/backend/test/runner/item.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import dataclasses
 from typing import Any, Callable, List, Optional, Union

--- a/onnx/backend/test/runner/item.py
+++ b/onnx/backend/test/runner/item.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Callable
 
 from onnx import ModelProto, NodeProto
 
@@ -15,4 +15,4 @@ from onnx import ModelProto, NodeProto
 @dataclasses.dataclass
 class TestItem:
     func: Callable[..., Any]
-    proto: List[Optional[Union[ModelProto, NodeProto]]]
+    proto: list[ModelProto | NodeProto | None]

--- a/onnx/backend/test/stat_coverage.py
+++ b/onnx/backend/test/stat_coverage.py
@@ -3,6 +3,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import os
 from typing import IO, Any, Dict, List, Sequence

--- a/onnx/backend/test/stat_coverage.py
+++ b/onnx/backend/test/stat_coverage.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import os
-from typing import IO, Any, Dict, List, Sequence
+from typing import IO, Any, Sequence
 
 from onnx import AttributeProto, defs, load
 from onnx.backend.test.case import collect_snippets
@@ -156,8 +156,8 @@ def gen_model_test_coverage(
         schema_dict[schema.name] = schema
     # Load models from each model test using Runner.prepare_model_data
     # Need to grab associated nodes
-    attrs: Dict[str, Dict[str, List[Any]]] = {}
-    model_paths: List[Any] = []
+    attrs: dict[str, dict[str, list[Any]]] = {}
+    model_paths: list[Any] = []
     for rt in load_model_tests(kind="real"):
         if rt.url.startswith("onnx/backend/test/data/light/"):
             # testing local files

--- a/onnx/bin/__init__.py
+++ b/onnx/bin/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations

--- a/onnx/bin/checker.py
+++ b/onnx/bin/checker.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import argparse
 

--- a/onnx/checker.py
+++ b/onnx/checker.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 """Graph utilities for checking whether an ONNX proto message is legal."""
 
 from __future__ import annotations

--- a/onnx/checker.py
+++ b/onnx/checker.py
@@ -1,8 +1,6 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from __future__ import annotations
-
 """Graph utilities for checking whether an ONNX proto message is legal."""
 
 from __future__ import annotations

--- a/onnx/checker.py
+++ b/onnx/checker.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 """Graph utilities for checking whether an ONNX proto message is legal."""
 
 from __future__ import annotations

--- a/onnx/compose.py
+++ b/onnx/compose.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 # pylint: disable=unidiomatic-typecheck
 

--- a/onnx/compose.py
+++ b/onnx/compose.py
@@ -3,16 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-# pylint: disable=unidiomatic-typecheck
-
-from typing import Dict, List, MutableMapping, Optional, Set, Tuple
+from typing import MutableMapping
 
 from onnx import GraphProto, ModelProto, TensorProto, checker, helper, utils
 
+# pylint: disable=unidiomatic-typecheck
+
 
 def check_overlapping_names(
-    g1: GraphProto, g2: GraphProto, io_map: Optional[List[Tuple[str, str]]] = None
-) -> List[Tuple[str, List[str]]]:
+    g1: GraphProto, g2: GraphProto, io_map: list[tuple[str, str]] | None = None
+) -> list[tuple[str, list[str]]]:
     """Checks whether there are name collisions between two graphs
 
     Returns a list of tuples where the first element represents the member containing overlapping names
@@ -27,10 +27,10 @@ def check_overlapping_names(
     if type(g2) is not GraphProto:
         raise ValueError("g2 argument is not an ONNX graph")
 
-    def _overlapping(c1: List[str], c2: List[str]) -> List[str]:
+    def _overlapping(c1: list[str], c2: list[str]) -> list[str]:
         return list(set(c1) & set(c2))
 
-    def _edge_names(graph: GraphProto, exclude: Optional[Set[str]] = None) -> List[str]:
+    def _edge_names(graph: GraphProto, exclude: set[str] | None = None) -> list[str]:
         if exclude is None:
             exclude = set()
         edges = []
@@ -82,13 +82,13 @@ def check_overlapping_names(
 def merge_graphs(  # pylint: disable=too-many-branches,too-many-statements
     g1: GraphProto,
     g2: GraphProto,
-    io_map: List[Tuple[str, str]],
-    inputs: Optional[List[str]] = None,
-    outputs: Optional[List[str]] = None,
-    prefix1: Optional[str] = None,
-    prefix2: Optional[str] = None,
-    name: Optional[str] = None,
-    doc_string: Optional[str] = None,
+    io_map: list[tuple[str, str]],
+    inputs: list[str] | None = None,
+    outputs: list[str] | None = None,
+    prefix1: str | None = None,
+    prefix2: str | None = None,
+    name: str | None = None,
+    doc_string: str | None = None,
 ) -> GraphProto:
     """Combines two ONNX graphs into a single one.
 
@@ -269,17 +269,17 @@ def merge_graphs(  # pylint: disable=too-many-branches,too-many-statements
 def merge_models(  # pylint: disable=too-many-branches
     m1: ModelProto,
     m2: ModelProto,
-    io_map: List[Tuple[str, str]],
-    inputs: Optional[List[str]] = None,
-    outputs: Optional[List[str]] = None,
-    prefix1: Optional[str] = None,
-    prefix2: Optional[str] = None,
-    name: Optional[str] = None,
-    doc_string: Optional[str] = None,
-    producer_name: Optional[str] = "onnx.compose.merge_models",
-    producer_version: Optional[str] = "1.0",
-    domain: Optional[str] = "",
-    model_version: Optional[int] = 1,
+    io_map: list[tuple[str, str]],
+    inputs: list[str] | None = None,
+    outputs: list[str] | None = None,
+    prefix1: str | None = None,
+    prefix2: str | None = None,
+    name: str | None = None,
+    doc_string: str | None = None,
+    producer_name: str | None = "onnx.compose.merge_models",
+    producer_version: str | None = "1.0",
+    domain: str | None = "",
+    model_version: int | None = 1,
 ) -> ModelProto:
     """Combines two ONNX models into a single one.
 
@@ -415,14 +415,14 @@ def merge_models(  # pylint: disable=too-many-branches
 def add_prefix_graph(  # pylint: disable=too-many-branches
     graph: GraphProto,
     prefix: str,
-    rename_nodes: Optional[bool] = True,
-    rename_edges: Optional[bool] = True,
-    rename_inputs: Optional[bool] = True,
-    rename_outputs: Optional[bool] = True,
-    rename_initializers: Optional[bool] = True,
-    rename_value_infos: Optional[bool] = True,
-    inplace: Optional[bool] = False,
-    name_map: Optional[Dict[str, str]] = None,
+    rename_nodes: bool | None = True,
+    rename_edges: bool | None = True,
+    rename_inputs: bool | None = True,
+    rename_outputs: bool | None = True,
+    rename_initializers: bool | None = True,
+    rename_value_infos: bool | None = True,
+    inplace: bool | None = False,
+    name_map: dict[str, str] | None = None,
 ) -> GraphProto:
     """Adds a prefix to names of elements in a graph: nodes, edges, inputs, outputs,
     initializers, sparse initializer, value infos.
@@ -532,14 +532,14 @@ def add_prefix_graph(  # pylint: disable=too-many-branches
 def add_prefix(
     model: ModelProto,
     prefix: str,
-    rename_nodes: Optional[bool] = True,
-    rename_edges: Optional[bool] = True,
-    rename_inputs: Optional[bool] = True,
-    rename_outputs: Optional[bool] = True,
-    rename_initializers: Optional[bool] = True,
-    rename_value_infos: Optional[bool] = True,
-    rename_functions: Optional[bool] = True,
-    inplace: Optional[bool] = False,
+    rename_nodes: bool | None = True,
+    rename_edges: bool | None = True,
+    rename_inputs: bool | None = True,
+    rename_outputs: bool | None = True,
+    rename_initializers: bool | None = True,
+    rename_value_infos: bool | None = True,
+    rename_functions: bool | None = True,
+    inplace: bool | None = False,
 ) -> ModelProto:
     """Adds a prefix to names of elements in a graph: nodes, edges, inputs, outputs,
     initializers, sparse initializer, value infos, and local functions.
@@ -606,7 +606,7 @@ def add_prefix(
 def expand_out_dim_graph(
     graph: GraphProto,
     dim_idx: int,
-    inplace: Optional[bool] = False,
+    inplace: bool | None = False,
 ) -> GraphProto:
     """Inserts an extra dimension with extent 1 to each output in the graph.
 
@@ -686,7 +686,7 @@ def expand_out_dim_graph(
 def expand_out_dim(
     model: ModelProto,
     dim_idx: int,
-    inplace: Optional[bool] = False,
+    inplace: bool | None = False,
 ) -> ModelProto:
     """Inserts an extra dimension with extent 1 to each output in the graph.
 

--- a/onnx/defs/__init__.py
+++ b/onnx/defs/__init__.py
@@ -112,7 +112,7 @@ def _op_schema_attribute_repr(self) -> str:
 OpSchema.Attribute.__repr__ = _op_schema_attribute_repr  # type: ignore
 
 
-def get_function_ops() -> List[OpSchema]:
+def get_function_ops() -> list[OpSchema]:
     """
     Return operators defined as functions.
     """

--- a/onnx/defs/__init__.py
+++ b/onnx/defs/__init__.py
@@ -18,7 +18,6 @@ __all__ = [
     "SchemaError",
 ]
 
-from typing import List
 
 import onnx.onnx_cpp2py_export.defs as C  # noqa: N812
 from onnx import AttributeProto, FunctionProto

--- a/onnx/defs/__init__.py
+++ b/onnx/defs/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 __all__ = [
     "C",

--- a/onnx/defs/gen_doc.py
+++ b/onnx/defs/gen_doc.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import os
 from collections import defaultdict
-from typing import Any, Dict, List, NamedTuple, Sequence, Set, Tuple
+from typing import Any, NamedTuple, Sequence
 
 import numpy as np
 
@@ -76,7 +76,7 @@ def display_version_link(name: str, version: int, changelog: str) -> str:
 
 
 def generate_formal_parameter_tags(formal_parameter: OpSchema.FormalParameter) -> str:
-    tags: List[str] = []
+    tags: list[str] = []
     if OpSchema.FormalParameterOption.Optional == formal_parameter.option:
         tags = ["optional"]
     elif OpSchema.FormalParameterOption.Variadic == formal_parameter.option:
@@ -256,7 +256,7 @@ def main(args: Args) -> None:  # pylint: disable=too-many-branches,too-many-stat
         )
 
         # domain -> version -> [schema]
-        dv_index: Dict[str, Dict[int, List[OpSchema]]] = defaultdict(
+        dv_index: dict[str, dict[int, list[OpSchema]]] = defaultdict(
             lambda: defaultdict(list)
         )
         for schema in defs.get_all_schemas_with_history():
@@ -300,7 +300,7 @@ def main(args: Args) -> None:  # pylint: disable=too-many-branches,too-many-stat
         )
 
         # domain -> support level -> name -> [schema]
-        index: Dict[str, Dict[int, Dict[str, List[OpSchema]]]] = defaultdict(
+        index: dict[str, dict[int, dict[str, list[OpSchema]]]] = defaultdict(
             lambda: defaultdict(lambda: defaultdict(list))
         )
         for schema in defs.get_all_schemas_with_history():
@@ -310,10 +310,10 @@ def main(args: Args) -> None:  # pylint: disable=too-many-branches,too-many-stat
 
         # Preprocess the Operator Schemas
         # [(domain, [(support_level, [(schema name, current schema, all versions schemas)])])]
-        operator_schemas: List[
-            Tuple[str, List[Tuple[int, List[Tuple[str, OpSchema, List[OpSchema]]]]]]
+        operator_schemas: list[
+            tuple[str, list[tuple[int, list[tuple[str, OpSchema, list[OpSchema]]]]]]
         ] = []
-        existing_ops: Set[str] = set()
+        existing_ops: set[str] = set()
         for domain, _supportmap in sorted(index.items()):
             if not should_render_domain(domain, args.output):
                 continue

--- a/onnx/defs/gen_doc.py
+++ b/onnx/defs/gen_doc.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import os
 from collections import defaultdict

--- a/onnx/defs/gen_shape_inference_information.py
+++ b/onnx/defs/gen_shape_inference_information.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from onnx import defs
 

--- a/onnx/external_data_helper.py
+++ b/onnx/external_data_helper.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 import os
 import re
 import sys
 import uuid
 from itertools import chain
-from typing import Callable, Iterable, Optional
+from typing import Callable, Iterable
 
 from onnx.onnx_pb import AttributeProto, GraphProto, ModelProto, TensorProto
 
@@ -73,10 +74,10 @@ def load_external_data_for_model(model: ModelProto, base_dir: str) -> None:
 def set_external_data(
     tensor: TensorProto,
     location: str,
-    offset: Optional[int] = None,
-    length: Optional[int] = None,
-    checksum: Optional[str] = None,
-    basepath: Optional[str] = None,
+    offset: int | None = None,
+    length: int | None = None,
+    checksum: str | None = None,
+    basepath: str | None = None,
 ) -> None:
     if not tensor.HasField("raw_data"):
         raise ValueError(
@@ -103,7 +104,7 @@ def set_external_data(
 def convert_model_to_external_data(
     model: ModelProto,
     all_tensors_to_one_file: bool = True,
-    location: Optional[str] = None,
+    location: str | None = None,
     size_threshold: int = 1024,
     convert_attribute: bool = False,
 ) -> None:

--- a/onnx/external_data_helper.py
+++ b/onnx/external_data_helper.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 import os
 import re
 import sys

--- a/onnx/frontend/__init__.py
+++ b/onnx/frontend/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 # pylint: disable=C0302,R0912
 import collections.abc
 import numbers
@@ -13,7 +14,6 @@ from typing import (
     Dict,
     KeysView,
     List,
-    Optional,
     Sequence,
     Tuple,
     TypeVar,
@@ -99,7 +99,7 @@ OP_SET_ID_VERSION_MAP = create_op_set_id_version_map(VERSION_TABLE)
 
 
 def find_min_ir_version_for(
-    opsetidlist: List[OperatorSetIdProto], ignore_unknown: bool = False
+    opsetidlist: list[OperatorSetIdProto], ignore_unknown: bool = False
 ) -> int:
     """Given list of opset ids, determine minimum IR version required.
 
@@ -111,7 +111,7 @@ def find_min_ir_version_for(
     """
     default_min_version = 3
 
-    def find_min(domain: Union[str, None], version: int) -> int:
+    def find_min(domain: str | None, version: int) -> int:
         key = (domain or "ai.onnx", version)
         if key in OP_SET_ID_VERSION_MAP:
             return OP_SET_ID_VERSION_MAP[key]
@@ -128,9 +128,9 @@ def make_node(
     op_type: str,
     inputs: Sequence[str],
     outputs: Sequence[str],
-    name: Optional[str] = None,
-    doc_string: Optional[str] = None,
-    domain: Optional[str] = None,
+    name: str | None = None,
+    doc_string: str | None = None,
+    domain: str | None = None,
     **kwargs: Any,
 ) -> NodeProto:
     """Construct a NodeProto.
@@ -191,10 +191,10 @@ def make_graph(
     name: str,
     inputs: Sequence[ValueInfoProto],
     outputs: Sequence[ValueInfoProto],
-    initializer: Optional[Sequence[TensorProto]] = None,
-    doc_string: Optional[str] = None,
-    value_info: Optional[Sequence[ValueInfoProto]] = None,
-    sparse_initializer: Optional[Sequence[SparseTensorProto]] = None,
+    initializer: Sequence[TensorProto] | None = None,
+    doc_string: str | None = None,
+    value_info: Sequence[ValueInfoProto] | None = None,
+    sparse_initializer: Sequence[SparseTensorProto] | None = None,
 ) -> GraphProto:
     """Construct a GraphProto
 
@@ -251,9 +251,9 @@ def make_function(
     outputs: Sequence[str],
     nodes: Sequence[NodeProto],
     opset_imports: Sequence[OperatorSetIdProto],
-    attributes: Optional[Sequence[str]] = None,
-    attribute_protos: Optional[Sequence[AttributeProto]] = None,
-    doc_string: Optional[str] = None,
+    attributes: Sequence[str] | None = None,
+    attribute_protos: Sequence[AttributeProto] | None = None,
+    doc_string: str | None = None,
 ) -> FunctionProto:
     if attributes is None:
         attributes = []
@@ -288,7 +288,7 @@ def make_model(graph: GraphProto, **kwargs: Any) -> ModelProto:
     model.ir_version = IR_VERSION
     model.graph.CopyFrom(graph)
 
-    opset_imports: Optional[Sequence[OperatorSetIdProto]] = None
+    opset_imports: Sequence[OperatorSetIdProto] | None = None
     opset_imports = kwargs.pop("opset_imports", None)  # type: ignore
     if opset_imports is not None:
         model.opset_import.extend(opset_imports)
@@ -297,7 +297,7 @@ def make_model(graph: GraphProto, **kwargs: Any) -> ModelProto:
         imp = model.opset_import.add()
         imp.version = defs.onnx_opset_version()
 
-    functions: Optional[Sequence[FunctionProto]] = None
+    functions: Sequence[FunctionProto] | None = None
     functions = kwargs.pop("functions", None)  # type: ignore
     if functions is not None:
         model.functions.extend(functions)
@@ -319,7 +319,7 @@ def make_model_gen_version(graph: GraphProto, **kwargs: Any) -> ModelProto:
     return make_model(graph, **kwargs)
 
 
-def set_model_props(model: ModelProto, dict_value: Dict[str, str]) -> None:
+def set_model_props(model: ModelProto, dict_value: dict[str, str]) -> None:
     del model.metadata_props[:]
     for k, v in dict_value.items():
         entry = model.metadata_props.add()
@@ -767,7 +767,7 @@ def make_sequence(
 
 
 def make_map(
-    name: str, key_type: int, keys: List[Any], values: SequenceProto
+    name: str, key_type: int, keys: list[Any], values: SequenceProto
 ) -> MapProto:
     """
     Make a Map with specified key-value pair arguments.
@@ -801,7 +801,7 @@ def make_map(
 def make_optional(
     name: str,
     elem_type: OptionalProto.DataType,
-    value: Optional[Any],
+    value: Any | None,
 ) -> OptionalProto:
     """
     Make an Optional with specified value arguments.
@@ -829,7 +829,7 @@ def make_optional(
     return optional
 
 
-def _to_bytes(value: Union[str, bytes]) -> bytes:
+def _to_bytes(value: str | bytes) -> bytes:
     """Coerce a string (or bytes) value into UTF-8 bytes."""
     return value if isinstance(value, bytes) else value.encode("utf-8")
 
@@ -837,8 +837,8 @@ def _to_bytes(value: Union[str, bytes]) -> bytes:
 def make_attribute(  # pylint: disable=too-many-statements
     key: str,
     value: Any,
-    doc_string: Optional[str] = None,
-    attr_type: Optional[int] = None,
+    doc_string: str | None = None,
+    attr_type: int | None = None,
 ) -> AttributeProto:
     """Makes an AttributeProto based on the value type."""
     attr = AttributeProto()
@@ -929,7 +929,7 @@ def make_attribute(  # pylint: disable=too-many-statements
 
 
 def make_attribute_ref(
-    name: str, attr_type: AttributeProto.AttributeType, doc_string: Optional[str] = None
+    name: str, attr_type: AttributeProto.AttributeType, doc_string: str | None = None
 ) -> AttributeProto:
     """Make an AttributeProto holding a reference to the parent function's attribute of given name and type."""
     attr = AttributeProto()
@@ -991,8 +991,8 @@ def make_empty_tensor_value_info(name: str) -> ValueInfoProto:
 
 def make_tensor_type_proto(
     elem_type: int,
-    shape: Optional[Sequence[Union[str, int, None]]],
-    shape_denotation: Optional[List[str]] = None,
+    shape: Sequence[str | int | None] | None,
+    shape_denotation: list[str] | None = None,
 ) -> TypeProto:
     """Makes a Tensor TypeProto based on the data type and shape."""
 
@@ -1038,9 +1038,9 @@ def make_tensor_type_proto(
 def make_tensor_value_info(
     name: str,
     elem_type: int,
-    shape: Optional[Sequence[Union[str, int, None]]],
+    shape: Sequence[str | int | None] | None,
     doc_string: str = "",
-    shape_denotation: Optional[List[str]] = None,
+    shape_denotation: list[str] | None = None,
 ) -> ValueInfoProto:
     """Makes a ValueInfoProto based on the data type and shape."""
     value_info_proto = ValueInfoProto()
@@ -1055,8 +1055,8 @@ def make_tensor_value_info(
 
 def make_sparse_tensor_type_proto(
     elem_type: int,
-    shape: Optional[Sequence[Union[str, int, None]]],
-    shape_denotation: Optional[List[str]] = None,
+    shape: Sequence[str | int | None] | None,
+    shape_denotation: list[str] | None = None,
 ) -> TypeProto:
     """Makes a SparseTensor TypeProto based on the data type and shape."""
 
@@ -1102,9 +1102,9 @@ def make_sparse_tensor_type_proto(
 def make_sparse_tensor_value_info(
     name: str,
     elem_type: int,
-    shape: Optional[Sequence[Union[str, int, None]]],
+    shape: Sequence[str | int | None] | None,
     doc_string: str = "",
-    shape_denotation: Optional[List[str]] = None,
+    shape_denotation: list[str] | None = None,
 ) -> ValueInfoProto:
     """Makes a SparseTensor ValueInfoProto based on the data type and shape."""
     value_info_proto = ValueInfoProto()
@@ -1165,7 +1165,7 @@ def make_value_info(
     return value_info_proto
 
 
-def _sanitize_str(s: Union[str, bytes]) -> str:
+def _sanitize_str(s: str | bytes) -> str:
     if isinstance(s, str):
         sanitized = s
     elif isinstance(s, bytes):
@@ -1180,9 +1180,9 @@ def _sanitize_str(s: Union[str, bytes]) -> str:
 def make_tensor_sequence_value_info(
     name: str,
     elem_type: int,
-    shape: Optional[Sequence[Union[str, int, None]]],
+    shape: Sequence[str | int | None] | None,
     doc_string: str = "",
-    elem_shape_denotation: Optional[List[str]] = None,
+    elem_shape_denotation: list[str] | None = None,
 ) -> ValueInfoProto:
     """Makes a Sequence[Tensors] ValueInfoProto based on the data type and shape."""
     value_info_proto = ValueInfoProto()
@@ -1199,7 +1199,7 @@ def make_tensor_sequence_value_info(
 
 def printable_attribute(
     attr: AttributeProto, subgraphs: bool = False
-) -> Union[str, Tuple[str, List[GraphProto]]]:
+) -> str | tuple[str, list[GraphProto]]:
     content = []
     content.append(attr.name)
     content.append("=")
@@ -1315,13 +1315,13 @@ def printable_tensor_proto(t: TensorProto) -> str:
 
 def printable_node(
     node: NodeProto, prefix: str = "", subgraphs: bool = False
-) -> Union[str, Tuple[str, List[GraphProto]]]:
+) -> str | tuple[str, list[GraphProto]]:
     content = []
     if len(node.output):
         content.append(", ".join([f"%{name}" for name in node.output]))
         content.append("=")
     # To deal with nested graphs
-    graphs: List[GraphProto] = []
+    graphs: list[GraphProto] = []
     printed_attrs = []
     for attr in node.attribute:
         if subgraphs:
@@ -1408,7 +1408,7 @@ def printable_graph(graph: GraphProto, prefix: str = "") -> str:
 
     header.append("{")
     content.append(prefix + " ".join(header))
-    graphs: List[GraphProto] = []
+    graphs: list[GraphProto] = []
     # body
     for node in graph.node:
         contents_subgraphs = printable_node(node, indent, subgraphs=True)
@@ -1450,8 +1450,8 @@ def strip_doc_string(proto: google.protobuf.message.Message) -> None:
 def make_training_info(
     algorithm: GraphProto,
     algorithm_bindings: AssignmentBindingType,
-    initialization: Optional[GraphProto],
-    initialization_bindings: Optional[AssignmentBindingType],
+    initialization: GraphProto | None,
+    initialization_bindings: AssignmentBindingType | None,
 ) -> TrainingInfoProto:
     training_info = TrainingInfoProto()
     training_info.algorithm.CopyFrom(algorithm)

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=C0302,R0912
 import collections.abc
 import numbers

--- a/onnx/hub.py
+++ b/onnx/hub.py
@@ -1,12 +1,13 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from __future__ import annotations
 
 """ONNX Model Hub
 
 This implements the python client for the ONNX model hub.
 """
+from __future__ import annotations
+
 import hashlib
 import json
 import os

--- a/onnx/hub.py
+++ b/onnx/hub.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 """ONNX Model Hub
 
 This implements the python client for the ONNX model hub.
@@ -13,7 +14,7 @@ import sys
 import tarfile
 from io import BytesIO
 from os.path import join
-from typing import IO, Any, Dict, List, Optional, Set, Tuple, cast
+from typing import IO, Any, Dict, List, cast
 from urllib.error import HTTPError
 from urllib.request import urlopen
 
@@ -41,7 +42,7 @@ class ModelInfo:
         opset: The opset version of the model.
     """
 
-    def __init__(self, raw_model_info: Dict[str, Any]) -> None:
+    def __init__(self, raw_model_info: dict[str, Any]) -> None:
         """
         Parameters:
             raw_model_info: A JSON dict containing the model info.
@@ -49,17 +50,17 @@ class ModelInfo:
         self.model = cast(str, raw_model_info["model"])
 
         self.model_path = cast(str, raw_model_info["model_path"])
-        self.metadata: Dict[str, Any] = cast(Dict[str, Any], raw_model_info["metadata"])
-        self.model_sha: Optional[str] = None
+        self.metadata: dict[str, Any] = cast(Dict[str, Any], raw_model_info["metadata"])
+        self.model_sha: str | None = None
         if "model_sha" in self.metadata:
             self.model_sha = cast(str, self.metadata["model_sha"])
 
-        self.tags: Set[str] = set()
+        self.tags: set[str] = set()
         if "tags" in self.metadata:
             self.tags = set(cast(List[str], self.metadata["tags"]))
 
         self.opset = cast(int, raw_model_info["opset_version"])
-        self.raw_model_info: Dict[str, Any] = raw_model_info
+        self.raw_model_info: dict[str, Any] = raw_model_info
 
     def __str__(self) -> str:
         return f"ModelInfo(model={self.model}, opset={self.opset}, path={self.model_path}, metadata={self.metadata})"
@@ -87,7 +88,7 @@ def get_dir() -> str:
     return _ONNX_HUB_DIR
 
 
-def _parse_repo_info(repo: str) -> Tuple[str, str, str]:
+def _parse_repo_info(repo: str) -> tuple[str, str, str]:
     """
     Gets the repo owner, name and ref from a repo specification string.
     """
@@ -144,9 +145,9 @@ def _download_file(url: str, file_name: str) -> None:
 
 def list_models(
     repo: str = "onnx/models:main",
-    model: Optional[str] = None,
-    tags: Optional[List[str]] = None,
-) -> List[ModelInfo]:
+    model: str | None = None,
+    tags: list[str] | None = None,
+) -> list[ModelInfo]:
     """
     Gets the list of model info consistent with a given name and tags
 
@@ -160,7 +161,7 @@ def list_models(
     manifest_url = base_url + "ONNX_HUB_MANIFEST.json"
     try:
         with urlopen(manifest_url) as response:
-            manifest: List[ModelInfo] = [
+            manifest: list[ModelInfo] = [
                 ModelInfo(info) for info in json.load(cast(IO[str], response))
             ]
     except HTTPError as e:
@@ -178,7 +179,7 @@ def list_models(
         return matching_models
 
     canonical_tags = {t.lower() for t in tags}
-    matching_info_list: List[ModelInfo] = []
+    matching_info_list: list[ModelInfo] = []
     for m in matching_models:
         model_tags = {t.lower() for t in m.tags}
         if len(canonical_tags.intersection(model_tags)) > 0:
@@ -187,7 +188,7 @@ def list_models(
 
 
 def get_model_info(
-    model: str, repo: str = "onnx/models:main", opset: Optional[int] = None
+    model: str, repo: str = "onnx/models:main", opset: int | None = None
 ) -> ModelInfo:
     """
     Gets the model info matching the given name and opset.
@@ -217,10 +218,10 @@ def get_model_info(
 def load(
     model: str,
     repo: str = "onnx/models:main",
-    opset: Optional[int] = None,
+    opset: int | None = None,
     force_reload: bool = False,
     silent: bool = False,
-) -> Optional[onnx.ModelProto]:
+) -> onnx.ModelProto | None:
     """
     Downloads a model by name from the onnx model hub
 
@@ -275,10 +276,10 @@ def load(
 def download_model_with_test_data(
     model: str,
     repo: str = "onnx/models:main",
-    opset: Optional[int] = None,
+    opset: int | None = None,
     force_reload: bool = False,
     silent: bool = False,
-) -> Optional[str]:
+) -> str | None:
     """
     Downloads a model along with test data by name from the onnx model hub and returns the directory to which the files have been extracted.
 
@@ -358,10 +359,10 @@ def load_composite_model(
     preprocessing_model: str,
     network_repo: str = "onnx/models:main",
     preprocessing_repo: str = "onnx/models:main",
-    opset: Optional[int] = None,
+    opset: int | None = None,
     force_reload: bool = False,
     silent: bool = False,
-) -> Optional[onnx.ModelProto]:
+) -> onnx.ModelProto | None:
     """
     Builds a composite model including data preprocessing by downloading a network and a preprocessing model
     and combine it into a single model
@@ -385,9 +386,9 @@ def load_composite_model(
     if network is None:
         raise RuntimeError(f"Could not load the network model: {network_model}")
 
-    all_domains: Set[str] = set()
-    domains_to_version_network: Dict[str, int] = {}
-    domains_to_version_preprocessing: Dict[str, int] = {}
+    all_domains: set[str] = set()
+    domains_to_version_network: dict[str, int] = {}
+    domains_to_version_preprocessing: dict[str, int] = {}
 
     for opset_import_entry in network.opset_import:
         domain = (

--- a/onnx/hub.py
+++ b/onnx/hub.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 """ONNX Model Hub
 
 This implements the python client for the ONNX model hub.

--- a/onnx/inliner.py
+++ b/onnx/inliner.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import onnx
 import onnx.onnx_cpp2py_export.inliner as C  # noqa: N812

--- a/onnx/mapping.py
+++ b/onnx/mapping.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import warnings
 from typing import Any, Dict, NamedTuple, Union, cast

--- a/onnx/mapping.py
+++ b/onnx/mapping.py
@@ -87,7 +87,7 @@ TENSOR_TYPE_MAP = {
 class DeprecatedWarningDict(dict):  # type: ignore
     def __init__(
         self,
-        dictionary: Dict[int, Union[int, str, np.dtype]],
+        dictionary: dict[int, int | str | np.dtype],
         original_function: str,
         future_function: str = "",
     ) -> None:
@@ -103,7 +103,7 @@ class DeprecatedWarningDict(dict):  # type: ignore
             and self._future_function == other._future_function
         )
 
-    def __getitem__(self, key: Union[int, str, np.dtype]) -> Any:
+    def __getitem__(self, key: int | str | np.dtype) -> Any:
         if not self._future_function:
             warnings.warn(
                 str(

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 # pylint: disable=C3001,isinstance-second-argument-not-valid-type
 

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -3,24 +3,24 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-# pylint: disable=C3001,isinstance-second-argument-not-valid-type
-
 import sys
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Sequence
 
 import numpy as np
 
 from onnx import MapProto, OptionalProto, SequenceProto, TensorProto, helper
 from onnx.external_data_helper import load_external_data_for_tensor, uses_external_data
 
+# pylint: disable=C3001,isinstance-second-argument-not-valid-type
 
-def combine_pairs_to_complex(fa: Sequence[int]) -> List[complex]:
+
+def combine_pairs_to_complex(fa: Sequence[int]) -> list[complex]:
     return [complex(fa[i * 2], fa[i * 2 + 1]) for i in range(len(fa) // 2)]
 
 
 def bfloat16_to_float32(
-    data: Union[np.int16, np.int32, np.ndarray],
-    dims: Optional[Union[int, Sequence[int]]] = None,
+    data: np.int16 | np.int32 | np.ndarray,
+    dims: int | Sequence[int] | None = None,
 ) -> np.ndarray:
     """Converts ndarray of bf16 (as uint32) to f32 (as uint32).
 
@@ -83,8 +83,8 @@ _float8e4m3_to_float32 = np.vectorize(
 
 
 def float8e4m3_to_float32(
-    data: Union[np.int16, np.int32, np.ndarray],
-    dims: Optional[Union[int, Sequence[int]]] = None,
+    data: np.int16 | np.int32 | np.ndarray,
+    dims: int | Sequence[int] | None = None,
     fn: bool = True,
     uz: bool = False,
 ) -> np.ndarray:
@@ -154,8 +154,8 @@ _float8e5m2_to_float32 = np.vectorize(
 
 
 def float8e5m2_to_float32(
-    data: Union[np.int16, np.int32, np.ndarray],
-    dims: Optional[Union[int, Sequence[int]]] = None,
+    data: np.int16 | np.int32 | np.ndarray,
+    dims: int | Sequence[int] | None = None,
     fn: bool = False,
     uz: bool = False,
 ) -> np.ndarray:
@@ -272,7 +272,7 @@ def to_array(  # pylint: disable=too-many-branches
     return np.asarray(data, dtype=storage_np_dtype).astype(np_dtype).reshape(dims)
 
 
-def from_array(arr: np.ndarray, name: Optional[str] = None) -> TensorProto:
+def from_array(arr: np.ndarray, name: str | None = None) -> TensorProto:
     """Converts a numpy array to a tensor def.
 
     Args:
@@ -332,7 +332,7 @@ def from_array(arr: np.ndarray, name: Optional[str] = None) -> TensorProto:
     return tensor
 
 
-def to_list(sequence: SequenceProto) -> List[Any]:
+def to_list(sequence: SequenceProto) -> list[Any]:
     """Converts a sequence def to a Python list.
 
     Args:
@@ -354,7 +354,7 @@ def to_list(sequence: SequenceProto) -> List[Any]:
 
 
 def from_list(  # pylint: disable=too-many-branches
-    lst: List[Any], name: Optional[str] = None, dtype: Optional[int] = None
+    lst: list[Any], name: str | None = None, dtype: int | None = None
 ) -> SequenceProto:  # pylint: disable=too-many-branches
     """Converts a list into a sequence def.
 
@@ -410,7 +410,7 @@ def from_list(  # pylint: disable=too-many-branches
     return sequence
 
 
-def to_dict(map_proto: MapProto) -> Dict[Any, Any]:
+def to_dict(map_proto: MapProto) -> dict[Any, Any]:
     """Converts a map def to a Python dictionary.
 
     Args:
@@ -419,7 +419,7 @@ def to_dict(map_proto: MapProto) -> Dict[Any, Any]:
     Returns:
         dict: the converted dictionary.
     """
-    key_list: List[Any] = []
+    key_list: list[Any] = []
     if map_proto.key_type == TensorProto.STRING:
         key_list = list(map_proto.string_keys)
     else:
@@ -436,7 +436,7 @@ def to_dict(map_proto: MapProto) -> Dict[Any, Any]:
     return dictionary
 
 
-def from_dict(dict_: Dict[Any, Any], name: Optional[str] = None) -> MapProto:
+def from_dict(dict_: dict[Any, Any], name: str | None = None) -> MapProto:
     """Converts a Python dictionary into a map def.
 
     Args:
@@ -495,7 +495,7 @@ def from_dict(dict_: Dict[Any, Any], name: Optional[str] = None) -> MapProto:
     return map_proto
 
 
-def to_optional(optional: OptionalProto) -> Optional[Any]:
+def to_optional(optional: OptionalProto) -> Any | None:
     """Converts an optional def to a Python optional.
 
     Args:
@@ -521,7 +521,7 @@ def to_optional(optional: OptionalProto) -> Optional[Any]:
 
 
 def from_optional(
-    opt: Optional[Any], name: Optional[str] = None, dtype: Optional[int] = None
+    opt: Any | None, name: str | None = None, dtype: int | None = None
 ) -> OptionalProto:
     """Converts an optional value into a Optional def.
 
@@ -587,7 +587,7 @@ def convert_endian(tensor: TensorProto) -> None:
 
 
 def create_random_int(
-    input_shape: Tuple[int], dtype: np.dtype, seed: int = 1
+    input_shape: tuple[int], dtype: np.dtype, seed: int = 1
 ) -> np.ndarray:
     """
     Create random integer array for backend/test/case/node.

--- a/onnx/parser.py
+++ b/onnx/parser.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import onnx
 import onnx.onnx_cpp2py_export.parser as C  # noqa: N812

--- a/onnx/printer.py
+++ b/onnx/printer.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from typing import Union
 

--- a/onnx/printer.py
+++ b/onnx/printer.py
@@ -3,13 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import Union
-
 import onnx
 import onnx.onnx_cpp2py_export.printer as C  # noqa: N812
 
 
-def to_text(proto: Union[onnx.ModelProto, onnx.FunctionProto, onnx.GraphProto]) -> str:
+def to_text(proto: onnx.ModelProto | onnx.FunctionProto | onnx.GraphProto) -> str:
     if isinstance(proto, onnx.ModelProto):
         return C.model_to_text(proto.SerializeToString())
     if isinstance(proto, onnx.FunctionProto):

--- a/onnx/reference/__init__.py
+++ b/onnx/reference/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from onnx.reference.reference_evaluator import ReferenceEvaluator

--- a/onnx/reference/custom_element_types.py
+++ b/onnx/reference/custom_element_types.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import numpy as np
 

--- a/onnx/reference/ops/__init__.py
+++ b/onnx/reference/ops/__init__.py
@@ -1,7 +1,6 @@
 # Copyright (c) ONNX Project Contributors
-
-# Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from onnx.reference.ops._op_list import load_op

--- a/onnx/reference/ops/_helpers.py
+++ b/onnx/reference/ops/_helpers.py
@@ -1,8 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
-# Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from typing import Any, Dict, Union
 

--- a/onnx/reference/ops/_helpers.py
+++ b/onnx/reference/ops/_helpers.py
@@ -3,15 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import Any, Dict, Union
+from typing import Any
 
 from onnx.reference.op_run import OpRun, _split_class_name
 
 
 def build_registered_operators_any_domain(
-    module_context: Dict[str, Any]
-) -> Dict[str, Dict[Union[int, None], OpRun]]:
-    reg_ops: Dict[str, Dict[Union[int, None], OpRun]] = {}
+    module_context: dict[str, Any]
+) -> dict[str, dict[int | None, OpRun]]:
+    reg_ops: dict[str, dict[int | None, OpRun]] = {}
     for class_name, class_type in module_context.items():
         if class_name.startswith("_") or class_name in {
             "Any",

--- a/onnx/reference/ops/_op.py
+++ b/onnx/reference/ops/_op.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any
 
 import numpy as np
 
@@ -17,7 +17,7 @@ class OpRunUnary(OpRun):  # pylint: disable=W0223
     Checks that input and output types are the same.
     """
 
-    def __init__(self, onnx_node: NodeProto, run_params: Dict[str, Any]):
+    def __init__(self, onnx_node: NodeProto, run_params: dict[str, Any]):
         OpRun.__init__(self, onnx_node, run_params)
 
     def run(self, x):  # type: ignore # pylint: disable=W0221
@@ -45,7 +45,7 @@ class OpRunUnaryNum(OpRunUnary):  # pylint: disable=W0223
     are the same.
     """
 
-    def __init__(self, onnx_node: NodeProto, run_params: Dict[str, Any]):
+    def __init__(self, onnx_node: NodeProto, run_params: dict[str, Any]):
         OpRunUnary.__init__(self, onnx_node, run_params)
 
     def run(self, x):  # type: ignore # pylint: disable=W0221
@@ -71,7 +71,7 @@ class OpRunBinary(OpRun):  # pylint: disable=W0223
     Checks that input and output types are the same.
     """
 
-    def __init__(self, onnx_node: NodeProto, run_params: Dict[str, Any]):
+    def __init__(self, onnx_node: NodeProto, run_params: dict[str, Any]):
         OpRun.__init__(self, onnx_node, run_params)
 
     def run(self, x, y):  # type: ignore # pylint: disable=W0221
@@ -108,7 +108,7 @@ class OpRunBinaryComparison(OpRunBinary):  # pylint: disable=W0223
     comparing tensors.
     """
 
-    def __init__(self, onnx_node: NodeProto, run_params: Dict[str, Any]):
+    def __init__(self, onnx_node: NodeProto, run_params: dict[str, Any]):
         OpRunBinary.__init__(self, onnx_node, run_params)
 
 
@@ -118,7 +118,7 @@ class OpRunBinaryNum(OpRunBinary):  # pylint: disable=W0223
     Checks that input oud output types are the same.
     """
 
-    def __init__(self, onnx_node: NodeProto, run_params: Dict[str, Any]):
+    def __init__(self, onnx_node: NodeProto, run_params: dict[str, Any]):
         OpRunBinary.__init__(self, onnx_node, run_params)
 
     def run(self, x, y):  # type: ignore # pylint: disable=W0221
@@ -143,7 +143,7 @@ class OpRunBinaryNumpy(OpRunBinaryNum):
     """
 
     def __init__(
-        self, numpy_fct: Any, onnx_node: NodeProto, run_params: Dict[str, Any]
+        self, numpy_fct: Any, onnx_node: NodeProto, run_params: dict[str, Any]
     ):
         OpRunBinaryNum.__init__(self, onnx_node, run_params)
         self.numpy_fct = numpy_fct
@@ -158,7 +158,7 @@ class OpRunReduceNumpy(OpRun):  # type: ignore
     It must have a parameter *axes*.
     """
 
-    def __init__(self, onnx_node: NodeProto, run_params: Dict[str, Any]):
+    def __init__(self, onnx_node: NodeProto, run_params: dict[str, Any]):
         OpRun.__init__(self, onnx_node, run_params)
         if hasattr(self, "axes"):
             if isinstance(self.axes, np.ndarray):  # type: ignore # pylint: disable=E0203

--- a/onnx/reference/ops/_op.py
+++ b/onnx/reference/ops/_op.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from typing import Any, Dict
 

--- a/onnx/reference/ops/_op_common_indices.py
+++ b/onnx/reference/ops/_op_common_indices.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/_op_common_indices.py
+++ b/onnx/reference/ops/_op_common_indices.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
+
+# pylint: disable=W0221
 
 
 def _get_indices(i, shape):  # type: ignore

--- a/onnx/reference/ops/_op_common_pool.py
+++ b/onnx/reference/ops/_op_common_pool.py
@@ -2,24 +2,24 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221,R0913,R0914
 
 import itertools
-from typing import Optional, Tuple
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
 from onnx.reference.ops._op_common_indices import _get_index, _get_indices
 
+# pylint: disable=W0221,R0913,R0914
+
 
 def _get_pad_shape(
     auto_pad: str,
-    input_spatial_shape: Tuple[int],
-    kernel_spatial_shape: Tuple[int],
-    strides_spatial: Tuple[int],
-    output_spatial_shape: Tuple[int],
-) -> Tuple[int]:
+    input_spatial_shape: tuple[int],
+    kernel_spatial_shape: tuple[int],
+    strides_spatial: tuple[int],
+    output_spatial_shape: tuple[int],
+) -> tuple[int]:
     pad_shape = [0] * len(input_spatial_shape)
     if auto_pad in ("SAME_UPPER", "SAME_LOWER"):
         for i in range(len(input_spatial_shape)):  # pylint: disable=C0200
@@ -42,10 +42,10 @@ def _get_pad_shape(
 
 def _get_output_shape_no_ceil(
     auto_pad: str,
-    input_spatial_shape: Tuple[int],
-    kernel_spatial_shape: Tuple[int],
-    strides_spatial: Tuple[int],
-) -> Tuple[int]:
+    input_spatial_shape: tuple[int],
+    kernel_spatial_shape: tuple[int],
+    strides_spatial: tuple[int],
+) -> tuple[int]:
     out_shape = [0] * len(input_spatial_shape)
     if auto_pad in ("SAME_UPPER", "SAME_LOWER"):
         for i in range(len(input_spatial_shape)):  # pylint: disable=C0200
@@ -65,12 +65,12 @@ def _get_output_shape_no_ceil(
 
 def _get_output_shape(
     auto_pad: str,
-    input_spatial_shape: Tuple[int],
-    kernel_spatial_shape: Tuple[int],
-    strides_spatial: Tuple[int],
-    pad_shape: Optional[Tuple[int]] = None,
-    ceil_mode: Optional[int] = 0,
-) -> Tuple[int]:
+    input_spatial_shape: tuple[int],
+    kernel_spatial_shape: tuple[int],
+    strides_spatial: tuple[int],
+    pad_shape: tuple[int] | None = None,
+    ceil_mode: int | None = 0,
+) -> tuple[int]:
     if not ceil_mode:
         out_shape = _get_output_shape_no_ceil(
             auto_pad, input_spatial_shape, kernel_spatial_shape, strides_spatial
@@ -120,16 +120,16 @@ def _get_output_shape(
 
 def _pool(
     padded: np.ndarray,
-    x_shape: Tuple[int],
-    kernel_shape: Tuple[int],
-    strides_shape: Tuple[int],
-    out_shape: Tuple[int],
-    pad_shape: Tuple[int],
+    x_shape: tuple[int],
+    kernel_shape: tuple[int],
+    strides_shape: tuple[int],
+    out_shape: tuple[int],
+    pad_shape: tuple[int],
     pooling_type: str,
-    count_include_pad: Optional[int] = 0,
-    ceil_mode: Optional[int] = 0,
+    count_include_pad: int | None = 0,
+    ceil_mode: int | None = 0,
     indices: bool = False,
-    pads: Optional[np.ndarray] = None,
+    pads: np.ndarray | None = None,
 ) -> np.ndarray:
     if pooling_type == "AVG":
         fpool = np.average

--- a/onnx/reference/ops/_op_common_pool.py
+++ b/onnx/reference/ops/_op_common_pool.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221,R0913,R0914
 
 import itertools

--- a/onnx/reference/ops/_op_common_random.py
+++ b/onnx/reference/ops/_op_common_random.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.helper import tensor_dtype_to_np_dtype
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class _CommonRandom(OpRun):

--- a/onnx/reference/ops/_op_common_random.py
+++ b/onnx/reference/ops/_op_common_random.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/_op_common_window.py
+++ b/onnx/reference/ops/_op_common_window.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0613,W0221
 
 import numpy as np
 
 from onnx.helper import tensor_dtype_to_np_dtype
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0613,W0221
 
 
 class _CommonWindow(OpRun):

--- a/onnx/reference/ops/_op_common_window.py
+++ b/onnx/reference/ops/_op_common_window.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0613,W0221
 
 import numpy as np

--- a/onnx/reference/ops/_op_list.py
+++ b/onnx/reference/ops/_op_list.py
@@ -1,7 +1,6 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from __future__ import annotations
 
 # pylint: disable=C0415,R0912,R0913,R0914,R0915,W0611,W0603
 """
@@ -13,10 +12,10 @@ with `_`, it means the implementation is valid for every opset.
 The operator may have been updated to support more types but that
 did not change the implementation.
 """
+from __future__ import annotations
+
 import textwrap
-from typing import Any, Dict, List
-from typing import Optional as TOptional
-from typing import Union
+from typing import Any
 
 from onnx import FunctionProto, NodeProto, TypeProto
 from onnx.defs import get_schema, onnx_opset_version

--- a/onnx/reference/ops/_op_list.py
+++ b/onnx/reference/ops/_op_list.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=C0415,R0912,R0913,R0914,R0915,W0611,W0603
 """
 Every class imported in this module defines an implementation of

--- a/onnx/reference/ops/_op_list.py
+++ b/onnx/reference/ops/_op_list.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 # pylint: disable=C0415,R0912,R0913,R0914,R0915,W0611,W0603
 """
 Every class imported in this module defines an implementation of
@@ -234,17 +235,17 @@ from onnx.reference.ops.op_where import Where
 from onnx.reference.ops.op_xor import Xor
 
 
-def _build_registered_operators() -> Dict[str, Dict[Union[int, None], OpRun]]:
+def _build_registered_operators() -> dict[str, dict[int | None, OpRun]]:
     return build_registered_operators_any_domain(globals().copy())
 
 
 def load_op(
     domain: str,
     op_type: str,
-    version: Union[None, int] = None,
+    version: None | int = None,
     custom: Any = None,
-    node: Union[None, NodeProto] = None,
-    input_types: Union[None, List[TypeProto]] = None,
+    node: None | NodeProto = None,
+    input_types: None | list[TypeProto] = None,
     expand: bool = False,
 ) -> Any:
     """
@@ -351,4 +352,4 @@ def load_op(
     return cl
 
 
-_registered_operators: TOptional[Dict[str, Dict[Union[int, None], OpRun]]] = None
+_registered_operators: dict[str, dict[int | None, OpRun]] | None = None

--- a/onnx/reference/ops/aionnx_preview_training/_op_list.py
+++ b/onnx/reference/ops/aionnx_preview_training/_op_list.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=C0415,R0912,W0611,W0603
 
 import textwrap

--- a/onnx/reference/ops/aionnx_preview_training/_op_list.py
+++ b/onnx/reference/ops/aionnx_preview_training/_op_list.py
@@ -1,12 +1,12 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=C0415,R0912,W0611,W0603
+
 from __future__ import annotations
 
 import textwrap
-from typing import Any, Dict
-from typing import Optional as TOptional
-from typing import Union
+from typing import Any
 
 from onnx.reference.op_run import OpFunction
 from onnx.reference.ops._helpers import build_registered_operators_any_domain
@@ -14,8 +14,6 @@ from onnx.reference.ops.aionnx_preview_training._op_run_training import OpRunTra
 from onnx.reference.ops.aionnx_preview_training.op_adagrad import Adagrad
 from onnx.reference.ops.aionnx_preview_training.op_adam import Adam
 from onnx.reference.ops.aionnx_preview_training.op_momentum import Momentum
-
-# pylint: disable=C0415,R0912,W0611,W0603
 
 
 def _build_registered_operators() -> dict[str, dict[int | None, OpRunTraining]]:

--- a/onnx/reference/ops/aionnx_preview_training/_op_list.py
+++ b/onnx/reference/ops/aionnx_preview_training/_op_list.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=C0415,R0912,W0611,W0603
 
 import textwrap
 from typing import Any, Dict
@@ -16,14 +15,14 @@ from onnx.reference.ops.aionnx_preview_training.op_adagrad import Adagrad
 from onnx.reference.ops.aionnx_preview_training.op_adam import Adam
 from onnx.reference.ops.aionnx_preview_training.op_momentum import Momentum
 
+# pylint: disable=C0415,R0912,W0611,W0603
 
-def _build_registered_operators() -> Dict[str, Dict[Union[int, None], OpRunTraining]]:
+
+def _build_registered_operators() -> dict[str, dict[int | None, OpRunTraining]]:
     return build_registered_operators_any_domain(globals().copy())  # type: ignore[return-value]
 
 
-def load_op(
-    domain: str, op_type: str, version: Union[None, int], custom: Any = None
-) -> Any:
+def load_op(domain: str, op_type: str, version: None | int, custom: Any = None) -> Any:
     """
     Loads the implemented for a specified operator.
 
@@ -78,6 +77,4 @@ def load_op(
     return cl
 
 
-_registered_operators: TOptional[
-    Dict[str, Dict[Union[int, None], OpRunTraining]]
-] = None
+_registered_operators: dict[str, dict[int | None, OpRunTraining]] | None = None

--- a/onnx/reference/ops/aionnx_preview_training/_op_run_training.py
+++ b/onnx/reference/ops/aionnx_preview_training/_op_run_training.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,W0221
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0913,W0221
 
 
 class OpRunTraining(OpRun):

--- a/onnx/reference/ops/aionnx_preview_training/_op_run_training.py
+++ b/onnx/reference/ops/aionnx_preview_training/_op_run_training.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,W0221
 
 from onnx.reference.op_run import OpRun

--- a/onnx/reference/ops/aionnx_preview_training/op_adagrad.py
+++ b/onnx/reference/ops/aionnx_preview_training/op_adagrad.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,W0221
 
 import numpy as np
 
 from onnx.reference.ops.aionnx_preview_training._op_run_training import OpRunTraining
+
+# pylint: disable=R0913,W0221
 
 
 def _apply_adagrad(r, t, x, g, h, norm_coefficient, epsilon, decay_factor):  # type: ignore

--- a/onnx/reference/ops/aionnx_preview_training/op_adagrad.py
+++ b/onnx/reference/ops/aionnx_preview_training/op_adagrad.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,W0221
 
 import numpy as np

--- a/onnx/reference/ops/aionnx_preview_training/op_adam.py
+++ b/onnx/reference/ops/aionnx_preview_training/op_adam.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,W0221
 
 import numpy as np

--- a/onnx/reference/ops/aionnx_preview_training/op_adam.py
+++ b/onnx/reference/ops/aionnx_preview_training/op_adam.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,W0221
 
 import numpy as np
 
 from onnx.reference.ops.aionnx_preview_training._op_run_training import OpRunTraining
+
+# pylint: disable=R0913,R0914,W0221
 
 
 def _apply_adam(  # type: ignore

--- a/onnx/reference/ops/aionnx_preview_training/op_momentum.py
+++ b/onnx/reference/ops/aionnx_preview_training/op_momentum.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,W0221
 
 from onnx.reference.ops.aionnx_preview_training._op_run_training import OpRunTraining
+
+# pylint: disable=R0913,R0914,W0221
 
 
 def _apply_momentum(r, t, x, g, v, norm_coefficient, alpha, beta):  # type: ignore

--- a/onnx/reference/ops/aionnx_preview_training/op_momentum.py
+++ b/onnx/reference/ops/aionnx_preview_training/op_momentum.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,W0221
 
 from onnx.reference.ops.aionnx_preview_training._op_run_training import OpRunTraining

--- a/onnx/reference/ops/aionnxml/op_array_feature_extractor.py
+++ b/onnx/reference/ops/aionnxml/op_array_feature_extractor.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,W0221
 
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl

--- a/onnx/reference/ops/aionnxml/op_array_feature_extractor.py
+++ b/onnx/reference/ops/aionnxml/op_array_feature_extractor.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,W0221
 
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl
+
+# pylint: disable=R0913,R0914,W0221
 
 
 def _array_feature_extrator(data, indices):  # type: ignore

--- a/onnx/reference/ops/aionnxml/op_binarizer.py
+++ b/onnx/reference/ops/aionnxml/op_binarizer.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,W0221
 
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl

--- a/onnx/reference/ops/aionnxml/op_binarizer.py
+++ b/onnx/reference/ops/aionnxml/op_binarizer.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,W0221
 
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl
+
+# pylint: disable=R0913,R0914,W0221
 
 
 def compute_binarizer(x, threshold=None):

--- a/onnx/reference/ops/aionnxml/op_dict_vectorizer.py
+++ b/onnx/reference/ops/aionnxml/op_dict_vectorizer.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,W0221
 
 import numpy as np

--- a/onnx/reference/ops/aionnxml/op_dict_vectorizer.py
+++ b/onnx/reference/ops/aionnxml/op_dict_vectorizer.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,W0221
 
 import numpy as np
 
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl
+
+# pylint: disable=R0913,R0914,W0221
 
 
 class DictVectorizer(OpRunAiOnnxMl):

--- a/onnx/reference/ops/aionnxml/op_feature_vectorizer.py
+++ b/onnx/reference/ops/aionnxml/op_feature_vectorizer.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,W0221
 
 import numpy as np

--- a/onnx/reference/ops/aionnxml/op_feature_vectorizer.py
+++ b/onnx/reference/ops/aionnxml/op_feature_vectorizer.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,W0221
 
 import numpy as np
 
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl
+
+# pylint: disable=R0913,R0914,W0221
 
 
 class FeatureVectorizer(OpRunAiOnnxMl):

--- a/onnx/reference/ops/aionnxml/op_imputer.py
+++ b/onnx/reference/ops/aionnxml/op_imputer.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,W0221
 
 import numpy as np

--- a/onnx/reference/ops/aionnxml/op_imputer.py
+++ b/onnx/reference/ops/aionnxml/op_imputer.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,W0221
 
 import numpy as np
 
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl
+
+# pylint: disable=R0913,R0914,W0221
 
 
 class Imputer(OpRunAiOnnxMl):

--- a/onnx/reference/ops/aionnxml/op_label_encoder.py
+++ b/onnx/reference/ops/aionnxml/op_label_encoder.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,W0221
 
 import numpy as np
 
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl
+
+# pylint: disable=R0913,R0914,W0221
 
 
 class LabelEncoder(OpRunAiOnnxMl):

--- a/onnx/reference/ops/aionnxml/op_label_encoder.py
+++ b/onnx/reference/ops/aionnxml/op_label_encoder.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,W0221
 
 import numpy as np

--- a/onnx/reference/ops/aionnxml/op_linear_classifier.py
+++ b/onnx/reference/ops/aionnxml/op_linear_classifier.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0912,R0913,R0914,W0221
 
 import numpy as np

--- a/onnx/reference/ops/aionnxml/op_linear_classifier.py
+++ b/onnx/reference/ops/aionnxml/op_linear_classifier.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0912,R0913,R0914,W0221
 
 import numpy as np
 
@@ -12,6 +11,8 @@ from onnx.reference.ops.aionnxml._common_classifier import (
     expit,
 )
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl
+
+# pylint: disable=R0912,R0913,R0914,W0221
 
 
 class LinearClassifier(OpRunAiOnnxMl):

--- a/onnx/reference/ops/aionnxml/op_linear_regressor.py
+++ b/onnx/reference/ops/aionnxml/op_linear_regressor.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,W0221
 
 import numpy as np
 
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl
+
+# pylint: disable=R0913,R0914,W0221
 
 
 class LinearRegressor(OpRunAiOnnxMl):

--- a/onnx/reference/ops/aionnxml/op_linear_regressor.py
+++ b/onnx/reference/ops/aionnxml/op_linear_regressor.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,W0221
 
 import numpy as np

--- a/onnx/reference/ops/aionnxml/op_normalizer.py
+++ b/onnx/reference/ops/aionnxml/op_normalizer.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,W0221
 
 import numpy as np
 
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl
+
+# pylint: disable=R0913,R0914,W0221
 
 
 class Normalizer(OpRunAiOnnxMl):

--- a/onnx/reference/ops/aionnxml/op_normalizer.py
+++ b/onnx/reference/ops/aionnxml/op_normalizer.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,W0221
 
 import numpy as np

--- a/onnx/reference/ops/aionnxml/op_one_hot_encoder.py
+++ b/onnx/reference/ops/aionnxml/op_one_hot_encoder.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0912,R0913,R0914,W0221
 
 import numpy as np

--- a/onnx/reference/ops/aionnxml/op_one_hot_encoder.py
+++ b/onnx/reference/ops/aionnxml/op_one_hot_encoder.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0912,R0913,R0914,W0221
 
 import numpy as np
 
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl
+
+# pylint: disable=R0912,R0913,R0914,W0221
 
 
 class OneHotEncoder(OpRunAiOnnxMl):

--- a/onnx/reference/ops/aionnxml/op_scaler.py
+++ b/onnx/reference/ops/aionnxml/op_scaler.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,W0221
 
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl

--- a/onnx/reference/ops/aionnxml/op_scaler.py
+++ b/onnx/reference/ops/aionnxml/op_scaler.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,W0221
 
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl
+
+# pylint: disable=R0913,R0914,W0221
 
 
 class Scaler(OpRunAiOnnxMl):

--- a/onnx/reference/ops/aionnxml/op_svm_classifier.py
+++ b/onnx/reference/ops/aionnxml/op_svm_classifier.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0911,R0912,R0913,R0914,W0221
 
 import numpy as np

--- a/onnx/reference/ops/aionnxml/op_svm_classifier.py
+++ b/onnx/reference/ops/aionnxml/op_svm_classifier.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0911,R0912,R0913,R0914,W0221
 
 import numpy as np
 
@@ -16,6 +15,8 @@ from onnx.reference.ops.aionnxml._common_classifier import (
 )
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl
 from onnx.reference.ops.aionnxml.op_svm_helper import SVMCommon
+
+# pylint: disable=R0911,R0912,R0913,R0914,W0221
 
 
 def multiclass_probability(k, R):

--- a/onnx/reference/ops/aionnxml/op_svm_helper.py
+++ b/onnx/reference/ops/aionnxml/op_svm_helper.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0911,R0913,R0914,W0221
 
 from typing import Any

--- a/onnx/reference/ops/aionnxml/op_svm_helper.py
+++ b/onnx/reference/ops/aionnxml/op_svm_helper.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0911,R0913,R0914,W0221
 
 from typing import Any
 
 import numpy as np
+
+# pylint: disable=R0911,R0913,R0914,W0221
 
 
 class SVMAttributes:

--- a/onnx/reference/ops/aionnxml/op_svm_regressor.py
+++ b/onnx/reference/ops/aionnxml/op_svm_regressor.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0912,R0913,R0914,W0221
 
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl

--- a/onnx/reference/ops/aionnxml/op_svm_regressor.py
+++ b/onnx/reference/ops/aionnxml/op_svm_regressor.py
@@ -2,10 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0912,R0913,R0914,W0221
 
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl
 from onnx.reference.ops.aionnxml.op_svm_helper import SVMCommon
+
+# pylint: disable=R0912,R0913,R0914,W0221
 
 
 class SVMRegressor(OpRunAiOnnxMl):

--- a/onnx/reference/ops/aionnxml/op_tree_ensemble_classifier.py
+++ b/onnx/reference/ops/aionnxml/op_tree_ensemble_classifier.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0912,R0913,R0914,W0221
 
 import numpy as np

--- a/onnx/reference/ops/aionnxml/op_tree_ensemble_classifier.py
+++ b/onnx/reference/ops/aionnxml/op_tree_ensemble_classifier.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0912,R0913,R0914,W0221
 
 import numpy as np
 
@@ -14,6 +13,8 @@ from onnx.reference.ops.aionnxml._common_classifier import (
 )
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl
 from onnx.reference.ops.aionnxml.op_tree_ensemble_helper import TreeEnsemble
+
+# pylint: disable=R0912,R0913,R0914,W0221
 
 
 class TreeEnsembleClassifier(OpRunAiOnnxMl):

--- a/onnx/reference/ops/aionnxml/op_tree_ensemble_helper.py
+++ b/onnx/reference/ops/aionnxml/op_tree_ensemble_helper.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0911,R0913,R0914,W0221
 
 import numpy as np
+
+# pylint: disable=R0911,R0913,R0914,W0221
 
 
 class TreeEnsembleAttributes:

--- a/onnx/reference/ops/aionnxml/op_tree_ensemble_helper.py
+++ b/onnx/reference/ops/aionnxml/op_tree_ensemble_helper.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0911,R0913,R0914,W0221
 
 import numpy as np

--- a/onnx/reference/ops/aionnxml/op_tree_ensemble_regressor.py
+++ b/onnx/reference/ops/aionnxml/op_tree_ensemble_regressor.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0912,R0913,R0914,W0221
 
 import numpy as np

--- a/onnx/reference/ops/aionnxml/op_tree_ensemble_regressor.py
+++ b/onnx/reference/ops/aionnxml/op_tree_ensemble_regressor.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0912,R0913,R0914,W0221
 
 import numpy as np
 
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl
 from onnx.reference.ops.aionnxml.op_tree_ensemble_helper import TreeEnsemble
+
+# pylint: disable=R0912,R0913,R0914,W0221
 
 
 class TreeEnsembleRegressor(OpRunAiOnnxMl):

--- a/onnx/reference/ops/experimental/__init__.py
+++ b/onnx/reference/ops/experimental/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from onnx.reference.ops.experimental._op_list import load_op

--- a/onnx/reference/ops/experimental/_op_list.py
+++ b/onnx/reference/ops/experimental/_op_list.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=C0415,R0912,W0611,W0603
 
 import textwrap

--- a/onnx/reference/ops/experimental/_op_list.py
+++ b/onnx/reference/ops/experimental/_op_list.py
@@ -2,28 +2,23 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=C0415,R0912,W0611,W0603
 
 import textwrap
-from typing import Any, Dict
-from typing import Optional as TOptional
-from typing import Union
+from typing import Any
 
 from onnx.reference.op_run import OpFunction
 from onnx.reference.ops._helpers import build_registered_operators_any_domain
 from onnx.reference.ops.experimental._op_run_experimental import OpRunExperimental
 from onnx.reference.ops.experimental.op_im2col import Im2Col  # noqa: F401
 
+# pylint: disable=C0415,R0912,W0611,W0603
 
-def _build_registered_operators() -> (
-    Dict[str, Dict[Union[int, None], OpRunExperimental]]
-):
+
+def _build_registered_operators() -> dict[str, dict[int | None, OpRunExperimental]]:
     return build_registered_operators_any_domain(globals().copy())  # type: ignore[return-value]
 
 
-def load_op(
-    domain: str, op_type: str, version: Union[None, int], custom: Any = None
-) -> Any:
+def load_op(domain: str, op_type: str, version: None | int, custom: Any = None) -> Any:
     """
     Loads the implemented for a specified operator.
 
@@ -78,6 +73,4 @@ def load_op(
     return cl
 
 
-_registered_operators: TOptional[
-    Dict[str, Dict[Union[int, None], OpRunExperimental]]
-] = None
+_registered_operators: dict[str, dict[int | None, OpRunExperimental]] | None = None

--- a/onnx/reference/ops/experimental/_op_list.py
+++ b/onnx/reference/ops/experimental/_op_list.py
@@ -1,6 +1,8 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=C0415,R0912,W0611,W0603
+
 from __future__ import annotations
 
 import textwrap
@@ -10,8 +12,6 @@ from onnx.reference.op_run import OpFunction
 from onnx.reference.ops._helpers import build_registered_operators_any_domain
 from onnx.reference.ops.experimental._op_run_experimental import OpRunExperimental
 from onnx.reference.ops.experimental.op_im2col import Im2Col  # noqa: F401
-
-# pylint: disable=C0415,R0912,W0611,W0603
 
 
 def _build_registered_operators() -> dict[str, dict[int | None, OpRunExperimental]]:

--- a/onnx/reference/ops/experimental/_op_run_experimental.py
+++ b/onnx/reference/ops/experimental/_op_run_experimental.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,W0221
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0913,W0221
 
 
 class OpRunExperimental(OpRun):

--- a/onnx/reference/ops/experimental/_op_run_experimental.py
+++ b/onnx/reference/ops/experimental/_op_run_experimental.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,W0221
 
 from onnx.reference.op_run import OpRun

--- a/onnx/reference/ops/experimental/op_im2col.py
+++ b/onnx/reference/ops/experimental/op_im2col.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,W0221
 
 from onnx.reference.ops.experimental._op_run_experimental import OpRunExperimental

--- a/onnx/reference/ops/experimental/op_im2col.py
+++ b/onnx/reference/ops/experimental/op_im2col.py
@@ -2,10 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,W0221
 
 from onnx.reference.ops.experimental._op_run_experimental import OpRunExperimental
 from onnx.reference.ops_optimized.op_conv_optimized import im2col_fast
+
+# pylint: disable=R0913,R0914,W0221
 
 
 class Im2Col(OpRunExperimental):

--- a/onnx/reference/ops/op_abs.py
+++ b/onnx/reference/ops/op_abs.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_abs.py
+++ b/onnx/reference/ops/op_abs.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Abs(OpRunUnaryNum):

--- a/onnx/reference/ops/op_acos.py
+++ b/onnx/reference/ops/op_acos.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Acos(OpRunUnaryNum):

--- a/onnx/reference/ops/op_acos.py
+++ b/onnx/reference/ops/op_acos.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_acosh.py
+++ b/onnx/reference/ops/op_acosh.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Acosh(OpRunUnaryNum):

--- a/onnx/reference/ops/op_acosh.py
+++ b/onnx/reference/ops/op_acosh.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_add.py
+++ b/onnx/reference/ops/op_add.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunBinaryNumpy
+
+# pylint: disable=W0221
 
 
 class Add(OpRunBinaryNumpy):

--- a/onnx/reference/ops/op_add.py
+++ b/onnx/reference/ops/op_add.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_affine_grid.py
+++ b/onnx/reference/ops/op_affine_grid.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0912,R0913,R0914,R0915,R1702,R1716,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_affine_grid.py
+++ b/onnx/reference/ops/op_affine_grid.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0912,R0913,R0914,R0915,R1702,R1716,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0912,R0913,R0914,R0915,R1702,R1716,W0221
 
 
 def construct_original_grid(data_size, align_corners):

--- a/onnx/reference/ops/op_and.py
+++ b/onnx/reference/ops/op_and.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunBinary
+
+# pylint: disable=W0221
 
 
 class And(OpRunBinary):

--- a/onnx/reference/ops/op_and.py
+++ b/onnx/reference/ops/op_and.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_argmax.py
+++ b/onnx/reference/ops/op_argmax.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_argmax.py
+++ b/onnx/reference/ops/op_argmax.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 def _argmax(data, axis=0, keepdims=True):  # type: ignore

--- a/onnx/reference/ops/op_argmin.py
+++ b/onnx/reference/ops/op_argmin.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 def _argmin(data, axis=0, keepdims=True):  # type: ignore

--- a/onnx/reference/ops/op_argmin.py
+++ b/onnx/reference/ops/op_argmin.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_asin.py
+++ b/onnx/reference/ops/op_asin.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_asin.py
+++ b/onnx/reference/ops/op_asin.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Asin(OpRunUnaryNum):

--- a/onnx/reference/ops/op_asinh.py
+++ b/onnx/reference/ops/op_asinh.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_asinh.py
+++ b/onnx/reference/ops/op_asinh.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Asinh(OpRunUnaryNum):

--- a/onnx/reference/ops/op_atan.py
+++ b/onnx/reference/ops/op_atan.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Atan(OpRunUnaryNum):

--- a/onnx/reference/ops/op_atan.py
+++ b/onnx/reference/ops/op_atan.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_atanh.py
+++ b/onnx/reference/ops/op_atanh.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_atanh.py
+++ b/onnx/reference/ops/op_atanh.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Atanh(OpRunUnaryNum):

--- a/onnx/reference/ops/op_attribute_has_value.py
+++ b/onnx/reference/ops/op_attribute_has_value.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,W0221,W0613
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0913,R0914,W0221,W0613
 
 
 class AttributeHasValue(OpRun):

--- a/onnx/reference/ops/op_attribute_has_value.py
+++ b/onnx/reference/ops/op_attribute_has_value.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,W0221,W0613
 
 import numpy as np

--- a/onnx/reference/ops/op_average_pool.py
+++ b/onnx/reference/ops/op_average_pool.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221,R0913,R0914
 
 from onnx.reference.ops.op_pool_common import CommonPool

--- a/onnx/reference/ops/op_average_pool.py
+++ b/onnx/reference/ops/op_average_pool.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221,R0913,R0914
 
 from onnx.reference.ops.op_pool_common import CommonPool
+
+# pylint: disable=W0221,R0913,R0914
 
 
 class AveragePool_1(CommonPool):

--- a/onnx/reference/ops/op_batch_normalization.py
+++ b/onnx/reference/ops/op_batch_normalization.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221,R0913,W0613
 
 import numpy as np

--- a/onnx/reference/ops/op_batch_normalization.py
+++ b/onnx/reference/ops/op_batch_normalization.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221,R0913,W0613
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221,R0913,W0613
 
 
 def _batchnorm_test_mode(

--- a/onnx/reference/ops/op_bernoulli.py
+++ b/onnx/reference/ops/op_bernoulli.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 from onnx.helper import np_dtype_to_tensor_dtype

--- a/onnx/reference/ops/op_bernoulli.py
+++ b/onnx/reference/ops/op_bernoulli.py
@@ -2,10 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 from onnx.helper import np_dtype_to_tensor_dtype
 from onnx.reference.ops._op_common_random import _CommonRandom
+
+# pylint: disable=W0221
 
 
 class Bernoulli(_CommonRandom):

--- a/onnx/reference/ops/op_bitshift.py
+++ b/onnx/reference/ops/op_bitshift.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunBinaryNumpy
+
+# pylint: disable=W0221
 
 
 class BitShift(OpRunBinaryNumpy):

--- a/onnx/reference/ops/op_bitshift.py
+++ b/onnx/reference/ops/op_bitshift.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_bitwise_and.py
+++ b/onnx/reference/ops/op_bitwise_and.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_bitwise_and.py
+++ b/onnx/reference/ops/op_bitwise_and.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunBinary
+
+# pylint: disable=W0221
 
 
 class BitwiseAnd(OpRunBinary):

--- a/onnx/reference/ops/op_bitwise_not.py
+++ b/onnx/reference/ops/op_bitwise_not.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnary
+
+# pylint: disable=W0221
 
 
 class BitwiseNot(OpRunUnary):

--- a/onnx/reference/ops/op_bitwise_not.py
+++ b/onnx/reference/ops/op_bitwise_not.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_bitwise_or.py
+++ b/onnx/reference/ops/op_bitwise_or.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_bitwise_or.py
+++ b/onnx/reference/ops/op_bitwise_or.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunBinary
+
+# pylint: disable=W0221
 
 
 class BitwiseOr(OpRunBinary):

--- a/onnx/reference/ops/op_bitwise_xor.py
+++ b/onnx/reference/ops/op_bitwise_xor.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunBinary
+
+# pylint: disable=W0221
 
 
 class BitwiseXor(OpRunBinary):

--- a/onnx/reference/ops/op_bitwise_xor.py
+++ b/onnx/reference/ops/op_bitwise_xor.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_blackman_window.py
+++ b/onnx/reference/ops/op_blackman_window.py
@@ -2,12 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
-
 
 import numpy as np
 
 from onnx.reference.ops._op_common_window import _CommonWindow
+
+# pylint: disable=W0221
 
 
 class BlackmanWindow(_CommonWindow):

--- a/onnx/reference/ops/op_blackman_window.py
+++ b/onnx/reference/ops/op_blackman_window.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 

--- a/onnx/reference/ops/op_cast.py
+++ b/onnx/reference/ops/op_cast.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0912,W0221
 
 import numpy as np
 
@@ -26,6 +25,8 @@ from onnx.reference.custom_element_types import (
     float8e5m2fnuz,
 )
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0912,W0221
 
 
 def cast_to(x, to, saturate):

--- a/onnx/reference/ops/op_cast.py
+++ b/onnx/reference/ops/op_cast.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0912,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_cast_like.py
+++ b/onnx/reference/ops/op_cast_like.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 from onnx.helper import np_dtype_to_tensor_dtype

--- a/onnx/reference/ops/op_cast_like.py
+++ b/onnx/reference/ops/op_cast_like.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 from onnx.helper import np_dtype_to_tensor_dtype
 from onnx.onnx_pb import TensorProto
@@ -15,6 +14,8 @@ from onnx.reference.ops.op_cast import (
     float8e5m2,
     float8e5m2fnuz,
 )
+
+# pylint: disable=W0221
 
 
 def _cast_like(x, y, saturate):

--- a/onnx/reference/ops/op_ceil.py
+++ b/onnx/reference/ops/op_ceil.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Ceil(OpRunUnaryNum):

--- a/onnx/reference/ops/op_ceil.py
+++ b/onnx/reference/ops/op_ceil.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_celu.py
+++ b/onnx/reference/ops/op_celu.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_celu.py
+++ b/onnx/reference/ops/op_celu.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 def _vcelu1(x: np.ndarray, alpha: float = 1.0) -> np.ndarray:

--- a/onnx/reference/ops/op_center_crop_pad.py
+++ b/onnx/reference/ops/op_center_crop_pad.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0912,R0914,R1702,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_center_crop_pad.py
+++ b/onnx/reference/ops/op_center_crop_pad.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0912,R0914,R1702,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0912,R0914,R1702,W0221
 
 
 class CenterCropPad(OpRun):

--- a/onnx/reference/ops/op_clip.py
+++ b/onnx/reference/ops/op_clip.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0622,W0622,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0622,W0622,W0221
 
 
 class Clip_6(OpRun):

--- a/onnx/reference/ops/op_clip.py
+++ b/onnx/reference/ops/op_clip.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0622,W0622,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_col2im.py
+++ b/onnx/reference/ops/op_col2im.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
 from onnx.reference.ops._op_common_indices import _get_indices, _is_out
+
+# pylint: disable=R0913,R0914,W0221
 
 
 def _col2im_shape_check_2d(X, output_shape, kernel_shape, dilations, pads, strides):  # type: ignore

--- a/onnx/reference/ops/op_col2im.py
+++ b/onnx/reference/ops/op_col2im.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_compress.py
+++ b/onnx/reference/ops/op_compress.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class Compress(OpRun):

--- a/onnx/reference/ops/op_compress.py
+++ b/onnx/reference/ops/op_compress.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_concat.py
+++ b/onnx/reference/ops/op_concat.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class Concat(OpRun):

--- a/onnx/reference/ops/op_concat.py
+++ b/onnx/reference/ops/op_concat.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_concat_from_sequence.py
+++ b/onnx/reference/ops/op_concat_from_sequence.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 from typing import Any, List

--- a/onnx/reference/ops/op_concat_from_sequence.py
+++ b/onnx/reference/ops/op_concat_from_sequence.py
@@ -2,16 +2,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
-from typing import Any, List
+from typing import Any
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
 
+# pylint: disable=W0221
 
-def _concat_from_sequence(seq: List[Any], axis: int, new_axis: int = 0) -> np.ndarray:
+
+def _concat_from_sequence(seq: list[Any], axis: int, new_axis: int = 0) -> np.ndarray:
     if new_axis == 1:
         seq2 = [s[..., np.newaxis] for s in seq]
         res = np.concatenate(seq2, axis=-1)

--- a/onnx/reference/ops/op_constant.py
+++ b/onnx/reference/ops/op_constant.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
@@ -14,6 +13,8 @@ from onnx.reference.custom_element_types import (
     float8e5m2fnuz,
 )
 from onnx.reference.op_run import OpRun, RefAttrName
+
+# pylint: disable=W0221
 
 
 def _check_dtype(val):  # type: ignore

--- a/onnx/reference/ops/op_constant.py
+++ b/onnx/reference/ops/op_constant.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_constant_of_shape.py
+++ b/onnx/reference/ops/op_constant_of_shape.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class ConstantOfShape(OpRun):

--- a/onnx/reference/ops/op_constant_of_shape.py
+++ b/onnx/reference/ops/op_constant_of_shape.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_conv.py
+++ b/onnx/reference/ops/op_conv.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0912,R0913,R0914,R0915,R1702,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_conv.py
+++ b/onnx/reference/ops/op_conv.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0912,R0913,R0914,R0915,R1702,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0912,R0913,R0914,R0915,R1702,W0221
 
 
 def _conv_implementation(  # type: ignore

--- a/onnx/reference/ops/op_conv_integer.py
+++ b/onnx/reference/ops/op_conv_integer.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
 from onnx.reference.ops.op_conv import _conv_implementation
+
+# pylint: disable=R0913,W0221
 
 
 class ConvInteger(OpRun):

--- a/onnx/reference/ops/op_conv_integer.py
+++ b/onnx/reference/ops/op_conv_integer.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_conv_transpose.py
+++ b/onnx/reference/ops/op_conv_transpose.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0912,R0913,R0914,R0915,R1702,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_conv_transpose.py
+++ b/onnx/reference/ops/op_conv_transpose.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0912,R0913,R0914,R0915,R1702,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
 from onnx.reference.ops.op_col2im import col2im_naive_implementation
+
+# pylint: disable=R0912,R0913,R0914,R0915,R1702,W0221
 
 
 class ConvTranspose(OpRun):

--- a/onnx/reference/ops/op_cos.py
+++ b/onnx/reference/ops/op_cos.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Cos(OpRunUnaryNum):

--- a/onnx/reference/ops/op_cos.py
+++ b/onnx/reference/ops/op_cos.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_cosh.py
+++ b/onnx/reference/ops/op_cosh.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Cosh(OpRunUnaryNum):

--- a/onnx/reference/ops/op_cosh.py
+++ b/onnx/reference/ops/op_cosh.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_cum_sum.py
+++ b/onnx/reference/ops/op_cum_sum.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_cum_sum.py
+++ b/onnx/reference/ops/op_cum_sum.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class CumSum(OpRun):

--- a/onnx/reference/ops/op_deform_conv.py
+++ b/onnx/reference/ops/op_deform_conv.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0912,R0913,R0914,R0915,R1702,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_deform_conv.py
+++ b/onnx/reference/ops/op_deform_conv.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0912,R0913,R0914,R0915,R1702,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0912,R0913,R0914,R0915,R1702,W0221
 
 
 def _deform_conv_implementation(  # type: ignore

--- a/onnx/reference/ops/op_depth_to_space.py
+++ b/onnx/reference/ops/op_depth_to_space.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_depth_to_space.py
+++ b/onnx/reference/ops/op_depth_to_space.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class DepthToSpace(OpRun):

--- a/onnx/reference/ops/op_dequantize_linear.py
+++ b/onnx/reference/ops/op_dequantize_linear.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 from typing import Optional, Tuple

--- a/onnx/reference/ops/op_dequantize_linear.py
+++ b/onnx/reference/ops/op_dequantize_linear.py
@@ -2,9 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
-
-from typing import Optional, Tuple
 
 import numpy as np
 
@@ -18,6 +15,8 @@ from onnx.reference.custom_element_types import (
     float8e5m2fnuz,
 )
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class DequantizeLinear(OpRun):
@@ -34,7 +33,7 @@ class DequantizeLinear(OpRun):
 
     @staticmethod
     def reshape_input(
-        value: np.ndarray, shape: Tuple[int, ...], axis: Optional[int]
+        value: np.ndarray, shape: tuple[int, ...], axis: int | None
     ) -> np.ndarray:
         if axis is None:
             raise ValueError("axis cannot be None.")
@@ -54,8 +53,8 @@ class DequantizeLinear(OpRun):
         self,
         x: np.ndarray,
         x_scale: np.ndarray,
-        x_zero_point: Optional[np.ndarray] = None,
-        axis: Optional[int] = None,
+        x_zero_point: np.ndarray | None = None,
+        axis: int | None = None,
     ):  # type: ignore
         if len(x_scale.shape) > 1:
             raise RuntimeError("Input 2 must be a vector or a number.")

--- a/onnx/reference/ops/op_det.py
+++ b/onnx/reference/ops/op_det.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class Det(OpRun):

--- a/onnx/reference/ops/op_det.py
+++ b/onnx/reference/ops/op_det.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_dft.py
+++ b/onnx/reference/ops/op_dft.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,W0221
 
 from typing import Sequence
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0913,W0221
 
 
 def _fft(x: np.ndarray, fft_length: Sequence[int], axis: int) -> np.ndarray:

--- a/onnx/reference/ops/op_dft.py
+++ b/onnx/reference/ops/op_dft.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,W0221
 
 from typing import Sequence

--- a/onnx/reference/ops/op_div.py
+++ b/onnx/reference/ops/op_div.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunBinaryNumpy
+
+# pylint: disable=W0221
 
 
 class Div(OpRunBinaryNumpy):

--- a/onnx/reference/ops/op_div.py
+++ b/onnx/reference/ops/op_div.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_dropout.py
+++ b/onnx/reference/ops/op_dropout.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 from typing import Optional, Tuple

--- a/onnx/reference/ops/op_dropout.py
+++ b/onnx/reference/ops/op_dropout.py
@@ -2,23 +2,22 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
-
-from typing import Optional, Tuple
 
 import numpy as np
 from numpy.random import RandomState  # type: ignore
 
 from onnx.reference.op_run import OpRun
 
+# pylint: disable=W0221
+
 
 def _dropout(
     X: np.ndarray,
     drop_probability: float = 0.5,
-    seed: Optional[int] = None,
+    seed: int | None = None,
     training_mode: bool = False,
     return_mask: bool = False,
-) -> Tuple[np.ndarray]:
+) -> tuple[np.ndarray]:
     if drop_probability == 0 or not training_mode:
         if return_mask:
             return X, np.ones(X.shape, dtype=bool)  # type: ignore
@@ -38,10 +37,10 @@ class DropoutBase(OpRun):
     def _private_run(
         self,
         X: np.ndarray,
-        seed: Optional[int] = None,
+        seed: int | None = None,
         ratio: float = 0.5,
         training_mode: bool = False,
-    ) -> Tuple[np.ndarray]:
+    ) -> tuple[np.ndarray]:
         return _dropout(
             X,
             ratio,

--- a/onnx/reference/ops/op_dynamic_quantize_linear.py
+++ b/onnx/reference/ops/op_dynamic_quantize_linear.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class DynamicQuantizeLinear(OpRun):

--- a/onnx/reference/ops/op_dynamic_quantize_linear.py
+++ b/onnx/reference/ops/op_dynamic_quantize_linear.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_einsum.py
+++ b/onnx/reference/ops/op_einsum.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=E0203,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=E0203,W0221
 
 
 class Einsum(OpRun):

--- a/onnx/reference/ops/op_einsum.py
+++ b/onnx/reference/ops/op_einsum.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=E0203,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_elu.py
+++ b/onnx/reference/ops/op_elu.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Elu(OpRunUnaryNum):

--- a/onnx/reference/ops/op_elu.py
+++ b/onnx/reference/ops/op_elu.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_equal.py
+++ b/onnx/reference/ops/op_equal.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunBinaryComparison
+
+# pylint: disable=W0221
 
 
 class Equal(OpRunBinaryComparison):

--- a/onnx/reference/ops/op_equal.py
+++ b/onnx/reference/ops/op_equal.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_erf.py
+++ b/onnx/reference/ops/op_erf.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 from math import erf

--- a/onnx/reference/ops/op_erf.py
+++ b/onnx/reference/ops/op_erf.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 from math import erf
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Erf(OpRunUnaryNum):

--- a/onnx/reference/ops/op_exp.py
+++ b/onnx/reference/ops/op_exp.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_exp.py
+++ b/onnx/reference/ops/op_exp.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Exp(OpRunUnaryNum):

--- a/onnx/reference/ops/op_expand.py
+++ b/onnx/reference/ops/op_expand.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_expand.py
+++ b/onnx/reference/ops/op_expand.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 def common_reference_implementation(data: np.ndarray, shape: np.ndarray) -> np.ndarray:

--- a/onnx/reference/ops/op_eyelike.py
+++ b/onnx/reference/ops/op_eyelike.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_eyelike.py
+++ b/onnx/reference/ops/op_eyelike.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.helper import tensor_dtype_to_np_dtype
 from onnx.onnx_pb import TensorProto
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class EyeLike(OpRun):

--- a/onnx/reference/ops/op_flatten.py
+++ b/onnx/reference/ops/op_flatten.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_flatten.py
+++ b/onnx/reference/ops/op_flatten.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnary
+
+# pylint: disable=W0221
 
 
 class Flatten(OpRunUnary):

--- a/onnx/reference/ops/op_floor.py
+++ b/onnx/reference/ops/op_floor.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_floor.py
+++ b/onnx/reference/ops/op_floor.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Floor(OpRunUnaryNum):

--- a/onnx/reference/ops/op_gather.py
+++ b/onnx/reference/ops/op_gather.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class Gather(OpRun):

--- a/onnx/reference/ops/op_gather.py
+++ b/onnx/reference/ops/op_gather.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_gather_elements.py
+++ b/onnx/reference/ops/op_gather_elements.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_gather_elements.py
+++ b/onnx/reference/ops/op_gather_elements.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 def gather_numpy_2(self: np.ndarray, index: np.ndarray) -> np.ndarray:

--- a/onnx/reference/ops/op_gathernd.py
+++ b/onnx/reference/ops/op_gathernd.py
@@ -2,18 +2,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
-
-from typing import Tuple
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
 
+# pylint: disable=W0221
+
 
 def _gather_nd_impl(
     data: np.ndarray, indices: np.ndarray, batch_dims: int
-) -> Tuple[np.ndarray]:
+) -> tuple[np.ndarray]:
     # Note the data rank - will be reused multiple times later
     data_rank = len(data.shape)
 

--- a/onnx/reference/ops/op_gathernd.py
+++ b/onnx/reference/ops/op_gathernd.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 from typing import Tuple

--- a/onnx/reference/ops/op_gemm.py
+++ b/onnx/reference/ops/op_gemm.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0913,W0221
 
 
 def _gemm00(a, b, c, alpha, beta):  # type: ignore

--- a/onnx/reference/ops/op_gemm.py
+++ b/onnx/reference/ops/op_gemm.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_global_average_pool.py
+++ b/onnx/reference/ops/op_global_average_pool.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_global_average_pool.py
+++ b/onnx/reference/ops/op_global_average_pool.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 def _global_average_pool(x: np.ndarray) -> np.ndarray:

--- a/onnx/reference/ops/op_global_max_pool.py
+++ b/onnx/reference/ops/op_global_max_pool.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 def _global_max_pool(x: np.ndarray) -> np.ndarray:

--- a/onnx/reference/ops/op_global_max_pool.py
+++ b/onnx/reference/ops/op_global_max_pool.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_greater.py
+++ b/onnx/reference/ops/op_greater.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunBinaryComparison
+
+# pylint: disable=W0221
 
 
 class Greater(OpRunBinaryComparison):

--- a/onnx/reference/ops/op_greater.py
+++ b/onnx/reference/ops/op_greater.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_greater_or_equal.py
+++ b/onnx/reference/ops/op_greater_or_equal.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunBinaryComparison
+
+# pylint: disable=W0221
 
 
 class GreaterOrEqual(OpRunBinaryComparison):

--- a/onnx/reference/ops/op_greater_or_equal.py
+++ b/onnx/reference/ops/op_greater_or_equal.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_grid_sample.py
+++ b/onnx/reference/ops/op_grid_sample.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0912,R0913,R0914,R0915,R1702,R1716,W0221
 
 import numbers

--- a/onnx/reference/ops/op_grid_sample.py
+++ b/onnx/reference/ops/op_grid_sample.py
@@ -2,15 +2,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0912,R0913,R0914,R0915,R1702,R1716,W0221
 
 import numbers
-from typing import List
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
 from onnx.reference.ops.op_resize import _get_all_coords
+
+# pylint: disable=R0912,R0913,R0914,R0915,R1702,R1716,W0221
 
 
 class GridSample(OpRun):
@@ -208,7 +208,7 @@ class GridSample(OpRun):
             return hi
         return val
 
-    def _pixel_at_ndarray(self, ndarray, x: List, border, padding_mode):  # type: ignore
+    def _pixel_at_ndarray(self, ndarray, x: list, border, padding_mode):  # type: ignore
         # boarder: [x_1_min, x_2_min, ..., x_1_max, x_2_max, ...]
         num_dims = ndarray.ndim
         assert num_dims == len(x) == int(len(border) / 2)

--- a/onnx/reference/ops/op_gru.py
+++ b/onnx/reference/ops/op_gru.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,W0221,W0613
 
 import numpy as np

--- a/onnx/reference/ops/op_gru.py
+++ b/onnx/reference/ops/op_gru.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,W0221,W0613
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0913,R0914,W0221,W0613
 
 
 class CommonGRU(OpRun):

--- a/onnx/reference/ops/op_hamming_window.py
+++ b/onnx/reference/ops/op_hamming_window.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_hamming_window.py
+++ b/onnx/reference/ops/op_hamming_window.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op_common_window import _CommonWindow
+
+# pylint: disable=W0221
 
 
 class HammingWindow(_CommonWindow):

--- a/onnx/reference/ops/op_hann_window.py
+++ b/onnx/reference/ops/op_hann_window.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op_common_window import _CommonWindow
+
+# pylint: disable=W0221
 
 
 class HannWindow(_CommonWindow):

--- a/onnx/reference/ops/op_hann_window.py
+++ b/onnx/reference/ops/op_hann_window.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_hard_sigmoid.py
+++ b/onnx/reference/ops/op_hard_sigmoid.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class HardSigmoid(OpRunUnaryNum):

--- a/onnx/reference/ops/op_hard_sigmoid.py
+++ b/onnx/reference/ops/op_hard_sigmoid.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_hardmax.py
+++ b/onnx/reference/ops/op_hardmax.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_hardmax.py
+++ b/onnx/reference/ops/op_hardmax.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Hardmax(OpRunUnaryNum):

--- a/onnx/reference/ops/op_identity.py
+++ b/onnx/reference/ops/op_identity.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 from onnx.reference.ops._op import OpRunUnaryNum

--- a/onnx/reference/ops/op_identity.py
+++ b/onnx/reference/ops/op_identity.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Identity(OpRunUnaryNum):

--- a/onnx/reference/ops/op_if.py
+++ b/onnx/reference/ops/op_if.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,W0221,W0613
 
 from onnx.reference.op_run import OpRun

--- a/onnx/reference/ops/op_if.py
+++ b/onnx/reference/ops/op_if.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,W0221,W0613
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0913,R0914,W0221,W0613
 
 
 class If(OpRun):

--- a/onnx/reference/ops/op_instance_normalization.py
+++ b/onnx/reference/ops/op_instance_normalization.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0913,R0914,W0221
 
 
 class InstanceNormalization(OpRun):

--- a/onnx/reference/ops/op_instance_normalization.py
+++ b/onnx/reference/ops/op_instance_normalization.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_isinf.py
+++ b/onnx/reference/ops/op_isinf.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class IsInf(OpRun):

--- a/onnx/reference/ops/op_isinf.py
+++ b/onnx/reference/ops/op_isinf.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_isnan.py
+++ b/onnx/reference/ops/op_isnan.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_isnan.py
+++ b/onnx/reference/ops/op_isnan.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnary
+
+# pylint: disable=W0221
 
 
 class IsNaN(OpRunUnary):

--- a/onnx/reference/ops/op_layer_normalization.py
+++ b/onnx/reference/ops/op_layer_normalization.py
@@ -2,13 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,W0221
-
-from typing import Tuple
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0913,R0914,W0221
 
 
 def _layer_normalization(
@@ -17,7 +16,7 @@ def _layer_normalization(
     B: np.ndarray,
     axis: int = -1,
     epsilon: float = 1e-5,
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     X_shape = X.shape
     X_rank = len(X_shape)
     if axis < 0:

--- a/onnx/reference/ops/op_layer_normalization.py
+++ b/onnx/reference/ops/op_layer_normalization.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,W0221
 
 from typing import Tuple

--- a/onnx/reference/ops/op_leaky_relu.py
+++ b/onnx/reference/ops/op_leaky_relu.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_leaky_relu.py
+++ b/onnx/reference/ops/op_leaky_relu.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 def _leaky_relu(x: np.ndarray, alpha: float) -> np.ndarray:

--- a/onnx/reference/ops/op_less.py
+++ b/onnx/reference/ops/op_less.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunBinaryComparison
+
+# pylint: disable=W0221
 
 
 class Less(OpRunBinaryComparison):

--- a/onnx/reference/ops/op_less.py
+++ b/onnx/reference/ops/op_less.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_less_or_equal.py
+++ b/onnx/reference/ops/op_less_or_equal.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_less_or_equal.py
+++ b/onnx/reference/ops/op_less_or_equal.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunBinaryComparison
+
+# pylint: disable=W0221
 
 
 class LessOrEqual(OpRunBinaryComparison):

--- a/onnx/reference/ops/op_log.py
+++ b/onnx/reference/ops/op_log.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Log(OpRunUnaryNum):

--- a/onnx/reference/ops/op_log.py
+++ b/onnx/reference/ops/op_log.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_log_softmax.py
+++ b/onnx/reference/ops/op_log_softmax.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_log_softmax.py
+++ b/onnx/reference/ops/op_log_softmax.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops.op_softmax import Softmax
+
+# pylint: disable=W0221
 
 
 class LogSoftmax(Softmax):

--- a/onnx/reference/ops/op_loop.py
+++ b/onnx/reference/ops/op_loop.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0912,R0914,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_loop.py
+++ b/onnx/reference/ops/op_loop.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0912,R0914,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0912,R0914,W0221
 
 
 class Loop(OpRun):

--- a/onnx/reference/ops/op_lp_normalization.py
+++ b/onnx/reference/ops/op_lp_normalization.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class LpNormalization(OpRunUnaryNum):

--- a/onnx/reference/ops/op_lp_normalization.py
+++ b/onnx/reference/ops/op_lp_normalization.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_lp_pool.py
+++ b/onnx/reference/ops/op_lp_pool.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221,R0913,R0914
 
 import numpy as np
 
 from onnx.reference.ops.op_pool_common import CommonPool
+
+# pylint: disable=W0221,R0913,R0914
 
 
 class LpPool(CommonPool):

--- a/onnx/reference/ops/op_lp_pool.py
+++ b/onnx/reference/ops/op_lp_pool.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221,R0913,R0914
 
 import numpy as np

--- a/onnx/reference/ops/op_lrn.py
+++ b/onnx/reference/ops/op_lrn.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,W0221
 
 import math
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0913,W0221
 
 
 class LRN(OpRun):

--- a/onnx/reference/ops/op_lrn.py
+++ b/onnx/reference/ops/op_lrn.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,W0221
 
 import math

--- a/onnx/reference/ops/op_lstm.py
+++ b/onnx/reference/ops/op_lstm.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,W0221,W0613
 
 from typing import Tuple

--- a/onnx/reference/ops/op_lstm.py
+++ b/onnx/reference/ops/op_lstm.py
@@ -2,13 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,W0221,W0613
-
-from typing import Tuple
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0913,R0914,W0221,W0613
 
 
 class CommonLSTM(OpRun):
@@ -36,7 +35,7 @@ class CommonLSTM(OpRun):
         C_0: np.ndarray,
         P: np.ndarray,
         num_directions: int,
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray]:
         seq_length = X.shape[0]
         hidden_size = H_0.shape[-1]
         batch_size = X.shape[1]

--- a/onnx/reference/ops/op_matmul.py
+++ b/onnx/reference/ops/op_matmul.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunBinaryNum
+
+# pylint: disable=W0221
 
 
 def numpy_matmul(a, b):  # type: ignore

--- a/onnx/reference/ops/op_matmul.py
+++ b/onnx/reference/ops/op_matmul.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_matmul_integer.py
+++ b/onnx/reference/ops/op_matmul_integer.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class MatMulInteger(OpRun):

--- a/onnx/reference/ops/op_matmul_integer.py
+++ b/onnx/reference/ops/op_matmul_integer.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_max.py
+++ b/onnx/reference/ops/op_max.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_max.py
+++ b/onnx/reference/ops/op_max.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunBinaryNumpy
+
+# pylint: disable=W0221
 
 
 class Max(OpRunBinaryNumpy):

--- a/onnx/reference/ops/op_max_pool.py
+++ b/onnx/reference/ops/op_max_pool.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=C0200,R0912,R0913,R0914,R0915,R0916,R1702,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_max_pool.py
+++ b/onnx/reference/ops/op_max_pool.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=C0200,R0912,R0913,R0914,R0915,R0916,R1702,W0221
 
 import numpy as np
 
 from onnx.reference.ops._op_common_pool import CommonPool
+
+# pylint: disable=C0200,R0912,R0913,R0914,R0915,R0916,R1702,W0221
 
 
 class MaxPool(CommonPool):

--- a/onnx/reference/ops/op_max_unpool.py
+++ b/onnx/reference/ops/op_max_unpool.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=C0200,R0913,R0914,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=C0200,R0913,R0914,W0221
 
 
 class MaxUnpool(OpRun):

--- a/onnx/reference/ops/op_max_unpool.py
+++ b/onnx/reference/ops/op_max_unpool.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=C0200,R0913,R0914,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_mean.py
+++ b/onnx/reference/ops/op_mean.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun

--- a/onnx/reference/ops/op_mean.py
+++ b/onnx/reference/ops/op_mean.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class Mean(OpRun):

--- a/onnx/reference/ops/op_mel_weight_matrix.py
+++ b/onnx/reference/ops/op_mel_weight_matrix.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,W0221
 
 import numpy as np
 
 from onnx.helper import tensor_dtype_to_np_dtype
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0913,R0914,W0221
 
 
 class MelWeightMatrix(OpRun):

--- a/onnx/reference/ops/op_mel_weight_matrix.py
+++ b/onnx/reference/ops/op_mel_weight_matrix.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_min.py
+++ b/onnx/reference/ops/op_min.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunBinaryNumpy
+
+# pylint: disable=W0221
 
 
 class Min(OpRunBinaryNumpy):

--- a/onnx/reference/ops/op_min.py
+++ b/onnx/reference/ops/op_min.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_mod.py
+++ b/onnx/reference/ops/op_mod.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_mod.py
+++ b/onnx/reference/ops/op_mod.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class Mod(OpRun):

--- a/onnx/reference/ops/op_mul.py
+++ b/onnx/reference/ops/op_mul.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_mul.py
+++ b/onnx/reference/ops/op_mul.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunBinaryNumpy
+
+# pylint: disable=W0221
 
 
 class Mul(OpRunBinaryNumpy):

--- a/onnx/reference/ops/op_neg.py
+++ b/onnx/reference/ops/op_neg.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_neg.py
+++ b/onnx/reference/ops/op_neg.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Neg(OpRunUnaryNum):

--- a/onnx/reference/ops/op_negative_log_likelihood_loss.py
+++ b/onnx/reference/ops/op_negative_log_likelihood_loss.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0912,R0913,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_negative_log_likelihood_loss.py
+++ b/onnx/reference/ops/op_negative_log_likelihood_loss.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0912,R0913,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0912,R0913,W0221
 
 
 def _compute_negative_log_likelihood_loss(x, target, weight=None, reduction="mean", ignore_index=None):  # type: ignore

--- a/onnx/reference/ops/op_non_max_suppression.py
+++ b/onnx/reference/ops/op_non_max_suppression.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0902,R0911,R0912,R0913,R0914,W0221
 
 import dataclasses

--- a/onnx/reference/ops/op_non_max_suppression.py
+++ b/onnx/reference/ops/op_non_max_suppression.py
@@ -2,25 +2,25 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0902,R0911,R0912,R0913,R0914,W0221
 
 import dataclasses
-from typing import Optional, Tuple
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
 
+# pylint: disable=R0902,R0911,R0912,R0913,R0914,W0221
+
 
 @dataclasses.dataclass
 class PrepareContext:
-    boxes_data_: Optional[np.ndarray] = None
+    boxes_data_: np.ndarray | None = None
     boxes_size_: int = 0
-    scores_data_: Optional[np.ndarray] = None
+    scores_data_: np.ndarray | None = None
     scores_size_: int = 0
-    max_output_boxes_per_class_: Optional[np.ndarray] = None
-    score_threshold_: Optional[np.ndarray] = None
-    iou_threshold_: Optional[np.ndarray] = None
+    max_output_boxes_per_class_: np.ndarray | None = None
+    score_threshold_: np.ndarray | None = None
+    iou_threshold_: np.ndarray | None = None
     num_batches_: int = 0
     num_classes_: int = 0
     num_boxes_: int = 0
@@ -37,7 +37,7 @@ class SelectedIndex:
         self.box_index_ = box_index
 
 
-def max_min(lhs: float, rhs: float) -> Tuple[float, float]:
+def max_min(lhs: float, rhs: float) -> tuple[float, float]:
     if lhs >= rhs:
         return rhs, lhs
     return lhs, rhs
@@ -134,7 +134,7 @@ class NonMaxSuppression(OpRun):
         max_output_boxes_per_class: int,
         iou_threshold: float,
         score_threshold: float,
-    ) -> Tuple[int, float, float]:
+    ) -> tuple[int, float, float]:
         if pc.max_output_boxes_per_class_ is not None:
             max_output_boxes_per_class = max(pc.max_output_boxes_per_class_[0], 0)
 

--- a/onnx/reference/ops/op_non_zero.py
+++ b/onnx/reference/ops/op_non_zero.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class NonZero(OpRun):

--- a/onnx/reference/ops/op_non_zero.py
+++ b/onnx/reference/ops/op_non_zero.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_not.py
+++ b/onnx/reference/ops/op_not.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_not.py
+++ b/onnx/reference/ops/op_not.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnary
+
+# pylint: disable=W0221
 
 
 class Not(OpRunUnary):

--- a/onnx/reference/ops/op_one_hot.py
+++ b/onnx/reference/ops/op_one_hot.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_one_hot.py
+++ b/onnx/reference/ops/op_one_hot.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 def _one_hot(indices, depth, axis=-1, dtype=np.float32):  # type: ignore

--- a/onnx/reference/ops/op_optional.py
+++ b/onnx/reference/ops/op_optional.py
@@ -2,10 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221,W0622
 
 from onnx.helper import tensor_dtype_to_np_dtype
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221,W0622
 
 
 class Optional(OpRun):

--- a/onnx/reference/ops/op_optional.py
+++ b/onnx/reference/ops/op_optional.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221,W0622
 
 from onnx.helper import tensor_dtype_to_np_dtype

--- a/onnx/reference/ops/op_optional_get_element.py
+++ b/onnx/reference/ops/op_optional_get_element.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun

--- a/onnx/reference/ops/op_optional_get_element.py
+++ b/onnx/reference/ops/op_optional_get_element.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class OptionalGetElement(OpRun):

--- a/onnx/reference/ops/op_optional_has_element.py
+++ b/onnx/reference/ops/op_optional_has_element.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class OptionalHasElement(OpRun):

--- a/onnx/reference/ops/op_optional_has_element.py
+++ b/onnx/reference/ops/op_optional_has_element.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_or.py
+++ b/onnx/reference/ops/op_or.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunBinary
+
+# pylint: disable=W0221
 
 
 class Or(OpRunBinary):

--- a/onnx/reference/ops/op_or.py
+++ b/onnx/reference/ops/op_or.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_pad.py
+++ b/onnx/reference/ops/op_pad.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0913,W0221
 
 
 def _pad_impl(data, raw_pads, mode, constant_values=0.0, axes=None):  # type: ignore

--- a/onnx/reference/ops/op_pad.py
+++ b/onnx/reference/ops/op_pad.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_pool_common.py
+++ b/onnx/reference/ops/op_pool_common.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import itertools
 import math

--- a/onnx/reference/ops/op_pool_common.py
+++ b/onnx/reference/ops/op_pool_common.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import itertools
 import math
-from typing import Sequence, Tuple, Union
+from typing import Sequence
 
 import numpy as np
 
@@ -55,9 +55,9 @@ def get_output_shape_explicit_padding(
     input_spatial_shape: Sequence[int],
     kernel_spatial_shape: Sequence[int],
     strides_spatial: Sequence[int],
-    dilations: Union[Sequence[int], None] = None,
+    dilations: Sequence[int] | None = None,
     ceil_mode: bool = False,
-) -> Tuple[Sequence[int], Sequence[int]]:
+) -> tuple[Sequence[int], Sequence[int]]:
     """
     compute output shape according to:
     https://pytorch.org/docs/stable/generated/torch.nn.MaxPool1d.html?highlight=max+pool#torch.nn.MaxPool1d
@@ -170,8 +170,8 @@ def pool(
     strides: Sequence[int],
     out_shape: Sequence[int],
     pooling_type: str,
-    pads: Union[Sequence[int], None] = None,
-    dilations: Union[Sequence[int], None] = None,
+    pads: Sequence[int] | None = None,
+    dilations: Sequence[int] | None = None,
     count_include_pad: int = 0,
     p: int = 1,
 ) -> np.ndarray:

--- a/onnx/reference/ops/op_pow.py
+++ b/onnx/reference/ops/op_pow.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 from warnings import catch_warnings, simplefilter

--- a/onnx/reference/ops/op_pow.py
+++ b/onnx/reference/ops/op_pow.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 from warnings import catch_warnings, simplefilter
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class Pow(OpRun):

--- a/onnx/reference/ops/op_prelu.py
+++ b/onnx/reference/ops/op_prelu.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_prelu.py
+++ b/onnx/reference/ops/op_prelu.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class PRelu(OpRun):

--- a/onnx/reference/ops/op_qlinear_conv.py
+++ b/onnx/reference/ops/op_qlinear_conv.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
 from onnx.reference.ops.op_conv import _conv_implementation
+
+# pylint: disable=R0913,R0914,W0221
 
 
 class QLinearConv(OpRun):

--- a/onnx/reference/ops/op_qlinear_conv.py
+++ b/onnx/reference/ops/op_qlinear_conv.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_qlinear_matmul.py
+++ b/onnx/reference/ops/op_qlinear_matmul.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0913,W0221
 
 
 class QLinearMatMul(OpRun):

--- a/onnx/reference/ops/op_qlinear_matmul.py
+++ b/onnx/reference/ops/op_qlinear_matmul.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_quantize_linear.py
+++ b/onnx/reference/ops/op_quantize_linear.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 from typing import Optional, Tuple

--- a/onnx/reference/ops/op_quantize_linear.py
+++ b/onnx/reference/ops/op_quantize_linear.py
@@ -2,9 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
-
-from typing import Optional, Tuple
 
 import numpy as np
 
@@ -22,6 +19,8 @@ from onnx.reference.custom_element_types import (
     float8e5m2fnuz,
 )
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class _CommonQuantizeLinear(OpRun):
@@ -52,10 +51,10 @@ class _CommonQuantizeLinear(OpRun):
         self,
         x: np.ndarray,
         y_scale: np.ndarray,
-        zero_point: Optional[np.ndarray] = None,
+        zero_point: np.ndarray | None = None,
         axis: int = 1,
         saturate: bool = True,
-    ) -> Tuple[np.ndarray]:
+    ) -> tuple[np.ndarray]:
         if len(y_scale.shape) > 1:
             raise RuntimeError("Input 2 must be a vector or a number.")
         if len(y_scale.shape) > 0 and y_scale.size == 1:

--- a/onnx/reference/ops/op_random_normal.py
+++ b/onnx/reference/ops/op_random_normal.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,W0221
 
 from onnx.reference.ops._op_common_random import _CommonRandom

--- a/onnx/reference/ops/op_random_normal.py
+++ b/onnx/reference/ops/op_random_normal.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,W0221
 
 from onnx.reference.ops._op_common_random import _CommonRandom
+
+# pylint: disable=R0913,W0221
 
 
 class RandomNormal(_CommonRandom):

--- a/onnx/reference/ops/op_random_normal_like.py
+++ b/onnx/reference/ops/op_random_normal_like.py
@@ -2,10 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,W0221
 
 from onnx.helper import np_dtype_to_tensor_dtype
 from onnx.reference.ops._op_common_random import _CommonRandom
+
+# pylint: disable=R0913,W0221
 
 
 class RandomNormalLike(_CommonRandom):

--- a/onnx/reference/ops/op_random_normal_like.py
+++ b/onnx/reference/ops/op_random_normal_like.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,W0221
 
 from onnx.helper import np_dtype_to_tensor_dtype

--- a/onnx/reference/ops/op_random_uniform.py
+++ b/onnx/reference/ops/op_random_uniform.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,W0221
 
 from onnx.reference.ops._op_common_random import _CommonRandom

--- a/onnx/reference/ops/op_random_uniform.py
+++ b/onnx/reference/ops/op_random_uniform.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,W0221
 
 from onnx.reference.ops._op_common_random import _CommonRandom
+
+# pylint: disable=R0913,W0221
 
 
 class RandomUniform(_CommonRandom):

--- a/onnx/reference/ops/op_random_uniform_like.py
+++ b/onnx/reference/ops/op_random_uniform_like.py
@@ -2,10 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,W0221
 
 from onnx.helper import np_dtype_to_tensor_dtype
 from onnx.reference.ops._op_common_random import _CommonRandom
+
+# pylint: disable=R0913,W0221
 
 
 class RandomUniformLike(_CommonRandom):

--- a/onnx/reference/ops/op_random_uniform_like.py
+++ b/onnx/reference/ops/op_random_uniform_like.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,W0221
 
 from onnx.helper import np_dtype_to_tensor_dtype

--- a/onnx/reference/ops/op_range.py
+++ b/onnx/reference/ops/op_range.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class Range(OpRun):

--- a/onnx/reference/ops/op_range.py
+++ b/onnx/reference/ops/op_range.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_reciprocal.py
+++ b/onnx/reference/ops/op_reciprocal.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_reciprocal.py
+++ b/onnx/reference/ops/op_reciprocal.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Reciprocal(OpRunUnaryNum):

--- a/onnx/reference/ops/op_reduce_l1.py
+++ b/onnx/reference/ops/op_reduce_l1.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunReduceNumpy
+
+# pylint: disable=W0221
 
 
 class ReduceL1_1(OpRunReduceNumpy):

--- a/onnx/reference/ops/op_reduce_l1.py
+++ b/onnx/reference/ops/op_reduce_l1.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_reduce_l2.py
+++ b/onnx/reference/ops/op_reduce_l2.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunReduceNumpy
+
+# pylint: disable=W0221
 
 
 class ReduceL2_1(OpRunReduceNumpy):

--- a/onnx/reference/ops/op_reduce_l2.py
+++ b/onnx/reference/ops/op_reduce_l2.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_reduce_log_sum.py
+++ b/onnx/reference/ops/op_reduce_log_sum.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_reduce_log_sum.py
+++ b/onnx/reference/ops/op_reduce_log_sum.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunReduceNumpy
+
+# pylint: disable=W0221
 
 
 class ReduceLogSum_1(OpRunReduceNumpy):

--- a/onnx/reference/ops/op_reduce_log_sum_exp.py
+++ b/onnx/reference/ops/op_reduce_log_sum_exp.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_reduce_log_sum_exp.py
+++ b/onnx/reference/ops/op_reduce_log_sum_exp.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunReduceNumpy
+
+# pylint: disable=W0221
 
 
 def compute_log_sum_exp(data, axes, keepdims):

--- a/onnx/reference/ops/op_reduce_max.py
+++ b/onnx/reference/ops/op_reduce_max.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=E1123,W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunReduceNumpy
+
+# pylint: disable=E1123,W0221
 
 
 class ReduceMax_1(OpRunReduceNumpy):

--- a/onnx/reference/ops/op_reduce_max.py
+++ b/onnx/reference/ops/op_reduce_max.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=E1123,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_reduce_mean.py
+++ b/onnx/reference/ops/op_reduce_mean.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunReduceNumpy
+
+# pylint: disable=W0221
 
 
 class ReduceMean_1(OpRunReduceNumpy):

--- a/onnx/reference/ops/op_reduce_mean.py
+++ b/onnx/reference/ops/op_reduce_mean.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_reduce_min.py
+++ b/onnx/reference/ops/op_reduce_min.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=E1123,W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunReduceNumpy
+
+# pylint: disable=E1123,W0221
 
 
 class ReduceMin_1(OpRunReduceNumpy):

--- a/onnx/reference/ops/op_reduce_min.py
+++ b/onnx/reference/ops/op_reduce_min.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=E1123,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_reduce_prod.py
+++ b/onnx/reference/ops/op_reduce_prod.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunReduceNumpy
+
+# pylint: disable=W0221
 
 
 class ReduceProd_1(OpRunReduceNumpy):

--- a/onnx/reference/ops/op_reduce_prod.py
+++ b/onnx/reference/ops/op_reduce_prod.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_reduce_sum.py
+++ b/onnx/reference/ops/op_reduce_sum.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_reduce_sum.py
+++ b/onnx/reference/ops/op_reduce_sum.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunReduceNumpy
+
+# pylint: disable=W0221
 
 
 class ReduceSum_1(OpRunReduceNumpy):

--- a/onnx/reference/ops/op_reduce_sum_square.py
+++ b/onnx/reference/ops/op_reduce_sum_square.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunReduceNumpy
+
+# pylint: disable=W0221
 
 
 class ReduceSumSquare_1(OpRunReduceNumpy):

--- a/onnx/reference/ops/op_reduce_sum_square.py
+++ b/onnx/reference/ops/op_reduce_sum_square.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_regex_full_match.py
+++ b/onnx/reference/ops/op_regex_full_match.py
@@ -2,11 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0912,R0913,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0912,R0913,W0221
+
 
 _acceptable_str_dtypes = ("U", "O")
 

--- a/onnx/reference/ops/op_regex_full_match.py
+++ b/onnx/reference/ops/op_regex_full_match.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0912,R0913,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_relu.py
+++ b/onnx/reference/ops/op_relu.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Relu(OpRunUnaryNum):

--- a/onnx/reference/ops/op_relu.py
+++ b/onnx/reference/ops/op_relu.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_reshape.py
+++ b/onnx/reference/ops/op_reshape.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 def reshape_reference_implementation(

--- a/onnx/reference/ops/op_reshape.py
+++ b/onnx/reference/ops/op_reshape.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_resize.py
+++ b/onnx/reference/ops/op_resize.py
@@ -2,18 +2,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=C0123,C3001,R0912,R0913,R0914,R1730,W0221,W0613
 
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
 
+# pylint: disable=C0123,C3001,R0912,R0913,R0914,R1730,W0221,W0613
 
-def _cartesian(
-    arrays: List[np.ndarray], out: Optional[np.ndarray] = None
-) -> np.ndarray:
+
+def _cartesian(arrays: list[np.ndarray], out: np.ndarray | None = None) -> np.ndarray:
     """
     From https://stackoverflow.com/a/1235363
     Generate a cartesian product of input arrays.
@@ -76,7 +75,7 @@ def _nearest_coeffs(ratio: float, mode: str = "round_prefer_floor") -> np.ndarra
 
 
 def _cubic_coeffs(
-    ratio: float, scale: Optional[float] = None, A: float = -0.75
+    ratio: float, scale: float | None = None, A: float = -0.75
 ) -> np.ndarray:
     # scale is unused
     coeffs = [
@@ -111,7 +110,7 @@ def _cubic_coeffs_antialias(ratio: float, scale: float, A: float = -0.75) -> np.
     return np.array(coeffs) / sum(coeffs)
 
 
-def _linear_coeffs(ratio: float, scale: Optional[float] = None) -> np.ndarray:
+def _linear_coeffs(ratio: float, scale: float | None = None) -> np.ndarray:
     # scale is unused
     return np.array([1 - ratio, ratio])
 
@@ -152,7 +151,7 @@ def _get_neighbor_idxes(x: float, n: int, limit: int) -> np.ndarray:
     return np.array(idxes)
 
 
-def _get_neighbor(x: float, n: int, data: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+def _get_neighbor(x: float, n: int, data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """
     Pad `data` in 'edge' mode, and get n nearest elements in the padded array
     and their indexes in the original array.
@@ -179,7 +178,7 @@ def _interpolate_1d_with_x(
     output_width_int: int,
     x: float,
     get_coeffs: Callable[[float, float], np.ndarray],
-    roi: Optional[np.ndarray] = None,
+    roi: np.ndarray | None = None,
     extrapolation_value: float = 0.0,
     coordinate_transformation_mode: str = "half_pixel",
     exclude_outside: bool = False,
@@ -248,11 +247,11 @@ def _interpolate_1d_with_x(
 def _interpolate_nd_with_x(
     data: np.ndarray,
     n: int,
-    scale_factors: List[float],
-    output_size: List[int],
-    x: List[float],
+    scale_factors: list[float],
+    output_size: list[int],
+    x: list[float],
     get_coeffs: Callable[[float, float], np.ndarray],
-    roi: Optional[np.ndarray] = None,
+    roi: np.ndarray | None = None,
     exclude_outside: bool = False,
     **kwargs: Any,
 ) -> np.ndarray:
@@ -304,11 +303,11 @@ def _get_all_coords(data: np.ndarray) -> np.ndarray:
 def _interpolate_nd(
     data: np.ndarray,
     get_coeffs: Callable[[float, float], np.ndarray],
-    output_size: Optional[List[int]] = None,
-    scale_factors: Optional[List[float]] = None,
-    axes: Optional[List[int]] = None,
-    roi: Optional[np.ndarray] = None,
-    keep_aspect_ratio_policy: Optional[str] = "stretch",
+    output_size: list[int] | None = None,
+    scale_factors: list[float] | None = None,
+    axes: list[int] | None = None,
+    roi: np.ndarray | None = None,
+    keep_aspect_ratio_policy: str | None = "stretch",
     exclude_outside: bool = False,
     **kwargs: Any,
 ) -> np.ndarray:

--- a/onnx/reference/ops/op_resize.py
+++ b/onnx/reference/ops/op_resize.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=C0123,C3001,R0912,R0913,R0914,R1730,W0221,W0613
 
 from typing import Any, Callable, List, Optional, Tuple

--- a/onnx/reference/ops/op_reverse_sequence.py
+++ b/onnx/reference/ops/op_reverse_sequence.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=C0123,R0912,R0913,R0914,W0221
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=C0123,R0912,R0913,R0914,W0221
 
 
 class ReverseSequence(OpRun):

--- a/onnx/reference/ops/op_reverse_sequence.py
+++ b/onnx/reference/ops/op_reverse_sequence.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=C0123,R0912,R0913,R0914,W0221
 
 from onnx.reference.op_run import OpRun

--- a/onnx/reference/ops/op_rnn.py
+++ b/onnx/reference/ops/op_rnn.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,W0221,W0613
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0913,R0914,W0221,W0613
 
 
 class CommonRNN(OpRun):

--- a/onnx/reference/ops/op_rnn.py
+++ b/onnx/reference/ops/op_rnn.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,W0221,W0613
 
 import numpy as np

--- a/onnx/reference/ops/op_roi_align.py
+++ b/onnx/reference/ops/op_roi_align.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0902,R0912,R0913,R0914,R0915,R1702,W0221
 
 from typing import Tuple

--- a/onnx/reference/ops/op_roi_align.py
+++ b/onnx/reference/ops/op_roi_align.py
@@ -2,13 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0902,R0912,R0913,R0914,R0915,R1702,W0221
-
-from typing import Tuple
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0902,R0912,R0913,R0914,R0915,R1702,W0221
 
 
 class PreCalc:
@@ -118,7 +117,7 @@ class RoiAlign(OpRun):
 
     @staticmethod
     def roi_align_forward(  # type: ignore
-        output_shape: Tuple[int, int, int, int],
+        output_shape: tuple[int, int, int, int],
         bottom_data,
         spatial_scale,
         height: int,

--- a/onnx/reference/ops/op_round.py
+++ b/onnx/reference/ops/op_round.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Round(OpRunUnaryNum):

--- a/onnx/reference/ops/op_round.py
+++ b/onnx/reference/ops/op_round.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_scan.py
+++ b/onnx/reference/ops/op_scan.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0912,R0914,W0221,W0613
 
 import numpy as np

--- a/onnx/reference/ops/op_scan.py
+++ b/onnx/reference/ops/op_scan.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0912,R0914,W0221,W0613
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0912,R0914,W0221,W0613
 
 
 class Scan(OpRun):

--- a/onnx/reference/ops/op_scatter_elements.py
+++ b/onnx/reference/ops/op_scatter_elements.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=C3001,R0912,R0913,R0914,R0915,W0108,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=C3001,R0912,R0913,R0914,R0915,W0108,W0221
 
 
 def scatter_elements(data, indices, updates, axis=0, reduction=None):  # type: ignore

--- a/onnx/reference/ops/op_scatter_elements.py
+++ b/onnx/reference/ops/op_scatter_elements.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=C3001,R0912,R0913,R0914,R0915,W0108,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_scatternd.py
+++ b/onnx/reference/ops/op_scatternd.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 def _scatter_nd_impl(data, indices, updates, reduction=None):  # type: ignore

--- a/onnx/reference/ops/op_scatternd.py
+++ b/onnx/reference/ops/op_scatternd.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_selu.py
+++ b/onnx/reference/ops/op_selu.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class Selu(OpRun):

--- a/onnx/reference/ops/op_selu.py
+++ b/onnx/reference/ops/op_selu.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_sequence_at.py
+++ b/onnx/reference/ops/op_sequence_at.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun

--- a/onnx/reference/ops/op_sequence_at.py
+++ b/onnx/reference/ops/op_sequence_at.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class SequenceAt(OpRun):

--- a/onnx/reference/ops/op_sequence_construct.py
+++ b/onnx/reference/ops/op_sequence_construct.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun

--- a/onnx/reference/ops/op_sequence_construct.py
+++ b/onnx/reference/ops/op_sequence_construct.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class SequenceConstruct(OpRun):

--- a/onnx/reference/ops/op_sequence_empty.py
+++ b/onnx/reference/ops/op_sequence_empty.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221,W0613
 
 from onnx.reference.op_run import OpRun

--- a/onnx/reference/ops/op_sequence_empty.py
+++ b/onnx/reference/ops/op_sequence_empty.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221,W0613
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221,W0613
 
 
 class SequenceEmpty(OpRun):

--- a/onnx/reference/ops/op_sequence_erase.py
+++ b/onnx/reference/ops/op_sequence_erase.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun

--- a/onnx/reference/ops/op_sequence_erase.py
+++ b/onnx/reference/ops/op_sequence_erase.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class SequenceErase(OpRun):

--- a/onnx/reference/ops/op_sequence_insert.py
+++ b/onnx/reference/ops/op_sequence_insert.py
@@ -2,22 +2,23 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
-from typing import Any, List, Optional, Union
+from typing import Any
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
 
+# pylint: disable=W0221
+
 
 def sequence_insert_reference_implementation(
-    sequence: Union[List[Any], np.ndarray],
+    sequence: list[Any] | np.ndarray,
     tensor: np.ndarray,
-    position: Optional[np.ndarray] = None,
-) -> List[Any]:
+    position: np.ndarray | None = None,
+) -> list[Any]:
     # make a copy of input sequence
-    seq: List[Any] = []
+    seq: list[Any] = []
     if sequence is not None and (
         not isinstance(sequence, np.ndarray) or len(sequence.shape) > 0
     ):

--- a/onnx/reference/ops/op_sequence_insert.py
+++ b/onnx/reference/ops/op_sequence_insert.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 from typing import Any, List, Optional, Union

--- a/onnx/reference/ops/op_sequence_length.py
+++ b/onnx/reference/ops/op_sequence_length.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_sequence_length.py
+++ b/onnx/reference/ops/op_sequence_length.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class SequenceLength(OpRun):

--- a/onnx/reference/ops/op_sequence_map.py
+++ b/onnx/reference/ops/op_sequence_map.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun

--- a/onnx/reference/ops/op_sequence_map.py
+++ b/onnx/reference/ops/op_sequence_map.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class SequenceMap(OpRun):

--- a/onnx/reference/ops/op_shape.py
+++ b/onnx/reference/ops/op_shape.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 from typing import Optional, Tuple

--- a/onnx/reference/ops/op_shape.py
+++ b/onnx/reference/ops/op_shape.py
@@ -2,13 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
-
-from typing import Optional, Tuple
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class Shape_1(OpRun):
@@ -18,9 +17,7 @@ class Shape_1(OpRun):
 
 class Shape_15(Shape_1):
     @staticmethod
-    def _interval(
-        n: int, start: Optional[int], end: Optional[int]
-    ) -> Optional[Tuple[int, int]]:
+    def _interval(n: int, start: int | None, end: int | None) -> tuple[int, int] | None:
         if start == 0:
             if end is None or np.isnan(end):
                 return None

--- a/onnx/reference/ops/op_shrink.py
+++ b/onnx/reference/ops/op_shrink.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=E1130,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_shrink.py
+++ b/onnx/reference/ops/op_shrink.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=E1130,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=E1130,W0221
 
 
 class Shrink(OpRun):

--- a/onnx/reference/ops/op_sigmoid.py
+++ b/onnx/reference/ops/op_sigmoid.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 def sigmoid(x):  # type: ignore

--- a/onnx/reference/ops/op_sigmoid.py
+++ b/onnx/reference/ops/op_sigmoid.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_sign.py
+++ b/onnx/reference/ops/op_sign.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Sign(OpRunUnaryNum):

--- a/onnx/reference/ops/op_sign.py
+++ b/onnx/reference/ops/op_sign.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_sin.py
+++ b/onnx/reference/ops/op_sin.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_sin.py
+++ b/onnx/reference/ops/op_sin.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Sin(OpRunUnaryNum):

--- a/onnx/reference/ops/op_sinh.py
+++ b/onnx/reference/ops/op_sinh.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_sinh.py
+++ b/onnx/reference/ops/op_sinh.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Sinh(OpRunUnaryNum):

--- a/onnx/reference/ops/op_size.py
+++ b/onnx/reference/ops/op_size.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_size.py
+++ b/onnx/reference/ops/op_size.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class Size(OpRun):

--- a/onnx/reference/ops/op_slice.py
+++ b/onnx/reference/ops/op_slice.py
@@ -2,21 +2,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0912,R0913,W0221
-
-from typing import Optional
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRun
+
+# pylint: disable=R0912,R0913,W0221
 
 
 def _slice(
     data: np.ndarray,
     starts: np.ndarray,
     ends: np.ndarray,
-    axes: Optional[np.ndarray] = None,
-    steps: Optional[np.ndarray] = None,
+    axes: np.ndarray | None = None,
+    steps: np.ndarray | None = None,
 ) -> np.ndarray:
     if isinstance(starts, list):
         starts = np.array(starts)

--- a/onnx/reference/ops/op_slice.py
+++ b/onnx/reference/ops/op_slice.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0912,R0913,W0221
 
 from typing import Optional

--- a/onnx/reference/ops/op_softmax.py
+++ b/onnx/reference/ops/op_softmax.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_softmax.py
+++ b/onnx/reference/ops/op_softmax.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Softmax(OpRunUnaryNum):

--- a/onnx/reference/ops/op_softmax_cross_entropy_loss.py
+++ b/onnx/reference/ops/op_softmax_cross_entropy_loss.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0912,R0913,R0914,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_softmax_cross_entropy_loss.py
+++ b/onnx/reference/ops/op_softmax_cross_entropy_loss.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0912,R0913,R0914,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0912,R0913,R0914,W0221
 
 
 def softmaxcrossentropy(  # type: ignore

--- a/onnx/reference/ops/op_softplus.py
+++ b/onnx/reference/ops/op_softplus.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_softplus.py
+++ b/onnx/reference/ops/op_softplus.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Softplus(OpRunUnaryNum):

--- a/onnx/reference/ops/op_softsign.py
+++ b/onnx/reference/ops/op_softsign.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Softsign(OpRunUnaryNum):

--- a/onnx/reference/ops/op_softsign.py
+++ b/onnx/reference/ops/op_softsign.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_space_to_depth.py
+++ b/onnx/reference/ops/op_space_to_depth.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class SpaceToDepth(OpRun):

--- a/onnx/reference/ops/op_space_to_depth.py
+++ b/onnx/reference/ops/op_space_to_depth.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_split.py
+++ b/onnx/reference/ops/op_split.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class CommonSplit(OpRun):

--- a/onnx/reference/ops/op_split.py
+++ b/onnx/reference/ops/op_split.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun

--- a/onnx/reference/ops/op_split_to_sequence.py
+++ b/onnx/reference/ops/op_split_to_sequence.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=C0200,W0221
 
 from typing import List, Optional, Tuple

--- a/onnx/reference/ops/op_split_to_sequence.py
+++ b/onnx/reference/ops/op_split_to_sequence.py
@@ -2,19 +2,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=C0200,W0221
-
-from typing import List, Optional, Tuple
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
 
+# pylint: disable=C0200,W0221
+
 
 class SplitToSequence(OpRun):
     def common_run(
-        self, mat: np.ndarray, split: Optional[np.ndarray], axis: int
-    ) -> List[np.ndarray]:
+        self, mat: np.ndarray, split: np.ndarray | None, axis: int
+    ) -> list[np.ndarray]:
         if split is None:
             split_length = [1 for _ in range(mat.shape[axis])]
         elif len(split.shape) == 0:
@@ -41,10 +40,10 @@ class SplitToSequence(OpRun):
     def _run(
         self,
         mat: np.ndarray,
-        split: Optional[np.ndarray] = None,
+        split: np.ndarray | None = None,
         axis: int = 0,
         keepdims: int = 1,
-    ) -> Tuple[np.ndarray]:
+    ) -> tuple[np.ndarray]:
         res = self.common_run(mat, split, axis=axis)
         if split is None and not keepdims:
             for i in range(len(res)):

--- a/onnx/reference/ops/op_sqrt.py
+++ b/onnx/reference/ops/op_sqrt.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 from warnings import catch_warnings, simplefilter
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Sqrt(OpRunUnaryNum):

--- a/onnx/reference/ops/op_sqrt.py
+++ b/onnx/reference/ops/op_sqrt.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 from warnings import catch_warnings, simplefilter

--- a/onnx/reference/ops/op_squeeze.py
+++ b/onnx/reference/ops/op_squeeze.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=E0203,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=E0203,W0221
 
 
 class Squeeze_1(OpRun):

--- a/onnx/reference/ops/op_squeeze.py
+++ b/onnx/reference/ops/op_squeeze.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=E0203,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_stft.py
+++ b/onnx/reference/ops/op_stft.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,R0914,R0915,W0613,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_stft.py
+++ b/onnx/reference/ops/op_stft.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,R0914,R0915,W0613,W0221
 
 import numpy as np
 
@@ -10,6 +9,8 @@ from onnx.reference.op_run import OpRun
 from onnx.reference.ops.op_concat_from_sequence import _concat_from_sequence
 from onnx.reference.ops.op_dft import _cfft as _dft
 from onnx.reference.ops.op_slice import _slice
+
+# pylint: disable=R0913,R0914,R0915,W0613,W0221
 
 
 def _concat(*args, axis=0):  # type: ignore

--- a/onnx/reference/ops/op_string_concat.py
+++ b/onnx/reference/ops/op_string_concat.py
@@ -2,11 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0912,R0913,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0912,R0913,W0221
+
 
 _acceptable_str_dtypes = ("U", "O")
 

--- a/onnx/reference/ops/op_string_concat.py
+++ b/onnx/reference/ops/op_string_concat.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0912,R0913,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_string_normalizer.py
+++ b/onnx/reference/ops/op_string_normalizer.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0912,R0913,W0221
 
 import locale as pylocale

--- a/onnx/reference/ops/op_string_normalizer.py
+++ b/onnx/reference/ops/op_string_normalizer.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0912,R0913,W0221
 
 import locale as pylocale
 import unicodedata
@@ -11,6 +10,8 @@ import warnings
 import numpy as np
 
 from onnx.reference.op_run import OpRun, RuntimeTypeError
+
+# pylint: disable=R0912,R0913,W0221
 
 
 class StringNormalizer(OpRun):

--- a/onnx/reference/ops/op_string_split.py
+++ b/onnx/reference/ops/op_string_split.py
@@ -2,20 +2,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0912,R0913,W0221
-
-from typing import Union
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
 
+# pylint: disable=R0912,R0913,W0221
+
+
 _acceptable_str_dtypes = ("U", "O")
 
 
-def pad_empty_string(
-    split_lists: Union[list, np.ndarray], padding_requirement: Union[list, int]
-):
+def pad_empty_string(split_lists: list | np.ndarray, padding_requirement: list | int):
     # pylint: disable=unidiomatic-typecheck`
     if type(split_lists) is list:
         return split_lists + ["" for _ in range(padding_requirement)]

--- a/onnx/reference/ops/op_string_split.py
+++ b/onnx/reference/ops/op_string_split.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0912,R0913,W0221
 
 from typing import Union

--- a/onnx/reference/ops/op_sub.py
+++ b/onnx/reference/ops/op_sub.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunBinaryNumpy
+
+# pylint: disable=W0221
 
 
 class Sub(OpRunBinaryNumpy):

--- a/onnx/reference/ops/op_sub.py
+++ b/onnx/reference/ops/op_sub.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_sum.py
+++ b/onnx/reference/ops/op_sum.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun

--- a/onnx/reference/ops/op_sum.py
+++ b/onnx/reference/ops/op_sum.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class Sum(OpRun):

--- a/onnx/reference/ops/op_tan.py
+++ b/onnx/reference/ops/op_tan.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_tan.py
+++ b/onnx/reference/ops/op_tan.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Tan(OpRunUnaryNum):

--- a/onnx/reference/ops/op_tanh.py
+++ b/onnx/reference/ops/op_tanh.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_tanh.py
+++ b/onnx/reference/ops/op_tanh.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class Tanh(OpRunUnaryNum):

--- a/onnx/reference/ops/op_tfidf_vectorizer.py
+++ b/onnx/reference/ops/op_tfidf_vectorizer.py
@@ -2,14 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=C0200,R0902,R0912,R0913,R0914,R0915,R1716,W0611,W0612,W0613,W0221
 
 from enum import IntEnum
-from typing import List
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=C0200,R0902,R0912,R0913,R0914,R0915,R1716,W0611,W0612,W0613,W0221
 
 
 class IntMap(dict):  # type: ignore
@@ -183,7 +183,7 @@ class TfIdfVectorizer(OpRun):
             ngram_size += 1
 
     def increment_count(
-        self, ngram_id: int, row_num: int, frequencies: List[int]
+        self, ngram_id: int, row_num: int, frequencies: list[int]
     ) -> None:
         ngram_id -= 1
         # assert(ngram_id < ngram_indexes_.size());
@@ -191,8 +191,8 @@ class TfIdfVectorizer(OpRun):
         # assert(static_cast<size_t>(output_idx) < frequencies.size());
         frequencies[output_idx] += 1
 
-    def output_result(self, B: int, frequencies: List[int]) -> np.ndarray:
-        l_output_dims: List[int] = []
+    def output_result(self, B: int, frequencies: list[int]) -> np.ndarray:
+        l_output_dims: list[int] = []
         if B == 0:
             l_output_dims.append(self.output_size_)
             B = 1
@@ -245,7 +245,7 @@ class TfIdfVectorizer(OpRun):
         X: np.ndarray,
         row_num: int,
         row_size: int,
-        frequencies: List[int],
+        frequencies: list[int],
         max_gram_length=None,
         max_skip_count=None,
         min_gram_length=None,

--- a/onnx/reference/ops/op_tfidf_vectorizer.py
+++ b/onnx/reference/ops/op_tfidf_vectorizer.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=C0200,R0902,R0912,R0913,R0914,R0915,R1716,W0611,W0612,W0613,W0221
 
 from enum import IntEnum

--- a/onnx/reference/ops/op_thresholded_relu.py
+++ b/onnx/reference/ops/op_thresholded_relu.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_thresholded_relu.py
+++ b/onnx/reference/ops/op_thresholded_relu.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+# pylint: disable=W0221
 
 
 class ThresholdedRelu(OpRunUnaryNum):

--- a/onnx/reference/ops/op_tile.py
+++ b/onnx/reference/ops/op_tile.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class Tile(OpRun):

--- a/onnx/reference/ops/op_tile.py
+++ b/onnx/reference/ops/op_tile.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_topk.py
+++ b/onnx/reference/ops/op_topk.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0913,W0221,W0622
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0913,W0221,W0622
 
 
 def topk_sorted_implementation(X, k, axis, largest):  # type: ignore

--- a/onnx/reference/ops/op_topk.py
+++ b/onnx/reference/ops/op_topk.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0913,W0221,W0622
 
 import numpy as np

--- a/onnx/reference/ops/op_transpose.py
+++ b/onnx/reference/ops/op_transpose.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class Transpose(OpRun):

--- a/onnx/reference/ops/op_transpose.py
+++ b/onnx/reference/ops/op_transpose.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_trilu.py
+++ b/onnx/reference/ops/op_trilu.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class Trilu(OpRun):

--- a/onnx/reference/ops/op_trilu.py
+++ b/onnx/reference/ops/op_trilu.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_unique.py
+++ b/onnx/reference/ops/op_unique.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221,W0622
 
 import numpy as np

--- a/onnx/reference/ops/op_unique.py
+++ b/onnx/reference/ops/op_unique.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221,W0622
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221,W0622
 
 
 def _specify_int64(indices, inverse_indices, counts):  # type: ignore

--- a/onnx/reference/ops/op_unsqueeze.py
+++ b/onnx/reference/ops/op_unsqueeze.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=E0203,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=E0203,W0221
 
 
 class Unsqueeze_1(OpRun):

--- a/onnx/reference/ops/op_unsqueeze.py
+++ b/onnx/reference/ops/op_unsqueeze.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=E0203,W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_upsample.py
+++ b/onnx/reference/ops/op_upsample.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221,R0913
 
 import numpy as np

--- a/onnx/reference/ops/op_upsample.py
+++ b/onnx/reference/ops/op_upsample.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221,R0913
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221,R0913
 
 
 class Upsample(OpRun):

--- a/onnx/reference/ops/op_where.py
+++ b/onnx/reference/ops/op_where.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=W0221
 
 
 class Where(OpRun):

--- a/onnx/reference/ops/op_where.py
+++ b/onnx/reference/ops/op_where.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops/op_xor.py
+++ b/onnx/reference/ops/op_xor.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=W0221
 
 import numpy as np
 
 from onnx.reference.ops._op import OpRunBinary
+
+# pylint: disable=W0221
 
 
 class Xor(OpRunBinary):

--- a/onnx/reference/ops/op_xor.py
+++ b/onnx/reference/ops/op_xor.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=W0221
 
 import numpy as np

--- a/onnx/reference/ops_optimized/__init__.py
+++ b/onnx/reference/ops_optimized/__init__.py
@@ -1,8 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
-# Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from onnx.reference.ops_optimized.op_conv_optimized import Conv
 

--- a/onnx/reference/ops_optimized/op_conv_optimized.py
+++ b/onnx/reference/ops_optimized/op_conv_optimized.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=R0912,R0913,R0914,R0915,R1702,W0221
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+# pylint: disable=R0912,R0913,R0914,R0915,R1702,W0221
 
 
 def _make_ind(dim, shape):

--- a/onnx/reference/ops_optimized/op_conv_optimized.py
+++ b/onnx/reference/ops_optimized/op_conv_optimized.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=R0912,R0913,R0914,R0915,R1702,W0221
 
 import numpy as np

--- a/onnx/reference/reference_evaluator.py
+++ b/onnx/reference/reference_evaluator.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 # pylint: disable=C3001,C0415,R0902,R0912,R0913,R0914,R0915
 from io import BytesIO
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
 
 import numpy as np
 
@@ -194,10 +195,10 @@ class ReferenceEvaluator:
     def __init__(  # type: ignore
         self,
         proto: Any,
-        opsets: Optional[Dict[str, int]] = None,
-        functions: Optional[List[Union["ReferenceEvaluator", FunctionProto]]] = None,  # type: ignore
+        opsets: dict[str, int] | None = None,
+        functions: list[ReferenceEvaluator | FunctionProto] | None = None,  # type: ignore
         verbose: int = 0,
-        new_ops: Optional[List[OpRun]] = None,
+        new_ops: list[OpRun] | None = None,
         optimized: bool = True,
     ):
         if optimized:
@@ -216,8 +217,8 @@ class ReferenceEvaluator:
         elif isinstance(proto, bytes):
             proto = load(BytesIO(proto))
         self.proto_ = proto
-        self.functions_: Dict[Tuple[str, str], ReferenceEvaluator] = {}
-        self.attributes_: List[str] = []
+        self.functions_: dict[tuple[str, str], ReferenceEvaluator] = {}
+        self.attributes_: list[str] = []
         if isinstance(proto, ModelProto):
             self.onnx_graph_ = proto.graph
             self.opsets_ = {d.domain: d.version for d in proto.opset_import}
@@ -279,7 +280,7 @@ class ReferenceEvaluator:
                 else:
                     raise TypeError(f"Unexpected type {type(f)!r} for a function.")
         self.verbose = verbose
-        self.new_ops_: Dict[Tuple[str, str], OpRun] = {}
+        self.new_ops_: dict[tuple[str, str], OpRun] = {}
         if new_ops is not None:
             for cl in new_ops:
                 if not hasattr(cl, "op_domain"):
@@ -310,7 +311,7 @@ class ReferenceEvaluator:
             return ", ".join(map(self._log_arg, a))
         return a
 
-    def _log(self, level: int, pattern: str, *args: List[Any]) -> None:
+    def _log(self, level: int, pattern: str, *args: list[Any]) -> None:
         if level < self.verbose:
             new_args = [self._log_arg(a) for a in args]
             print(pattern % tuple(new_args))
@@ -417,9 +418,7 @@ class ReferenceEvaluator:
                 ) from e
             self.rt_nodes_.append(inst)
 
-    def _load_impl(
-        self, node: NodeProto, input_types: Optional[TypeProto] = None
-    ) -> Any:
+    def _load_impl(self, node: NodeProto, input_types: TypeProto | None = None) -> Any:
         """
         Loads the implementation for a specified runtime.
         """
@@ -490,7 +489,7 @@ class ReferenceEvaluator:
             f"is unknown, known functions: {sorted(self.functions_)}."
         )
 
-    def run(self, output_names, feed_inputs: Dict[str, Any], attributes: Optional[Dict[str, Any]] = None):  # type: ignore
+    def run(self, output_names, feed_inputs: dict[str, Any], attributes: dict[str, Any] | None = None):  # type: ignore
         """
         Executes the onnx model.
 
@@ -534,7 +533,7 @@ class ReferenceEvaluator:
                 results[name] = value
 
         # return the results
-        list_results: List[Any] = []
+        list_results: list[Any] = []
         for name in output_names:
             if name not in results:
                 raise RuntimeError(

--- a/onnx/reference/reference_evaluator.py
+++ b/onnx/reference/reference_evaluator.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=C3001,C0415,R0902,R0912,R0913,R0914,R0915
 from io import BytesIO
 from typing import Any, Dict, List, Optional, Tuple, Union

--- a/onnx/serialization.py
+++ b/onnx/serialization.py
@@ -1,7 +1,6 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-
 from __future__ import annotations
 
 __all__ = [

--- a/onnx/shape_inference.py
+++ b/onnx/shape_inference.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 """onnx shape inference. Shape inference is not guaranteed to be
 complete.

--- a/onnx/shape_inference.py
+++ b/onnx/shape_inference.py
@@ -1,8 +1,6 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from __future__ import annotations
-
 """onnx shape inference. Shape inference is not guaranteed to be
 complete.
 

--- a/onnx/test/automatic_upgrade_test.py
+++ b/onnx/test/automatic_upgrade_test.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 import string
 import unittest
-from typing import Any, Dict, List, Optional, Sequence, Union, cast
+from typing import Any, List, Sequence, cast
 
 import numpy as np
 
@@ -26,12 +27,12 @@ class TestAutomaticUpgrade(unittest.TestCase):
         self,
         op: str,
         from_opset: int,
-        input_shapes: Sequence[Union[Sequence[Optional[int]], str]] = ((3, 4, 5),),
-        output_shapes: Sequence[Sequence[Optional[int]]] = ((3, 4, 5),),
-        input_types: Optional[Sequence[Any]] = None,
-        output_types: Optional[Sequence[Any]] = None,
+        input_shapes: Sequence[Sequence[int | None] | str] = ((3, 4, 5),),
+        output_shapes: Sequence[Sequence[int | None]] = ((3, 4, 5),),
+        input_types: Sequence[Any] | None = None,
+        output_types: Sequence[Any] | None = None,
         initializer: Sequence[Any] = (),
-        attrs: Optional[Dict[str, Any]] = None,
+        attrs: dict[str, Any] | None = None,
         seq_inputs: Sequence[int] = (),
         seq_outputs: Sequence[int] = (),
         optional_inputs: Sequence[int] = (),
@@ -58,7 +59,7 @@ class TestAutomaticUpgrade(unittest.TestCase):
             List[List[int]],
             [[0] if isinstance(shape, str) else shape for shape in input_shapes],
         )
-        inputs: List[ValueInfoProto] = []
+        inputs: list[ValueInfoProto] = []
         for name, ttype, shape, is_seq, is_opt in zip(
             input_names, input_types, input_shapes_cast, is_sequence, is_optional
         ):
@@ -86,7 +87,7 @@ class TestAutomaticUpgrade(unittest.TestCase):
             List[List[int]],
             [[0] if isinstance(shape, str) else shape for shape in output_shapes],
         )
-        outputs: List[ValueInfoProto] = []
+        outputs: list[ValueInfoProto] = []
         for name, ttype, shape, is_seq, is_opt in zip(
             output_names, output_types, output_shapes_cast, is_sequence, is_optional
         ):

--- a/onnx/test/automatic_upgrade_test.py
+++ b/onnx/test/automatic_upgrade_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 import string
 import unittest
 from typing import Any, Dict, List, Optional, Sequence, Union, cast

--- a/onnx/test/basic_test.py
+++ b/onnx/test/basic_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import io
 import os

--- a/onnx/test/checker_test.py
+++ b/onnx/test/checker_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 import unittest
 from typing import Sequence
 

--- a/onnx/test/checker_test.py
+++ b/onnx/test/checker_test.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 import unittest
 from typing import Sequence
 

--- a/onnx/test/compose_test.py
+++ b/onnx/test/compose_test.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import unittest
-from typing import Callable, List, Optional, Sequence, Tuple
+from typing import Callable, Sequence
 
 import numpy as np
 
@@ -40,7 +40,7 @@ def _prefixed(prefix: str, s: str) -> str:
     return prefix + s if len(s) > 0 else s
 
 
-def _get_shape(value_info: ValueInfoProto) -> List[int]:
+def _get_shape(value_info: ValueInfoProto) -> list[int]:
     """
     Returns a list of integers representing the shape of the provided ValueInfoProto
     """
@@ -104,12 +104,12 @@ class TestComposeFunctions(unittest.TestCase):
         self,
         m1def: str,
         m2def: str,
-        io_map: List[Tuple[str, str]],
+        io_map: list[tuple[str, str]],
         check_expectations: Callable[[GraphProto, GraphProto, GraphProto], None],
-        inputs: Optional[List[str]] = None,
-        outputs: Optional[List[str]] = None,
-        prefix1: Optional[str] = None,
-        prefix2: Optional[str] = None,
+        inputs: list[str] | None = None,
+        outputs: list[str] | None = None,
+        prefix1: str | None = None,
+        prefix2: str | None = None,
     ) -> None:
         m1, m2 = _load_model(m1def), _load_model(m2def)
         g3 = compose.merge_graphs(
@@ -814,9 +814,9 @@ class TestComposeFunctions(unittest.TestCase):
         def _make_function(
             domain: str,
             fname: str,
-            inputs: List[str],
-            outputs: List[str],
-            nodes: List[NodeProto],
+            inputs: list[str],
+            outputs: list[str],
+            nodes: list[NodeProto],
         ) -> FunctionProto:
             f = FunctionProto()
             f.domain = domain

--- a/onnx/test/compose_test.py
+++ b/onnx/test/compose_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import unittest
 from typing import Callable, List, Optional, Sequence, Tuple

--- a/onnx/test/data_propagation_test.py
+++ b/onnx/test/data_propagation_test.py
@@ -1,7 +1,6 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
-
 from __future__ import annotations
 
 import unittest

--- a/onnx/test/elu_test.py
+++ b/onnx/test/elu_test.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 import unittest
 
 from onnx import checker, defs, helper

--- a/onnx/test/elu_test.py
+++ b/onnx/test/elu_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 import unittest
 
 from onnx import checker, defs, helper

--- a/onnx/test/function_inference_test.py
+++ b/onnx/test/function_inference_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 import unittest
 from typing import Sequence
 

--- a/onnx/test/function_inference_test.py
+++ b/onnx/test/function_inference_test.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 import unittest
 from typing import Sequence
 

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -3,12 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-# pylint: disable=unnecessary-lambda
-
 import random
 import struct
 import unittest
-from typing import Any, List, Tuple
+from typing import Any
 
 import numpy as np
 import pytest
@@ -26,6 +24,8 @@ from onnx import (
     helper,
     numpy_helper,
 )
+
+# pylint: disable=unnecessary-lambda
 
 
 class TestHelperAttributeFunctions(unittest.TestCase):
@@ -247,7 +247,7 @@ class TestHelperAttributeFunctions(unittest.TestCase):
         def _extend(
             attr: AttributeProto,
             type_: AttributeProto.AttributeType,
-            var: List[Any],
+            var: list[Any],
             value: Any,
         ) -> None:
             var.extend(value)
@@ -376,14 +376,14 @@ class TestHelperNodeFunctions(unittest.TestCase):
         self.assertRaises(checker.ValidationError, checker.check_model, model_def)
 
     def test_model_irversion(self) -> None:
-        def mk_model(opset_versions: List[Tuple[str, int]]) -> ModelProto:
+        def mk_model(opset_versions: list[tuple[str, int]]) -> ModelProto:
             graph = helper.make_graph([], "my graph", [], [])
             return helper.make_model_gen_version(
                 graph,
                 opset_imports=[helper.make_opsetid(*pair) for pair in opset_versions],
             )
 
-        def test(opset_versions: List[Tuple[str, int]], ir_version: int) -> None:
+        def test(opset_versions: list[tuple[str, int]], ir_version: int) -> None:
             model = mk_model(opset_versions)
             self.assertEqual(model.ir_version, ir_version)
 

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 # pylint: disable=unnecessary-lambda
 

--- a/onnx/test/hub_test.py
+++ b/onnx/test/hub_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 # pylint: disable=protected-access
 import glob

--- a/onnx/test/inliner_test.py
+++ b/onnx/test/inliner_test.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 import unittest
 
 from onnx import inliner, parser

--- a/onnx/test/inliner_test.py
+++ b/onnx/test/inliner_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 import unittest
 
 from onnx import inliner, parser

--- a/onnx/test/model_inference_test.py
+++ b/onnx/test/model_inference_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 import typing
 import unittest
 

--- a/onnx/test/model_inference_test.py
+++ b/onnx/test/model_inference_test.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 import typing
 import unittest
 

--- a/onnx/test/numpy_helper_test.py
+++ b/onnx/test/numpy_helper_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import unittest
 from typing import Any

--- a/onnx/test/parser_test.py
+++ b/onnx/test/parser_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 import unittest
 
 from parameterized import parameterized

--- a/onnx/test/parser_test.py
+++ b/onnx/test/parser_test.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 import unittest
 
 from parameterized import parameterized

--- a/onnx/test/printer_test.py
+++ b/onnx/test/printer_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 import unittest
 
 import onnx

--- a/onnx/test/printer_test.py
+++ b/onnx/test/printer_test.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 import unittest
 
 import onnx

--- a/onnx/test/reference_evaluator_backend_test.py
+++ b/onnx/test/reference_evaluator_backend_test.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 # type: ignore
 # pylint: disable=C0415,R0912,R0913,R0914,R0915,W0613,W0640,W0703
 """

--- a/onnx/test/reference_evaluator_backend_test.py
+++ b/onnx/test/reference_evaluator_backend_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # type: ignore
 # pylint: disable=C0415,R0912,R0913,R0914,R0915,W0613,W0640,W0703
 """

--- a/onnx/test/reference_evaluator_backend_test.py
+++ b/onnx/test/reference_evaluator_backend_test.py
@@ -1,8 +1,6 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from __future__ import annotations
-
 # type: ignore
 # pylint: disable=C0415,R0912,R0913,R0914,R0915,W0613,W0640,W0703
 """
@@ -21,6 +19,8 @@ You may refine the absolute or relative tolerance for a test by
 adding an item in method `setUpClass` and attributes
 `atol` or `rtol`.
 """
+
+from __future__ import annotations
 
 import os
 import pprint

--- a/onnx/test/reference_evaluator_ml_test.py
+++ b/onnx/test/reference_evaluator_ml_test.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# type: ignore
-# pylint: disable=C3001,C0302,C0415,R0904,R0913,R0914,R0915,W0221,W0707
 
 import unittest
 from functools import wraps
@@ -23,6 +21,10 @@ from onnx.helper import (
     make_tensor_value_info,
 )
 from onnx.reference import ReferenceEvaluator
+
+# type: ignore
+# pylint: disable=C3001,C0302,C0415,R0904,R0913,R0914,R0915,W0221,W0707
+
 
 # TODO (https://github.com/microsoft/onnxruntime/issues/14932): Get max supported version from onnxruntime directly
 # For now, bump the version in CIs whenever there is a new onnxruntime release

--- a/onnx/test/reference_evaluator_ml_test.py
+++ b/onnx/test/reference_evaluator_ml_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # type: ignore
 # pylint: disable=C3001,C0302,C0415,R0904,R0913,R0914,R0915,W0221,W0707
 

--- a/onnx/test/reference_evaluator_test.py
+++ b/onnx/test/reference_evaluator_test.py
@@ -1,7 +1,6 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from __future__ import annotations
 
 # type: ignore
 # pylint: disable=C3001,C0302,C0415,R0904,R0913,R0914,R0915,W0221,W0707
@@ -12,6 +11,7 @@ You can run a specific test by using the following syntax.
 
     python onnx/test/reference_evaluator_test.py TestReferenceEvaluator.test_function_attribute_nested_graph
 """
+from __future__ import annotations
 
 import itertools
 import math
@@ -22,7 +22,7 @@ from functools import wraps
 from io import StringIO
 from os import getenv
 from textwrap import dedent
-from typing import Sequence
+from typing import Any, Sequence
 
 import numpy as np
 import parameterized
@@ -1296,8 +1296,7 @@ class TestReferenceEvaluator(unittest.TestCase):
         )
 
         trip_count = np.array(5).astype(np.int64)
-        seq_empty = []  # type: List[Any]
-        # seq_res = [x[:int(i)] for i in x]
+        seq_empty: list[Any] = []
         cond = np.array(1).astype(np.bool_)
 
         model_def = make_model(

--- a/onnx/test/reference_evaluator_test.py
+++ b/onnx/test/reference_evaluator_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # type: ignore
 # pylint: disable=C3001,C0302,C0415,R0904,R0913,R0914,R0915,W0221,W0707
 """

--- a/onnx/test/reference_evaluator_test.py
+++ b/onnx/test/reference_evaluator_test.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 # type: ignore
 # pylint: disable=C3001,C0302,C0415,R0904,R0913,R0914,R0915,W0221,W0707
 """
@@ -21,7 +22,7 @@ from functools import wraps
 from io import StringIO
 from os import getenv
 from textwrap import dedent
-from typing import Sequence, Tuple
+from typing import Sequence
 
 import numpy as np
 import parameterized
@@ -188,7 +189,7 @@ def im2col_naive_implementation(data, kernel_shape, dilations, pads, strides):  
 
 def im2col(
     img: np.ndarray,
-    kernel_shape: Tuple[int, ...],
+    kernel_shape: tuple[int, ...],
     dilations: Sequence[int],
     pads: Sequence[int],
     strides: Sequence[int],

--- a/onnx/test/relu_test.py
+++ b/onnx/test/relu_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 import unittest
 
 from onnx import defs, helper

--- a/onnx/test/relu_test.py
+++ b/onnx/test/relu_test.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 import unittest
 
 from onnx import defs, helper

--- a/onnx/test/schema_test.py
+++ b/onnx/test/schema_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 import unittest
 from typing import Sequence
 

--- a/onnx/test/schema_test.py
+++ b/onnx/test/schema_test.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 import unittest
 from typing import Sequence
 

--- a/onnx/test/serialization_test.py
+++ b/onnx/test/serialization_test.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 import os
 import tempfile
 import unittest

--- a/onnx/test/serialization_test.py
+++ b/onnx/test/serialization_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 import os
 import tempfile
 import unittest

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -1,7 +1,6 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
-
 from __future__ import annotations
 
 import unittest

--- a/onnx/test/symbolic_shape_test.py
+++ b/onnx/test/symbolic_shape_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import unittest
 from typing import List, Optional

--- a/onnx/test/symbolic_shape_test.py
+++ b/onnx/test/symbolic_shape_test.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import unittest
-from typing import List, Optional
 
 import onnx.shape_inference
 from onnx import ModelProto, TensorProto, TensorShapeProto, ValueInfoProto, helper
@@ -13,7 +12,7 @@ from onnx.helper import make_model, make_tensor_value_info
 
 class TestSymbolicShape(unittest.TestCase):
     def _assert_valueinfo_shape(
-        self, onnx_model: ModelProto, value_infos: List[ValueInfoProto]
+        self, onnx_model: ModelProto, value_infos: list[ValueInfoProto]
     ) -> None:
         """
         Assert onnx_model.value_info should be the same as expected value_infos
@@ -52,7 +51,7 @@ class TestSymbolicShape(unittest.TestCase):
 
     def _get_shape_from_name(
         self, onnx_model: ModelProto, name: str
-    ) -> Optional[TensorShapeProto]:
+    ) -> TensorShapeProto | None:
         """
         Get shape from tensor_type or sparse_tensor_type according to given name
         """

--- a/onnx/test/test_backend_onnxruntime.py
+++ b/onnx/test/test_backend_onnxruntime.py
@@ -1,7 +1,6 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
-
 from __future__ import annotations
 
 import os

--- a/onnx/test/test_backend_reference.py
+++ b/onnx/test/test_backend_reference.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import os
 import platform

--- a/onnx/test/test_backend_test.py
+++ b/onnx/test/test_backend_test.py
@@ -7,7 +7,7 @@ import itertools
 import os
 import platform
 import unittest
-from typing import Any, Optional, Sequence, Tuple
+from typing import Any, Sequence
 
 import numpy
 
@@ -35,7 +35,7 @@ class DummyBackend(onnx.backend.base.Backend):
     @classmethod
     def prepare(
         cls, model: ModelProto, device: str = "CPU", **kwargs: Any
-    ) -> Optional[onnx.backend.base.BackendRep]:
+    ) -> onnx.backend.base.BackendRep | None:
         super().prepare(model, device, **kwargs)
 
         # test strict shape inference
@@ -70,9 +70,9 @@ class DummyBackend(onnx.backend.base.Backend):
         node: NodeProto,
         inputs: Any,
         device: str = "CPU",
-        outputs_info: Optional[Sequence[Tuple[numpy.dtype, Tuple[int, ...]]]] = None,
+        outputs_info: Sequence[tuple[numpy.dtype, tuple[int, ...]]] | None = None,
         **kwargs: Any,
-    ) -> Optional[Tuple[Any, ...]]:
+    ) -> tuple[Any, ...] | None:
         super().run_node(node, inputs, device=device, outputs_info=outputs_info)
         raise BackendIsNotSupposedToImplementIt(
             "This is the dummy backend test that doesn't verify the results but does run the checker"

--- a/onnx/test/test_backend_test.py
+++ b/onnx/test/test_backend_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import itertools
 import os

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 from __future__ import annotations
 
 import os

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-from __future__ import annotations
 
 import os
 import pathlib

--- a/onnx/test/test_with_ort.py
+++ b/onnx/test/test_with_ort.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 # This file is for testing ONNX with ONNX Runtime
 # Create a general scenario to use ONNX Runtime with ONNX
 # pylint: disable=C0415

--- a/onnx/test/test_with_ort.py
+++ b/onnx/test/test_with_ort.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # This file is for testing ONNX with ONNX Runtime
 # Create a general scenario to use ONNX Runtime with ONNX
 # pylint: disable=C0415

--- a/onnx/test/tools_test.py
+++ b/onnx/test/tools_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import unittest
 

--- a/onnx/test/training_tool_test.py
+++ b/onnx/test/training_tool_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import unittest
 

--- a/onnx/test/utils_test.py
+++ b/onnx/test/utils_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import os
 import shutil

--- a/onnx/test/version_converter_test.py
+++ b/onnx/test/version_converter_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import struct
 import unittest

--- a/onnx/tools/__init__.py
+++ b/onnx/tools/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations

--- a/onnx/tools/net_drawer.py
+++ b/onnx/tools/net_drawer.py
@@ -2,6 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from typing import Any, Callable
+
+import pydot
+
+from onnx import GraphProto, ModelProto, NodeProto
+
 # A library and utility for drawing ONNX nets. Most of this implementation has
 # been borrowed from the caffe2 implementation
 # https://github.com/pytorch/pytorch/blob/master/caffe2/python/net_drawer.py
@@ -15,14 +25,6 @@ from __future__ import annotations
 #
 #   $ dot -Tsvg my_output.dot -o my_output.svg
 
-import argparse
-import json
-from collections import defaultdict
-from typing import Any, Callable, Dict, Optional
-
-import pydot
-
-from onnx import GraphProto, ModelProto, NodeProto
 
 OP_STYLE = {
     "shape": "box",
@@ -71,16 +73,16 @@ def GetOpNodeProducer(  # noqa: N802
 
 def GetPydotGraph(  # noqa: N802
     graph: GraphProto,
-    name: Optional[str] = None,
+    name: str | None = None,
     rankdir: str = "LR",
-    node_producer: Optional[_NodeProducer] = None,
+    node_producer: _NodeProducer | None = None,
     embed_docstring: bool = False,
 ) -> pydot.Dot:
     if node_producer is None:
         node_producer = GetOpNodeProducer(embed_docstring=embed_docstring, **OP_STYLE)
     pydot_graph = pydot.Dot(name, rankdir=rankdir)
-    pydot_nodes: Dict[str, pydot.Node] = {}
-    pydot_node_counts: Dict[str, int] = defaultdict(int)
+    pydot_nodes: dict[str, pydot.Node] = {}
+    pydot_node_counts: dict[str, int] = defaultdict(int)
     for op_id, op in enumerate(graph.node):
         op_node = node_producer(op, op_id)
         pydot_graph.add_node(op_node)

--- a/onnx/tools/net_drawer.py
+++ b/onnx/tools/net_drawer.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # A library and utility for drawing ONNX nets. Most of this implementation has
 # been borrowed from the caffe2 implementation
 # https://github.com/pytorch/pytorch/blob/master/caffe2/python/net_drawer.py

--- a/onnx/tools/replace_constants.py
+++ b/onnx/tools/replace_constants.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 # pylint: disable=too-many-statements,too-many-branches
 from typing import List, Optional, Union
 

--- a/onnx/tools/replace_constants.py
+++ b/onnx/tools/replace_constants.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-# pylint: disable=too-many-statements,too-many-branches
-from typing import List, Optional, Union
 
 import numpy as np
 
@@ -29,10 +27,12 @@ from onnx.helper import (
 )
 from onnx.numpy_helper import from_array
 
+# pylint: disable=too-many-statements,too-many-branches
+
 
 def _replace_constant(
     node: NodeProto, threshold: int, value_constant_of_shape: float
-) -> List[NodeProto]:
+) -> list[NodeProto]:
     """
     Replaces a Constant node with a large tensor (with more than threshold elements)
     by a sequence of nodes that produces a dummy constant of same shape as original tensor.
@@ -74,8 +74,8 @@ def _replace_constant(
 
 
 def _replace_constant_of_shape_with_range(
-    onx: Union[GraphProto, FunctionProto]
-) -> Union[GraphProto, FunctionProto]:
+    onx: GraphProto | FunctionProto,
+) -> GraphProto | FunctionProto:
     """
     Replaces all *ConstantOfShape* by node *Range* to avoid constant tensors.
     The function is not recursive. The recursivity is done by
@@ -163,8 +163,8 @@ def _replace_constant_of_shape_with_range(
 
 
 def _replace_constant_of_shape_value(
-    onx: Union[GraphProto, FunctionProto], value_constant_of_shape: float
-) -> Union[GraphProto, FunctionProto]:
+    onx: GraphProto | FunctionProto, value_constant_of_shape: float
+) -> GraphProto | FunctionProto:
     """
     Replaces all fill value of all nodes *ConstantOfShape*.
     *replace_initializer_by_constant_of_shape*.
@@ -222,9 +222,9 @@ def _replace_constant_of_shape_value(
 
 
 def replace_initializer_by_constant_of_shape(
-    onx: Union[FunctionProto, GraphProto, ModelProto],
+    onx: FunctionProto | GraphProto | ModelProto,
     threshold: int = 128,
-    ir_version: Optional[int] = None,
+    ir_version: int | None = None,
     use_range: bool = False,
     value_constant_of_shape: float = 0.5,
 ):
@@ -249,7 +249,7 @@ def replace_initializer_by_constant_of_shape(
     """
     if isinstance(onx, FunctionProto):
         modified = False
-        new_nodes: List[NodeProto] = []
+        new_nodes: list[NodeProto] = []
         for node in onx.node:
             if node.op_type == "Constant":
                 cst_nodes = _replace_constant(node, threshold, value_constant_of_shape)
@@ -336,7 +336,7 @@ def replace_initializer_by_constant_of_shape(
     removed = set()
     additional_inputs = []
 
-    new_inits: List[TensorProto] = []
+    new_inits: list[TensorProto] = []
     for init in onx.initializer:
         dims = tuple(init.dims)
         size = np.prod(dims)
@@ -362,7 +362,7 @@ def replace_initializer_by_constant_of_shape(
                 make_tensor_value_info(new_name, TensorProto.INT64, [len(dims)])
             )
 
-    new_sparse_inits: List[SparseTensorProto] = []
+    new_sparse_inits: list[SparseTensorProto] = []
     for sp_init in onx.sparse_initializer:
         dims = tuple(sp_init.dims)
         size = np.prod(dims)

--- a/onnx/tools/update_model_dims.py
+++ b/onnx/tools/update_model_dims.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import Any, Dict, List, Set
+from typing import Any
 
 import onnx.checker
 from onnx import ModelProto, ValueInfoProto
@@ -11,8 +11,8 @@ from onnx import ModelProto, ValueInfoProto
 
 def update_inputs_outputs_dims(
     model: ModelProto,
-    input_dims: Dict[str, List[Any]],
-    output_dims: Dict[str, List[Any]],
+    input_dims: dict[str, list[Any]],
+    output_dims: dict[str, list[Any]],
 ) -> ModelProto:
     """
     This function updates the dimension sizes of the model's inputs and outputs to the values
@@ -45,10 +45,10 @@ def update_inputs_outputs_dims(
         updated_model = update_inputs_outputs_dims(model, input_dims, output_dims)
         onnx.save(updated_model, 'model.onnx')
     """
-    dim_param_set: Set[str] = set()
+    dim_param_set: set[str] = set()
 
     def init_dim_param_set(
-        dim_param_set: Set[str], value_infos: List[ValueInfoProto]
+        dim_param_set: set[str], value_infos: list[ValueInfoProto]
     ) -> None:
         for info in value_infos:
             shape = info.type.tensor_type.shape

--- a/onnx/tools/update_model_dims.py
+++ b/onnx/tools/update_model_dims.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 from typing import Any, Dict, List, Set
 

--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-from __future__ import annotations
 
 import os
 

--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+from __future__ import annotations
 
 import os
 

--- a/onnx/version_converter.py
+++ b/onnx/version_converter.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 """onnx version converter
 
 This enables users to convert their models between different opsets within the

--- a/onnx/version_converter.py
+++ b/onnx/version_converter.py
@@ -1,13 +1,13 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from __future__ import annotations
 
 """onnx version converter
 
 This enables users to convert their models between different opsets within the
 default domain ("" or "ai.onnx").
 """
+from __future__ import annotations
 
 import onnx
 import onnx.onnx_cpp2py_export.version_converter as C  # noqa: N812

--- a/onnx/version_converter.py
+++ b/onnx/version_converter.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 """onnx version converter
 
 This enables users to convert their models between different opsets within the

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import glob
 import multiprocessing

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from datetime import date
 from distutils import log, sysconfig
 from distutils.spawn import find_executable
 from textwrap import dedent
-from typing import ClassVar, List
+from typing import ClassVar
 
 import setuptools
 import setuptools.command.build_ext
@@ -339,7 +339,7 @@ packages = setuptools.find_packages() + setuptools.find_namespace_packages(
 )
 
 
-def load_packages_from_requirements(requirements_file: str) -> List[str]:
+def load_packages_from_requirements(requirements_file: str) -> list[str]:
     """Load required packages from requirements-*.txt.
 
     Arguments:

--- a/tools/gen_coverage_report.py
+++ b/tools/gen_coverage_report.py
@@ -3,6 +3,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 import argparse
 import os

--- a/tools/protoc-gen-mypy.py
+++ b/tools/protoc-gen-mypy.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 
 # Copyright (c) ONNX Project Contributors
-
-# Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 # Taken from https://github.com/dropbox/mypy-protobuf/blob/d984389124eae6dbbb517f766b9266bb32171510/python/protoc-gen-mypy
 # (Apache 2.0 License)

--- a/tools/protoc-gen-mypy.py
+++ b/tools/protoc-gen-mypy.py
@@ -3,7 +3,6 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from __future__ import annotations
 
 # Taken from https://github.com/dropbox/mypy-protobuf/blob/d984389124eae6dbbb517f766b9266bb32171510/python/protoc-gen-mypy
 # (Apache 2.0 License)
@@ -15,8 +14,9 @@ from __future__ import annotations
 #    on CI, which by the original protoc-gen-mypy script was recognized to be
 #    camel case and therefore handled as an entry in the local package)
 
-
 """Protoc Plugin to generate mypy stubs. Loosely based on @zbarsky's go implementation"""
+
+from __future__ import annotations
 
 import sys
 from collections import defaultdict

--- a/tools/protoc-gen-mypy.py
+++ b/tools/protoc-gen-mypy.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import sys
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import Any, Callable, Dict, Generator, List, Optional, Set, cast
+from typing import Any, Callable, Generator, cast
 
 try:
     import google.protobuf.descriptor_pb2 as d_typed
@@ -46,10 +46,10 @@ class Descriptors:
     def __init__(self, request: plugin.CodeGeneratorRequest) -> None:
         files = {f.name: f for f in request.proto_file}
         to_generate = {n: files[n] for n in request.file_to_generate}
-        self.files: Dict[str, d.FileDescriptorProto] = files
-        self.to_generate: Dict[str, d.FileDescriptorProto] = to_generate
-        self.messages: Dict[str, d.DescriptorProto] = {}
-        self.message_to_fd: Dict[str, d.FileDescriptorProto] = {}
+        self.files: dict[str, d.FileDescriptorProto] = files
+        self.to_generate: dict[str, d.FileDescriptorProto] = to_generate
+        self.messages: dict[str, d.DescriptorProto] = {}
+        self.message_to_fd: dict[str, d.FileDescriptorProto] = {}
 
         def _add_enums(
             enums: d.EnumDescriptorProto, prefix: str, fd: d.FileDescriptorProto
@@ -79,14 +79,14 @@ class PkgWriter:
     def __init__(self, fd: d.FileDescriptorProto, descriptors: Descriptors) -> None:
         self.fd = fd
         self.descriptors = descriptors
-        self.lines: List[str] = []
+        self.lines: list[str] = []
         self.indent = ""
 
         # dictionary of x->y for `from {x} import {y}`
-        self.imports: Dict[str, Set[str]] = defaultdict(set)
-        self.locals: Set[str] = set()
+        self.imports: dict[str, set[str]] = defaultdict(set)
+        self.locals: set[str] = set()
 
-    def _import(self, path: str, name: str, import_as: Optional[str] = None) -> str:
+    def _import(self, path: str, name: str, import_as: str | None = None) -> str:
         """Imports a stdlib path and returns a handle to it
         eg. self._import("typing", "Optional") -> "Optional"
         """
@@ -139,7 +139,7 @@ class PkgWriter:
     def _write_line(self, line: str, *args: str) -> None:
         self.lines.append(self.indent + line.format(*args))
 
-    def write_enums(self, enums: List[d.EnumDescriptorProto]) -> None:
+    def write_enums(self, enums: list[d.EnumDescriptorProto]) -> None:
         line = self._write_line
         for enum in enums:
             line("class {}(int):", enum.name)
@@ -169,7 +169,7 @@ class PkgWriter:
                 )
             line("")
 
-    def write_messages(self, messages: List[d.DescriptorProto], prefix: str) -> None:
+    def write_messages(self, messages: list[d.DescriptorProto], prefix: str) -> None:
         line = self._write_line
         message_class = self._import("google.protobuf.message", "Message")
 
@@ -330,7 +330,7 @@ class PkgWriter:
                 )
 
     def python_type(self, field: d.FieldDescriptorProto) -> str:
-        mapping: Dict[int, Callable[[], str]] = {
+        mapping: dict[int, Callable[[], str]] = {
             d.FieldDescriptorProto.TYPE_DOUBLE: lambda: "float",
             d.FieldDescriptorProto.TYPE_FLOAT: lambda: "float",
             d.FieldDescriptorProto.TYPE_INT64: lambda: "int",

--- a/workflow_scripts/config.py
+++ b/workflow_scripts/config.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-
 SKIP_VERSION_CONVERTER_MODELS = {
     "vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-6.onnx",  # the converted opset 7 model cannot pass shape inference:
     # [ShapeInferenceError] (op_type:Mul, node name: ): [ShapeInferenceError] Inferred shape and existing shape differ in dimension 0: (64) vs (1)

--- a/workflow_scripts/config.py
+++ b/workflow_scripts/config.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 
 
 SKIP_VERSION_CONVERTER_MODELS = {

--- a/workflow_scripts/test_model_zoo.py
+++ b/workflow_scripts/test_model_zoo.py
@@ -1,6 +1,7 @@
 # Copyright (c) ONNX Project Contributors
-
+#
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 import argparse
 import gc
 import os

--- a/workflow_scripts/test_model_zoo.py
+++ b/workflow_scripts/test_model_zoo.py
@@ -2,12 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
+
 import argparse
 import gc
 import os
 import sys
 import time
-from typing import List
 
 import config
 
@@ -15,7 +15,7 @@ import onnx
 from onnx import hub, version_converter
 
 
-def skip_model(error_message: str, skip_list: List[str], model_name: str):
+def skip_model(error_message: str, skip_list: list[str], model_name: str):
     print(error_message)
     skip_list.append(model_name)
 
@@ -37,7 +37,7 @@ def main():
     # run checker on each model
     failed_models = []
     failed_messages = []
-    skip_models: List[str] = []
+    skip_models: list[str] = []
     for m in model_list:
         start = time.time()
         model_name = m.model


### PR DESCRIPTION
Add `from __future__ import annotations` to all files and use ruff to update to the latest format.

### Motivation and Context

Annotations are delayed evaluated by default in future Python versions.
