### PR TITLE
Getting onnx to treat `inf/-inf` as float literals.

### DIFF
--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -55,7 +55,7 @@ Status ParserBase::Parse(Literal& result) {
       }
     } else
       result.value = std::string(from + 1, next_ - from - 2); // skip enclosing quotes
-      return Status::OK();
+    return Status::OK();
   }
 
   // Simplify the next ifs by consuming a possible negative sign.
@@ -119,27 +119,25 @@ Status ParserBase::Parse(Literal& result) {
 }
 
 bool OnnxParser::NextIsValidFloatString() {
-    auto nextch = NextChar();
-    auto from = next_;
+  auto nextch = NextChar();
+  auto from = next_;
 
-    if (isalpha(nextch)) {
-        while(next_ < end_ && isalpha(*next_)) {
-            ++next_;
-        }
-        std::string candidate = std::string(from, next_ - from);
-
-        // Reset parser location before continuing.
-        next_ = from;
-
-        std::transform(candidate.begin(), candidate.end(), candidate.begin(),
-            [](unsigned char c){ return std::tolower(c); });
-        if (candidate == std::string("inf") ||
-           candidate == std::string("infinity") ||
-           candidate == std::string("nan")) {
-            return true;
-        }
+  if (isalpha(nextch)) {
+    while (next_ < end_ && isalpha(*next_)) {
+      ++next_;
     }
-    return false;
+    std::string candidate = std::string(from, next_ - from);
+
+    // Reset parser location before continuing.
+    next_ = from;
+
+    std::transform(
+        candidate.begin(), candidate.end(), candidate.begin(), [](unsigned char c) { return std::tolower(c); });
+    if (candidate == std::string("inf") || candidate == std::string("infinity") || candidate == std::string("nan")) {
+      return true;
+    }
+  }
+  return false;
 }
 
 Status OnnxParser::Parse(IdList& idlist) {
@@ -496,8 +494,8 @@ Status OnnxParser::ParseSingleAttributeValue(AttributeProto& attr, AttributeProt
         attr.set_type(AttributeProto_AttributeType_FLOAT);
         attr.set_f(static_cast<float>(std::stof(literal.value)));
       } else {
-          attr.set_type(AttributeProto_AttributeType_GRAPH);
-          Parse(*attr.mutable_g());
+        attr.set_type(AttributeProto_AttributeType_GRAPH);
+        Parse(*attr.mutable_g());
       }
     }
   } else if (Matches('@')) {

--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -55,29 +55,28 @@ Status ParserBase::Parse(Literal& result) {
       result.value = std::string(from + 1, next_ - from - 2); // skip enclosing quotes
   }
 
-  bool negative = false;
+  // Simplify the next if by consuming a possible negative sign.
   if (nextch == '-') {
-    negative = true;
     ++next_;
   }
 
-  // Has to be a float literal now: nan, inf, infinity.
+  // Check for float literals that start with alphabet characters.
   if (isalpha(*next_)) {
-    auto float_try_start = next_;
-    while (next_ < end_ && isalpha(*next_)) {
-      ++next_;
-    }
+    // Has to be a special float literal now: (-)*(nan|inf|infinity).
+    while(next_ < end_ && isalpha(*next_)) { ++next_; }
     try {
-      std::stof(std::string(from, next_ - from));
-      result.type = LiteralType::FLOAT_LITERAL;
-      result.value = std::string(from, next_ - from);
+        std::stof(std::string(from, next_ - from));
+        result.type = LiteralType::FLOAT_LITERAL;
+        result.value = std::string(from, next_ - from);
     } catch (const std::invalid_argument& e) {
-      // TODO: How do we rewind?
+      // Rewind the parser if this is not a valid float literal.
       next_ = from;
     }
+    // Either way we're done at this point.
     return Status::OK();
   }
 
+  // Checking for numeric ints or float literal.
   if (isdigit(nextch) || nextch == '-') {
     ++next_;
 

--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -68,7 +68,7 @@ Status ParserBase::Parse(Literal& result) {
       ++next_;
     }
     ONNX_TRY {
-      std::stof(std::string(from, next_ - from));
+      static_cast<void>(std::stof(std::string(from, next_ - from)));
       result.type = LiteralType::FLOAT_LITERAL;
       result.value = std::string(from, next_ - from);
     }

--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -54,24 +54,7 @@ Status ParserBase::Parse(Literal& result) {
     } else
       result.value = std::string(from + 1, next_ - from - 2); // skip enclosing quotes
   } else if ((isdigit(nextch) || (nextch == '-'))) {
-    bool could_be_inf = nextch == '-';
-
     ++next_;
-
-    // negative inf, has to be '-inf' now or nothing...
-    if (*next_ == 'i' && could_be_inf) {
-      ++next_;
-      if (*next_ == 'n' && next_ < end_) {
-        ++next_;
-        if (*next_ == 'f') {
-          ++next_;
-          result.value = std::string(from, next_ - from);
-          result.type = LiteralType::FLOAT_LITERAL;
-          return Status::OK();
-        }
-      }
-      return ParseError("'-inf' expected but not found.");
-    }
 
     while ((next_ < end_) && (isdigit(*next_) || (*next_ == '.'))) {
       if (*next_ == '.') {
@@ -94,19 +77,9 @@ Status ParserBase::Parse(Literal& result) {
       while ((next_ < end_) && (isdigit(*next_)))
         ++next_;
     }
+
     result.value = std::string(from, next_ - from);
     result.type = decimal_point ? LiteralType::FLOAT_LITERAL : LiteralType::INT_LITERAL;
-  } else if (nextch == 'i') { // positive infinity case: inf
-    ++next_;
-    if (*next_ == 'n' && next_ < end_) {
-      ++next_;
-      if (*next_ == 'f') {
-        result.value = std::string(from, next_ - from);
-        result.type = LiteralType::FLOAT_LITERAL;
-        return Status::OK();
-      }
-    }
-    return ParseError("'inf' expected but not found.");
   }
   return Status::OK();
 }

--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -54,7 +54,24 @@ Status ParserBase::Parse(Literal& result) {
     } else
       result.value = std::string(from + 1, next_ - from - 2); // skip enclosing quotes
   } else if ((isdigit(nextch) || (nextch == '-'))) {
+    bool could_be_inf = nextch == '-';
+
     ++next_;
+
+    // negative inf, has to be '-inf' now or nothing...
+    if (*next_ == 'i' && could_be_inf) {
+      ++next_;
+      if (*next_ == 'n' && next_ < end_) {
+        ++next_;
+        if (*next_ == 'f') {
+          ++next_;
+          result.value = std::string(from, next_ - from);
+          result.type = LiteralType::FLOAT_LITERAL;
+          return Status::OK();
+        }
+      }
+      return ParseError("'-inf' expected but not found.");
+    }
 
     while ((next_ < end_) && (isdigit(*next_) || (*next_ == '.'))) {
       if (*next_ == '.') {
@@ -77,9 +94,19 @@ Status ParserBase::Parse(Literal& result) {
       while ((next_ < end_) && (isdigit(*next_)))
         ++next_;
     }
-
     result.value = std::string(from, next_ - from);
     result.type = decimal_point ? LiteralType::FLOAT_LITERAL : LiteralType::INT_LITERAL;
+  } else if (nextch == 'i') { // positive infinity case: inf
+    ++next_;
+    if (*next_ == 'n' && next_ < end_) {
+      ++next_;
+      if (*next_ == 'f') {
+        result.value = std::string(from, next_ - from);
+        result.type = LiteralType::FLOAT_LITERAL;
+        return Status::OK();
+      }
+    }
+    return ParseError("'inf' expected but not found.");
   }
   return Status::OK();
 }

--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -56,7 +56,7 @@ Status ParserBase::Parse(Literal& result) {
       }
     } else
       result.value = std::string(from + 1, next_ - from - 2); // skip enclosing quotes
-      return Status::OK();
+    return Status::OK();
   }
 
   // Simplify the next ifs by consuming a possible negative sign.
