### PR TITLE
Do not raise an exception in printable_graph when shape is not specified

### DIFF
--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -1280,7 +1280,7 @@ def printable_attribute(
 def printable_dim(dim: TensorShapeProto.Dimension) -> str:
     which = dim.WhichOneof("value")
     if which is None:
-        return "."
+        return "?"
     return str(getattr(dim, which))
 
 

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -1280,7 +1280,7 @@ def printable_attribute(
 def printable_dim(dim: TensorShapeProto.Dimension) -> str:
     which = dim.WhichOneof("value")
     if which is None:
-        raise TypeError(f"which cannot be {None}.")
+        return "."
     return str(getattr(dim, which))
 
 

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -804,7 +804,7 @@ class TestPrintableGraph(unittest.TestCase):
         checker.check_model(model)
 
         graph_str = helper.printable_graph(graph)
-        self.assertIn("X[FLOAT, .]", graph_str)
+        self.assertIn("X[FLOAT, ?]", graph_str)
 
 
 @pytest.mark.parametrize(

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -789,6 +789,23 @@ class TestPrintableGraph(unittest.TestCase):
             graph_str,
         )
 
+    def test_unknown_dimensions(self) -> None:
+        graph = helper.make_graph(
+            [helper.make_node("Add", ["X", "Y_Initializer"], ["Z"])],
+            "test",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, [None])],  # inputs
+            [helper.make_tensor_value_info("Z", TensorProto.FLOAT, [None])],  # outputs
+            [
+                helper.make_tensor("Y_Initializer", TensorProto.FLOAT, [1], [1])
+            ],  # initializers
+            doc_string=None,
+        )
+        model = helper.make_model(graph)
+        checker.check_model(model)
+
+        graph_str = helper.printable_graph(graph)
+        self.assertIn("X[FLOAT, .]", graph_str)
+
 
 @pytest.mark.parametrize(
     "tensor_dtype",


### PR DESCRIPTION
### Description
`make_tensor_value_info("X", TensorProto.FLOAT, [None])` is a valid input (according to `check_model`) but `printable_graph` raises an exception because the shape is unknown.

### Motivation and Context
Prints out `'.'` when a dimension is unknown.
