### PR TITLE
Fix sed -i error in Mac release Pipeline for onnx-weekly

### DIFF
--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -63,7 +63,7 @@ jobs:
         export NUM_CORES=`sysctl -n hw.logicalcpu`
         source workflow_scripts/protobuf/build_protobuf_unix.sh $NUM_CORES $(pwd)/protobuf/protobuf_install
         if [ '${{ github.event_name }}' == 'schedule' ]; then
-          sed -i 's/name = "onnx"/name = "onnx-weekly"/' 'pyproject.toml'
+          sed -i '' 's/name = "onnx"/name = "onnx-weekly"/' 'pyproject.toml'
           export ONNX_PREVIEW_BUILD=1
         fi
         python -m build --wheel
@@ -124,7 +124,7 @@ jobs:
       run: |
         # Build and upload source distribution to PyPI
         git clean -xdf
-        sed -i 's/name = "onnx"/name = "onnx-weekly"/' 'pyproject.toml'
+        sed -i '' 's/name = "onnx"/name = "onnx-weekly"/' 'pyproject.toml'
         ONNX_PREVIEW_BUILD=1 python -m build --sdist
         twine upload dist/* --repository-url https://upload.pypi.org/legacy/ -u ${{ secrets.ONNXWEEKLY_USERNAME }} -p ${{ secrets.ONNXWEEKLY_TOKEN }}
 


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Fix sed -i error in Mac release Pipeline for onnx-weekly.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/onnx/onnx/actions/runs/6216622822/job/16870683053. sed command on Mac is slightly different from the one on Linux: the suffix is mandatory. 