@@ -69,21 +69,19 @@ Status ParserBase::Parse(Literal& result) {
   if (isalpha(nextch)) {
     // Has to be a special float literal now: (-)*(nan|inf|infinity).
     if (NextIsValidFloatString()) {
-        while (next_ < end_ && isalpha(*next_)) {
-          ++next_;
-        }
-        ONNX_TRY {
-          static_cast<void>(std::stof(std::string(from, next_ - from)));
-          result.type = LiteralType::FLOAT_LITERAL;
-          result.value = std::string(from, next_ - from);
-        }
-        ONNX_CATCH(...) {
-          ONNX_HANDLE_EXCEPTION([&]() {
-            return ParseError("Encountered invalid float literal!");
-          });
-        }
+      while (next_ < end_ && isalpha(*next_)) {
+        ++next_;
+      }
+      ONNX_TRY {
+        static_cast<void>(std::stof(std::string(from, next_ - from)));
+        result.type = LiteralType::FLOAT_LITERAL;
+        result.value = std::string(from, next_ - from);
+      }
+      ONNX_CATCH(...) {
+        ONNX_HANDLE_EXCEPTION([&]() { return ParseError("Encountered invalid float literal!"); });
+      }
     } else {
-        return ParseError("Encountered invalid float literal!");
+      return ParseError("Encountered invalid float literal!");
     }
     return Status::OK();
   }
@@ -121,34 +119,32 @@ Status ParserBase::Parse(Literal& result) {
 }
 
 bool ParserBase::NextIsValidFloatString() {
-    auto nextch = NextChar();
-    auto from = next_;
-    constexpr int INFINITY_LENGTH = 8;
+  auto nextch = NextChar();
+  auto from = next_;
+  constexpr int INFINITY_LENGTH = 8;
 
-    if (isalpha(nextch)) {
-        while(next_ < end_ && isalpha(*next_) && (next_ - from) <= INFINITY_LENGTH) {
-            ++next_;
-        }
-
-        if (isdigit(*next_)) { // No trailing digits
-            next_ = from;
-            return false;
-        }
-
-        std::string candidate = std::string(from, next_ - from);
-
-        // Reset parser location before continuing.
-        next_ = from;
-
-        std::transform(candidate.begin(), candidate.end(), candidate.begin(),
-            [](unsigned char c){ return std::tolower(c); });
-        if (candidate == std::string("inf") ||
-           candidate == std::string("infinity") ||
-           candidate == std::string("nan")) {
-            return true;
-        }
+  if (isalpha(nextch)) {
+    while (next_ < end_ && isalpha(*next_) && (next_ - from) <= INFINITY_LENGTH) {
+      ++next_;
     }
-    return false;
+
+    if (isdigit(*next_)) { // No trailing digits
+      next_ = from;
+      return false;
+    }
+
+    std::string candidate = std::string(from, next_ - from);
+
+    // Reset parser location before continuing.
+    next_ = from;
+
+    std::transform(
+        candidate.begin(), candidate.end(), candidate.begin(), [](unsigned char c) { return std::tolower(c); });
+    if (candidate == std::string("inf") || candidate == std::string("infinity") || candidate == std::string("nan")) {
+      return true;
+    }
+  }
+  return false;
 }
 
 Status OnnxParser::Parse(IdList& idlist) {
@@ -505,8 +501,8 @@ Status OnnxParser::ParseSingleAttributeValue(AttributeProto& attr, AttributeProt
         attr.set_type(AttributeProto_AttributeType_FLOAT);
         attr.set_f(static_cast<float>(std::stof(literal.value)));
       } else {
-          attr.set_type(AttributeProto_AttributeType_GRAPH);
-          PARSE(*attr.mutable_g());
+        attr.set_type(AttributeProto_AttributeType_GRAPH);
+        PARSE(*attr.mutable_g());
       }
     }
   } else if (Matches('@')) {

--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -64,17 +64,19 @@ Status ParserBase::Parse(Literal& result) {
   // Check for float literals that start with alphabet characters.
   if (isalpha(*next_)) {
     // Has to be a special float literal now: (-)*(nan|inf|infinity).
-    while(next_ < end_ && isalpha(*next_)) { ++next_; }
+    while (next_ < end_ && isalpha(*next_)) {
+      ++next_;
+    }
     ONNX_TRY {
-        std::stof(std::string(from, next_ - from));
-        result.type = LiteralType::FLOAT_LITERAL;
-        result.value = std::string(from, next_ - from);
-    } ONNX_CATCH(const std::invalid_argument& e) {
-        ONNX_HANDLE_EXCEPTION([&]() {
-          // Rewind the parser if this is not a valid float literal.
-          next_ = from;
-
-        });
+      std::stof(std::string(from, next_ - from));
+      result.type = LiteralType::FLOAT_LITERAL;
+      result.value = std::string(from, next_ - from);
+    }
+    ONNX_CATCH(...) {
+      ONNX_HANDLE_EXCEPTION([&]() {
+        // Rewind the parser if this is not a valid float literal.
+        next_ = from;
+      });
     }
     // Either way we're done at this point.
     return Status::OK();

--- a/onnx/defs/parser.h
+++ b/onnx/defs/parser.h
@@ -376,6 +376,8 @@ class ParserBase {
   const char* next_;
   const char* end_;
   const char* saved_pos_;
+
+  bool NextIsValidFloatString();
 };
 
 class OnnxParser : public ParserBase {
@@ -438,8 +440,6 @@ class OnnxParser : public ParserBase {
   bool NextIsType();
 
   bool NextIsIdentifier();
-
-  bool NextIsValidFloatString();
 };
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/parser.h
+++ b/onnx/defs/parser.h
@@ -438,6 +438,8 @@ class OnnxParser : public ParserBase {
   bool NextIsType();
 
   bool NextIsIdentifier();
+
+  bool NextIsValidFloatString();
 };
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/test/parser_test.py
+++ b/onnx/test/parser_test.py
@@ -220,15 +220,13 @@ class TestBasicFunctions(unittest.TestCase):
 
     @parameterized.expand(
         [
-            (
-                "not_a_good_float"
-            ),  # Not a good float value, but shouldn't blow up the parser.
-            ("inf"),
-            ("-inf"),
-            ("infinity"),
-            ("-infinity"),
-            ("-NaN"),
-            ("nan"),
+            "not_a_good_float",  # Not a good float value, but shouldn't blow up the parser.
+            "inf",
+            "-inf",
+            "infinity",
+            "-infinity",
+            "-NaN",
+            "nan",
         ]
     )
     def test_parse_various_float_values(self, test_literal):

--- a/onnx/test/parser_test.py
+++ b/onnx/test/parser_test.py
@@ -218,8 +218,22 @@ class TestBasicFunctions(unittest.TestCase):
         self.assertEqual(node.domain, "SomeDomain")
         self.assertEqual(node.op_type, "SomeOp")
 
-    def test_parse_negative_infinity_float(self):
-        model_text = """
+    @parameterized.expand(
+        [
+            (
+                "not_a_good_float"
+            ),  # Not a good float value, but shouldn't blow up the parser.
+            ("inf"),
+            ("-inf"),
+            ("infinity"),
+            ("-infinity"),
+            ("-NaN"),
+            ("nan"),
+        ]
+    )
+    def test_parse_various_float_values(self, test_literal):
+        model_text = (
+            """
         <
         ir_version: 8,
         opset_import: ["" : 18, "onnxscript.atenlib" : 1, "this" : 1],
@@ -228,24 +242,12 @@ class TestBasicFunctions(unittest.TestCase):
         >
         _func () => ()
         {
-        tmp_11 = Constant <value_float = -inf> ()
+        tmp_11 = Constant <value_float = """
+            + test_literal
+            + """> ()
         }
         """
-        onnx.parser.parse_model(model_text)
-
-    def test_parse_positive_infinity_float(self):
-        model_text = """
-        <
-        ir_version: 8,
-        opset_import: ["" : 18, "onnxscript.atenlib" : 1, "this" : 1],
-        producer_name: "pytorch",
-        producer_version: "2.1.0"
-        >
-        _func () => ()
-        {
-        tmp_11 = Constant <value_float = inf> ()
-        }
-        """
+        )
         onnx.parser.parse_model(model_text)
 
 

--- a/onnx/test/parser_test.py
+++ b/onnx/test/parser_test.py
@@ -218,6 +218,36 @@ class TestBasicFunctions(unittest.TestCase):
         self.assertEqual(node.domain, "SomeDomain")
         self.assertEqual(node.op_type, "SomeOp")
 
+    def test_parse_negative_infinity_float(self):
+        model_text = """
+        <
+        ir_version: 8,
+        opset_import: ["" : 18, "onnxscript.atenlib" : 1, "this" : 1],
+        producer_name: "pytorch",
+        producer_version: "2.1.0"
+        >
+        _func () => ()
+        {
+        tmp_11 = Constant <value_float = -inf> ()
+        }
+        """
+        onnx.parser.parse_model(model_text)
+
+    def test_parse_positive_infinity_float(self):
+        model_text = """
+        <
+        ir_version: 8,
+        opset_import: ["" : 18, "onnxscript.atenlib" : 1, "this" : 1],
+        producer_name: "pytorch",
+        producer_version: "2.1.0"
+        >
+        _func () => ()
+        {
+        tmp_11 = Constant <value_float = inf> ()
+        }
+        """
+        onnx.parser.parse_model(model_text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/onnx/test/parser_test.py
+++ b/onnx/test/parser_test.py
@@ -225,8 +225,8 @@ class TestBasicFunctions(unittest.TestCase):
             "-inf",
             "infinity",
             "-infinity",
-            "-NaN",
             "nan",
+            "-NaN",
         ]
     )
     def test_parse_various_float_values(self, test_literal):
@@ -242,8 +242,19 @@ class TestBasicFunctions(unittest.TestCase):
         tmp = Constant <value_float = {test_literal}>()
         }}
         """
-
-        onnx.parser.parse_model(model_text)
+        model = onnx.parser.parse_model(model_text)
+        self.assertEqual(model.ir_version, 8)
+        self.assertEqual(model.producer_name, "FunctionProtoTest")
+        self.assertEqual(model.producer_version, "1.0")
+        self.assertEqual(len(model.graph.node), 1)
+        self.assertEqual(len(model.graph.node[0].attribute), 1)
+        self.assertEqual(model.graph.node[0].attribute[0].name, "value_float")
+        self.assertEqual(
+            model.graph.node[0].attribute[0].type, onnx.AttributeProto.FLOAT
+        )
+        self.assertEqual(
+            str(model.graph.node[0].attribute[0].f), str(float(test_literal))
+        )
 
 
 if __name__ == "__main__":

--- a/onnx/test/parser_test.py
+++ b/onnx/test/parser_test.py
@@ -230,22 +230,19 @@ class TestBasicFunctions(unittest.TestCase):
         ]
     )
     def test_parse_various_float_values(self, test_literal):
-        model_text = (
-            """
+        model_text = f"""
         <
         ir_version: 8,
-        opset_import: ["" : 18, "onnxscript.atenlib" : 1, "this" : 1],
-        producer_name: "pytorch",
-        producer_version: "2.1.0"
+        opset_import: ["" : 18, "this" : 1],
+        producer_name: "FunctionProtoTest",
+        producer_version: "1.0"
         >
         _func () => ()
-        {
-        tmp_11 = Constant <value_float = """
-            + test_literal
-            + """> ()
-        }
+        {{
+        tmp = Constant <value_float = {test_literal}>()
+        }}
         """
-        )
+
         onnx.parser.parse_model(model_text)
 
 

--- a/onnx/test/parser_test.py
+++ b/onnx/test/parser_test.py
@@ -220,16 +220,19 @@ class TestBasicFunctions(unittest.TestCase):
 
     @parameterized.expand(
         [
-            "not_a_good_float",  # Not a good float value, but shouldn't blow up the parser.
-            "inf",
-            "-inf",
-            "infinity",
-            "-infinity",
-            "nan",
-            "-NaN",
+            (
+                "not_a_good_float",
+                onnx.AttributeProto.GRAPH,
+            ),  # Not a good float value, but shouldn't blow up the parser.
+            ("inf", onnx.AttributeProto.FLOAT),
+            ("-inf", onnx.AttributeProto.FLOAT),
+            ("infinity", onnx.AttributeProto.FLOAT),
+            ("-infinity", onnx.AttributeProto.FLOAT),
+            ("nan", onnx.AttributeProto.FLOAT),
+            ("-NaN", onnx.AttributeProto.FLOAT),
         ]
     )
-    def test_parse_various_float_values(self, test_literal):
+    def test_parse_various_float_values(self, test_literal, expected_attribute_type):
         model_text = f"""
         <
         ir_version: 8,
@@ -249,12 +252,11 @@ class TestBasicFunctions(unittest.TestCase):
         self.assertEqual(len(model.graph.node), 1)
         self.assertEqual(len(model.graph.node[0].attribute), 1)
         self.assertEqual(model.graph.node[0].attribute[0].name, "value_float")
-        self.assertEqual(
-            model.graph.node[0].attribute[0].type, onnx.AttributeProto.FLOAT
-        )
-        self.assertEqual(
-            str(model.graph.node[0].attribute[0].f), str(float(test_literal))
-        )
+        self.assertEqual(model.graph.node[0].attribute[0].type, expected_attribute_type)
+        if expected_attribute_type == onnx.AttributeProto.FLOAT:
+            self.assertEqual(
+                str(model.graph.node[0].attribute[0].f), str(float(test_literal))
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
onnx seems to ignore certain possibilities when it comes to otherwise valid IEEE float values. So far this change just adds functionality to the parser to recognize `inf` or `-inf` as floats. However, this seems to point towards more issues. Should onnx recognize any string parse-able by `std::stof` as a float literal?

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
The current state of this PR does address #5102, although not in a very elegant fashion. 
