### PR TITLE
Create the onnxtxt serialization format

### DIFF
--- a/onnx/serialization.py
+++ b/onnx/serialization.py
@@ -11,9 +11,9 @@ __all__ = [
 import typing
 from typing import Any, Collection, Optional, Protocol, TypeVar
 
+import google.protobuf.json_format
 import google.protobuf.message
 import google.protobuf.text_format
-import google.protobuf.json_format
 
 import onnx
 
@@ -143,13 +143,15 @@ class _TextProtoSerializer(ProtoSerializer):
 
 
 class _JsonSerializer(ProtoSerializer):
-    """Serialize and deserialize text proto."""
+    """Serialize and deserialize JSON."""
 
     supported_format = "json"
     file_extensions = frozenset({".json"})
 
     def serialize_proto(self, proto: _Proto) -> bytes:
-        json_message = google.protobuf.json_format.MessageToJson(proto, preserving_proto_field_name=True)
+        json_message = google.protobuf.json_format.MessageToJson(
+            proto, preserving_proto_field_name=True
+        )
         return json_message.encode(_ENCODING)
 
     def deserialize_proto(self, serialized: bytes | str, proto: _Proto) -> _Proto:
@@ -161,6 +163,7 @@ class _JsonSerializer(ProtoSerializer):
             serialized = serialized.decode(_ENCODING)
         assert isinstance(serialized, str)
         return google.protobuf.json_format.Parse(serialized, proto)
+
 
 # Register default serializers
 registry = _Registry()

--- a/onnx/serialization.py
+++ b/onnx/serialization.py
@@ -13,6 +13,7 @@ from typing import Any, Collection, Optional, Protocol, TypeVar
 
 import google.protobuf.message
 import google.protobuf.text_format
+import google.protobuf.json_format
 
 import onnx
 
@@ -141,7 +142,28 @@ class _TextProtoSerializer(ProtoSerializer):
         return google.protobuf.text_format.Parse(serialized, proto)
 
 
+class _JsonSerializer(ProtoSerializer):
+    """Serialize and deserialize text proto."""
+
+    supported_format = "json"
+    file_extensions = frozenset({".json"})
+
+    def serialize_proto(self, proto: _Proto) -> bytes:
+        json_message = google.protobuf.json_format.MessageToJson(proto, preserving_proto_field_name=True)
+        return json_message.encode(_ENCODING)
+
+    def deserialize_proto(self, serialized: bytes | str, proto: _Proto) -> _Proto:
+        if not isinstance(serialized, (bytes, str)):
+            raise TypeError(
+                f"Parameter 'serialized' must be bytes or str, but got type: {type(serialized)}"
+            )
+        if isinstance(serialized, bytes):
+            serialized = serialized.decode(_ENCODING)
+        assert isinstance(serialized, str)
+        return google.protobuf.json_format.Parse(serialized, proto)
+
 # Register default serializers
 registry = _Registry()
 registry.register(_ProtobufSerializer())
 registry.register(_TextProtoSerializer())
+registry.register(_JsonSerializer())

--- a/onnx/serialization.py
+++ b/onnx/serialization.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
+
 import warnings
 
 __all__ = [
@@ -190,13 +191,13 @@ class _TextualSerializer(ProtoSerializer):
         else:
             text = serialized
         if isinstance(proto, onnx.ModelProto):
-            return onnx.parser.parse_model(text)
+            return onnx.parser.parse_model(text)  # type: ignore[return-value]
         if isinstance(proto, onnx.GraphProto):
-            return onnx.parser.parse_graph(text)
+            return onnx.parser.parse_graph(text)  # type: ignore[return-value]
         if isinstance(proto, onnx.FunctionProto):
-            return onnx.parser.parse_function(text)
+            return onnx.parser.parse_function(text)  # type: ignore[return-value]
         if isinstance(proto, onnx.NodeProto):
-            return onnx.parser.parse_node(text)
+            return onnx.parser.parse_node(text)  # type: ignore[return-value]
         raise ValueError(f"Unsupported proto type: {type(proto)}")
 
 

--- a/onnx/serialization.py
+++ b/onnx/serialization.py
@@ -173,7 +173,7 @@ class _TextualSerializer(ProtoSerializer):
     file_extensions = frozenset({".onnxtxt"})
 
     def serialize_proto(self, proto: _Proto) -> bytes:
-        text = onnx.printer.to_text(proto)
+        text = onnx.printer.to_text(proto)  # type: ignore[arg-type]
         return text.encode(_ENCODING)
 
     def deserialize_proto(self, serialized: bytes | str, proto: _Proto) -> _Proto:
@@ -186,7 +186,9 @@ class _TextualSerializer(ProtoSerializer):
                 f"Parameter 'serialized' must be bytes or str, but got type: {type(serialized)}"
             )
         if isinstance(serialized, bytes):
-            serialized = serialized.decode(_ENCODING)
+            text = serialized.decode(_ENCODING)
+        else:
+            text = serialized
         if isinstance(proto, onnx.ModelProto):
             return onnx.parser.parse_model(text)
         if isinstance(proto, onnx.GraphProto):

--- a/onnx/serialization.py
+++ b/onnx/serialization.py
@@ -166,7 +166,7 @@ class _JsonSerializer(ProtoSerializer):
         return google.protobuf.json_format.Parse(serialized, proto)
 
 
-class _TextualSerializer(onnx.serialization.ProtoSerializer):
+class _TextualSerializer(ProtoSerializer):
     """Serialize and deserialize the ONNX textual representation."""
 
     supported_format = "onnxtxt"

--- a/onnx/serialization.py
+++ b/onnx/serialization.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
+import warnings
 
 __all__ = [
     "registry",
@@ -165,8 +166,41 @@ class _JsonSerializer(ProtoSerializer):
         return google.protobuf.json_format.Parse(serialized, proto)
 
 
+class _TextualSerializer(onnx.serialization.ProtoSerializer):
+    """Serialize and deserialize the ONNX textual representation."""
+
+    supported_format = "onnxtxt"
+    file_extensions = frozenset({".onnxtxt"})
+
+    def serialize_proto(self, proto: _Proto) -> bytes:
+        text = onnx.printer.to_text(proto)
+        return text.encode(_ENCODING)
+
+    def deserialize_proto(self, serialized: bytes | str, proto: _Proto) -> _Proto:
+        warnings.warn(
+            "The onnxtxt format is experimental. Please report any errors to the ONNX GitHub repository.",
+            stacklevel=2,
+        )
+        if not isinstance(serialized, (bytes, str)):
+            raise TypeError(
+                f"Parameter 'serialized' must be bytes or str, but got type: {type(serialized)}"
+            )
+        if isinstance(serialized, bytes):
+            serialized = serialized.decode(_ENCODING)
+        if isinstance(proto, onnx.ModelProto):
+            return onnx.parser.parse_model(text)
+        if isinstance(proto, onnx.GraphProto):
+            return onnx.parser.parse_graph(text)
+        if isinstance(proto, onnx.FunctionProto):
+            return onnx.parser.parse_function(text)
+        if isinstance(proto, onnx.NodeProto):
+            return onnx.parser.parse_node(text)
+        raise ValueError(f"Unsupported proto type: {type(proto)}")
+
+
 # Register default serializers
 registry = _Registry()
 registry.register(_ProtobufSerializer())
 registry.register(_TextProtoSerializer())
 registry.register(_JsonSerializer())
+registry.register(_TextualSerializer())

--- a/onnx/serialization.py
+++ b/onnx/serialization.py
@@ -146,7 +146,7 @@ class _JsonSerializer(ProtoSerializer):
     """Serialize and deserialize JSON."""
 
     supported_format = "json"
-    file_extensions = frozenset({".json"})
+    file_extensions = frozenset({".json", ".onnxjson"})
 
     def serialize_proto(self, proto: _Proto) -> bytes:
         json_message = google.protobuf.json_format.MessageToJson(

--- a/onnx/test/basic_test.py
+++ b/onnx/test/basic_test.py
@@ -68,8 +68,6 @@ class TestIO(unittest.TestCase):
             model_path = os.path.join(temp_dir, "model.onnx")
             onnx.save_model(proto, model_path, format=self.format)
             loaded_proto = onnx.load_model(model_path, format=self.format)
-            print(proto)
-            print(loaded_proto)
             self.assertEqual(proto, loaded_proto)
 
     def test_save_and_load_model_when_input_is_pathlike(self) -> None:

--- a/onnx/test/basic_test.py
+++ b/onnx/test/basic_test.py
@@ -36,6 +36,7 @@ def _simple_tensor() -> onnx.TensorProto:
     [
         {"format": "protobuf"},
         {"format": "textproto"},
+        {"format": "json"},
     ]
 )
 class TestIO(unittest.TestCase):

--- a/onnx/test/basic_test.py
+++ b/onnx/test/basic_test.py
@@ -37,6 +37,7 @@ def _simple_tensor() -> onnx.TensorProto:
         {"format": "protobuf"},
         {"format": "textproto"},
         {"format": "json"},
+        {"format": "onnxtxt"},
     ]
 )
 class TestIO(unittest.TestCase):

