### PR TITLE
Fix affineGrid doc error - output shape shall has no 'C' in it

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -23972,7 +23972,7 @@ This version of the operator has been available since version 20 of the default 
 
 <dl>
 <dt><tt>grid</tt> (differentiable) : T1</dt>
-<dd>output tensor of shape (N, C, H, W, 2) of 2D sample coordinates or (N, C, D, H, W, 3) of 3D sample coordinates.</dd>
+<dd>output tensor of shape (N, H, W, 2) of 2D sample coordinates or (N, D, H, W, 3) of 3D sample coordinates.</dd>
 </dl>
 
 #### Type Constraints

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -545,7 +545,7 @@ This version of the operator has been available since version 20 of the default 
 
 <dl>
 <dt><tt>grid</tt> (differentiable) : T1</dt>
-<dd>output tensor of shape (N, C, H, W, 2) of 2D sample coordinates or (N, C, D, H, W, 3) of 3D sample coordinates.</dd>
+<dd>output tensor of shape (N, H, W, 2) of 2D sample coordinates or (N, D, H, W, 3) of 3D sample coordinates.</dd>
 </dl>
 
 #### Type Constraints

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -2527,7 +2527,7 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Output(
             0,
             "grid",
-            "output tensor of shape (N, C, H, W, 2) of 2D sample coordinates or (N, C, D, H, W, 3) of 3D sample coordinates.",
+            "output tensor of shape (N, H, W, 2) of 2D sample coordinates or (N, D, H, W, 3) of 3D sample coordinates.",
             "T1",
             OpSchema::Single,
             true,


### PR DESCRIPTION
### Description
doc for affineGrid: output shape is in correct. See https://pytorch.org/docs/stable/generated/torch.nn.functional.affine_grid.html. It shoud be (N, H, W, 2) or (N, D, H, W, 3) 

### Motivation and Context
fix for 1.15.0 release