### PR TITLE
[CI] Move onnxruntime test from Windows to MacOS

### DIFF
--- a/.azure-pipelines/MacOS-CI.yml
+++ b/.azure-pipelines/MacOS-CI.yml
@@ -79,6 +79,16 @@ jobs:
         exit 1
       fi
 
+      python -m pip install onnxruntime
+      export ORT_MAX_IR_SUPPORTED_VERSION=8
+      export ORT_MAX_ML_OPSET_SUPPORTED_VERSION=3
+      export ORT_MAX_ONNX_OPSET_SUPPORTED_VERSION=18
+      pytest
+      if [ $? -ne 0 ]; then
+        echo "pytest failed when testing onnx with onnxruntime"
+        exit 1
+      fi
+
       # onnx c++ API tests
       export LD_LIBRARY_PATH="./.setuptools-cmake-build/:$LD_LIBRARY_PATH"
       ./.setuptools-cmake-build/onnx_gtests

--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -78,16 +78,6 @@ jobs:
         EXIT 1
       )
 
-      python -m pip install onnxruntime
-      set ORT_MAX_IR_SUPPORTED_VERSION=8
-      set ORT_MAX_ML_OPSET_SUPPORTED_VERSION=3
-      set ORT_MAX_ONNX_OPSET_SUPPORTED_VERSION=18
-      pytest
-      IF NOT %ERRORLEVEL% EQU 0 (
-        @echo "pytest failed when testing onnx with onnxruntime"
-        EXIT 1
-      )
-
       python onnx/backend/test/cmd_tools.py generate-data --clean
       git status
       git diff --exit-code -- . :!onnx/onnx-data.proto :!onnx/onnx-data.proto3 :!*output_*.pb :!*input_*.pb


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Move onnxruntime test from Windows to MacOS.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Currently Windows-CI failed, because it tested with the latest onnxruntime (1.16.0 just out yesterday) without setting the max supported versions correctly before "pytest":
https://github.com/onnx/onnx/blob/3d015412360115e989ea78c5eb75911374fd0dd0/.azure-pipelines/Windows-CI.yml#L131

To fix such failure, instead of adding more setting commands in Windows CI, I prefer to move the equivalent onnxruntime test to MacOS, because MacOS is averagely the fastest CI in onnx repo. This move can make the cost time for each AzurePipelines CI more even.
