### PR TITLE
[Web] Use tensor_dtype_to_np_dtype instead of deprecated function

### DIFF
--- a/docs/docsgen/source/intro/python.md
+++ b/docs/docsgen/source/intro/python.md
@@ -148,7 +148,7 @@ of each object of the graph.
             node.name, node.op_type, node.input, node.output))
 ```
 
-The tensor type is an integer (= 1). The following helper function (tensor_dtype_to_np_dtype) gives the
+The tensor type is an integer (= 1). The helper function {func}`onnx.helper.tensor_dtype_to_np_dtype` gives the
 corresponding type with numpy.
 
 ```{eval-rst}

--- a/docs/docsgen/source/intro/python.md
+++ b/docs/docsgen/source/intro/python.md
@@ -159,7 +159,6 @@ corresponding type with numpy.
 
     np_dtype = tensor_dtype_to_np_dtype(TensorProto.FLOAT)
     print(f"The converted numpy dtype for {tensor_dtype_to_string(TensorProto.FLOAT)} is {np_dtype}.")
-    # print "The converted numpy dtype for TensorProto.FLOAT is float32."
 ```
 
 ## Serialization

--- a/docs/docsgen/source/intro/python.md
+++ b/docs/docsgen/source/intro/python.md
@@ -148,16 +148,18 @@ of each object of the graph.
             node.name, node.op_type, node.input, node.output))
 ```
 
-The tensor type is an integer (= 1). The following array gives the
-equivalent type with numpy.
+The tensor type is an integer (= 1). The following helper function (tensor_dtype_to_np_dtype) gives the
+corresponding type with numpy.
 
 ```{eval-rst}
 .. exec_code::
 
-    import pprint
-    from onnx.mapping import TENSOR_TYPE_TO_NP_TYPE
+    from onnx import TensorProto
+    from onnx.helper import tensor_dtype_to_np_dtype, tensor_dtype_to_string
 
-    pprint.pprint(TENSOR_TYPE_TO_NP_TYPE)
+    np_dtype = tensor_dtype_to_np_dtype(TensorProto.FLOAT)
+    print(f"The converted numpy dtype for {tensor_dtype_to_string(TensorProto.FLOAT)} is {np_dtype}.")
+    # print "The converted numpy dtype for TensorProto.FLOAT is float32."
 ```
 
 ## Serialization


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Use tensor_dtype_to_np_dtype instead of deprecated TENSOR_TYPE_TO_NP_TYPE in https://onnx.ai/onnx/intro/python.html. This is the only place I found which mentions deprecated functions from mapping.py.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/onnx/onnx/issues/5392.
