### PR TITLE
Rename source/target to inferred/declared

### DIFF
--- a/onnx/defs/shape_inference.cc
+++ b/onnx/defs/shape_inference.cc
@@ -120,9 +120,9 @@ void mergeInShapeInfo(const TensorShapeProto& source, TensorShapeProto& target) 
   auto num_target_dims = target.dim_size();
   if (num_source_dims != num_target_dims) {
     fail_shape_inference(
-        "Mismatch between number of source and target dimensions. Source=",
+        "Mismatch between number of inferred and declared dimensions. inferred=",
         num_source_dims,
-        " Target=",
+        " declared=",
         num_target_dims);
   }
 
@@ -261,7 +261,8 @@ void UnionShapeInfo(const TensorShapeProto& source_shape, TypeProto_SparseTensor
 
 void UnionTypeInfo(const TypeProto& source_type, TypeProto& target_type) {
   if (source_type.value_case() != target_type.value_case()) {
-    fail_type_inference("Mismatched type:", " source=", source_type.value_case(), " target=", target_type.value_case());
+    fail_type_inference(
+        "Mismatched type:", " inferred=", source_type.value_case(), " declared=", target_type.value_case());
   }
 
   const auto target_case = target_type.value_case();
@@ -271,7 +272,7 @@ void UnionTypeInfo(const TypeProto& source_type, TypeProto& target_type) {
 
     if (source_elem_type != target_elem_type) {
       fail_type_inference(
-          "Mismatched tensor element type:", " source=", source_elem_type, " target=", target_elem_type);
+          "Mismatched tensor element type:", " inferred=", source_elem_type, " declared=", target_elem_type);
     }
 
     UnionShapeInfo(source_type.tensor_type(), *target_type.mutable_tensor_type());
@@ -280,7 +281,7 @@ void UnionTypeInfo(const TypeProto& source_type, TypeProto& target_type) {
     auto target_elem_type = target_type.sparse_tensor_type().elem_type();
     if (source_elem_type != target_elem_type) {
       fail_type_inference(
-          "Mismatched sparse tensor element type:", " source=", source_elem_type, " target=", target_elem_type);
+          "Mismatched sparse tensor element type:", " inferred=", source_elem_type, " declared=", target_elem_type);
     }
     UnionShapeInfo(source_type.sparse_tensor_type(), *target_type.mutable_sparse_tensor_type());
   } else if (target_case == TypeProto::ValueCase::kSequenceType) {
@@ -311,9 +312,9 @@ void UnionTypeInfo(const TypeProto& source_type, TypeProto& target_type) {
     if (source_key_type != target_key_type) {
       fail_type_inference(
           "Mismatched map tensor key type:",
-          " source=",
+          " inferred=",
           Utils::DataTypeUtils::ToDataTypeString(source_key_type),
-          " target=",
+          " declared=",
           Utils::DataTypeUtils::ToDataTypeString(target_key_type));
     }
 

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -378,7 +378,8 @@ inline void propagateShape(const TypeProto* from_type, TypeProto* to_type) {
   const auto from_type_case = from_type->value_case();
   const auto to_type_case = to_type->value_case();
   if (from_type_case != to_type_case) {
-    fail_shape_inference("Mismatch between source and target type. Source=", from_type_case, " Target=", to_type_case);
+    fail_shape_inference(
+        "Mismatch between inferred and declared type. Inferred=", from_type_case, " Declared=", to_type_case);
   }
 
   if (TypeProto::kTensorType == from_type_case || TypeProto::kSparseTensorType == from_type_case) {
@@ -649,9 +650,9 @@ inline void mergeInDimensionInfo(
       if (target_value != source_value) {
         fail_shape_inference(
             "Can't merge shape info. "
-            "Both source and target dimension have values but they differ. Source=",
+            "Both inferred and declared dimension have values but they differ. Inferred=",
             source_value,
-            " Target=",
+            " Declared=",
             target_value,
             " Dimension=",
             dim_index);


### PR DESCRIPTION
### Description

Rename source/target to inferred/declared in shape inference code to reduce confusion

### Motivation and Context

Fixes #5470 
