### PR TITLE
Support for parsing and printing empty list value as attribute

### DIFF
--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -465,16 +465,15 @@ Status OnnxParser::ParseSingleAttributeValue(AttributeProto& attr, AttributeProt
     // Mismatch between type-annotation and attribute-value. We do an implicit cast
     // only in the special case of FLOAT type and integral value like 2
     if ((expected == AttributeProto_AttributeType_FLOAT) && (attr.type() == AttributeProto_AttributeType_INT)) {
-        attr.set_type(AttributeProto_AttributeType_FLOAT);
-        attr.set_f(static_cast<float>(attr.i()));      
+      attr.set_type(AttributeProto_AttributeType_FLOAT);
+      attr.set_f(static_cast<float>(attr.i()));
     } else {
-      return ParseError("Mismatch between expected type ",
-        AttributeProto_AttributeType_Name(expected),
-        " and specified value's type",
-        AttributeProto_AttributeType_Name(attr.type())
-        );
+      return ParseError(
+          "Mismatch between expected type ",
+          AttributeProto_AttributeType_Name(expected),
+          " and specified value's type",
+          AttributeProto_AttributeType_Name(attr.type()));
     }
-
   }
   return Status::OK();
 }
@@ -518,7 +517,7 @@ AttributeProto_AttributeType ToSingletonType(AttributeProto_AttributeType type) 
     case AttributeProto_AttributeType_TYPE_PROTOS:
       return AttributeProto_AttributeType_TYPE_PROTO;
     default:
-      return type;  
+      return type;
   }
 }
 

--- a/onnx/defs/parser.h
+++ b/onnx/defs/parser.h
@@ -421,7 +421,7 @@ class OnnxParser : public ParserBase {
 
   Status Parse(char open, IdList& idlist, AttrList& attrlist, char close);
 
-  Status ParseSingleAttributeValue(AttributeProto& attr);
+  Status ParseSingleAttributeValue(AttributeProto& attr, AttributeProto_AttributeType expected);
 
   Status Parse(ValueInfoProto& valueinfo);
 

--- a/onnx/defs/printer.cc
+++ b/onnx/defs/printer.cc
@@ -268,7 +268,7 @@ void ProtoPrinter::print(const AttributeProto& attr) {
     return;
   }
   // General case:
-  output_ << attr.name() << " = ";
+  output_ << attr.name() << ": " << AttributeTypeNameMap::ToString(attr.type()) << " = ";
   switch (attr.type()) {
     case AttributeProto_AttributeType_INT:
       output_ << attr.i();

--- a/onnx/test/cpp/parser_test.cc
+++ b/onnx/test/cpp/parser_test.cc
@@ -186,6 +186,10 @@ TEST(ParserTest, AttributeTest) {
   EXPECT_EQ(attr.ref_attr_name(), "xyz");
   EXPECT_EQ(attr.type(), AttributeProto_AttributeType::AttributeProto_AttributeType_INTS);
 
+  Parse(attr, "x : ints = []");
+  EXPECT_EQ(attr.type(), AttributeProto_AttributeType::AttributeProto_AttributeType_INTS);
+  EXPECT_EQ(attr.ints_size(), 0);
+
   Parse(attr, R"ONNX(
     body = somegraph (float[N] y, float[N] z) => (float[N] w)
       {


### PR DESCRIPTION
The existing parser and printer for ONNX text format does not support an empty list as an attribute value. Fix this.