### PR TITLE
Enable pylint checks with Ruff and remove pylint from lintrunner

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -183,42 +183,6 @@ init_command = [
 is_formatter = true
 
 [[linter]]
-code = 'PYLINT'
-include_patterns = [
-    'onnx/**/*.py',
-    'tools/**/*.py',
-]
-exclude_patterns = [
-    'onnx/backend/test/**',
-    'onnx/backend/sample/ops/abs.py', # redefined-builtin
-    'onnx/checker.py',
-    'tools/protoc-gen-mypy.py',
-    'onnx/test/basic_test.py',
-    'onnx/test/parser_test.py',
-    'onnx/test/version_converter_test.py',
-]
-command = [
-    'python',
-    '-m',
-    'lintrunner_adapters',
-    'run',
-    'pylint_linter',
-    '--rcfile=pyproject_pylint.toml',
-    '--show-disable',
-    '--',
-    '@{{PATHSFILE}}'
-]
-init_command = [
-    'python',
-    '-m',
-    'lintrunner_adapters',
-    'run',
-    'pip_init',
-    '--dry-run={{DRYRUN}}',
-    '--requirement=requirements-lintrunner.txt',
-]
-
-[[linter]]
 code = 'EDITORCONFIG-CHECKER'
 include_patterns=[
     '**/*.py',

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,6 @@
 {
     "[python]": {
         "editor.tabSize": 4,
-        // Auto sort imports
-        "editor.codeActionsOnSave": {
-            "source.organizeImports": true
-        }
     },
     "python.formatting.provider": "black",
     "python.sortImports.args": [

--- a/docs/docsgen/source/conf.py
+++ b/docs/docsgen/source/conf.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# pylint: disable=W0622
+
 # type: ignore
 import os
 import sys

--- a/docs/docsgen/source/intro/python.md
+++ b/docs/docsgen/source/intro/python.md
@@ -843,7 +843,7 @@ neighbors.
     set_model_props(onnx_model, {})
 
     # opsets
-    del onnx_model.opset_import[:]  # pylint: disable=E1101
+    del onnx_model.opset_import[:]
     for dom, value in opsets.items():
         op_set = onnx_model.opset_import.add()
         op_set.domain = dom

--- a/docs/docsgen/source/onnx_sphinx.py
+++ b/docs/docsgen/source/onnx_sphinx.py
@@ -261,7 +261,7 @@ def _populate_all_schemas_with_history():
 
 
 def _get_all_schemas_with_history():
-    global _all_schemas_with_history  # pylint: disable=global-statement
+    global _all_schemas_with_history
     if _all_schemas_with_history is None:
         _all_schemas_with_history = _populate_all_schemas_with_history()
     return _all_schemas_with_history
@@ -677,7 +677,7 @@ def get_onnx_example(op_name, domain):
             found = textwrap.dedent(found)
             lines = found.split("\n")
             first = 0
-            for i in range(len(lines)):  # pylint: disable=C0200
+            for i in range(len(lines)):
                 if lines[i].startswith("def "):
                     first = i + 1
             found = textwrap.dedent("\n".join(lines[first:]))
@@ -761,7 +761,7 @@ def onnx_documentation_folder(
                 table_dom.append(f"      - {col2}")
             table_dom.append("")
             if indent != "":
-                for i in range(len(table_dom)):  # pylint: disable=C0200
+                for i in range(len(table_dom)):
                     table_dom[i] = indent + table_dom[i]
             res = "\n".join(table_dom)
             return res

--- a/onnx/__init__.py
+++ b/onnx/__init__.py
@@ -186,7 +186,7 @@ def _get_serializer(
 
 def load_model(
     f: IO[bytes] | str | os.PathLike,
-    format: _SupportedFormat | None = None,  # pylint: disable=redefined-builtin
+    format: _SupportedFormat | None = None,
     load_external_data: bool = True,
 ) -> ModelProto:
     """Loads a serialized ModelProto into memory.
@@ -218,7 +218,7 @@ def load_model(
 
 def load_tensor(
     f: IO[bytes] | str | os.PathLike,
-    format: _SupportedFormat | None = None,  # pylint: disable=redefined-builtin
+    format: _SupportedFormat | None = None,
 ) -> TensorProto:
     """Loads a serialized TensorProto into memory.
 
@@ -237,7 +237,7 @@ def load_tensor(
 
 def load_model_from_string(
     s: bytes | str,
-    format: _SupportedFormat = _DEFAULT_FORMAT,  # pylint: disable=redefined-builtin
+    format: _SupportedFormat = _DEFAULT_FORMAT,
 ) -> ModelProto:
     """Loads a binary string (bytes) that contains serialized ModelProto.
 
@@ -256,7 +256,7 @@ def load_model_from_string(
 
 def load_tensor_from_string(
     s: bytes,
-    format: _SupportedFormat = _DEFAULT_FORMAT,  # pylint: disable=redefined-builtin
+    format: _SupportedFormat = _DEFAULT_FORMAT,
 ) -> TensorProto:
     """Loads a binary string (bytes) that contains serialized TensorProto.
 
@@ -276,7 +276,7 @@ def load_tensor_from_string(
 def save_model(
     proto: ModelProto | bytes,
     f: IO[bytes] | str | os.PathLike,
-    format: _SupportedFormat | None = None,  # pylint: disable=redefined-builtin
+    format: _SupportedFormat | None = None,
     *,
     save_as_external_data: bool = False,
     all_tensors_to_one_file: bool = True,
@@ -330,7 +330,7 @@ def save_model(
 def save_tensor(
     proto: TensorProto,
     f: IO[bytes] | str | os.PathLike,
-    format: _SupportedFormat | None = None,  # pylint: disable=redefined-builtin
+    format: _SupportedFormat | None = None,
 ) -> None:
     """
     Saves the TensorProto to the specified path.

--- a/onnx/backend/base.py
+++ b/onnx/backend/base.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0613
+
 
 from collections import namedtuple
 from typing import Any, Dict, NewType, Optional, Sequence, Tuple, Type

--- a/onnx/backend/test/case/node/__init__.py
+++ b/onnx/backend/test/case/node/__init__.py
@@ -370,7 +370,7 @@ def expect(
 def collect_testcases(op_type: str) -> List[TestCase]:
     """Collect node test cases"""
     # only keep those tests related to this operator
-    global _TargetOpType
+    global _TargetOpType  # noqa: PLW0603
     _TargetOpType = op_type
 
     import_recursive(sys.modules[__name__])

--- a/onnx/backend/test/case/node/image_decoder.py
+++ b/onnx/backend/test/case/node/image_decoder.py
@@ -50,7 +50,6 @@ def _generate_test_data(
     tile_sz: int = 5,
 ) -> tuple[np.ndarray, np.ndarray]:
     try:
-
         import PIL.Image
     except ImportError:
         # Since pillow is not installed to generate test data for the ImageDecoder operator

--- a/onnx/backend/test/case/node/image_decoder.py
+++ b/onnx/backend/test/case/node/image_decoder.py
@@ -50,7 +50,7 @@ def _generate_test_data(
     tile_sz: int = 5,
 ) -> tuple[np.ndarray, np.ndarray]:
     try:
-        # pylint: disable=import-outside-toplevel
+
         import PIL.Image
     except ImportError:
         # Since pillow is not installed to generate test data for the ImageDecoder operator

--- a/onnx/backend/test/report/coverage.py
+++ b/onnx/backend/test/report/coverage.py
@@ -147,7 +147,7 @@ class Coverage:
         self, all_ops: List[str], passed: List[Optional[str]], experimental: List[str]
     ) -> None:
         for schema in _all_schemas:
-            if schema.domain == "" or schema.domain == "ai.onnx":
+            if schema.domain in {"", "ai.onnx"}:
                 all_ops.append(schema.name)
                 if schema.support_level == defs.OpSchema.SupportType.EXPERIMENTAL:
                     experimental.append(schema.name)

--- a/onnx/backend/test/stat_coverage.py
+++ b/onnx/backend/test/stat_coverage.py
@@ -136,7 +136,7 @@ def gen_node_test_coverage(
                     f.write(f"<summary>{summary}</summary>\n\n")
                     f.write(f"```python\n{code}\n```\n\n")
                     f.write("</details>\n")
-            else:
+            else:  # noqa: PLR5501
                 if s in generators:
                     f.write(" (random generator operator)\n")
                 else:

--- a/onnx/backend/test/stat_coverage.py
+++ b/onnx/backend/test/stat_coverage.py
@@ -36,8 +36,8 @@ experimental_covered: Sequence[str] = []
 def gen_node_test_coverage(
     schemas: Sequence[defs.OpSchema], f: IO[Any], ml: bool
 ) -> None:
-    global common_covered
-    global experimental_covered
+    global common_covered  # noqa: PLW0603
+    global experimental_covered  # noqa: PLW0603
     generators = set(
         {
             "Multinomial",

--- a/onnx/compose.py
+++ b/onnx/compose.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-
 from typing import Dict, List, MutableMapping, Optional, Set, Tuple
 
 from onnx import GraphProto, ModelProto, TensorProto, checker, helper, utils

--- a/onnx/compose.py
+++ b/onnx/compose.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# pylint: disable=unidiomatic-typecheck
+
 
 from typing import Dict, List, MutableMapping, Optional, Set, Tuple
 
@@ -78,7 +78,7 @@ def check_overlapping_names(
     return result
 
 
-def merge_graphs(  # pylint: disable=too-many-branches,too-many-statements
+def merge_graphs(
     g1: GraphProto,
     g2: GraphProto,
     io_map: List[Tuple[str, str]],
@@ -265,7 +265,7 @@ def merge_graphs(  # pylint: disable=too-many-branches,too-many-statements
     return g
 
 
-def merge_models(  # pylint: disable=too-many-branches
+def merge_models(
     m1: ModelProto,
     m2: ModelProto,
     io_map: List[Tuple[str, str]],
@@ -411,7 +411,7 @@ def merge_models(  # pylint: disable=too-many-branches
     return model
 
 
-def add_prefix_graph(  # pylint: disable=too-many-branches
+def add_prefix_graph(
     graph: GraphProto,
     prefix: str,
     rename_nodes: Optional[bool] = True,

--- a/onnx/defs/__init__.py
+++ b/onnx/defs/__init__.py
@@ -44,7 +44,7 @@ def onnx_opset_version() -> int:
 @property  # type: ignore
 def _function_proto(self):  # type: ignore
     func_proto = FunctionProto()
-    func_proto.ParseFromString(self._function_body)  # pylint: disable=protected-access
+    func_proto.ParseFromString(self._function_body)
     return func_proto
 
 
@@ -55,7 +55,7 @@ OpSchema.function_body = _function_proto  # type: ignore
 @property  # type: ignore
 def _attribute_default_value(self):  # type: ignore
     attr = AttributeProto()
-    attr.ParseFromString(self._default_value)  # pylint: disable=protected-access
+    attr.ParseFromString(self._default_value)
     return attr
 
 

--- a/onnx/defs/gen_doc.py
+++ b/onnx/defs/gen_doc.py
@@ -97,7 +97,7 @@ def generate_formal_parameter_tags(formal_parameter: OpSchema.FormalParameter) -
     return "" if len(tags) == 0 else " (" + ", ".join(tags) + ")"
 
 
-def display_schema(  # pylint: disable=too-many-branches,too-many-statements
+def display_schema(
     schema: OpSchema, versions: Sequence[OpSchema], changelog: str
 ) -> str:
     s = ""
@@ -123,7 +123,7 @@ def display_schema(  # pylint: disable=too-many-branches,too-many-statements
         s += f" of {display_domain(schema.domain)}.\n"
         if len(versions) > 1:
             # TODO: link to the Changelog.md
-            s += "\nOther versions of this operator: {}\n".format(  # pylint: disable=consider-using-f-string
+            s += "\nOther versions of this operator: {}\n".format(
                 ", ".join(
                     display_version_link(
                         format_name_with_domain(v.domain, v.name),
@@ -234,7 +234,7 @@ class Args(NamedTuple):
     changelog: str
 
 
-def main(args: Args) -> None:  # pylint: disable=too-many-branches,too-many-statements
+def main(args: Args) -> None:
     base_dir = os.path.dirname(
         os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
     )
@@ -346,7 +346,7 @@ def main(args: Args) -> None:  # pylint: disable=too-many-branches,too-many-stat
                         function_versions = schema.all_function_opset_versions  # type: ignore
                         function_ops.append((n, schema, versions, function_versions))
                         continue
-                    s = '|{}<a href="#{}">{}</a>{}|{}|\n'.format(  # pylint: disable=consider-using-f-string
+                    s = '|{}<a href="#{}">{}</a>{}|{}|\n'.format(
                         support_level_str(schema.support_level),
                         format_name_with_domain(domain, n),
                         format_name_with_domain(domain, n),
@@ -357,7 +357,7 @@ def main(args: Args) -> None:  # pylint: disable=too-many-branches,too-many-stat
             if function_ops:
                 fout.write("|**Function**|**Since version**|**Function version**|\n")
                 for n, schema, versions, function_versions in function_ops:
-                    s = '|{}<a href="#{}">{}</a>|{}|{}|\n'.format(  # pylint: disable=consider-using-f-string
+                    s = '|{}<a href="#{}">{}</a>|{}|{}|\n'.format(
                         support_level_str(schema.support_level),
                         format_name_with_domain(domain, n),
                         format_name_with_domain(domain, n),

--- a/onnx/defs/gen_doc.py
+++ b/onnx/defs/gen_doc.py
@@ -155,7 +155,7 @@ def display_schema(
                     if isinstance(value, float):
                         formatted = str(np.round(value, 5))
                         # use default formatting, unless too long.
-                        if len(formatted) > 10:
+                        if len(formatted) > 10:  # noqa: PLR2004
                             formatted = str(f"({value:e})")
                         return formatted
                     if isinstance(value, (bytes, bytearray)):

--- a/onnx/gen_proto.py
+++ b/onnx/gen_proto.py
@@ -42,14 +42,14 @@ def process_ifs(lines: Iterable[str], onnx_ml: bool) -> Iterable[str]:
             assert in_if == 1
             in_if = 2
         elif ENDIF_ONNX_ML_REGEX.match(line):
-            assert in_if == 1 or in_if == 2
+            assert in_if == 1 or in_if == 2  # noqa: PLR1714, PLR2004
             in_if = 0
-        else:
+        else:  # noqa: PLR5501
             if in_if == 0:
                 yield line
             elif in_if == 1 and onnx_ml:
                 yield line
-            elif in_if == 2 and not onnx_ml:
+            elif in_if == 2 and not onnx_ml:  # noqa: PLR2004
                 yield line
 
 
@@ -114,10 +114,10 @@ def translate(source: str, proto: int, onnx_ml: bool, package_name: str) -> str:
     lines: Iterable[str] = source.splitlines()
     lines = process_ifs(lines, onnx_ml=onnx_ml)
     lines = process_package_name(lines, package_name=package_name)
-    if proto == 3:
+    if proto == 3:  # noqa: PLR2004
         lines = convert_to_proto3(lines)
     else:
-        assert proto == 2
+        assert proto == 2  # noqa: PLR2004
     return "\n".join(lines)  # TODO: not Windows friendly
 
 
@@ -194,7 +194,7 @@ def convert(
     pb_py = qualify(f"{stem.replace('-', '_')}_pb.py", pardir=output)
     if need_rename:
         pb2_py = qualify(f"{proto_base.replace('-', '_')}_pb2.py", pardir=output)
-    else:
+    else:  # noqa: PLR5501
         if do_onnx_ml:
             pb2_py = qualify(f"{stem.replace('-', '_')}_ml_pb2.py", pardir=output)
         else:

--- a/onnx/gen_proto.py
+++ b/onnx/gen_proto.py
@@ -42,7 +42,7 @@ def process_ifs(lines: Iterable[str], onnx_ml: bool) -> Iterable[str]:
             assert in_if == 1
             in_if = 2
         elif ENDIF_ONNX_ML_REGEX.match(line):
-            assert in_if == 1 or in_if == 2  # pylint: disable=consider-using-in
+            assert in_if == 1 or in_if == 2
             in_if = 0
         else:
             if in_if == 0:
@@ -127,7 +127,7 @@ def qualify(f: str, pardir: Optional[str] = None) -> str:
     return os.path.join(pardir, f)
 
 
-def convert(  # pylint: disable=too-many-branches,too-many-statements
+def convert(
     stem: str,
     package_name: str,
     output: str,

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=C0302,R0912
+
 import collections.abc
 import numbers
 import struct
@@ -355,7 +355,7 @@ def float32_to_bfloat16(fval: float, truncate: bool = False) -> int:
     return (ival + rounded) >> 16
 
 
-def float32_to_float8e4m3(  # pylint: disable=too-many-statements
+def float32_to_float8e4m3(
     fval: float,
     scale: float = 1.0,
     fn: bool = True,
@@ -405,7 +405,7 @@ def float32_to_float8e4m3(  # pylint: disable=too-many-statements
                 elif m > 0:
                     ret |= 1
                 mask = 1 << (20 - ex)
-                if m & mask and (  # pylint: disable=too-many-boolean-expressions
+                if m & mask and (
                     ret & 1
                     or m & (mask - 1) > 0
                     or (m & mask and m & (mask << 1) and m & (mask - 1) == 0)
@@ -457,7 +457,7 @@ def float32_to_float8e4m3(  # pylint: disable=too-many-statements
                 elif m > 0:
                     ret |= 1
                 mask = 1 << (20 - ex)
-                if m & mask and (  # pylint: disable=too-many-boolean-expressions
+                if m & mask and (
                     ret & 1
                     or m & (mask - 1) > 0
                     or (m & mask and m & (mask << 1) and m & (mask - 1) == 0)
@@ -488,7 +488,7 @@ def float32_to_float8e4m3(  # pylint: disable=too-many-statements
         return int(ret)
 
 
-def float32_to_float8e5m2(  # pylint: disable=too-many-statements
+def float32_to_float8e5m2(
     fval: float,
     scale: float = 1.0,
     fn: bool = False,
@@ -534,7 +534,7 @@ def float32_to_float8e5m2(  # pylint: disable=too-many-statements
                 elif m > 0:
                     ret |= 1
                 mask = 1 << (21 - ex)
-                if m & mask and (  # pylint: disable=too-many-boolean-expressions
+                if m & mask and (
                     ret & 1
                     or m & (mask - 1) > 0
                     or (m & mask and m & (mask << 1) and m & (mask - 1) == 0)
@@ -584,7 +584,7 @@ def float32_to_float8e5m2(  # pylint: disable=too-many-statements
                 elif m > 0:
                     ret |= 1
                 mask = 1 << (21 - ex)
-                if m & mask and (  # pylint: disable=too-many-boolean-expressions
+                if m & mask and (
                     ret & 1
                     or m & (mask - 1) > 0
                     or (m & mask and m & (mask << 1) and m & (mask - 1) == 0)
@@ -661,7 +661,7 @@ def make_tensor(
             expected_size = np_dtype.itemsize
 
     if (
-        type(vals) is np.ndarray  # pylint: disable=unidiomatic-typecheck
+        type(vals) is np.ndarray
         and len(vals.shape) > 1
     ):
         vals = vals.flatten()
@@ -837,7 +837,7 @@ def _to_bytes(value: Union[str, bytes]) -> bytes:
     return value if isinstance(value, bytes) else value.encode("utf-8")
 
 
-def make_attribute(  # pylint: disable=too-many-statements
+def make_attribute(
     key: str,
     value: Any,
     doc_string: Optional[str] = None,
@@ -1514,7 +1514,7 @@ def tensor_dtype_to_field(tensor_dtype: int) -> str:
     :param tensor_dtype: TensorProto's data_type
     :return: field name
     """
-    return mapping._STORAGE_TENSOR_TYPE_TO_FIELD[  # pylint: disable=protected-access
+    return mapping._STORAGE_TENSOR_TYPE_TO_FIELD[
         mapping.TENSOR_TYPE_MAP[tensor_dtype].storage_dtype
     ]
 
@@ -1528,7 +1528,7 @@ def np_dtype_to_tensor_dtype(np_dtype: np.dtype) -> int:
     """
     return cast(
         int,
-        mapping._NP_TYPE_TO_TENSOR_TYPE[np_dtype],  # pylint: disable=protected-access
+        mapping._NP_TYPE_TO_TENSOR_TYPE[np_dtype],
     )
 
 

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -660,10 +660,7 @@ def make_tensor(
         else:
             expected_size = np_dtype.itemsize
 
-    if (
-        type(vals) is np.ndarray
-        and len(vals.shape) > 1
-    ):
+    if type(vals) is np.ndarray and len(vals.shape) > 1:
         vals = vals.flatten()
     for d in dims:
         expected_size *= d

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -355,7 +355,7 @@ def float32_to_bfloat16(fval: float, truncate: bool = False) -> int:
     return (ival + rounded) >> 16
 
 
-def float32_to_float8e4m3(
+def float32_to_float8e4m3(  # noqa: PLR0911
     fval: float,
     scale: float = 1.0,
     fn: bool = True,
@@ -384,7 +384,7 @@ def float32_to_float8e4m3(
     b = int.from_bytes(struct.pack("<f", np.float32(x)), "little")
     ret = (b & 0x80000000) >> 24  # sign
     if uz:
-        if (b & 0x7FC00000) == 0x7FC00000:
+        if (b & 0x7FC00000) == 0x7FC00000:  # noqa: PLR2004
             return 0x80
         if np.isinf(x):
             if saturate:
@@ -394,12 +394,12 @@ def float32_to_float8e4m3(
         m = b & 0x007FFFFF  # mantissa
 
         if e != 0:
-            if e < 116:
+            if e < 116:  # noqa: PLR2004
                 pass
-            elif e < 120:
+            elif e < 120:  # noqa: PLR2004
                 # denormalized number
                 ex = e - 119
-                if ex >= -2:
+                if ex >= -2:  # noqa: PLR2004
                     ret |= 1 << (2 + ex)
                     ret |= m >> (21 - ex)
                 elif m > 0:
@@ -412,7 +412,7 @@ def float32_to_float8e4m3(
                 ):
                     # rounding
                     ret += 1
-            elif e < 135:
+            elif e < 135:  # noqa: PLR2004
                 # normalized number
                 ex = e - 119  # 127 - 8
                 if ex == 0:
@@ -422,7 +422,7 @@ def float32_to_float8e4m3(
                     ret |= ex << 3
                     ret |= m >> 20
                 if m & 0x80000 and ((m & 0x100000) or (m & 0x7FFFF)):
-                    if (ret & 0x7F) < 0x7F:
+                    if (ret & 0x7F) < 0x7F:  # noqa: PLR2004
                         # rounding
                         ret += 1
                     elif not saturate:
@@ -436,7 +436,7 @@ def float32_to_float8e4m3(
             ret = 0
         return int(ret)
     else:
-        if (b & 0x7FC00000) == 0x7FC00000:
+        if (b & 0x7FC00000) == 0x7FC00000:  # noqa: PLR2004
             return 0x7F | ret
         if np.isinf(x):
             if saturate:
@@ -446,12 +446,12 @@ def float32_to_float8e4m3(
         m = b & 0x007FFFFF  # mantissa
 
         if e != 0:
-            if e < 117:
+            if e < 117:  # noqa: PLR2004
                 pass
-            elif e < 121:
+            elif e < 121:  # noqa: PLR2004
                 # denormalized number
                 ex = e - 120
-                if ex >= -2:
+                if ex >= -2:  # noqa: PLR2004
                     ret |= 1 << (2 + ex)
                     ret |= m >> (21 - ex)
                 elif m > 0:
@@ -464,7 +464,7 @@ def float32_to_float8e4m3(
                 ):
                     # rounding
                     ret += 1
-            elif e < 136:
+            elif e < 136:  # noqa: PLR2004
                 # normalized number
                 ex = e - 120
                 if ex == 0:
@@ -473,10 +473,10 @@ def float32_to_float8e4m3(
                 else:
                     ret |= ex << 3
                     ret |= m >> 20
-                    if (ret & 0x7F) == 0x7F:
+                    if (ret & 0x7F) == 0x7F:  # noqa: PLR2004
                         ret &= 0xFE
                 if (m & 0x80000) and ((m & 0x100000) or (m & 0x7FFFF)):
-                    if (ret & 0x7F) < 0x7E:
+                    if (ret & 0x7F) < 0x7E:  # noqa: PLR2004
                         # rounding
                         ret += 1
                     elif not saturate:
@@ -488,7 +488,7 @@ def float32_to_float8e4m3(
         return int(ret)
 
 
-def float32_to_float8e5m2(
+def float32_to_float8e5m2(  # noqa: PLR0911
     fval: float,
     scale: float = 1.0,
     fn: bool = False,
@@ -512,9 +512,9 @@ def float32_to_float8e5m2(
     ret = (b & 0x80000000) >> 24  # sign
 
     if fn and uz:
-        if (b & 0x7FC00000) == 0x7FC00000:
+        if (b & 0x7FC00000) == 0x7FC00000:  # noqa: PLR2004
             return 0x80
-        if (b & 0x7FFFFFFF) == 0x7F800000:
+        if (b & 0x7FFFFFFF) == 0x7F800000:  # noqa: PLR2004
             # inf
             if saturate:
                 return ret | 0x7F
@@ -523,9 +523,9 @@ def float32_to_float8e5m2(
         m = b & 0x007FFFFF  # mantissa
 
         if e != 0:
-            if e < 109:
+            if e < 109:  # noqa: PLR2004
                 pass
-            elif e < 112:
+            elif e < 112:  # noqa: PLR2004
                 # denormalized number
                 ex = e - 111
                 if ex >= -1:
@@ -541,18 +541,18 @@ def float32_to_float8e5m2(
                 ):
                     # rounding
                     ret += 1
-            elif e < 143:
+            elif e < 143:  # noqa: PLR2004
                 # normalized number
                 ex = e - 111
                 ret |= ex << 2
                 ret |= m >> 21
                 if m & 0x100000 and ((m & 0xFFFFF) or (m & 0x200000)):
-                    if (ret & 0x7F) < 0x7F:
+                    if (ret & 0x7F) < 0x7F:  # noqa: PLR2004
                         # rounding
                         ret += 1
                     elif not saturate:
                         ret = 0x80
-            elif e == 255 and m == 0:  # inf
+            elif e == 255 and m == 0:  # inf  # noqa: PLR2004
                 ret = 0x80
             elif saturate:
                 ret |= 0x7F  # last possible number
@@ -563,7 +563,7 @@ def float32_to_float8e5m2(
             ret = 0
         return int(ret)
     elif not fn and not uz:
-        if (b & 0x7FC00000) == 0x7FC00000:
+        if (b & 0x7FC00000) == 0x7FC00000:  # noqa: PLR2004
             return 0x7F | ret
         if np.isinf(x):
             if saturate:
@@ -573,9 +573,9 @@ def float32_to_float8e5m2(
         m = b & 0x007FFFFF  # mantissa
 
         if e != 0:
-            if e < 110:
+            if e < 110:  # noqa: PLR2004
                 pass
-            elif e < 113:
+            elif e < 113:  # noqa: PLR2004
                 # denormalized number
                 ex = e - 112
                 if ex >= -1:
@@ -591,13 +591,13 @@ def float32_to_float8e5m2(
                 ):
                     # rounding
                     ret += 1
-            elif e < 143:
+            elif e < 143:  # noqa: PLR2004
                 # normalized number
                 ex = e - 112
                 ret |= ex << 2
                 ret |= m >> 21
                 if m & 0x100000 and ((m & 0xFFFFF) or (m & 0x200000)):
-                    if (ret & 0x7F) < 0x7B:
+                    if (ret & 0x7F) < 0x7B:  # noqa: PLR2004
                         # rounding
                         ret += 1
                     elif saturate:
@@ -940,7 +940,7 @@ def make_attribute_ref(
     return attr
 
 
-def get_attribute_value(attr: AttributeProto) -> Any:
+def get_attribute_value(attr: AttributeProto) -> Any:  # noqa: PLR0911
     if attr.ref_attr_name:
         raise ValueError(f"Cannot get value of reference attribute: {attr}")
     if attr.type == AttributeProto.FLOAT:
@@ -1174,7 +1174,7 @@ def _sanitize_str(s: Union[str, bytes]) -> str:
         sanitized = s.decode("utf-8", errors="ignore")
     else:
         sanitized = str(s)
-    if len(sanitized) < 64:
+    if len(sanitized) < 64:  # noqa: PLR2004
         return sanitized
     return sanitized[:64] + f"...<+len={(len(sanitized) - 64)}>"
 

--- a/onnx/hub.py
+++ b/onnx/hub.py
@@ -73,7 +73,7 @@ def set_dir(new_dir: str) -> None:
 
     :param new_dir: location of new model hub cache
     """
-    global _ONNX_HUB_DIR  # pylint: disable=global-statement
+    global _ONNX_HUB_DIR
     _ONNX_HUB_DIR = new_dir
 
 

--- a/onnx/hub.py
+++ b/onnx/hub.py
@@ -73,7 +73,7 @@ def set_dir(new_dir: str) -> None:
 
     :param new_dir: location of new model hub cache
     """
-    global _ONNX_HUB_DIR
+    global _ONNX_HUB_DIR  # noqa: PLW0603
     _ONNX_HUB_DIR = new_dir
 
 

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-
 import sys
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
@@ -172,9 +171,7 @@ def float8e5m2_to_float32(
     return res.reshape(dims)  # type: ignore[no-any-return]
 
 
-def to_array(
-    tensor: TensorProto, base_dir: str = ""
-) -> np.ndarray:
+def to_array(tensor: TensorProto, base_dir: str = "") -> np.ndarray:
     """Converts a tensor def object to a numpy array.
 
     Args:
@@ -271,9 +268,7 @@ def to_array(
     return np.asarray(data, dtype=storage_np_dtype).astype(np_dtype).reshape(dims)
 
 
-def from_array(
-    arr: np.ndarray, name: Optional[str] = None
-) -> TensorProto:
+def from_array(arr: np.ndarray, name: Optional[str] = None) -> TensorProto:
     """Converts a numpy array to a tensor def.
 
     Args:

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# pylint: disable=C3001,isinstance-second-argument-not-valid-type
+
 
 import sys
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
@@ -72,7 +72,7 @@ def _float8e4m3_to_float32_scalar(ival: int, fn: bool, uz: bool) -> np.float32:
         res |= mant << 20
         expo += 0x7F - exponent_bias
         res |= expo << 23
-    f = np.uint32(res).view(np.float32)  # pylint: disable=E1121
+    f = np.uint32(res).view(np.float32)
     return f
 
 
@@ -143,7 +143,7 @@ def _float8e5m2_to_float32_scalar(ival: int, fn: bool, uz: bool) -> np.float32:
         res |= mant << 21
         expo += 0x7F - exponent_bias
         res |= expo << 23
-    f = np.uint32(res).view(np.float32)  # pylint: disable=E1121
+    f = np.uint32(res).view(np.float32)
     return f
 
 
@@ -172,7 +172,7 @@ def float8e5m2_to_float32(
     return res.reshape(dims)  # type: ignore[no-any-return]
 
 
-def to_array(  # pylint: disable=too-many-branches
+def to_array(
     tensor: TensorProto, base_dir: str = ""
 ) -> np.ndarray:
     """Converts a tensor def object to a numpy array.
@@ -271,7 +271,7 @@ def to_array(  # pylint: disable=too-many-branches
     return np.asarray(data, dtype=storage_np_dtype).astype(np_dtype).reshape(dims)
 
 
-def from_array(  # pylint: disable=too-many-branches
+def from_array(
     arr: np.ndarray, name: Optional[str] = None
 ) -> TensorProto:
     """Converts a numpy array to a tensor def.
@@ -359,9 +359,9 @@ def to_list(sequence: SequenceProto) -> List[Any]:
     raise TypeError("The element type in the input sequence is not supported.")
 
 
-def from_list(  # pylint: disable=too-many-branches
+def from_list(
     lst: List[Any], name: Optional[str] = None, dtype: Optional[int] = None
-) -> SequenceProto:  # pylint: disable=too-many-branches
+) -> SequenceProto:
     """Converts a list into a sequence def.
 
     Args:

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -37,17 +37,17 @@ def bfloat16_to_float32(
 def _float8e4m3_to_float32_scalar(ival: int, fn: bool, uz: bool) -> np.float32:
     if not fn:
         raise NotImplementedError("fn=False is not implemented.")
-    if ival < 0 or ival > 255:
+    if ival < 0 or ival > 255:  # noqa: PLR2004
         raise ValueError(f"{ival} is not a float8.")
     if uz:
         exponent_bias = 8
-        if ival == 0x80:
+        if ival == 0x80:  # noqa: PLR2004
             return np.nan  # type: ignore[return-value]
     else:
         exponent_bias = 7
-        if ival == 255:
+        if ival == 255:  # noqa: PLR2004
             return np.float32(-np.nan)
-        if ival == 127:
+        if ival == 127:  # noqa: PLR2004
             return np.float32(np.nan)
 
     expo = (ival & 0x78) >> 3
@@ -109,7 +109,7 @@ def float8e4m3_to_float32(
 
 def _float8e5m2_to_float32_scalar(ival: int, fn: bool, uz: bool) -> np.float32:
     if fn and uz:
-        if ival == 0x80:
+        if ival == 0x80:  # noqa: PLR2004
             return np.float32(np.nan)
         exponent_bias = 16
     elif not fn and not uz:
@@ -117,9 +117,9 @@ def _float8e5m2_to_float32_scalar(ival: int, fn: bool, uz: bool) -> np.float32:
             return np.float32(-np.nan)
         if ival in {125, 126, 127}:
             return np.float32(np.nan)
-        if ival == 252:
+        if ival == 252:  # noqa: PLR2004
             return np.float32(-np.inf)
-        if ival == 124:
+        if ival == 124:  # noqa: PLR2004
             return np.float32(np.inf)
         exponent_bias = 15
     else:
@@ -171,7 +171,7 @@ def float8e5m2_to_float32(
     return res.reshape(dims)  # type: ignore[no-any-return]
 
 
-def to_array(tensor: TensorProto, base_dir: str = "") -> np.ndarray:
+def to_array(tensor: TensorProto, base_dir: str = "") -> np.ndarray:  # noqa: PLR0911
     """Converts a tensor def object to a numpy array.
 
     Args:

--- a/onnx/reference/op_run.py
+++ b/onnx/reference/op_run.py
@@ -614,9 +614,7 @@ class OpRunExpand(OpRun):
     Class any operator to avoid must inherit from.
     """
 
-    def __init__(
-        self, onnx_node: NodeProto, log_function: Any, impl: Any = None
-    ):
+    def __init__(self, onnx_node: NodeProto, log_function: Any, impl: Any = None):
         raise RuntimeError(
             f"The reference implementation must not use this node ({type(self)})."
         )
@@ -710,8 +708,6 @@ class OpFunctionContextDependant(OpFunction):
                 else:
                     raise e
             types.append(make_tensor_type_proto(ttype, t.shape))
-        cl = self.parent._load_impl(
-            self.onnx_node, types
-        )
+        cl = self.parent._load_impl(self.onnx_node, types)
         inst = cl(self.onnx_node, self.run_params)
         return self._run_impl(inst.impl_, *inputs, **kwargs)

--- a/onnx/reference/op_run.py
+++ b/onnx/reference/op_run.py
@@ -312,7 +312,7 @@ class OpRun(abc.ABC):
                         )
                     if hasattr(v, "default_value"):
                         if v.default_value.type == 0 or (
-                            v.default_value.type == 4
+                            v.default_value.type == 4  # noqa: PLR2004
                             and v.default_value.t.data_type == 0
                         ):
                             # default value is undefined, it depends on the inputs

--- a/onnx/reference/op_run.py
+++ b/onnx/reference/op_run.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=C0415,R0912
+
 
 from __future__ import annotations
 
@@ -616,7 +616,7 @@ class OpRunExpand(OpRun):
 
     def __init__(
         self, onnx_node: NodeProto, log_function: Any, impl: Any = None
-    ):  # pylint: disable=super-init-not-called
+    ):
         raise RuntimeError(
             f"The reference implementation must not use this node ({type(self)})."
         )
@@ -653,10 +653,10 @@ class OpFunction(OpRun):
             for name in getattr(self.impl_, "attributes_", attributes)  # type: ignore[union-attr]
         }
 
-    def _run(self, *inputs, **kwargs):  # type: ignore # pylint: disable=W0221
+    def _run(self, *inputs, **kwargs):  # type: ignore
         return self._run_impl(self.impl_, *inputs, **kwargs)
 
-    def _run_impl(self, impl, *inputs, **kwargs):  # type: ignore # pylint: disable=W0221
+    def _run_impl(self, impl, *inputs, **kwargs):  # type: ignore
         if len(impl.input_names) != len(inputs):
             raise RuntimeError(
                 f"Mismatch lengths between the number of inputs {len(inputs)} "
@@ -710,7 +710,7 @@ class OpFunctionContextDependant(OpFunction):
                 else:
                     raise e
             types.append(make_tensor_type_proto(ttype, t.shape))
-        cl = self.parent._load_impl(  # pylint: disable=protected-access
+        cl = self.parent._load_impl(
             self.onnx_node, types
         )
         inst = cl(self.onnx_node, self.run_params)

--- a/onnx/reference/ops/_op.py
+++ b/onnx/reference/ops/_op.py
@@ -173,7 +173,7 @@ class OpRunReduceNumpy(OpRun):  # type: ignore
     def is_axes_empty(self, axes):
         return axes is None
 
-    def handle_axes(self, axes):
+    def handle_axes(self, axes):  # noqa: PLR0911
         if isinstance(axes, tuple):
             if len(axes) == 0:
                 return None

--- a/onnx/reference/ops/_op.py
+++ b/onnx/reference/ops/_op.py
@@ -10,7 +10,7 @@ from onnx.onnx_pb import NodeProto
 from onnx.reference.op_run import OpRun, RuntimeTypeError
 
 
-class OpRunUnary(OpRun):  # pylint: disable=W0223
+class OpRunUnary(OpRun):
     """
     Ancestor to all unary operators in this subfolder.
     Checks that input and output types are the same.
@@ -19,7 +19,7 @@ class OpRunUnary(OpRun):  # pylint: disable=W0223
     def __init__(self, onnx_node: NodeProto, run_params: Dict[str, Any]):
         OpRun.__init__(self, onnx_node, run_params)
 
-    def run(self, x):  # type: ignore # pylint: disable=W0221
+    def run(self, x):  # type: ignore
         """
         Calls method ``_run``, catches exceptions,
         displays a longer error message.
@@ -37,7 +37,7 @@ class OpRunUnary(OpRun):  # pylint: disable=W0223
         return res
 
 
-class OpRunUnaryNum(OpRunUnary):  # pylint: disable=W0223
+class OpRunUnaryNum(OpRunUnary):
     """
     Ancestor to all unary and numerical operators
     in this subfolder. Checks that input and output types
@@ -47,7 +47,7 @@ class OpRunUnaryNum(OpRunUnary):  # pylint: disable=W0223
     def __init__(self, onnx_node: NodeProto, run_params: Dict[str, Any]):
         OpRunUnary.__init__(self, onnx_node, run_params)
 
-    def run(self, x):  # type: ignore # pylint: disable=W0221
+    def run(self, x):  # type: ignore
         """
         Calls method ``OpRunUnary.run``, catches exceptions,
         displays a longer error message.
@@ -64,7 +64,7 @@ class OpRunUnaryNum(OpRunUnary):  # pylint: disable=W0223
         return res
 
 
-class OpRunBinary(OpRun):  # pylint: disable=W0223
+class OpRunBinary(OpRun):
     """
     Ancestor to all binary operators in this subfolder.
     Checks that input and output types are the same.
@@ -73,7 +73,7 @@ class OpRunBinary(OpRun):  # pylint: disable=W0223
     def __init__(self, onnx_node: NodeProto, run_params: Dict[str, Any]):
         OpRun.__init__(self, onnx_node, run_params)
 
-    def run(self, x, y):  # type: ignore # pylint: disable=W0221
+    def run(self, x, y):  # type: ignore
         """
         Calls method ``_run``, catches exceptions,
         displays a longer error message.
@@ -101,7 +101,7 @@ class OpRunBinary(OpRun):  # pylint: disable=W0223
         return res
 
 
-class OpRunBinaryComparison(OpRunBinary):  # pylint: disable=W0223
+class OpRunBinaryComparison(OpRunBinary):
     """
     Ancestor to all binary operators in this subfolder
     comparing tensors.
@@ -111,7 +111,7 @@ class OpRunBinaryComparison(OpRunBinary):  # pylint: disable=W0223
         OpRunBinary.__init__(self, onnx_node, run_params)
 
 
-class OpRunBinaryNum(OpRunBinary):  # pylint: disable=W0223
+class OpRunBinaryNum(OpRunBinary):
     """
     Ancestor to all binary operators in this subfolder.
     Checks that input oud output types are the same.
@@ -120,7 +120,7 @@ class OpRunBinaryNum(OpRunBinary):  # pylint: disable=W0223
     def __init__(self, onnx_node: NodeProto, run_params: Dict[str, Any]):
         OpRunBinary.__init__(self, onnx_node, run_params)
 
-    def run(self, x, y):  # type: ignore # pylint: disable=W0221
+    def run(self, x, y):  # type: ignore
         """
         Calls method ``OpRunBinary.run``, catches exceptions,
         displays a longer error message.
@@ -147,7 +147,7 @@ class OpRunBinaryNumpy(OpRunBinaryNum):
         OpRunBinaryNum.__init__(self, onnx_node, run_params)
         self.numpy_fct = numpy_fct
 
-    def _run(self, a, b):  # type: ignore # pylint: disable=W0221
+    def _run(self, a, b):  # type: ignore
         return (self.numpy_fct(a, b),)
 
 
@@ -160,8 +160,8 @@ class OpRunReduceNumpy(OpRun):  # type: ignore
     def __init__(self, onnx_node: NodeProto, run_params: Dict[str, Any]):
         OpRun.__init__(self, onnx_node, run_params)
         if hasattr(self, "axes"):
-            if isinstance(self.axes, np.ndarray):  # type: ignore # pylint: disable=E0203
-                if len(self.axes.shape) == 0 or self.axes.shape[0] == 0:  # type: ignore # pylint: disable=E0203
+            if isinstance(self.axes, np.ndarray):  # type: ignore
+                if len(self.axes.shape) == 0 or self.axes.shape[0] == 0:  # type: ignore
                     self.axes = None
                 else:
                     self.axes = tuple(self.axes)

--- a/onnx/reference/ops/_op_common_indices.py
+++ b/onnx/reference/ops/_op_common_indices.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/_op_common_pool.py
+++ b/onnx/reference/ops/_op_common_pool.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221,R0913,R0914
+
 
 import itertools
 from typing import Optional, Tuple
@@ -21,7 +21,7 @@ def _get_pad_shape(
 ) -> Tuple[int]:
     pad_shape = [0] * len(input_spatial_shape)
     if auto_pad in ("SAME_UPPER", "SAME_LOWER"):
-        for i in range(len(input_spatial_shape)):  # pylint: disable=C0200
+        for i in range(len(input_spatial_shape)):
             pad_shape[i] = (
                 (output_spatial_shape[i] - 1) * strides_spatial[i]
                 + kernel_spatial_shape[i]
@@ -47,12 +47,12 @@ def _get_output_shape_no_ceil(
 ) -> Tuple[int]:
     out_shape = [0] * len(input_spatial_shape)
     if auto_pad in ("SAME_UPPER", "SAME_LOWER"):
-        for i in range(len(input_spatial_shape)):  # pylint: disable=C0200
+        for i in range(len(input_spatial_shape)):
             out_shape[i] = int(
                 np.ceil(float(input_spatial_shape[i]) / float(strides_spatial[i]))
             )
     elif auto_pad == "VALID":
-        for i in range(len(input_spatial_shape)):  # pylint: disable=C0200
+        for i in range(len(input_spatial_shape)):
             out_shape[i] = int(
                 np.ceil(
                     float(input_spatial_shape[i] - (kernel_spatial_shape[i] - 1))
@@ -78,7 +78,7 @@ def _get_output_shape(
         round_fct = np.ceil if ceil_mode else np.floor
         out_shape = [0] * len(input_spatial_shape)  # type: ignore
         if auto_pad in ("SAME_UPPER", "SAME_LOWER"):
-            for i in range(len(input_spatial_shape)):  # pylint: disable=C0200
+            for i in range(len(input_spatial_shape)):
                 out_shape[i] = int(  # type: ignore
                     round_fct(float(input_spatial_shape[i]) / float(strides_spatial[i]))  # type: ignore
                 )
@@ -88,7 +88,7 @@ def _get_output_shape(
                     "pad_shape cannot be None if auto_pad is "
                     "'VALID' and ceil_mode is 1."
                 )
-            for i in range(len(input_spatial_shape)):  # pylint: disable=C0200
+            for i in range(len(input_spatial_shape)):
                 out_shape[i] = int(  # type: ignore
                     round_fct(  # type: ignore
                         float(
@@ -210,7 +210,7 @@ class CommonPool(OpRun):
         dilations=None,
         kernel_shape=None,
         pads=None,
-        storage_order=None,  # pylint: disable=W0613
+        storage_order=None,
         strides=None,
     ):
         if pooling_type == "MAX" and dilations is None:

--- a/onnx/reference/ops/_op_common_random.py
+++ b/onnx/reference/ops/_op_common_random.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/_op_common_window.py
+++ b/onnx/reference/ops/_op_common_window.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0613,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/_op_list.py
+++ b/onnx/reference/ops/_op_list.py
@@ -12,8 +12,9 @@ The operator may have been updated to support more types but that
 did not change the implementation.
 """
 import textwrap
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List
 from typing import Optional as TOptional
+from typing import Union
 
 from onnx import FunctionProto, NodeProto, TypeProto
 from onnx.defs import get_schema, onnx_opset_version
@@ -261,7 +262,7 @@ def load_op(
         of its reference implementation
     :return: class
     """
-    global _registered_operators
+    global _registered_operators  # noqa: PLW0603
     schema = None
     if _registered_operators is None:
         _registered_operators = _build_registered_operators()  # type: ignore[assignment]

--- a/onnx/reference/ops/_op_list.py
+++ b/onnx/reference/ops/_op_list.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=C0415,R0912,R0913,R0914,R0915,W0611,W0603
+
 """
 Every class imported in this module defines an implementation of
 an operator of the main domain. Any class name uses `_` to specify a
@@ -12,9 +12,8 @@ The operator may have been updated to support more types but that
 did not change the implementation.
 """
 import textwrap
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 from typing import Optional as TOptional
-from typing import Union
 
 from onnx import FunctionProto, NodeProto, TypeProto
 from onnx.defs import get_schema, onnx_opset_version
@@ -279,7 +278,7 @@ def load_op(
         try:
             schema = get_schema(op_type, version, domain)  # type: ignore
         except SchemaError:
-            raise NotImplementedError(  # pylint: disable=W0707
+            raise NotImplementedError(
                 f"No registered schema for operator {op_type!r} "
                 f"and domain {domain!r}. Did you recompile the sources after updating the repository?"
             ) from None

--- a/onnx/reference/ops/aionnx_preview_training/_op_list.py
+++ b/onnx/reference/ops/aionnx_preview_training/_op_list.py
@@ -1,12 +1,11 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=C0415,R0912,W0611,W0603
+
 
 import textwrap
-from typing import Any, Dict
+from typing import Any, Dict, Union
 from typing import Optional as TOptional
-from typing import Union
 
 from onnx.reference.op_run import OpFunction
 from onnx.reference.ops._helpers import build_registered_operators_any_domain

--- a/onnx/reference/ops/aionnx_preview_training/_op_list.py
+++ b/onnx/reference/ops/aionnx_preview_training/_op_list.py
@@ -4,8 +4,9 @@
 
 
 import textwrap
-from typing import Any, Dict, Union
+from typing import Any, Dict
 from typing import Optional as TOptional
+from typing import Union
 
 from onnx.reference.op_run import OpFunction
 from onnx.reference.ops._helpers import build_registered_operators_any_domain
@@ -31,7 +32,7 @@ def load_op(
     :param custom: custom implementation (like a function)
     :return: class
     """
-    global _registered_operators
+    global _registered_operators  # noqa: PLW0603
     if _registered_operators is None:
         _registered_operators = _build_registered_operators()  # type: ignore[assignment]
     if custom is not None:

--- a/onnx/reference/ops/aionnx_preview_training/_op_run_training.py
+++ b/onnx/reference/ops/aionnx_preview_training/_op_run_training.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
+
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/aionnx_preview_training/op_adagrad.py
+++ b/onnx/reference/ops/aionnx_preview_training/op_adagrad.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/aionnx_preview_training/op_adam.py
+++ b/onnx/reference/ops/aionnx_preview_training/op_adam.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/aionnx_preview_training/op_momentum.py
+++ b/onnx/reference/ops/aionnx_preview_training/op_momentum.py
@@ -1,7 +1,6 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221
 
 from onnx.reference.ops.aionnx_preview_training._op_run_training import OpRunTraining
 

--- a/onnx/reference/ops/aionnxml/_common_classifier.py
+++ b/onnx/reference/ops/aionnxml/_common_classifier.py
@@ -18,7 +18,7 @@ def compute_softmax_zero(values: np.ndarray) -> np.ndarray:
     v_max = values.max()
     exp_neg_v_max = np.exp(-v_max)
     s = 0
-    for i in range(len(values)):  # pylint: disable=C0200
+    for i in range(len(values)):
         v = values[i]
         if v > 0.0000001 or v < -0.0000001:
             values[i] = np.exp(v - v_max)

--- a/onnx/reference/ops/aionnxml/_op_list.py
+++ b/onnx/reference/ops/aionnxml/_op_list.py
@@ -5,8 +5,9 @@
 # probabilites not consumed by any operator.
 
 import textwrap
-from typing import Any, Dict, Union
+from typing import Any, Dict
 from typing import Optional as TOptional
+from typing import Union
 
 from onnx.reference.op_run import OpFunction
 from onnx.reference.ops._helpers import build_registered_operators_any_domain
@@ -46,7 +47,7 @@ def load_op(
     :param custom: custom implementation (like a function)
     :return: class
     """
-    global _registered_operators
+    global _registered_operators  # noqa: PLW0603
     if _registered_operators is None:
         _registered_operators = _build_registered_operators()  # type: ignore[assignment]
     if custom is not None:

--- a/onnx/reference/ops/aionnxml/_op_list.py
+++ b/onnx/reference/ops/aionnxml/_op_list.py
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=C0415,R0912,W0611,W0603
+
 # Operator ZipMap is not implemented. Its use should
 # be discouraged. It is just a different way to output
 # probabilites not consumed by any operator.
 
 import textwrap
-from typing import Any, Dict
+from typing import Any, Dict, Union
 from typing import Optional as TOptional
-from typing import Union
 
 from onnx.reference.op_run import OpFunction
 from onnx.reference.ops._helpers import build_registered_operators_any_domain

--- a/onnx/reference/ops/aionnxml/_op_run_aionnxml.py
+++ b/onnx/reference/ops/aionnxml/_op_run_aionnxml.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
+
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/aionnxml/op_array_feature_extractor.py
+++ b/onnx/reference/ops/aionnxml/op_array_feature_extractor.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221
+
 
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl
 

--- a/onnx/reference/ops/aionnxml/op_binarizer.py
+++ b/onnx/reference/ops/aionnxml/op_binarizer.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221
+
 
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl
 

--- a/onnx/reference/ops/aionnxml/op_dict_vectorizer.py
+++ b/onnx/reference/ops/aionnxml/op_dict_vectorizer.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/aionnxml/op_feature_vectorizer.py
+++ b/onnx/reference/ops/aionnxml/op_feature_vectorizer.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/aionnxml/op_imputer.py
+++ b/onnx/reference/ops/aionnxml/op_imputer.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/aionnxml/op_label_encoder.py
+++ b/onnx/reference/ops/aionnxml/op_label_encoder.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/aionnxml/op_linear_classifier.py
+++ b/onnx/reference/ops/aionnxml/op_linear_classifier.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,R0914,W0221
+
 
 import numpy as np
 
@@ -31,7 +31,7 @@ class LinearClassifier(OpRunAiOnnxMl):
         classlabels_strings=None,
         coefficients=None,
         intercepts=None,
-        multi_class=None,  # pylint: disable=W0613
+        multi_class=None,
         post_transform=None,
     ):
         # multi_class is unused
@@ -59,7 +59,7 @@ class LinearClassifier(OpRunAiOnnxMl):
         elif post_transform == "SOFTMAX":
             np.subtract(
                 scores,
-                scores.max(axis=1, keepdims=1),  # pylint: disable=E1123
+                scores.max(axis=1, keepdims=1),
                 out=scores,
             )
             scores = np.exp(scores)

--- a/onnx/reference/ops/aionnxml/op_linear_regressor.py
+++ b/onnx/reference/ops/aionnxml/op_linear_regressor.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/aionnxml/op_normalizer.py
+++ b/onnx/reference/ops/aionnxml/op_normalizer.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/aionnxml/op_one_hot_encoder.py
+++ b/onnx/reference/ops/aionnxml/op_one_hot_encoder.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,R0914,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/aionnxml/op_scaler.py
+++ b/onnx/reference/ops/aionnxml/op_scaler.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221
+
 
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl
 

--- a/onnx/reference/ops/aionnxml/op_svm_classifier.py
+++ b/onnx/reference/ops/aionnxml/op_svm_classifier.py
@@ -61,7 +61,7 @@ def sigmoid_probability(score, proba, probb):
     return 1 - compute_logistic(val)
 
 
-def write_scores(n_classes, scores, post_transform, add_second_class):
+def write_scores(n_classes, scores, post_transform, add_second_class):  # noqa: PLR0911
     if n_classes >= 2:
         if post_transform == "PROBIT":
             res = [compute_probit(score) for score in scores]

--- a/onnx/reference/ops/aionnxml/op_svm_classifier.py
+++ b/onnx/reference/ops/aionnxml/op_svm_classifier.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0911,R0912,R0913,R0914,W0221
+
 
 import numpy as np
 
@@ -245,7 +245,7 @@ class SVMClassifier(OpRunAiOnnxMl):
             vectors_per_class=vectors_per_class,
         )
         # unused unless for debugging purposes
-        self._svm = svm  # pylint: disable=W0201
+        self._svm = svm
 
         vector_count_ = 0
         class_count_ = max(len(classlabels_ints or classlabels_strings or []), 1)

--- a/onnx/reference/ops/aionnxml/op_svm_helper.py
+++ b/onnx/reference/ops/aionnxml/op_svm_helper.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0911,R0913,R0914,W0221
+
 
 from typing import Any
 

--- a/onnx/reference/ops/aionnxml/op_svm_regressor.py
+++ b/onnx/reference/ops/aionnxml/op_svm_regressor.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,R0914,W0221
+
 
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl
 from onnx.reference.ops.aionnxml.op_svm_helper import SVMCommon
@@ -37,7 +37,7 @@ class SVMRegressor(OpRunAiOnnxMl):
             support_vectors=support_vectors,
         )
         # adding an attribute for debugging purpose
-        self._svm = svm  # pylint: disable=W0201
+        self._svm = svm
         res = svm.run_reg(X)
 
         if post_transform in (None, "NONE"):

--- a/onnx/reference/ops/aionnxml/op_tree_ensemble_classifier.py
+++ b/onnx/reference/ops/aionnxml/op_tree_ensemble_classifier.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,R0914,W0221
+
 
 import numpy as np
 
@@ -60,7 +60,7 @@ class TreeEnsembleClassifier(OpRunAiOnnxMl):
             class_weights_as_tensor=class_weights_as_tensor,
         )
         # unused unless for debugging purposes
-        self._tree = tr  # pylint: disable=W0201
+        self._tree = tr
         if X.dtype not in (np.float32, np.float64):
             X = X.astype(np.float32)
         leaves_index = tr.leave_index_tree(X)

--- a/onnx/reference/ops/aionnxml/op_tree_ensemble_helper.py
+++ b/onnx/reference/ops/aionnxml/op_tree_ensemble_helper.py
@@ -29,7 +29,7 @@ class TreeEnsembleAttributes:
         rows = ["Attributes"]
         for name in self._names:
             if name.endswith("_as_tensor"):
-                name = name.replace("_as_tensor", "")
+                name = name.replace("_as_tensor", "")  # noqa: PLW2901
             rows.append(f"  {name}={getattr(self, name)}")
         return "\n".join(rows)
 

--- a/onnx/reference/ops/aionnxml/op_tree_ensemble_helper.py
+++ b/onnx/reference/ops/aionnxml/op_tree_ensemble_helper.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0911,R0913,R0914,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/aionnxml/op_tree_ensemble_regressor.py
+++ b/onnx/reference/ops/aionnxml/op_tree_ensemble_regressor.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,R0914,W0221
+
 
 import numpy as np
 
@@ -58,7 +58,7 @@ class TreeEnsembleRegressor(OpRunAiOnnxMl):
             target_weights_as_tensor=target_weights_as_tensor,
         )
         # unused unless for debugging purposes
-        self._tree = tr  # pylint: disable=W0201
+        self._tree = tr
         leaves_index = tr.leave_index_tree(X)
         res = np.zeros((leaves_index.shape[0], n_targets), dtype=X.dtype)
         n_trees = len(set(tr.atts.nodes_treeids))  # type: ignore

--- a/onnx/reference/ops/experimental/_op_list.py
+++ b/onnx/reference/ops/experimental/_op_list.py
@@ -1,12 +1,11 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=C0415,R0912,W0611,W0603
+
 
 import textwrap
-from typing import Any, Dict
+from typing import Any, Dict, Union
 from typing import Optional as TOptional
-from typing import Union
 
 from onnx.reference.op_run import OpFunction
 from onnx.reference.ops._helpers import build_registered_operators_any_domain

--- a/onnx/reference/ops/experimental/_op_list.py
+++ b/onnx/reference/ops/experimental/_op_list.py
@@ -4,8 +4,9 @@
 
 
 import textwrap
-from typing import Any, Dict, Union
+from typing import Any, Dict
 from typing import Optional as TOptional
+from typing import Union
 
 from onnx.reference.op_run import OpFunction
 from onnx.reference.ops._helpers import build_registered_operators_any_domain
@@ -31,7 +32,7 @@ def load_op(
     :param custom: custom implementation (like a function)
     :return: class
     """
-    global _registered_operators
+    global _registered_operators  # noqa: PLW0603
     if _registered_operators is None:
         _registered_operators = _build_registered_operators()  # type: ignore[assignment]
     if custom is not None:

--- a/onnx/reference/ops/experimental/_op_run_experimental.py
+++ b/onnx/reference/ops/experimental/_op_run_experimental.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
+
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/experimental/op_im2col.py
+++ b/onnx/reference/ops/experimental/op_im2col.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221
+
 
 from onnx.reference.ops.experimental._op_run_experimental import OpRunExperimental
 from onnx.reference.ops_optimized.op_conv_optimized import im2col_fast

--- a/onnx/reference/ops/op_abs.py
+++ b/onnx/reference/ops/op_abs.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_acos.py
+++ b/onnx/reference/ops/op_acos.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_acosh.py
+++ b/onnx/reference/ops/op_acosh.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_add.py
+++ b/onnx/reference/ops/op_add.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_affine_grid.py
+++ b/onnx/reference/ops/op_affine_grid.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,R0914,R0915,R1702,R1716,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_and.py
+++ b/onnx/reference/ops/op_and.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_argmax.py
+++ b/onnx/reference/ops/op_argmax.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_argmin.py
+++ b/onnx/reference/ops/op_argmin.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_asin.py
+++ b/onnx/reference/ops/op_asin.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_asinh.py
+++ b/onnx/reference/ops/op_asinh.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_atan.py
+++ b/onnx/reference/ops/op_atan.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_atanh.py
+++ b/onnx/reference/ops/op_atanh.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_attribute_has_value.py
+++ b/onnx/reference/ops/op_attribute_has_value.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221,W0613
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_average_pool.py
+++ b/onnx/reference/ops/op_average_pool.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221,R0913,R0914
+
 
 from onnx.reference.ops.op_pool_common import CommonPool
 

--- a/onnx/reference/ops/op_batch_normalization.py
+++ b/onnx/reference/ops/op_batch_normalization.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221,R0913,W0613
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_bernoulli.py
+++ b/onnx/reference/ops/op_bernoulli.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 from onnx.helper import np_dtype_to_tensor_dtype
 from onnx.reference.ops._op_common_random import _CommonRandom

--- a/onnx/reference/ops/op_bitshift.py
+++ b/onnx/reference/ops/op_bitshift.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_bitwise_and.py
+++ b/onnx/reference/ops/op_bitwise_and.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_bitwise_not.py
+++ b/onnx/reference/ops/op_bitwise_not.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_bitwise_or.py
+++ b/onnx/reference/ops/op_bitwise_or.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_bitwise_xor.py
+++ b/onnx/reference/ops/op_bitwise_xor.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_blackman_window.py
+++ b/onnx/reference/ops/op_blackman_window.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-
 import numpy as np
 
 from onnx.reference.ops._op_common_window import _CommonWindow

--- a/onnx/reference/ops/op_blackman_window.py
+++ b/onnx/reference/ops/op_blackman_window.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 
 import numpy as np

--- a/onnx/reference/ops/op_cast.py
+++ b/onnx/reference/ops/op_cast.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_cast.py
+++ b/onnx/reference/ops/op_cast.py
@@ -27,7 +27,7 @@ from onnx.reference.custom_element_types import (
 from onnx.reference.op_run import OpRun
 
 
-def cast_to(x, to, saturate):
+def cast_to(x, to, saturate):  # noqa: PLR0911
     if x.dtype == bfloat16 and x.dtype.descr[0][0] == "bfloat16":
         if to == TensorProto.BFLOAT16:
             return x

--- a/onnx/reference/ops/op_cast_like.py
+++ b/onnx/reference/ops/op_cast_like.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 from onnx.helper import np_dtype_to_tensor_dtype
 from onnx.onnx_pb import TensorProto

--- a/onnx/reference/ops/op_ceil.py
+++ b/onnx/reference/ops/op_ceil.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_celu.py
+++ b/onnx/reference/ops/op_celu.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_center_crop_pad.py
+++ b/onnx/reference/ops/op_center_crop_pad.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0914,R1702,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_clip.py
+++ b/onnx/reference/ops/op_clip.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0622,W0622,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_col2im.py
+++ b/onnx/reference/ops/op_col2im.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_compress.py
+++ b/onnx/reference/ops/op_compress.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_concat.py
+++ b/onnx/reference/ops/op_concat.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_concat_from_sequence.py
+++ b/onnx/reference/ops/op_concat_from_sequence.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 from typing import Any, List
 

--- a/onnx/reference/ops/op_constant.py
+++ b/onnx/reference/ops/op_constant.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_constant_of_shape.py
+++ b/onnx/reference/ops/op_constant_of_shape.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_conv.py
+++ b/onnx/reference/ops/op_conv.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,R0914,R0915,R1702,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_conv_integer.py
+++ b/onnx/reference/ops/op_conv_integer.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_conv_transpose.py
+++ b/onnx/reference/ops/op_conv_transpose.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,R0914,R0915,R1702,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_cos.py
+++ b/onnx/reference/ops/op_cos.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_cosh.py
+++ b/onnx/reference/ops/op_cosh.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_cum_sum.py
+++ b/onnx/reference/ops/op_cum_sum.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_deform_conv.py
+++ b/onnx/reference/ops/op_deform_conv.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,R0914,R0915,R1702,W0221
+
 
 import numpy as np
 
@@ -51,7 +51,7 @@ def _deform_conv_implementation(  # type: ignore
         mask = np.ones((n, offset_group * np.prod(kernel_shape), *output_shape))
     mask = mask.reshape((n, offset_group, *kernel_shape, *output_shape))
 
-    # pylint: disable=import-outside-toplevel
+
     from onnx.reference.ops._op_list import GridSample
 
     if len(X.shape) == 4:

--- a/onnx/reference/ops/op_deform_conv.py
+++ b/onnx/reference/ops/op_deform_conv.py
@@ -51,7 +51,6 @@ def _deform_conv_implementation(  # type: ignore
         mask = np.ones((n, offset_group * np.prod(kernel_shape), *output_shape))
     mask = mask.reshape((n, offset_group, *kernel_shape, *output_shape))
 
-
     from onnx.reference.ops._op_list import GridSample
 
     if len(X.shape) == 4:

--- a/onnx/reference/ops/op_depth_to_space.py
+++ b/onnx/reference/ops/op_depth_to_space.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_dequantize_linear.py
+++ b/onnx/reference/ops/op_dequantize_linear.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 from typing import Optional, Tuple
 

--- a/onnx/reference/ops/op_det.py
+++ b/onnx/reference/ops/op_det.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_dft.py
+++ b/onnx/reference/ops/op_dft.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
+
 
 from typing import Sequence
 

--- a/onnx/reference/ops/op_div.py
+++ b/onnx/reference/ops/op_div.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_dropout.py
+++ b/onnx/reference/ops/op_dropout.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 from typing import Optional, Tuple
 

--- a/onnx/reference/ops/op_dynamic_quantize_linear.py
+++ b/onnx/reference/ops/op_dynamic_quantize_linear.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_einsum.py
+++ b/onnx/reference/ops/op_einsum.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=E0203,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_elu.py
+++ b/onnx/reference/ops/op_elu.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_equal.py
+++ b/onnx/reference/ops/op_equal.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_erf.py
+++ b/onnx/reference/ops/op_erf.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 from math import erf
 

--- a/onnx/reference/ops/op_exp.py
+++ b/onnx/reference/ops/op_exp.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_expand.py
+++ b/onnx/reference/ops/op_expand.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_eyelike.py
+++ b/onnx/reference/ops/op_eyelike.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_flatten.py
+++ b/onnx/reference/ops/op_flatten.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_floor.py
+++ b/onnx/reference/ops/op_floor.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_gather.py
+++ b/onnx/reference/ops/op_gather.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_gather_elements.py
+++ b/onnx/reference/ops/op_gather_elements.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_gathernd.py
+++ b/onnx/reference/ops/op_gathernd.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 from typing import Tuple
 

--- a/onnx/reference/ops/op_gemm.py
+++ b/onnx/reference/ops/op_gemm.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_global_average_pool.py
+++ b/onnx/reference/ops/op_global_average_pool.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_global_max_pool.py
+++ b/onnx/reference/ops/op_global_max_pool.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_greater.py
+++ b/onnx/reference/ops/op_greater.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_greater_or_equal.py
+++ b/onnx/reference/ops/op_greater_or_equal.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_grid_sample.py
+++ b/onnx/reference/ops/op_grid_sample.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,R0914,R0915,R1702,R1716,W0221
+
 
 import numbers
 from typing import List

--- a/onnx/reference/ops/op_gru.py
+++ b/onnx/reference/ops/op_gru.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221,W0613
+
 
 import numpy as np
 
@@ -38,7 +38,7 @@ class CommonGRU(OpRun):
         H_t = H_0
         for x in np.split(X, X.shape[0], axis=0):
             gates = np.dot(x, gates_w) + np.dot(H_t, gates_r) + gates_b
-            z, r = np.split(gates, 2, -1)  # pylint: disable=W0632
+            z, r = np.split(gates, 2, -1)
             z = self.f(z)
             r = self.f(r)
             h_default = self.g(

--- a/onnx/reference/ops/op_hamming_window.py
+++ b/onnx/reference/ops/op_hamming_window.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_hann_window.py
+++ b/onnx/reference/ops/op_hann_window.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_hard_sigmoid.py
+++ b/onnx/reference/ops/op_hard_sigmoid.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_hardmax.py
+++ b/onnx/reference/ops/op_hardmax.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_identity.py
+++ b/onnx/reference/ops/op_identity.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 from onnx.reference.ops._op import OpRunUnaryNum
 

--- a/onnx/reference/ops/op_if.py
+++ b/onnx/reference/ops/op_if.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221,W0613
+
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/op_image_decoder.py
+++ b/onnx/reference/ops/op_image_decoder.py
@@ -14,7 +14,7 @@ from onnx.reference.op_run import OpRun
 class ImageDecoder(OpRun):
     def _run(self, encoded: np.ndarray, pixel_format="RGB") -> tuple[np.ndarray]:  # type: ignore
         try:
-            import PIL.Image  # pylint: disable=import-outside-toplevel
+            import PIL.Image
         except ImportError as e:
             raise ImportError(
                 "Pillow must be installed to use the reference implementation of the ImageDecoder operator"

--- a/onnx/reference/ops/op_instance_normalization.py
+++ b/onnx/reference/ops/op_instance_normalization.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_isinf.py
+++ b/onnx/reference/ops/op_isinf.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_isnan.py
+++ b/onnx/reference/ops/op_isnan.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_layer_normalization.py
+++ b/onnx/reference/ops/op_layer_normalization.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221
+
 
 from typing import Tuple
 

--- a/onnx/reference/ops/op_leaky_relu.py
+++ b/onnx/reference/ops/op_leaky_relu.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_less.py
+++ b/onnx/reference/ops/op_less.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_less_or_equal.py
+++ b/onnx/reference/ops/op_less_or_equal.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_log.py
+++ b/onnx/reference/ops/op_log.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_log_softmax.py
+++ b/onnx/reference/ops/op_log_softmax.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_loop.py
+++ b/onnx/reference/ops/op_loop.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0914,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_lp_normalization.py
+++ b/onnx/reference/ops/op_lp_normalization.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_lp_pool.py
+++ b/onnx/reference/ops/op_lp_pool.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221,R0913,R0914
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_lrn.py
+++ b/onnx/reference/ops/op_lrn.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
+
 
 import math
 

--- a/onnx/reference/ops/op_lstm.py
+++ b/onnx/reference/ops/op_lstm.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221,W0613
+
 
 from typing import Tuple
 

--- a/onnx/reference/ops/op_matmul.py
+++ b/onnx/reference/ops/op_matmul.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_matmul_integer.py
+++ b/onnx/reference/ops/op_matmul_integer.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_max.py
+++ b/onnx/reference/ops/op_max.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_max_pool.py
+++ b/onnx/reference/ops/op_max_pool.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=C0200,R0912,R0913,R0914,R0915,R0916,R1702,W0221
+
 
 import numpy as np
 
@@ -177,12 +177,12 @@ class MaxPool(CommonPool):
     def _max_pool_1d(  # type: ignore
         self,
         x,
-        auto_pad,  # pylint: disable=W0613
-        ceil_mode,  # pylint: disable=W0613
+        auto_pad,
+        ceil_mode,
         dilations,
         kernel_shape,
         new_pads,
-        storage_order,  # pylint: disable=W0613
+        storage_order,
         strides,
         output_spatial_shape,
     ):
@@ -233,8 +233,8 @@ class MaxPool(CommonPool):
     def _max_pool_2d(  # type: ignore
         self,
         x,
-        auto_pad,  # pylint: disable=W0613
-        ceil_mode,  # pylint: disable=W0613
+        auto_pad,
+        ceil_mode,
         dilations,
         kernel_shape,
         new_pads,
@@ -310,8 +310,8 @@ class MaxPool(CommonPool):
     def _max_pool_3d(  # type: ignore
         self,
         x,
-        auto_pad,  # pylint: disable=W0613
-        ceil_mode,  # pylint: disable=W0613
+        auto_pad,
+        ceil_mode,
         dilations,
         kernel_shape,
         new_pads,

--- a/onnx/reference/ops/op_max_unpool.py
+++ b/onnx/reference/ops/op_max_unpool.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=C0200,R0913,R0914,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_mean.py
+++ b/onnx/reference/ops/op_mean.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/op_mel_weight_matrix.py
+++ b/onnx/reference/ops/op_mel_weight_matrix.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_min.py
+++ b/onnx/reference/ops/op_min.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_mod.py
+++ b/onnx/reference/ops/op_mod.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_mul.py
+++ b/onnx/reference/ops/op_mul.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_neg.py
+++ b/onnx/reference/ops/op_neg.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_negative_log_likelihood_loss.py
+++ b/onnx/reference/ops/op_negative_log_likelihood_loss.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_non_max_suppression.py
+++ b/onnx/reference/ops/op_non_max_suppression.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0902,R0911,R0912,R0913,R0914,W0221
+
 
 import dataclasses
 from typing import Optional, Tuple

--- a/onnx/reference/ops/op_non_max_suppression.py
+++ b/onnx/reference/ops/op_non_max_suppression.py
@@ -42,7 +42,7 @@ def max_min(lhs: float, rhs: float) -> Tuple[float, float]:
     return lhs, rhs
 
 
-def suppress_by_iou(
+def suppress_by_iou(  # noqa: PLR0911
     boxes_data: np.ndarray,
     box_index1: int,
     box_index2: int,

--- a/onnx/reference/ops/op_non_zero.py
+++ b/onnx/reference/ops/op_non_zero.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_not.py
+++ b/onnx/reference/ops/op_not.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_one_hot.py
+++ b/onnx/reference/ops/op_one_hot.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_optional.py
+++ b/onnx/reference/ops/op_optional.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221,W0622
+
 
 from onnx.helper import tensor_dtype_to_np_dtype
 from onnx.reference.op_run import OpRun

--- a/onnx/reference/ops/op_optional_get_element.py
+++ b/onnx/reference/ops/op_optional_get_element.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/op_optional_has_element.py
+++ b/onnx/reference/ops/op_optional_has_element.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_or.py
+++ b/onnx/reference/ops/op_or.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_pad.py
+++ b/onnx/reference/ops/op_pad.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_pool_common.py
+++ b/onnx/reference/ops/op_pool_common.py
@@ -130,7 +130,7 @@ def get_output_shape_auto_pad(
     """
     strides_spatial = strides_spatial or [1] * len(input_spatial_shape)
     out_shape = [0] * len(input_spatial_shape)
-    for i in range(  # pylint: disable=consider-using-enumerate
+    for i in range(
         len(input_spatial_shape)
     ):
         if auto_pad in ("SAME_UPPER", "SAME_LOWER"):
@@ -257,7 +257,7 @@ def pool(
 
 
 class CommonPool(OpRun):
-    def _run(  # pylint: disable=arguments-differ
+    def _run(
         self,
         pooling_type,
         count_include_pad,

--- a/onnx/reference/ops/op_pool_common.py
+++ b/onnx/reference/ops/op_pool_common.py
@@ -130,9 +130,7 @@ def get_output_shape_auto_pad(
     """
     strides_spatial = strides_spatial or [1] * len(input_spatial_shape)
     out_shape = [0] * len(input_spatial_shape)
-    for i in range(
-        len(input_spatial_shape)
-    ):
+    for i in range(len(input_spatial_shape)):
         if auto_pad in ("SAME_UPPER", "SAME_LOWER"):
             out_shape[i] = (
                 math.floor((input_spatial_shape[i] - 1) / strides_spatial[i]) + 1

--- a/onnx/reference/ops/op_pow.py
+++ b/onnx/reference/ops/op_pow.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 from warnings import catch_warnings, simplefilter
 

--- a/onnx/reference/ops/op_prelu.py
+++ b/onnx/reference/ops/op_prelu.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_qlinear_conv.py
+++ b/onnx/reference/ops/op_qlinear_conv.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_qlinear_matmul.py
+++ b/onnx/reference/ops/op_qlinear_matmul.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_quantize_linear.py
+++ b/onnx/reference/ops/op_quantize_linear.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 from typing import Optional, Tuple
 
@@ -47,7 +47,7 @@ class _CommonQuantizeLinear(OpRun):
             return TensorProto.FLOAT8E5M2FNUZ
         return np_dtype_to_tensor_dtype(zero_point.dtype)
 
-    def common_run(  # pylint: disable=too-many-branches
+    def common_run(
         self,
         x: np.ndarray,
         y_scale: np.ndarray,

--- a/onnx/reference/ops/op_quantize_linear.py
+++ b/onnx/reference/ops/op_quantize_linear.py
@@ -47,7 +47,7 @@ class _CommonQuantizeLinear(OpRun):
             return TensorProto.FLOAT8E5M2FNUZ
         return np_dtype_to_tensor_dtype(zero_point.dtype)
 
-    def common_run(
+    def common_run(  # noqa: PLR0911
         self,
         x: np.ndarray,
         y_scale: np.ndarray,

--- a/onnx/reference/ops/op_random_normal.py
+++ b/onnx/reference/ops/op_random_normal.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
+
 
 from onnx.reference.ops._op_common_random import _CommonRandom
 

--- a/onnx/reference/ops/op_random_normal_like.py
+++ b/onnx/reference/ops/op_random_normal_like.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
+
 
 from onnx.helper import np_dtype_to_tensor_dtype
 from onnx.reference.ops._op_common_random import _CommonRandom

--- a/onnx/reference/ops/op_random_uniform.py
+++ b/onnx/reference/ops/op_random_uniform.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
+
 
 from onnx.reference.ops._op_common_random import _CommonRandom
 

--- a/onnx/reference/ops/op_random_uniform_like.py
+++ b/onnx/reference/ops/op_random_uniform_like.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221
+
 
 from onnx.helper import np_dtype_to_tensor_dtype
 from onnx.reference.ops._op_common_random import _CommonRandom

--- a/onnx/reference/ops/op_range.py
+++ b/onnx/reference/ops/op_range.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reciprocal.py
+++ b/onnx/reference/ops/op_reciprocal.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reduce_l1.py
+++ b/onnx/reference/ops/op_reduce_l1.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reduce_l2.py
+++ b/onnx/reference/ops/op_reduce_l2.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reduce_log_sum.py
+++ b/onnx/reference/ops/op_reduce_log_sum.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reduce_log_sum_exp.py
+++ b/onnx/reference/ops/op_reduce_log_sum_exp.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reduce_max.py
+++ b/onnx/reference/ops/op_reduce_max.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=E1123,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reduce_mean.py
+++ b/onnx/reference/ops/op_reduce_mean.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reduce_min.py
+++ b/onnx/reference/ops/op_reduce_min.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=E1123,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reduce_prod.py
+++ b/onnx/reference/ops/op_reduce_prod.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reduce_sum.py
+++ b/onnx/reference/ops/op_reduce_sum.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 
@@ -9,7 +9,7 @@ from onnx.reference.ops._op import OpRunReduceNumpy
 
 
 class ReduceSum_1(OpRunReduceNumpy):
-    def _run(self, x, axes=None, keepdims=None):  # type: ignore # pylint: disable=W0221
+    def _run(self, x, axes=None, keepdims=None):  # type: ignore
         axes = tuple(axes) if axes is not None else None
         res = np.sum(x, axis=axes, keepdims=keepdims, dtype=x.dtype)
         if keepdims == 0 and not isinstance(res, np.ndarray):

--- a/onnx/reference/ops/op_reduce_sum_square.py
+++ b/onnx/reference/ops/op_reduce_sum_square.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_regex_full_match.py
+++ b/onnx/reference/ops/op_regex_full_match.py
@@ -13,7 +13,6 @@ _acceptable_str_dtypes = ("U", "O")
 class RegexFullMatch(OpRun):
     def _run(self, x, pattern=None):
         try:
-
             import re2
         except ImportError as e:
             raise ImportError(

--- a/onnx/reference/ops/op_regex_full_match.py
+++ b/onnx/reference/ops/op_regex_full_match.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,W0221
+
 
 import numpy as np
 
@@ -13,7 +13,7 @@ _acceptable_str_dtypes = ("U", "O")
 class RegexFullMatch(OpRun):
     def _run(self, x, pattern=None):
         try:
-            # pylint: disable=import-outside-toplevel`
+
             import re2
         except ImportError as e:
             raise ImportError(

--- a/onnx/reference/ops/op_relu.py
+++ b/onnx/reference/ops/op_relu.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_reshape.py
+++ b/onnx/reference/ops/op_reshape.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_resize.py
+++ b/onnx/reference/ops/op_resize.py
@@ -173,7 +173,7 @@ def _get_neighbor(x: float, n: int, data: np.ndarray) -> tuple[np.ndarray, np.nd
     return idxes - pad_width, ret
 
 
-def _interpolate_1d_with_x(  # pylint: disable=too-many-branches
+def _interpolate_1d_with_x(
     data: np.ndarray,
     scale_factor: float,
     output_width_int: int,
@@ -301,7 +301,7 @@ def _get_all_coords(data: np.ndarray) -> np.ndarray:
     )
 
 
-def _interpolate_nd(  # pylint: disable=too-many-branches
+def _interpolate_nd(
     data: np.ndarray,
     get_coeffs: Callable[[float, float], np.ndarray],
     output_size: list[int] | None = None,
@@ -386,7 +386,7 @@ def _interpolate_nd(  # pylint: disable=too-many-branches
 
 
 class Resize(OpRun):
-    def _run(  # type: ignore  # pylint: disable=arguments-differ
+    def _run(  # type: ignore
         self,
         X,
         roi,

--- a/onnx/reference/ops/op_reverse_sequence.py
+++ b/onnx/reference/ops/op_reverse_sequence.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=C0123,R0912,R0913,R0914,W0221
+
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/op_rnn.py
+++ b/onnx/reference/ops/op_rnn.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,W0221,W0613
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_roi_align.py
+++ b/onnx/reference/ops/op_roi_align.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0902,R0912,R0913,R0914,R0915,R1702,W0221
+
 
 from typing import Tuple
 

--- a/onnx/reference/ops/op_round.py
+++ b/onnx/reference/ops/op_round.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_scan.py
+++ b/onnx/reference/ops/op_scan.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0914,W0221,W0613
+
 
 import numpy as np
 
@@ -102,11 +102,11 @@ class Scan(OpRun):
         # TODO: support overridden attributes.
         (
             num_loop_state_vars,
-            num_scan_outputs,  # pylint: disable=W0612
-            output_directions,  # pylint: disable=W0612
-            max_dir_out,  # pylint: disable=W0612
-            output_axes,  # pylint: disable=W0612
-            max_axe_out,  # pylint: disable=W0612
+            num_scan_outputs,
+            output_directions,
+            max_dir_out,
+            output_axes,
+            max_axe_out,
             state_names_in,
             state_names_out,
             scan_names_in,

--- a/onnx/reference/ops/op_scatter_elements.py
+++ b/onnx/reference/ops/op_scatter_elements.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=C3001,R0912,R0913,R0914,R0915,W0108,W0221
+
 
 import numpy as np
 
@@ -34,7 +34,7 @@ def scatter_elements(data, indices, updates, axis=0, reduction=None):  # type: i
 
     else:
 
-        def f(x, y):  # pylint: disable=unused-argument
+        def f(x, y):
             return y
 
     if axis < 0:

--- a/onnx/reference/ops/op_scatternd.py
+++ b/onnx/reference/ops/op_scatternd.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_selu.py
+++ b/onnx/reference/ops/op_selu.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_sequence_at.py
+++ b/onnx/reference/ops/op_sequence_at.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/op_sequence_construct.py
+++ b/onnx/reference/ops/op_sequence_construct.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/op_sequence_empty.py
+++ b/onnx/reference/ops/op_sequence_empty.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221,W0613
+
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/op_sequence_erase.py
+++ b/onnx/reference/ops/op_sequence_erase.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/op_sequence_insert.py
+++ b/onnx/reference/ops/op_sequence_insert.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 from typing import Any, List, Optional, Union
 

--- a/onnx/reference/ops/op_sequence_length.py
+++ b/onnx/reference/ops/op_sequence_length.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_sequence_map.py
+++ b/onnx/reference/ops/op_sequence_map.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/op_shape.py
+++ b/onnx/reference/ops/op_shape.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 from typing import Optional, Tuple
 

--- a/onnx/reference/ops/op_shrink.py
+++ b/onnx/reference/ops/op_shrink.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=E1130,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_sigmoid.py
+++ b/onnx/reference/ops/op_sigmoid.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_sign.py
+++ b/onnx/reference/ops/op_sign.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_sin.py
+++ b/onnx/reference/ops/op_sin.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_sinh.py
+++ b/onnx/reference/ops/op_sinh.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_size.py
+++ b/onnx/reference/ops/op_size.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_slice.py
+++ b/onnx/reference/ops/op_slice.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,W0221
+
 
 from typing import Optional
 

--- a/onnx/reference/ops/op_slice.py
+++ b/onnx/reference/ops/op_slice.py
@@ -34,7 +34,7 @@ def _slice(
             slices = [slice(s, e) for s, e in zip(starts, ends)]
         else:
             slices = [slice(s, e, d) for s, e, d in zip(starts, ends, steps)]
-    else:
+    else:  # noqa: PLR5501
         if steps is None:
             slices = [slice(0, a) for a in data.shape]
             for s, e, a in zip(starts, ends, axes):

--- a/onnx/reference/ops/op_softmax.py
+++ b/onnx/reference/ops/op_softmax.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_softmax_cross_entropy_loss.py
+++ b/onnx/reference/ops/op_softmax_cross_entropy_loss.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,R0914,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_softplus.py
+++ b/onnx/reference/ops/op_softplus.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_softsign.py
+++ b/onnx/reference/ops/op_softsign.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_space_to_depth.py
+++ b/onnx/reference/ops/op_space_to_depth.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_split.py
+++ b/onnx/reference/ops/op_split.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/op_split_to_sequence.py
+++ b/onnx/reference/ops/op_split_to_sequence.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=C0200,W0221
+
 
 from typing import List, Optional, Tuple
 

--- a/onnx/reference/ops/op_sqrt.py
+++ b/onnx/reference/ops/op_sqrt.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 from warnings import catch_warnings, simplefilter
 

--- a/onnx/reference/ops/op_squeeze.py
+++ b/onnx/reference/ops/op_squeeze.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=E0203,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_stft.py
+++ b/onnx/reference/ops/op_stft.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,R0914,R0915,W0613,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_string_concat.py
+++ b/onnx/reference/ops/op_string_concat.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_string_normalizer.py
+++ b/onnx/reference/ops/op_string_normalizer.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,W0221
+
 
 import locale as pylocale
 import unicodedata

--- a/onnx/reference/ops/op_string_split.py
+++ b/onnx/reference/ops/op_string_split.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,W0221
+
 
 from typing import Union
 

--- a/onnx/reference/ops/op_sub.py
+++ b/onnx/reference/ops/op_sub.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_sum.py
+++ b/onnx/reference/ops/op_sum.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 from onnx.reference.op_run import OpRun
 

--- a/onnx/reference/ops/op_tan.py
+++ b/onnx/reference/ops/op_tan.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_tanh.py
+++ b/onnx/reference/ops/op_tanh.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_tfidf_vectorizer.py
+++ b/onnx/reference/ops/op_tfidf_vectorizer.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=C0200,R0902,R0912,R0913,R0914,R0915,R1716,W0611,W0612,W0613,W0221
+
 
 from enum import IntEnum
 from typing import List

--- a/onnx/reference/ops/op_thresholded_relu.py
+++ b/onnx/reference/ops/op_thresholded_relu.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_tile.py
+++ b/onnx/reference/ops/op_tile.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_topk.py
+++ b/onnx/reference/ops/op_topk.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0913,W0221,W0622
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_transpose.py
+++ b/onnx/reference/ops/op_transpose.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_trilu.py
+++ b/onnx/reference/ops/op_trilu.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_unique.py
+++ b/onnx/reference/ops/op_unique.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221,W0622
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_unsqueeze.py
+++ b/onnx/reference/ops/op_unsqueeze.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=E0203,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_upsample.py
+++ b/onnx/reference/ops/op_upsample.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221,R0913
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_where.py
+++ b/onnx/reference/ops/op_where.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops/op_xor.py
+++ b/onnx/reference/ops/op_xor.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops_optimized/op_conv_optimized.py
+++ b/onnx/reference/ops_optimized/op_conv_optimized.py
@@ -32,10 +32,8 @@ def im2col_fast(X, kernel_shape, pads, strides):
     for i in range(len(shape_out)):
         kind = _make_ind(i, kernel_shape)
         iind = _make_ind(i, shape_out) * strides[i]
-        i = np.tile(kind.ravel(), n_C).reshape(-1, 1) + iind.reshape(
-            1, -1
-        )  # noqa: PLW2901
-        indices.append(i)
+        index = np.tile(kind.ravel(), n_C).reshape(-1, 1) + iind.reshape(1, -1)
+        indices.append(index)
 
     d = np.repeat(np.arange(n_C), kernel_size).reshape(-1, 1)
 
@@ -179,7 +177,7 @@ class Conv(OpRun):
         pads=None,
         strides=None,
     ):
-        if len(X.shape) < 3:
+        if len(X.shape) < 3:  # noqa: PLR2004
             raise ValueError(
                 f"X must have at least 3 dimensions but its shape is {X.shape}."
             )

--- a/onnx/reference/ops_optimized/op_conv_optimized.py
+++ b/onnx/reference/ops_optimized/op_conv_optimized.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=R0912,R0913,R0914,R0915,R1702,W0221
+
 
 import numpy as np
 

--- a/onnx/reference/ops_optimized/op_conv_optimized.py
+++ b/onnx/reference/ops_optimized/op_conv_optimized.py
@@ -32,7 +32,9 @@ def im2col_fast(X, kernel_shape, pads, strides):
     for i in range(len(shape_out)):
         kind = _make_ind(i, kernel_shape)
         iind = _make_ind(i, shape_out) * strides[i]
-        i = np.tile(kind.ravel(), n_C).reshape(-1, 1) + iind.reshape(1, -1)
+        i = np.tile(kind.ravel(), n_C).reshape(-1, 1) + iind.reshape(
+            1, -1
+        )  # noqa: PLW2901
         indices.append(i)
 
     d = np.repeat(np.arange(n_C), kernel_size).reshape(-1, 1)

--- a/onnx/reference/reference_evaluator.py
+++ b/onnx/reference/reference_evaluator.py
@@ -1,7 +1,7 @@
 # Copyright (c) ONNX Project Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=C3001,C0415,R0902,R0912,R0913,R0914,R0915
+
 from io import BytesIO
 from typing import Any, Dict, List, Optional, Tuple, Union
 

--- a/onnx/reference/reference_evaluator.py
+++ b/onnx/reference/reference_evaluator.py
@@ -298,10 +298,10 @@ class ReferenceEvaluator:
         if isinstance(a, (str, int, float)):
             return a
         if isinstance(a, np.ndarray):
-            if self.verbose < 4:
+            if self.verbose < 4:  # noqa: PLR2004
                 return f"{a.dtype}:{a.shape} in [{a.min()}, {a.max()}]"
             elements = a.ravel().tolist()
-            if len(elements) > 5:
+            if len(elements) > 5:  # noqa: PLR2004
                 elements = elements[:5]
                 return f"{a.dtype}:{a.shape}:{','.join(map(str, elements))}..."
             return f"{a.dtype}:{a.shape}:{elements}"
@@ -416,7 +416,7 @@ class ReferenceEvaluator:
                 ) from e
             self.rt_nodes_.append(inst)
 
-    def _load_impl(
+    def _load_impl(  # noqa: PLR0911
         self, node: NodeProto, input_types: Optional[TypeProto] = None
     ) -> Any:
         """

--- a/onnx/shape_inference.py
+++ b/onnx/shape_inference.py
@@ -133,7 +133,7 @@ def infer_node_outputs(
         if key in input_sparse_data
     }
 
-    outputs = schema._infer_node_outputs(  # pylint: disable=protected-access
+    outputs = schema._infer_node_outputs(
         node.SerializeToString(),
         passed_input_types,
         passed_input_data,

--- a/onnx/test/compose_test.py
+++ b/onnx/test/compose_test.py
@@ -409,7 +409,7 @@ class TestComposeFunctions(unittest.TestCase):
         checker.check_model(m3)
 
     # FIXME: This function should be removed, as tests should not contain a copy of the tested logic.
-    def _test_add_prefix(  # pylint: disable=too-many-branches
+    def _test_add_prefix(
         self,
         rename_nodes: bool = False,
         rename_edges: bool = False,

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-
 import random
 import struct
 import unittest

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-# pylint: disable=unnecessary-lambda
+
 
 import random
 import struct
@@ -925,11 +925,11 @@ class TestAttrTypeToStr(unittest.TestCase):
         ]
     )
     def test_attr_type_to_str(self, attr_type, expected_str):
-        result = helper._attr_type_to_str(attr_type)  # pylint: disable=protected-access
+        result = helper._attr_type_to_str(attr_type)
         self.assertEqual(result, expected_str)
 
     def test_attr_type_to_str_undefined(self):
-        result = helper._attr_type_to_str(9999)  # pylint: disable=protected-access
+        result = helper._attr_type_to_str(9999)
         self.assertEqual(result, "UNDEFINED")
 
 

--- a/onnx/test/hub_test.py
+++ b/onnx/test/hub_test.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-# pylint: disable=protected-access
+
 import glob
 import os
 import unittest

--- a/onnx/test/reference_evaluator_backend_test.py
+++ b/onnx/test/reference_evaluator_backend_test.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 # type: ignore
-# pylint: disable=C0415,R0912,R0913,R0914,R0915,W0613,W0640,W0703
+
 """
 These test evaluates the python runtime (class ReferenceEvaluator) against
 all the backend tests (in onnx/backend/test/case/node) and checks
@@ -28,7 +28,7 @@ import unittest
 try:
     from packaging.version import parse as version
 except ImportError:
-    from distutils.version import (  # noqa: N813 # pylint: disable=deprecated-module
+    from distutils.version import (  # noqa: N813
         StrictVersion as version,
     )
 
@@ -536,7 +536,7 @@ class TestOnnxBackEndWithReferenceEvaluator(unittest.TestCase):
         return ReferenceEvaluator(obj, verbose=verbose)
 
     @staticmethod
-    def run_fct(obj, *inputs, verbose=0):  # pylint: disable=W0613
+    def run_fct(obj, *inputs, verbose=0):
         if hasattr(obj, "input_names"):
             input_names = obj.input_names
         elif hasattr(obj, "get_inputs"):
@@ -550,7 +550,7 @@ class TestOnnxBackEndWithReferenceEvaluator(unittest.TestCase):
                 f"Got {len(inputs)} inputs but expecting {len(obj.input_names)}."
             )
         rewrite = False
-        for i in range(len(inputs)):  # pylint: disable=C0200
+        for i in range(len(inputs)):
             if (
                 isinstance(inputs[i], np.ndarray)
                 and inputs[i].dtype == np.uint16
@@ -560,7 +560,7 @@ class TestOnnxBackEndWithReferenceEvaluator(unittest.TestCase):
         if rewrite:
             # bfloat16 does not exist for numpy.
             inputs = list(inputs)
-            for i in range(len(inputs)):  # pylint: disable=C0200
+            for i in range(len(inputs)):
                 if (
                     isinstance(inputs[i], np.ndarray)
                     and inputs[i].dtype == np.uint16

--- a/onnx/test/reference_evaluator_backend_test.py
+++ b/onnx/test/reference_evaluator_backend_test.py
@@ -114,7 +114,7 @@ def assert_allclose_string(expected, value):
         expected_float = expected.astype(np.float32)
         value_float = value.astype(np.float32)
         assert_allclose(expected_float, value_float)
-    else:
+    else:  # noqa: PLR5501
         if expected.tolist() != value.tolist():
             raise AssertionError(f"Mismatches {expected} != {value}.")
 

--- a/onnx/test/reference_evaluator_ml_test.py
+++ b/onnx/test/reference_evaluator_ml_test.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 # type: ignore
-# pylint: disable=C3001,C0302,C0415,R0904,R0913,R0914,R0915,W0221,W0707
+
 
 import unittest
 from functools import wraps
@@ -41,7 +41,7 @@ OPSETS = [make_opsetid("", TARGET_OPSET), make_opsetid("ai.onnx.ml", TARGET_OPSE
 
 def has_onnxruntime():
     try:
-        import onnxruntime  # pylint: disable=W0611
+        import onnxruntime
 
         del onnxruntime
 

--- a/onnx/test/reference_evaluator_test.py
+++ b/onnx/test/reference_evaluator_test.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 # type: ignore
-# pylint: disable=C3001,C0302,C0415,R0904,R0913,R0914,R0915,W0221,W0707
+
 """
 You can run a specific test by using the following syntax.
 
@@ -74,7 +74,7 @@ def skip_if_no_onnxruntime(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):
         try:
-            import onnxruntime  # pylint: disable=W0611
+            import onnxruntime
 
             del onnxruntime
         except ImportError:
@@ -88,7 +88,7 @@ def skip_if_no_torch(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):
         try:
-            import torch  # pylint: disable=W0611
+            import torch
 
             del torch
         except ImportError:
@@ -102,7 +102,7 @@ def skip_if_no_torchvision(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):
         try:
-            import torchvision  # pylint: disable=W0611
+            import torchvision
 
             del torchvision
         except ImportError:
@@ -2944,7 +2944,7 @@ class TestReferenceEvaluator(unittest.TestCase):
             for n in sess.rt_nodes_[0].body.rt_nodes_
             if n.__class__.__name__.startswith(reduce_op)
         ]
-        schema = cl[0]._schema  # pylint: disable=protected-access
+        schema = cl[0]._schema
         new_cl = type(reduce_op, (cl[0].__class__,), {"op_schema": schema})
         sess = ReferenceEvaluator(model, new_ops=[new_cl])
         got = sess.run(None, {"input": X})

--- a/onnx/test/test_backend_onnxruntime.py
+++ b/onnx/test/test_backend_onnxruntime.py
@@ -21,9 +21,8 @@ from onnx import ModelProto
 from onnx.backend.base import Device, DeviceType
 
 try:
-    from onnxruntime import InferenceSession
+    from onnxruntime import InferenceSession, get_available_providers
     from onnxruntime import __version__ as ort_version
-    from onnxruntime import get_available_providers
     from onnxruntime.capi.onnxruntime_pybind11_state import InvalidArgument
 except ImportError:
     # onnxruntime is not installed, all tests are skipped.
@@ -70,7 +69,7 @@ class InferenceSessionBackend(onnx.backend.base.Backend):
     providers: ClassVar[set[str]] = set(get_available_providers())
 
     @classmethod
-    def is_opset_supported(cls, model):  # pylint: disable=unused-argument
+    def is_opset_supported(cls, model):
         return True, ""
 
     @classmethod

--- a/onnx/test/test_backend_onnxruntime.py
+++ b/onnx/test/test_backend_onnxruntime.py
@@ -21,8 +21,9 @@ from onnx import ModelProto
 from onnx.backend.base import Device, DeviceType
 
 try:
-    from onnxruntime import InferenceSession, get_available_providers
+    from onnxruntime import InferenceSession
     from onnxruntime import __version__ as ort_version
+    from onnxruntime import get_available_providers
     from onnxruntime.capi.onnxruntime_pybind11_state import InvalidArgument
 except ImportError:
     # onnxruntime is not installed, all tests are skipped.

--- a/onnx/test/test_backend_reference.py
+++ b/onnx/test/test_backend_reference.py
@@ -53,7 +53,7 @@ class ReferenceEvaluatorBackendRep(onnx.backend.base.BackendRep):
 
 class ReferenceEvaluatorBackend(onnx.backend.base.Backend):
     @classmethod
-    def is_opset_supported(cls, model):  # pylint: disable=unused-argument
+    def is_opset_supported(cls, model):
         return True, ""
 
     @classmethod

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -35,7 +35,7 @@ class TestLoadExternalDataBase(unittest.TestCase):
 
     def setUp(self) -> None:
         self._temp_dir_obj = (
-            tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+            tempfile.TemporaryDirectory()
         )
         self.temp_dir: str = self._temp_dir_obj.name
         self.initializer_value = np.arange(6).reshape(3, 2).astype(np.float32) + 512
@@ -218,7 +218,7 @@ class TestSaveAllTensorsAsExternalData(unittest.TestCase):
 
     def setUp(self) -> None:
         self._temp_dir_obj = (
-            tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+            tempfile.TemporaryDirectory()
         )
         self.temp_dir: str = self._temp_dir_obj.name
         self.initializer_value = np.arange(6).reshape(3, 2).astype(np.float32) + 512
@@ -522,7 +522,7 @@ class TestExternalDataToArray(unittest.TestCase):
 
     def setUp(self) -> None:
         self._temp_dir_obj = (
-            tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+            tempfile.TemporaryDirectory()
         )
         self.temp_dir: str = self._temp_dir_obj.name
         self._model_file_path: str = os.path.join(self.temp_dir, "model.onnx")

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -34,9 +34,7 @@ class TestLoadExternalDataBase(unittest.TestCase):
     serialization_format: str = "protobuf"
 
     def setUp(self) -> None:
-        self._temp_dir_obj = (
-            tempfile.TemporaryDirectory()
-        )
+        self._temp_dir_obj = tempfile.TemporaryDirectory()
         self.temp_dir: str = self._temp_dir_obj.name
         self.initializer_value = np.arange(6).reshape(3, 2).astype(np.float32) + 512
         self.attribute_value = np.arange(6).reshape(2, 3).astype(np.float32) + 256
@@ -217,9 +215,7 @@ class TestSaveAllTensorsAsExternalData(unittest.TestCase):
     serialization_format: str = "protobuf"
 
     def setUp(self) -> None:
-        self._temp_dir_obj = (
-            tempfile.TemporaryDirectory()
-        )
+        self._temp_dir_obj = tempfile.TemporaryDirectory()
         self.temp_dir: str = self._temp_dir_obj.name
         self.initializer_value = np.arange(6).reshape(3, 2).astype(np.float32) + 512
         self.attribute_value = np.arange(6).reshape(2, 3).astype(np.float32) + 256
@@ -521,9 +517,7 @@ class TestExternalDataToArray(unittest.TestCase):
     serialization_format: str = "protobuf"
 
     def setUp(self) -> None:
-        self._temp_dir_obj = (
-            tempfile.TemporaryDirectory()
-        )
+        self._temp_dir_obj = tempfile.TemporaryDirectory()
         self.temp_dir: str = self._temp_dir_obj.name
         self._model_file_path: str = os.path.join(self.temp_dir, "model.onnx")
         self.large_data = np.random.rand(10, 60, 100).astype(np.float32)

--- a/onnx/test/test_with_ort.py
+++ b/onnx/test/test_with_ort.py
@@ -3,14 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # This file is for testing ONNX with ONNX Runtime
 # Create a general scenario to use ONNX Runtime with ONNX
-# pylint: disable=C0415
+
 import unittest
 
 
 class TestONNXRuntime(unittest.TestCase):
     def test_with_ort_example(self) -> None:
         try:
-            import onnxruntime  # pylint: disable=W0611
+            import onnxruntime
 
             del onnxruntime
         except ImportError:

--- a/onnx/tools/replace_constants.py
+++ b/onnx/tools/replace_constants.py
@@ -1,7 +1,6 @@
 # Copyright (c) ONNX Project Contributors
 
 # SPDX-License-Identifier: Apache-2.0
-# pylint: disable=too-many-statements,too-many-branches
 from typing import List, Optional, Union
 
 import numpy as np
@@ -311,9 +310,9 @@ def replace_initializer_by_constant_of_shape(
             values = {p.key: p.value for p in onx.metadata_props}
             set_model_props(model, values)
 
-        del model.opset_import[:]  # pylint: disable=E1101
+        del model.opset_import[:]
         for oimp in onx.opset_import:
-            op_set = model.opset_import.add()  # pylint: disable=E1101
+            op_set = model.opset_import.add()
             if oimp.domain == "" and oimp.version < 11 and use_range:
                 raise RuntimeError(
                     f"Range was introduced in opset 11 but opset is {oimp.version}."

--- a/onnx/tools/replace_constants.py
+++ b/onnx/tools/replace_constants.py
@@ -397,7 +397,7 @@ def replace_initializer_by_constant_of_shape(
                 )
                 if id(g) != id(att.g):
                     modified = True
-                    att = make_attribute(att.name, g)
+                    att = make_attribute(att.name, g)  # noqa: PLW2901
             atts.append(att)
         if modified:
             new_node = make_node(node.op_type, node.input, node.output)

--- a/onnx/tools/replace_constants.py
+++ b/onnx/tools/replace_constants.py
@@ -219,7 +219,7 @@ def _replace_constant_of_shape_value(
     raise TypeError(f"Not implemented for type {type(onx)}.")
 
 
-def replace_initializer_by_constant_of_shape(
+def replace_initializer_by_constant_of_shape(  # noqa: PLR0911
     onx: Union[FunctionProto, GraphProto, ModelProto],
     threshold: int = 128,
     ir_version: Optional[int] = None,
@@ -251,7 +251,7 @@ def replace_initializer_by_constant_of_shape(
         for node in onx.node:
             if node.op_type == "Constant":
                 cst_nodes = _replace_constant(node, threshold, value_constant_of_shape)
-                if len(cst_nodes) == 2:
+                if len(cst_nodes) == 2:  # noqa: PLR2004
                     modified = True
                 new_nodes.extend(cst_nodes)
                 continue
@@ -313,11 +313,11 @@ def replace_initializer_by_constant_of_shape(
         del model.opset_import[:]
         for oimp in onx.opset_import:
             op_set = model.opset_import.add()
-            if oimp.domain == "" and oimp.version < 11 and use_range:
+            if oimp.domain == "" and oimp.version < 11 and use_range:  # noqa: PLR2004
                 raise RuntimeError(
                     f"Range was introduced in opset 11 but opset is {oimp.version}."
                 )
-            if oimp.domain == "" and oimp.version < 9:
+            if oimp.domain == "" and oimp.version < 9:  # noqa: PLR2004
                 raise RuntimeError(
                     f"ConstantOfShape was introduced in "
                     f"opset 9 but opset is {oimp.version}."
@@ -355,7 +355,7 @@ def replace_initializer_by_constant_of_shape(
         )
         new_nodes.append(node)
         removed.add(init.name)
-        if ir_version is not None and ir_version <= 3:
+        if ir_version is not None and ir_version <= 3:  # noqa: PLR2004
             additional_inputs.append(
                 make_tensor_value_info(new_name, TensorProto.INT64, [len(dims)])
             )
@@ -376,7 +376,7 @@ def replace_initializer_by_constant_of_shape(
     for node in onx.node:
         if node.op_type == "Constant":
             shape_nodes = _replace_constant(node, threshold, value_constant_of_shape)
-            if len(shape_nodes) == 2:
+            if len(shape_nodes) == 2:  # noqa: PLR2004
                 n_modifications += 1
             new_nodes.extend(shape_nodes)
             continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,9 @@ select = [
     "ISC", # flake8-implicit-str-concat
     "N", # pep8-naming
     "NPY", # modern numpy
+    "PLC", # pylint
+    "PLE", # pylint
+    "PLW", # pylint
     "RUF", # Ruff-specific rules
     "SIM", # flake8-simplify
     "TID252", # Relative imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,9 +123,7 @@ select = [
     "ISC", # flake8-implicit-str-concat
     "N", # pep8-naming
     "NPY", # modern numpy
-    "PLC", # pylint
-    "PLE", # pylint
-    "PLW", # pylint
+    "PL", # pylint
     "RUF", # Ruff-specific rules
     "SIM", # flake8-simplify
     "TID252", # Relative imports
@@ -141,6 +139,9 @@ ignore = [
     "N806", # Relax: Variable name in function should be lowercase
     "N999", # Module names
     "NPY002", # np.random.Generator may not be preferred in all cases
+    "PLR0912", # Too many branches
+    "PLR0913", # Too many arguments to function call
+    "PLR0915", # Too many statements
     "RUF015", # next(iter(...)) sometimes obscures the intent when we access the 0th element of a shape
     "SIM102", # We don't perfer always combining if branches
     "SIM108", # We don't encourage ternary operators
@@ -161,8 +162,12 @@ ban-relative-imports = "all"
 # Prefer inline ignores with `noqa: xxx`.
 # Eventually this list should become empty.
 "**/*_test*" = ["N802"] # Function casing
+"onnx/backend/test/**" = ["PLR2004"] # Magic numbers allowed in tests
 "onnx/backend/test/case/**" = ["N802"] # Function casing
-"onnx/reference/ops/**" = ["N801"] # Class casing
+"onnx/reference/ops/**" = [
+    "N801", # Class casing
+    "PLR2004", # Magic numbers
+]
 "onnx/reference/ops/_op_list.py" = ["F401"]
 "onnx/__init__.py" = ["F401"]
 "onnx/reference/__init__.py" = ["F401"]
@@ -173,4 +178,5 @@ ban-relative-imports = "all"
 "onnx/reference/ops/aionnx_preview_training/_op_list.py" = ["F401"]
 "onnx/reference/ops/experimental/__init__.py" = ["F401"]
 "onnx/test/reference_evaluator_test.py"= ["C408"]  # dict(...) -> { ... }
+"onnx/test/**" = ["PLR2004"] # Magic numbers allowed in tests
 "onnx/onnx_cpp2py_export/defs.pyi" = ["N802"]

--- a/requirements-lintrunner.txt
+++ b/requirements-lintrunner.txt
@@ -1,7 +1,7 @@
 # This file is auto updated by dependabot
 lintrunner-adapters>=0.8.0
-# RUFF, RUFF-FIX
-ruff==0.0.286
+# RUFF
+ruff==0.0.289
 # MYPY
 mypy==1.5.1
 types-protobuf==4.24.0.1
@@ -10,7 +10,5 @@ black==23.7.0
 isort==5.12.0
 # CLANG-FORMAT
 clang-format==16.0.6
-# PYLINT
-pylint==2.17.5
 # EDITORCONFIG-CHECKER
 editorconfig-checker==2.7.2

--- a/setup.py
+++ b/setup.py
@@ -193,7 +193,7 @@ class CmakeBuild(setuptools.Command):
                         cmake_args.extend(["-A", "ARM64"])
                     else:
                         cmake_args.extend(["-A", "x64", "-T", "host=x64"])
-                else:
+                else:  # noqa: PLR5501
                     if "arm" in platform.machine().lower():
                         cmake_args.extend(["-A", "ARM"])
                     else:

--- a/tools/protoc-gen-mypy.py
+++ b/tools/protoc-gen-mypy.py
@@ -377,7 +377,7 @@ class PkgWriter:
 
 def is_scalar(fd: d.FileDescriptorProto) -> bool:
     return not (
-        fd.type == d.FieldDescriptorProto.TYPE_MESSAGE
+        fd.type == d.FieldDescriptorProto.TYPE_MESSAGE  # noqa: PLR1714
         or fd.type == d.FieldDescriptorProto.TYPE_GROUP
     )
 

--- a/workflow_scripts/test_model_zoo.py
+++ b/workflow_scripts/test_model_zoo.py
@@ -13,6 +13,8 @@ import config
 import onnx
 from onnx import hub, version_converter
 
+MIN_SHAPE_INFERENCE_OPSET = 4
+
 
 def skip_model(error_message: str, skip_list: List[str], model_name: str):
     print(error_message)
@@ -45,7 +47,7 @@ def main():
         try:
             model = hub.load(model_name)
             # 1) Test onnx checker and shape inference
-            if model.opset_import[0].version < 4:
+            if model.opset_import[0].version < MIN_SHAPE_INFERENCE_OPSET:
                 # Ancient opset version does not have defined shape inference function
                 onnx.checker.check_model(model)
                 print(f"[PASS]: {model_name} is checked by onnx checker. ")


### PR DESCRIPTION
### Description

Remove the `pylint` linter in favor of the `PL` rules provided by ruff. This change removes all of the `pylint: disable` directives in comments and added `noqa` directives accordingly for ruff.

- Remove auto format at VS Code save: Removed because they significantly slow down file save when doing a bulk find and replace. Since we have introduced lintrunner autofix, developers can use a single command for formatting which should be easy enough.

### Motivation and Context

Ruff has implemented most of the pylint checks we care and it runs much faster.
