### PR TITLE
Revert "Specify the build-system in pyproject.toml"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["setuptools>=61.0.0"]
-build-backend = "setuptools.build_meta"
-
 [tool.mypy]
 follow_imports = "silent"
 strict_optional = true


### PR DESCRIPTION
Reverts onnx/onnx#5531 because the macos release pipeline is broken due to the change.