### PR TITLE
Show human-readable attribute type names in `helper.make_attribute` exception

### DIFF
--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -925,7 +925,7 @@ def make_attribute(  # pylint: disable=too-many-statements
 
     if attr_type is not None and attr.type != attr_type:
         raise TypeError(
-            f"Inferred attribute type {attr.type} mismatched with specified type {attr_type}"
+            f"Inferred attribute type {attr_type_to_str(attr.type)}({attr.type}) mismatched with specified type {attr_type_to_str(attr_type)}({attr_type})"
         )
     return attr
 

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -925,7 +925,7 @@ def make_attribute(  # pylint: disable=too-many-statements
 
     if attr_type is not None and attr.type != attr_type:
         raise TypeError(
-            f"Inferred attribute type {attr_type_to_str(attr.type)}({attr.type}) mismatched with specified type {attr_type_to_str(attr_type)}({attr_type})"
+            f"Inferred attribute type '{_attr_type_to_str(attr.type)}'({attr.type}) mismatched with specified type '{_attr_type_to_str(attr_type)}'({attr_type})"
         )
     return attr
 
@@ -1540,32 +1540,13 @@ def get_all_tensor_dtypes() -> KeysView[int]:
     return mapping.TENSOR_TYPE_MAP.keys()
 
 
-attribute_proto_type_to_str = {
-    AttributeProto.FLOAT: "float",
-    AttributeProto.FLOATS: "floats",
-    AttributeProto.GRAPH: "graph",
-    AttributeProto.GRAPHS: "graphs",
-    AttributeProto.INT: "int",
-    AttributeProto.INTS: "ints",
-    AttributeProto.SPARSE_TENSOR: "sparse_tensor",
-    AttributeProto.SPARSE_TENSORS: "sparse_tensors",
-    AttributeProto.STRING: "string",
-    AttributeProto.STRINGS: "strings",
-    AttributeProto.TENSOR: "tensor",
-    AttributeProto.TENSORS: "tensors",
-    AttributeProto.TYPE_PROTO: "proto",
-    AttributeProto.TYPE_PROTOS: "protos",
-}
-
-
-def attr_type_to_str(attr_type: int) -> str:
+def _attr_type_to_str(attr_type: int) -> str:
     """
     Convert AttributeProto type to string.
 
     :param attr_type: AttributeProto type.
-    :return: String representing the supplied attr_type. Raises ValueError if
-        attr_type is not a valid AttributeProto type.
+    :return: String representing the supplied attr_type.
     """
-    if attr_type in attribute_proto_type_to_str:
-        return attribute_proto_type_to_str[attr_type]
-    raise ValueError(f"Unsupported ONNX attribute type: {attr_type}")
+    if attr_type in AttributeProto.AttributeType.values():
+        return AttributeProto.AttributeType.keys()[attr_type]
+    return AttributeProto.AttributeType.keys()[0]

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -1540,6 +1540,9 @@ def get_all_tensor_dtypes() -> KeysView[int]:
     return mapping.TENSOR_TYPE_MAP.keys()
 
 
+_ATTRIBUTE_TYPE_TO_STR = {k: v for v, k in AttributeProto.AttributeType.items()}
+
+
 def _attr_type_to_str(attr_type: int) -> str:
     """
     Convert AttributeProto type to string.
@@ -1548,5 +1551,5 @@ def _attr_type_to_str(attr_type: int) -> str:
     :return: String representing the supplied attr_type.
     """
     if attr_type in AttributeProto.AttributeType.values():
-        return AttributeProto.AttributeType.keys()[attr_type]
+        return _ATTRIBUTE_TYPE_TO_STR[attr_type]
     return AttributeProto.AttributeType.keys()[0]

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -1538,3 +1538,34 @@ def get_all_tensor_dtypes() -> KeysView[int]:
     :return: all tensor types from TensorProto
     """
     return mapping.TENSOR_TYPE_MAP.keys()
+
+
+attribute_proto_type_to_str = {
+    AttributeProto.FLOAT: "float",
+    AttributeProto.FLOATS: "floats",
+    AttributeProto.GRAPH: "graph",
+    AttributeProto.GRAPHS: "graphs",
+    AttributeProto.INT: "int",
+    AttributeProto.INTS: "ints",
+    AttributeProto.SPARSE_TENSOR: "sparse_tensor",
+    AttributeProto.SPARSE_TENSORS: "sparse_tensors",
+    AttributeProto.STRING: "string",
+    AttributeProto.STRINGS: "strings",
+    AttributeProto.TENSOR: "tensor",
+    AttributeProto.TENSORS: "tensors",
+    AttributeProto.TYPE_PROTO: "proto",
+    AttributeProto.TYPE_PROTOS: "protos",
+}
+
+
+def attr_type_to_str(attr_type: int) -> str:
+    """
+    Convert AttributeProto type to string.
+
+    :param attr_type: AttributeProto type.
+    :return: String representing the supplied attr_type. Raises ValueError if
+        attr_type is not a valid AttributeProto type.
+    """
+    if attr_type in attribute_proto_type_to_str:
+        return attribute_proto_type_to_str[attr_type]
+    raise ValueError(f"Unsupported ONNX attribute type: {attr_type}")

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -218,6 +218,12 @@ class TestHelperAttributeFunctions(unittest.TestCase):
         self.assertEqual(len(attr.strings), 0)
         self.assertRaises(ValueError, helper.make_attribute, "empty", [])
 
+    def test_attr_mismatch(self) -> None:
+        with pytest.raises(TypeError) as te:
+            attr = helper.make_attribute("test", 6.4, attr_type=AttributeProto.STRING)
+        assert "float" in str(te.value)
+        assert "string" in str(te.value)
+
     def test_is_attr_legal(self) -> None:
         # no name, no field
         attr = AttributeProto()
@@ -893,11 +899,8 @@ def test_attr_type_to_str(attr_type):
 
 
 def test_attr_type_to_str_raises():
-    try:
+    with pytest.raises(ValueError):
         result = helper.attr_type_to_str(9999)
-    except ValueError as e:
-        return
-    assert False, "Should have raised a ValueError"
 
 
 if __name__ == "__main__":

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -219,10 +219,8 @@ class TestHelperAttributeFunctions(unittest.TestCase):
         self.assertRaises(ValueError, helper.make_attribute, "empty", [])
 
     def test_attr_mismatch(self) -> None:
-        with pytest.raises(TypeError) as te:
+        with self.assertRaisesRegex(TypeError, "Inferred attribute type 'FLOAT'"):
             helper.make_attribute("test", 6.4, attr_type=AttributeProto.STRING)
-        assert "FLOAT" in str(te.value)
-        assert "STRING" in str(te.value)
 
     def test_is_attr_legal(self) -> None:
         # no name, no field

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -10,8 +10,8 @@ import unittest
 from typing import Any, List, Tuple
 
 import numpy as np
-import pytest
 import parameterized
+import pytest
 
 from onnx import (
     AttributeProto,
@@ -891,20 +891,20 @@ class TestHelperMappingFunctions(unittest.TestCase):
 class TestAttrTypeToStr(unittest.TestCase):
     @parameterized.parameterized.expand(
         [
-            (AttributeProto.AttributeType.FLOAT, "FLOAT"),
-            (AttributeProto.AttributeType.INT, "INT"),
-            (AttributeProto.AttributeType.STRING, "STRING"),
-            (AttributeProto.AttributeType.TENSOR, "TENSOR"),
-            (AttributeProto.AttributeType.GRAPH, "GRAPH"),
-            (AttributeProto.AttributeType.SPARSE_TENSOR, "SPARSE_TENSOR"),
-            (AttributeProto.AttributeType.TYPE_PROTO, "TYPE_PROTO"),
-            (AttributeProto.AttributeType.FLOATS, "FLOATS"),
-            (AttributeProto.AttributeType.INTS, "INTS"),
-            (AttributeProto.AttributeType.STRINGS, "STRINGS"),
-            (AttributeProto.AttributeType.TENSORS, "TENSORS"),
-            (AttributeProto.AttributeType.GRAPHS, "GRAPHS"),
-            (AttributeProto.AttributeType.SPARSE_TENSORS, "SPARSE_TENSORS"),
-            (AttributeProto.AttributeType.TYPE_PROTOS, "TYPE_PROTOS"),
+            (AttributeProto.AttributeType.FLOAT, "FLOAT"),  # type: ignore[attr-defined]
+            (AttributeProto.AttributeType.INT, "INT"),  # type: ignore[attr-defined]
+            (AttributeProto.AttributeType.STRING, "STRING"),  # type: ignore[attr-defined]
+            (AttributeProto.AttributeType.TENSOR, "TENSOR"),  # type: ignore[attr-defined]
+            (AttributeProto.AttributeType.GRAPH, "GRAPH"),  # type: ignore[attr-defined]
+            (AttributeProto.AttributeType.SPARSE_TENSOR, "SPARSE_TENSOR"),  # type: ignore[attr-defined]
+            (AttributeProto.AttributeType.TYPE_PROTO, "TYPE_PROTO"),  # type: ignore[attr-defined]
+            (AttributeProto.AttributeType.FLOATS, "FLOATS"),  # type: ignore[attr-defined]
+            (AttributeProto.AttributeType.INTS, "INTS"),  # type: ignore[attr-defined]
+            (AttributeProto.AttributeType.STRINGS, "STRINGS"),  # type: ignore[attr-defined]
+            (AttributeProto.AttributeType.TENSORS, "TENSORS"),  # type: ignore[attr-defined]
+            (AttributeProto.AttributeType.GRAPHS, "GRAPHS"),  # type: ignore[attr-defined]
+            (AttributeProto.AttributeType.SPARSE_TENSORS, "SPARSE_TENSORS"),  # type: ignore[attr-defined]
+            (AttributeProto.AttributeType.TYPE_PROTOS, "TYPE_PROTOS"),  # type: ignore[attr-defined]
         ]
     )
     def test_attr_type_to_str(self, attr_type, expected_str):

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -892,11 +892,13 @@ class TestAttrTypeToStr(unittest.TestCase):
         for item in AttributeProto.AttributeType.items():
             with self.subTest(item=item):
                 attr_str, attr_type = item
-                result = helper._attr_type_to_str(attr_type)
+                result = helper._attr_type_to_str(
+                    attr_type
+                )  # pylint: disable=protected-access
                 self.assertEqual(result, attr_str)
 
     def test_attr_type_to_str_undefined(self):
-        result = helper._attr_type_to_str(9999)
+        result = helper._attr_type_to_str(9999)  # pylint: disable=protected-access
         self.assertEqual(result, "UNDEFINED")
 
 

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -883,6 +883,23 @@ class TestHelperMappingFunctions(unittest.TestCase):
         )
 
 
+@pytest.mark.parametrize(
+    "attr_type",
+    helper.attribute_proto_type_to_str.keys(),
+)
+def test_attr_type_to_str(attr_type):
+    result = helper.attr_type_to_str(attr_type)
+    assert result is not None
+
+
+def test_attr_type_to_str_raises():
+    try:
+        result = helper.attr_type_to_str(9999)
+    except ValueError as e:
+        return
+    assert False, "Should have raised a ValueError"
+
+
 if __name__ == "__main__":
     unittest.main()
     pytest.main([__file__])

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -889,18 +889,17 @@ class TestHelperMappingFunctions(unittest.TestCase):
         )
 
 
-@pytest.mark.parametrize(
-    "attr_type",
-    AttributeProto.AttributeType.values(),
-)
-def test_attr_type_to_str(attr_type):
-    result = helper._attr_type_to_str(attr_type)
-    assert result == AttributeProto.AttributeType.keys()[attr_type]
+class TestAttrTypeToStr(unittest.TestCase):
+    def test_attr_type_to_str(self):
+        for item in AttributeProto.AttributeType.items():
+            with self.subTest(item=item):
+                attr_str, attr_type = item
+                result = helper._attr_type_to_str(attr_type)
+                self.assertEqual(result, attr_str)
 
-
-def test_attr_type_to_str_undefined():
-    result = helper._attr_type_to_str(9999)
-    assert result == "UNDEFINED"
+    def test_attr_type_to_str_undefined(self):
+        result = helper._attr_type_to_str(9999)
+        self.assertEqual(result, "UNDEFINED")
 
 
 if __name__ == "__main__":

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -11,6 +11,7 @@ from typing import Any, List, Tuple
 
 import numpy as np
 import pytest
+import parameterized
 
 from onnx import (
     AttributeProto,
@@ -888,14 +889,27 @@ class TestHelperMappingFunctions(unittest.TestCase):
 
 
 class TestAttrTypeToStr(unittest.TestCase):
-    def test_attr_type_to_str(self):
-        for item in AttributeProto.AttributeType.items():
-            with self.subTest(item=item):
-                attr_str, attr_type = item
-                result = helper._attr_type_to_str(
-                    attr_type
-                )  # pylint: disable=protected-access
-                self.assertEqual(result, attr_str)
+    @parameterized.parameterized.expand(
+        [
+            (AttributeProto.AttributeType.FLOAT, "FLOAT"),
+            (AttributeProto.AttributeType.INT, "INT"),
+            (AttributeProto.AttributeType.STRING, "STRING"),
+            (AttributeProto.AttributeType.TENSOR, "TENSOR"),
+            (AttributeProto.AttributeType.GRAPH, "GRAPH"),
+            (AttributeProto.AttributeType.SPARSE_TENSOR, "SPARSE_TENSOR"),
+            (AttributeProto.AttributeType.TYPE_PROTO, "TYPE_PROTO"),
+            (AttributeProto.AttributeType.FLOATS, "FLOATS"),
+            (AttributeProto.AttributeType.INTS, "INTS"),
+            (AttributeProto.AttributeType.STRINGS, "STRINGS"),
+            (AttributeProto.AttributeType.TENSORS, "TENSORS"),
+            (AttributeProto.AttributeType.GRAPHS, "GRAPHS"),
+            (AttributeProto.AttributeType.SPARSE_TENSORS, "SPARSE_TENSORS"),
+            (AttributeProto.AttributeType.TYPE_PROTOS, "TYPE_PROTOS"),
+        ]
+    )
+    def test_attr_type_to_str(self, attr_type, expected_str):
+        result = helper._attr_type_to_str(attr_type)  # pylint: disable=protected-access
+        self.assertEqual(result, expected_str)
 
     def test_attr_type_to_str_undefined(self):
         result = helper._attr_type_to_str(9999)  # pylint: disable=protected-access

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -220,9 +220,9 @@ class TestHelperAttributeFunctions(unittest.TestCase):
 
     def test_attr_mismatch(self) -> None:
         with pytest.raises(TypeError) as te:
-            attr = helper.make_attribute("test", 6.4, attr_type=AttributeProto.STRING)
-        assert "float" in str(te.value)
-        assert "string" in str(te.value)
+            helper.make_attribute("test", 6.4, attr_type=AttributeProto.STRING)
+        assert "FLOAT" in str(te.value)
+        assert "STRING" in str(te.value)
 
     def test_is_attr_legal(self) -> None:
         # no name, no field
@@ -891,16 +891,16 @@ class TestHelperMappingFunctions(unittest.TestCase):
 
 @pytest.mark.parametrize(
     "attr_type",
-    helper.attribute_proto_type_to_str.keys(),
+    AttributeProto.AttributeType.values(),
 )
 def test_attr_type_to_str(attr_type):
-    result = helper.attr_type_to_str(attr_type)
-    assert result is not None
+    result = helper._attr_type_to_str(attr_type)
+    assert result == AttributeProto.AttributeType.keys()[attr_type]
 
 
-def test_attr_type_to_str_raises():
-    with pytest.raises(ValueError):
-        result = helper.attr_type_to_str(9999)
+def test_attr_type_to_str_undefined():
+    result = helper._attr_type_to_str(9999)
+    assert result == "UNDEFINED"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Adds a helper function to translate `AttributeProto` types to human-readable strings. This function is used to improve the exception string generated when the inferred `AttributeProto` type mismatches the specified `AttributeProto` type supplied to `make_attribute`.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Fixes #5442 
