### PR TITLE
Specify the build-system in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=61.0.0"]
+build-backend = "setuptools.build_meta"
+
 [tool.mypy]
 follow_imports = "silent"
 strict_optional = true


### PR DESCRIPTION
### Description

Specify setuptools in the build-system section in pyproject.toml. So that setuptools gets installed when it is not in the environment when doing local install. 

### Motivation and Context

Fixes https://github.com/onnx/onnx/issues/4878