--- a/onnx/test/basic_test.py
+++ b/onnx/test/basic_test.py
@@ -19,6 +19,8 @@ from onnx import serialization
 def _simple_model() -> onnx.ModelProto:
     model = onnx.ModelProto()
     model.ir_version = onnx.IR_VERSION
+    model.producer_name = "onnx-test"
+    model.graph.name = "test"
     return model
 
 
@@ -66,6 +68,8 @@ class TestIO(unittest.TestCase):
             model_path = os.path.join(temp_dir, "model.onnx")
             onnx.save_model(proto, model_path, format=self.format)
             loaded_proto = onnx.load_model(model_path, format=self.format)
+            print(proto)
+            print(loaded_proto)
             self.assertEqual(proto, loaded_proto)
 
     def test_save_and_load_model_when_input_is_pathlike(self) -> None:
@@ -75,6 +79,20 @@ class TestIO(unittest.TestCase):
             onnx.save_model(proto, model_path, format=self.format)
             loaded_proto = onnx.load_model(model_path, format=self.format)
             self.assertEqual(proto, loaded_proto)
+
+
+@parameterized.parameterized_class(
+    [
+        {"format": "protobuf"},
+        {"format": "textproto"},
+        {"format": "json"},
+        # The onnxtxt format does not support saving/loading tensors yet
+    ]
+)
+class TestIOTensor(unittest.TestCase):
+    """Test loading and saving of TensorProto."""
+
+    format: str
 
     def test_load_tensor_when_input_is_bytes(self) -> None:
         proto = _simple_tensor()


### PR DESCRIPTION
Add support for serializing to and deserializing from the ONNX textual representation, and register it under the `onnxtxt` file extension and format. 

Users can now save a model to the textual representation with `onnx.save_model(model, "model.onnxtxt")`

Note that the textual format has known limitations, including (1) it doesn’t serialize tensor protos or initializers and (2) bugs like #5102. We will call this out in a documentation in a separate PR. 