### PR TITLE
Disable non-const reference check from cpplint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,6 +48,7 @@ jobs:
           reporter: github-pr-check
           level: warning
           flags: --linelength=120
+          filter: "-runtime/references"
 
 
   enforce-style:


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Disable non-const reference check from cpplint.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Preferred coding-style: over pointers, when non-null.