### PR TITLE
Specify the build-system in pyproject.toml - second attempt

### DIFF
--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -13,7 +13,7 @@ on:
 # Use MACOSX_DEPLOYMENT_TARGET=10.12 to produce compatible wheel
 env:
   MACOSX_DEPLOYMENT_TARGET: 10.12
-  
+
 permissions:
   contents: read
 
@@ -129,7 +129,7 @@ jobs:
         # Test weekly source distribution from PyPI
         python -m pip uninstall -y onnx-weekly
         python -m pip install setuptools
-        python -m pip install --use-deprecated=legacy-resolver --no-use-pep517 --no-binary onnx-weekly onnx-weekly
+        python -m pip install --no-binary onnx-weekly onnx-weekly
         pytest
 
     - name: Verify ONNX with ONNX Runtime PyPI package

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -129,7 +129,7 @@ jobs:
         # Test weekly source distribution from PyPI
         python -m pip uninstall -y onnx-weekly
         python -m pip install setuptools
-        python -m pip install --no-binary onnx-weekly onnx-weekly
+        python -m pip install --use-deprecated=legacy-resolver --no-binary onnx-weekly onnx-weekly
         pytest
 
     - name: Verify ONNX with ONNX Runtime PyPI package

--- a/docs/OnnxReleases.md
+++ b/docs/OnnxReleases.md
@@ -94,7 +94,7 @@ The ONNX project, going forward, will plan to release roughly on a four month ca
 **Source Distribution**
 * Follow the same process in TestPyPI to produce the source distribution.
 * Use ``twine upload --verbose dist/* --repository-url https://upload.pypi.org/legacy/`` instead to upload to the official PyPI.
-* Test with ``pip install --no-binary onnx onnx``
+* Test with ``pip install --use-deprecated=legacy-resolver --no-binary onnx onnx``
 
 ## After PyPI Release
 

--- a/docs/OnnxReleases.md
+++ b/docs/OnnxReleases.md
@@ -94,7 +94,7 @@ The ONNX project, going forward, will plan to release roughly on a four month ca
 **Source Distribution**
 * Follow the same process in TestPyPI to produce the source distribution.
 * Use ``twine upload --verbose dist/* --repository-url https://upload.pypi.org/legacy/`` instead to upload to the official PyPI.
-* Test with ``pip install --use-deprecated=legacy-resolver --no-use-pep517 --no-binary onnx onnx``
+* Test with ``pip install --no-binary onnx onnx``
 
 ## After PyPI Release
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=61.0.0"]
+build-backend = "setuptools.build_meta"
+
 [tool.mypy]
 follow_imports = "silent"
 strict_optional = true


### PR DESCRIPTION
### Description

Specify setuptools in the build-system section in pyproject.toml. So that setuptools gets installed when it is not in the environment when doing local install. 

Second attempt of #5531 by removing `--no-use-pep517` in the test pipeline

### Motivation and Context

Fixes https://github.com/onnx/onnx/issues/4878
