### PR TITLE
Fix Windows weekly release CI failure

### DIFF
--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -72,7 +72,7 @@ jobs:
         if ('${{ github.event_name }}' -eq 'schedule') {
           echo "Build weekly PyPI package"
           (Get-Content -Path 'pyproject.toml') | ForEach-Object { $_ -replace 'name = "onnx"', 'name = "onnx-weekly"' } | Set-Content -Path 'pyproject.toml'
-          set ONNX_PREVIEW_BUILD=1
+          $Env:ONNX_PREVIEW_BUILD=1
         }
         python -m build --wheel
         Get-ChildItem -Path dist/*.whl | foreach {python -m pip install --upgrade $_.fullname}


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Fix Windows weekly release CI failure: use the correct env setting method in Windows GitHub Action.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Windows release CI misused the package name as onnx-weekly without dev version: https://pypi.org/project/onnx-weekly/1.15.0/#files. I will delete this wheel.