### PR TITLE
Update diff bakend node tests for auto update doc

### DIFF
--- a/.github/workflows/auto_update_doc.yml
+++ b/.github/workflows/auto_update_doc.yml
@@ -1,4 +1,4 @@
-name: Auto update documentation
+name: Auto update documentation/backend test data
 on:
   pull_request_target:
   workflow_dispatch:
@@ -32,14 +32,19 @@ jobs:
         git submodule update --init --recursive
         export ONNX_ML=1
         pip install -e .
+
         python onnx/defs/gen_doc.py
         python onnx/gen_proto.py -l
         python onnx/gen_proto.py -l --ml
         python onnx/backend/test/stat_coverage.py
+
+        python onnx/backend/test/cmd_tools.py generate-data --diff
+
         git diff -- . ':(exclude)onnx/onnx-data.proto' ':(exclude)onnx/onnx-data.proto3'
 
-    - name: Commit changes with updated documentation
+
+    - name: Commit changes with updated files
       uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # v4.16.0
       with:
-        commit_message: CI:apply auto updated documentation
+        commit_message: CI:apply auto updated documentation/backend test data
         commit_options: "--signoff"

--- a/onnx/backend/test/case/node/__init__.py
+++ b/onnx/backend/test/case/node/__init__.py
@@ -2,8 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import subprocess
 import sys
 from copy import deepcopy
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -21,8 +23,6 @@ from onnx.onnx_pb import (
     TypeProto,
 )
 
-from pathlib import Path
-import subprocess
 
 _NodeTestCases = []
 _TargetOpType = None

--- a/onnx/backend/test/case/node/__init__.py
+++ b/onnx/backend/test/case/node/__init__.py
@@ -386,20 +386,20 @@ def collect_testcases(op_type: str) -> List[TestCase]:
 def collect_diff_testcases() -> List[TestCase]:
     """Collect node test cases which are different from the main branch"""
     global _DiffOpTypes  # noqa: PLW0603
-    _DiffOpTypes = get_changed_op_types()
+    _DiffOpTypes = get_diff_op_types()
 
     import_recursive(sys.modules[__name__])
     return _NodeTestCases
 
 
-def get_changed_op_types():
+def get_diff_op_types():
     cwd_path = Path.cwd()
     # git fetch first for git diff on GitHub Action
     subprocess.run(
         ["git", "fetch", "origin", "main:main"],
         cwd=cwd_path,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
+        check=True,
     )
     # obtain list of added or modified files in this PR
     obtain_diff = subprocess.Popen(

--- a/onnx/backend/test/case/node/__init__.py
+++ b/onnx/backend/test/case/node/__init__.py
@@ -23,7 +23,6 @@ from onnx.onnx_pb import (
     TypeProto,
 )
 
-
 _NodeTestCases = []
 _TargetOpType = None
 _DiffOpTypes = None

--- a/onnx/backend/test/cmd_tools.py
+++ b/onnx/backend/test/cmd_tools.py
@@ -36,7 +36,10 @@ def generate_data(args: argparse.Namespace) -> None:
     cases = model_test.collect_testcases()
     # If op_type is specified, only include those testcases including the given operator
     # Otherwise, include all of the testcases
-    cases += node_test.collect_testcases(args.op_type)
+    if args.diff:
+        cases += node_test.collect_diff_testcases()
+    else:
+        cases += node_test.collect_testcases(args.op_type)
     node_number = 0
 
     for case in cases:
@@ -164,6 +167,13 @@ def parse_args() -> argparse.Namespace:
         "--op_type",
         default=None,
         help="op_type for test case generation. (generates test data for the specified op_type only.)",
+    )
+    subparser.add_argument(
+        "-d",
+        "--diff",
+        default=False,
+        action="store_true",
+        help="only generates test data for those changed files (compared to the main branch).",
     )
     subparser.set_defaults(func=generate_data)
 


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
- Extend `onnx/backend/test/cmd_tools.py` with a new option: "diff", which will only update the backend node test data whose script has been updated.
- Make `auto_update_doc.yml` CI utilize "--diff" and update the backend node test data accordingly.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
https://github.com/onnx/onnx/pull/5450 "auto update doc" was introduced for helping users update docs like Operators.md and TestCoverage.md. It will be also useful that the CI can help users update backend node test as well.