### PR TITLE
Numpy helper `from_dict` raises type error fix

### DIFF
--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -283,7 +283,7 @@ def from_array(  # pylint: disable=too-many-branches
     Returns:
         TensorProto: the converted tensor def.
     """
-    if not isinstance(arr, np.ndarray) and not isinstance(arr, np.generic):
+    if not isinstance(arr, (np.ndarray, np.generic)):
         raise TypeError(
             f"arr must be of type np.generic or np.ndarray, got {type(arr)}"
         )

--- a/onnx/test/numpy_helper_test.py
+++ b/onnx/test/numpy_helper_test.py
@@ -547,11 +547,41 @@ class TestNumpyHelper(unittest.TestCase):
         back = numpy_helper.float8e4m3_to_float32(to, fn=True, uz=True)
         self.assertTrue(np.isnan(back))
 
-    def test_from_dict(self):
+    def test_from_dict_values_are_np_arrays_of_float(self):
         map_proto = numpy_helper.from_dict({0: np.array(0.1), 1: np.array(0.9)})
         self.assertIsInstance(map_proto, onnx.MapProto)
+        self.assertEqual(
+            numpy_helper.to_array(map_proto.values.tensor_values[0]), np.array(0.1)
+        )
+        self.assertEqual(
+            numpy_helper.to_array(map_proto.values.tensor_values[1]), np.array(0.9)
+        )
 
-    def test_from_dict_no_np_array(self):
+    def test_from_dict_values_are_np_arrays_of_int(self):
+        map_proto = numpy_helper.from_dict({0: np.array(1), 1: np.array(9)})
+        self.assertIsInstance(map_proto, onnx.MapProto)
+        self.assertEqual(
+            numpy_helper.to_array(map_proto.values.tensor_values[0]), np.array(1)
+        )
+        self.assertEqual(
+            numpy_helper.to_array(map_proto.values.tensor_values[1]), np.array(9)
+        )
+
+    def test_from_dict_values_are_np_arrays_of_ints(self):
+        zero_array = np.array([1, 2])
+        one_array = np.array([9, 10])
+        map_proto = numpy_helper.from_dict({0: zero_array, 1: one_array})
+        self.assertIsInstance(map_proto, onnx.MapProto)
+
+        out_tensor = numpy_helper.to_array(map_proto.values.tensor_values[0])
+        self.assertEqual(out_tensor[0], zero_array[0])
+        self.assertEqual(out_tensor[1], zero_array[1])
+
+        out_tensor = numpy_helper.to_array(map_proto.values.tensor_values[1])
+        self.assertEqual(out_tensor[0], one_array[0])
+        self.assertEqual(out_tensor[1], one_array[1])
+
+    def test_from_dict_raises_type_error_when_values_are_not_np_arrays(self):
         with self.assertRaises(TypeError):
             # from_dict/from_array expects tensors to be numpy array's or similar.
             numpy_helper.from_dict({0: 0.1, 1: 0.9})


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Improves (hopefully) how `from_dict` determines the numpy type of dictionary keys and values by using [`numpy.result_type`](https://numpy.org/doc/stable/reference/generated/numpy.result_type.html#numpy-result-type).

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Trying to solve #5522. This PR alone doesn't fully address the issue raised, because the example given in the issue has bare floats as dictionary values, while code in `numpy_helper.py` seems to expect tensors to already be `numpy.array`s or similar types. 

So an open question is should `from_dict` support non-numpy types as tensors?
