### PR TITLE
Update clang-format config to be more readable and modern

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,93 +1,244 @@
 ---
 Language: Cpp
-BasedOnStyle: Google
 AccessModifierOffset: -1
-AlignAfterOpenBracket: AlwaysBreak
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
+AlignAfterOpenBracket: BlockIndent
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: false
+AlignConsecutiveBitFields:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: false
+AlignConsecutiveDeclarations:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: false
+AlignConsecutiveMacros:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: false
 AlignEscapedNewlines: Left
-AlignOperands:   false
-AlignTrailingComments: false
-AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortBlocksOnASingleLine: false
+AlignOperands: DontAlign
+AlignTrailingComments:
+  Kind: Never
+  OverEmptyLines: 0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Empty
-AllowShortIfStatementsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
-AlwaysBreakTemplateDeclarations: true
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
 BinPackArguments: false
 BinPackParameters: false
+BitFieldColonSpacing: Both
 BraceWrapping:
-  AfterClass:      false
-  AfterControlStatement: false
-  AfterEnum:       false
-  AfterFunction:   false
-  AfterNamespace:  false
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterExternBlock: false
+  AfterFunction: false
+  AfterNamespace: false
   AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
-  BeforeCatch:     false
-  BeforeElse:      false
-  IndentBraces:    false
+  AfterStruct: false
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: false
+  BeforeLambdaBody: false
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAfterAttributes: Never
 BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
 BreakBeforeBraces: Attach
-BreakBeforeInheritanceComma: false
+BreakBeforeInlineASMColon: OnlyMultiline
 BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
 BreakStringLiterals: false
-ColumnLimit:     120
-CommentPragmas:  '^ IWYU pragma:'
+ColumnLimit: 120
+CommentPragmas: "^ IWYU pragma:"
 CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
-DisableFormat:   false
-ExperimentalAutoDetectBinPacking: false
+DisableFormat: false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
 FixNamespaceComments: true
 ForEachMacros:
   - FOR_EACH_RANGE
   - FOR_EACH
   - BOOST_FOREACH
-IncludeIsMainRegex: '(Test)?$'
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex: '^<ext/.*\.h>'
+    Priority: 2
+    SortPriority: 0
+    CaseSensitive: false
+  - Regex: '^<.*\.h>'
+    Priority: 1
+    SortPriority: 0
+    CaseSensitive: false
+  - Regex: "^<.*"
+    Priority: 2
+    SortPriority: 0
+    CaseSensitive: false
+  - Regex: ".*"
+    Priority: 3
+    SortPriority: 0
+    CaseSensitive: false
+IncludeIsMainRegex: "([-_](test|unittest))?$"
+IncludeIsMainSourceRegex: ""
+IndentAccessModifiers: false
+IndentCaseBlocks: false
 IndentCaseLabels: true
-IndentWidth:     2
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth: 2
 IndentWrappedFunctionNames: false
-JavaScriptQuotes: Leave
-JavaScriptWrapImports: true
+InsertBraces: false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: Wrapped
+IntegerLiteralSeparator:
+  Binary: 0
+  BinaryMinDigits: 0
+  Decimal: 0
+  DecimalMinDigits: 0
+  Hex: 0
+  HexMinDigits: 0
 KeepEmptyLinesAtTheStartOfBlocks: false
-MacroBlockBegin: ''
-MacroBlockEnd:   ''
+LambdaBodyIndentation: Signature
+LineEnding: DeriveLF
+MacroBlockBegin: ""
+MacroBlockEnd: ""
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
 ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: false
+ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: NextLine
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 1
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
 PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
-ReflowComments:  true
-SortIncludes:    true
+PPIndentWidth: -1
+QualifierAlignment: Leave
+RawStringFormats:
+  - Language: Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - "c++"
+      - "C++"
+    CanonicalDelimiter: ""
+    BasedOnStyle: google
+  - Language: TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: pb
+    BasedOnStyle: google
+ReferenceAlignment: Pointer
+ReflowComments: true
+RemoveBracesLLVM: false
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes: true
+SortJavaStaticImport: Before
+SortUsingDeclarations: LexicographicNumeric
 SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
 SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros: true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 1
-SpacesInAngles:  false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: Never
+SpacesInConditionalStatement: false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: -1
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-TabWidth:        8
-UseTab:          Never
+Standard: Auto
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth: 8
+UseTab: Never

--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -25,7 +25,7 @@
 
 #include <filesystem>
 
-#else // POSIX
+#else  // POSIX
 #include <sys/stat.h>
 #endif
 
@@ -128,7 +128,8 @@ void check_tensor(const TensorProto& tensor, const CheckerContext& ctx) {
           "Data of TensorProto ( tensor name: ",
           tensor.name(),
           ") is stored externally and should not have data field.",
-          value_field);
+          value_field
+      );
     }
 
     bool has_location = false;
@@ -142,7 +143,8 @@ void check_tensor(const TensorProto& tensor, const CheckerContext& ctx) {
               "Location of external TensorProto ( tensor name: ",
               tensor.name(),
               ") should be a relative path, but it is an absolute path: ",
-              entry.value());
+              entry.value()
+          );
         }
         auto relative_path = file_path.lexically_normal().make_preferred().wstring();
         // Check that normalized relative path contains ".." on Windows.
@@ -154,7 +156,8 @@ void check_tensor(const TensorProto& tensor, const CheckerContext& ctx) {
               ctx.get_model_dir(),
               ", but the '",
               entry.value(),
-              "' points outside the directory");
+              "' points outside the directory"
+          );
         }
         std::wstring data_path = path_join(utf8str_to_wstring(ctx.get_model_dir()), relative_path);
         struct _stat64 buff;
@@ -164,9 +167,10 @@ void check_tensor(const TensorProto& tensor, const CheckerContext& ctx) {
               tensor.name(),
               ") should be stored in ",
               entry.value(),
-              ", but it doesn't exist or is not accessible.");
+              ", but it doesn't exist or is not accessible."
+          );
         }
-#else // POSIX
+#else  // POSIX
         if (entry.value().empty()) {
           fail_check("Location of external TensorProto ( tensor name: ", tensor.name(), ") should not be empty.");
         } else if (entry.value()[0] == '/') {
@@ -174,7 +178,8 @@ void check_tensor(const TensorProto& tensor, const CheckerContext& ctx) {
               "Location of external TensorProto ( tensor name: ",
               tensor.name(),
               ") should be a relative path, but it is an absolute path: ",
-              entry.value());
+              entry.value()
+          );
         }
         std::string relative_path = clean_relative_path(entry.value());
         // Check that normalized relative path contains ".." on POSIX
@@ -186,15 +191,16 @@ void check_tensor(const TensorProto& tensor, const CheckerContext& ctx) {
               ctx.get_model_dir(),
               ", but the '",
               entry.value(),
-              "' points outside the directory");
+              "' points outside the directory"
+          );
         }
         std::string data_path = path_join(ctx.get_model_dir(), relative_path);
         // use stat64 to check whether the file exists
 #if defined(__APPLE__) || defined(__wasm__)
-        struct stat buffer; // APPLE does not have stat64
+        struct stat buffer;  // APPLE does not have stat64
         if (stat((data_path).c_str(), &buffer) != 0) {
 #else
-        struct stat64 buffer; // All POSIX except APPLE have stat64
+        struct stat64 buffer;  // All POSIX except APPLE have stat64
         if (stat64((data_path).c_str(), &buffer) != 0) {
 #endif
           fail_check(
@@ -202,7 +208,8 @@ void check_tensor(const TensorProto& tensor, const CheckerContext& ctx) {
               tensor.name(),
               ") should be stored in ",
               data_path,
-              ", but it doesn't exist or is not accessible.");
+              ", but it doesn't exist or is not accessible."
+          );
         }
         // Do not allow symlinks or directories.
         if (!S_ISREG(buffer.st_mode)) {
@@ -211,7 +218,8 @@ void check_tensor(const TensorProto& tensor, const CheckerContext& ctx) {
               tensor.name(),
               ") should be stored in ",
               data_path,
-              ", but it is not regular file.");
+              ", but it is not regular file."
+          );
         }
 #endif
       }
@@ -246,7 +254,8 @@ void check_tensor(const TensorProto& tensor, const CheckerContext& ctx) {
         #field,                          \
         "' instead of '",                \
         value_field,                     \
-        "'");                            \
+        "'"                              \
+    );                                   \
   }
 
     switch (tensor.data_type()) {
@@ -320,7 +329,8 @@ void check_sequence(const SequenceProto& sequence, const CheckerContext& ctx) {
         sequence.name(),
         ", elem_type: ",
         sequence.elem_type(),
-        ") is not have a valid element type.");
+        ") is not have a valid element type."
+    );
   }
 }
 
@@ -346,7 +356,8 @@ void check_optional(const OptionalProto& optional, const CheckerContext& ctx) {
         optional.name(),
         ", elem_type: ",
         optional.elem_type(),
-        ") is not have a valid element type.");
+        ") is not have a valid element type."
+    );
   }
 }
 
@@ -365,7 +376,8 @@ void check_map(const MapProto& map, const CheckerContext& ctx) {
         map.name(),
         ") to invalid TensorProto key_type ",
         map.key_type(),
-        " is not allowed");
+        " is not allowed"
+    );
   }
 
   // MapProto will use either keys or string_keys, so only one should be > 0.
@@ -398,9 +410,8 @@ void check_map(const MapProto& map, const CheckerContext& ctx) {
 // indices: a 1-dimensional tensor; indices[i] represents the
 // linearized index value for the i-th nonzero value.
 void check_sparse_tensor_indices_1(
-    const TensorProto& indices,
-    const SparseTensorProto& sparse_tensor_proto,
-    size_t nnz) {
+    const TensorProto& indices, const SparseTensorProto& sparse_tensor_proto, size_t nnz
+) {
   int dense_rank = sparse_tensor_proto.dims_size();
   int64_t dense_size = 1;
   for (int i = 0; i < dense_rank; ++i)
@@ -416,7 +427,7 @@ void check_sparse_tensor_indices_1(
 
   int64_t prev_index = -1;
   for (size_t i = 0; i < nnz; ++i) {
-    int64_t curr_index = index_data[i]; // linearized index of i-th value
+    int64_t curr_index = index_data[i];  // linearized index of i-th value
     if (curr_index < 0 || curr_index >= dense_size) {
       fail_check(
           "Sparse tensor (",
@@ -425,7 +436,8 @@ void check_sparse_tensor_indices_1(
           i,
           "] out of range [0, ",
           dense_size - 1,
-          "]");
+          "]"
+      );
     }
     if (curr_index <= prev_index) {
       fail_check("Sparse tensor (", indices.name(), ") index value at position [", i, "] not in sorted order.");
@@ -438,9 +450,8 @@ void check_sparse_tensor_indices_1(
 // indices: a 2-dimensional tensor; indices[i,j] represents the j-th
 // index value for the i-th nonzero value.
 void check_sparse_tensor_indices_2(
-    const TensorProto& indices,
-    const SparseTensorProto& sparse_tensor_proto,
-    size_t nnz) {
+    const TensorProto& indices, const SparseTensorProto& sparse_tensor_proto, size_t nnz
+) {
   int dense_rank = sparse_tensor_proto.dims_size();
   if (static_cast<size_t>(indices.dims(0)) != nnz) {
     fail_check("Sparse tensor indices (", indices.name(), ") first dimension size does not equal NNZ.");
@@ -454,7 +465,7 @@ void check_sparse_tensor_indices_2(
   const std::vector<int64_t> index_data = ParseData<int64_t>(&indices);
   int64_t prev_index = -1;
   for (size_t i = 0; i < nnz; ++i) {
-    int64_t curr_index = 0; // linearized index of i-th value
+    int64_t curr_index = 0;  // linearized index of i-th value
     for (int j = 0; j < dense_rank; ++j) {
       auto index_ij = index_data[i * dense_rank + j];
       if ((index_ij < 0) || (index_ij >= sparse_tensor_proto.dims(j))) {
@@ -464,7 +475,8 @@ void check_sparse_tensor_indices_2(
     }
     if (curr_index <= prev_index) {
       fail_check(
-          "Sparse tensor (", indices.name(), ") index value at position [", i, "] not in lexicographic sorted order.");
+          "Sparse tensor (", indices.name(), ") index value at position [", i, "] not in lexicographic sorted order."
+      );
     }
     prev_index = curr_index;
   }
@@ -660,7 +672,8 @@ void check_node(const NodeProto& node, const CheckerContext& ctx, const LexicalS
       // fail the checker if op in built-in domains has no schema
       fail_check(
           "No Op registered for " + node.op_type() + " with domain_version of " +
-          ONNX_NAMESPACE::to_string(domain_version));
+          ONNX_NAMESPACE::to_string(domain_version)
+      );
     } else {
       // TODO: expose the registration of the op schemas appropriately in
       // python, so we can load and register operators in other domains
@@ -671,7 +684,8 @@ void check_node(const NodeProto& node, const CheckerContext& ctx, const LexicalS
   } else if (schema->Deprecated()) {
     fail_check(
         "Op registered for " + node.op_type() + " is deprecated in domain_version of " +
-        ONNX_NAMESPACE::to_string(domain_version));
+        ONNX_NAMESPACE::to_string(domain_version)
+    );
   } else {
     schema->Verify(node);
   }
@@ -699,7 +713,8 @@ void check_graph(const GraphProto& graph, const CheckerContext& ctx, const Lexic
       fail_check(
           "Graph must be in single static assignment (SSA) form, however '",
           value_info.name(),
-          "' has been used as graph input names multiple times.");
+          "' has been used as graph input names multiple times."
+      );
     }
     lex_ctx.add(value_info.name());
   }
@@ -762,7 +777,8 @@ void check_graph(const GraphProto& graph, const CheckerContext& ctx, const Lexic
             node.name(),
             " OpType: ",
             node.op_type(),
-            "\n is not output of any previous nodes.");
+            "\n is not output of any previous nodes."
+        );
       }
     }
 
@@ -794,7 +810,8 @@ void check_graph(const GraphProto& graph, const CheckerContext& ctx, const Lexic
         fail_check(
             "Graph must be in single static assignment (SSA) form, however '",
             output,
-            "' has been used as output names multiple times.");
+            "' has been used as output names multiple times."
+        );
       }
       lex_ctx.add(output);
     }
@@ -817,7 +834,8 @@ void check_opset_compatibility(
     const NodeProto& node,
     const CheckerContext& ctx,
     const std::unordered_map<std::string, int>& func_opset_imports,
-    const std::unordered_map<std::string, int>& model_opset_imports) {
+    const std::unordered_map<std::string, int>& model_opset_imports
+) {
   auto func_opset_version = get_version_for_domain(node.domain(), func_opset_imports);
   auto model_opset_version = get_version_for_domain(node.domain(), model_opset_imports);
 
@@ -854,14 +872,14 @@ void check_opset_compatibility(
         "Opset import for domain " + node.domain() + " in function op " + node.op_type() +
         "is not compatible with the version imported by model. FunctionOp imports version " +
         ONNX_NAMESPACE::to_string(func_opset_version) + " whereas model imports version " +
-        ONNX_NAMESPACE::to_string(model_opset_version));
+        ONNX_NAMESPACE::to_string(model_opset_version)
+    );
   }
 }
 
 void check_model_local_functions(
-    const ModelProto& model,
-    const CheckerContext& ctx,
-    const LexicalScopeContext& parent_lex) {
+    const ModelProto& model, const CheckerContext& ctx, const LexicalScopeContext& parent_lex
+) {
   // make a copy of model opset imports to maintain a main copy of opset imports across the model and
   // all model local functions to verify opset compatibility
   std::unordered_map<std::string, int> model_opset_imports(ctx.get_opset_imports());
@@ -910,7 +928,8 @@ void check_function(const FunctionProto& function, const CheckerContext& ctx, co
     // this_or_ancestor_graph_has
     if (lex_ctx.this_graph_has(input)) {
       fail_check(
-          "Graph must be in single static assignment (SSA) form, however '", input, "' has been used multiple times.");
+          "Graph must be in single static assignment (SSA) form, however '", input, "' has been used multiple times."
+      );
     }
     lex_ctx.add(input);
   }
@@ -947,7 +966,8 @@ void check_function(const FunctionProto& function, const CheckerContext& ctx, co
             node.name(),
             " OpType: ",
             node.op_type(),
-            "\n is neither output of any previous nodes nor input of the function.");
+            "\n is neither output of any previous nodes nor input of the function."
+        );
       }
     }
 
@@ -970,7 +990,8 @@ void check_function(const FunctionProto& function, const CheckerContext& ctx, co
         fail_check(
             "Function must be in single static assignment (SSA) form, however '",
             output,
-            "' has been used as output names multiple times.");
+            "' has been used as output names multiple times."
+        );
       }
       lex_ctx.add(output);
     }
@@ -1065,7 +1086,8 @@ std::set<std::string> experimental_ops = {
     "ImageScaler",
     "ParametricSoftplus",
     "Scale",
-    "ScaledTanh"};
+    "ScaledTanh"
+};
 
 bool check_is_experimental_op(const NodeProto& node) {
   return (node.domain() == ONNX_DOMAIN || node.domain() == "ai.onnx") && experimental_ops.count(node.op_type());
@@ -1076,5 +1098,5 @@ bool check_is_experimental_op(const NodeProto& node) {
 #undef enforce_has_repeated_field
 #undef enforce_non_empty_field
 
-} // namespace checker
-} // namespace ONNX_NAMESPACE
+}  // namespace checker
+}  // namespace ONNX_NAMESPACE

--- a/onnx/checker.h
+++ b/onnx/checker.h
@@ -150,18 +150,18 @@ void check_opset_compatibility(
     const NodeProto& node,
     const CheckerContext& ctx,
     const std::unordered_map<std::string, int>& func_opset_imports,
-    const std::unordered_map<std::string, int>& model_opset_imports);
+    const std::unordered_map<std::string, int>& model_opset_imports
+);
 
 // Checks all model local functions present in ModelProto
 void check_model_local_functions(
-    const ModelProto& model,
-    const CheckerContext& ctx,
-    const LexicalScopeContext& parent_lex);
+    const ModelProto& model, const CheckerContext& ctx, const LexicalScopeContext& parent_lex
+);
 
 void check_model(const ModelProto& model, bool full_check = false, bool skip_opset_compatibility_check = false);
 void check_model(const std::string& model_path, bool full_check = false, bool skip_opset_compatibility_check = false);
 
 bool check_is_experimental_op(const NodeProto& node);
 
-} // namespace checker
-} // namespace ONNX_NAMESPACE
+}  // namespace checker
+}  // namespace ONNX_NAMESPACE

--- a/onnx/common/array_ref.h
+++ b/onnx/common/array_ref.h
@@ -196,4 +196,4 @@ class ArrayRef {
   /// @}
 };
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/common/assertions.cc
+++ b/onnx/common/assertions.cc
@@ -37,4 +37,4 @@ void throw_tensor_error(std::string& msg) {
   ONNX_THROW_EX(tensor_error(msg));
 }
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/common/assertions.h
+++ b/onnx/common/assertions.h
@@ -30,7 +30,7 @@ std::string barf(const char* fmt, ...);
 
 [[noreturn]] void throw_tensor_error(std::string&);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE
 
 #if defined(__GNUC__) || defined(__ICL) || defined(__clang__)
 #define _ONNX_EXPECT(x, y) (__builtin_expect((x), (y)))
@@ -50,11 +50,12 @@ std::string barf(const char* fmt, ...);
 #define ONNX_EXPAND(x) x
 
 // Note: msg must be a string literal
-#define _ONNX_ASSERTM(cond, msg, ...)                                                                \
-  if (_ONNX_EXPECT(!(cond), 0)) {                                                                    \
-    std::string error_msg = ::ONNX_NAMESPACE::barf(                                                  \
-        "%s:%u: %s: Assertion `%s` failed: " msg, __FILE__, __LINE__, __func__, #cond, __VA_ARGS__); \
-    throw_assert_error(error_msg);                                                                   \
+#define _ONNX_ASSERTM(cond, msg, ...)                                                              \
+  if (_ONNX_EXPECT(!(cond), 0)) {                                                                  \
+    std::string error_msg = ::ONNX_NAMESPACE::barf(                                                \
+        "%s:%u: %s: Assertion `%s` failed: " msg, __FILE__, __LINE__, __func__, #cond, __VA_ARGS__ \
+    );                                                                                             \
+    throw_assert_error(error_msg);                                                                 \
   }
 
 // The trailing ' ' argument is a hack to deal with the extra comma when ... is empty.
@@ -62,11 +63,12 @@ std::string barf(const char* fmt, ...);
 // extension we shouldn't use.
 #define ONNX_ASSERTM(...) ONNX_EXPAND(_ONNX_ASSERTM(__VA_ARGS__, " "))
 
-#define _TENSOR_ASSERTM(cond, msg, ...)                                                              \
-  if (_ONNX_EXPECT(!(cond), 0)) {                                                                    \
-    std::string error_msg = ::ONNX_NAMESPACE::barf(                                                  \
-        "%s:%u: %s: Assertion `%s` failed: " msg, __FILE__, __LINE__, __func__, #cond, __VA_ARGS__); \
-    throw_tensor_error(error_msg);                                                                   \
+#define _TENSOR_ASSERTM(cond, msg, ...)                                                            \
+  if (_ONNX_EXPECT(!(cond), 0)) {                                                                  \
+    std::string error_msg = ::ONNX_NAMESPACE::barf(                                                \
+        "%s:%u: %s: Assertion `%s` failed: " msg, __FILE__, __LINE__, __func__, #cond, __VA_ARGS__ \
+    );                                                                                             \
+    throw_tensor_error(error_msg);                                                                 \
   }
 
 #define TENSOR_ASSERTM(...) ONNX_EXPAND(_TENSOR_ASSERTM(__VA_ARGS__, " "))

--- a/onnx/common/constants.h
+++ b/onnx/common/constants.h
@@ -42,4 +42,4 @@ constexpr const char* IMAGE = "IMAGE";
 constexpr const char* AUDIO = "AUDIO";
 constexpr const char* TEXT = "TEXT";
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/common/file_utils.h
+++ b/onnx/common/file_utils.h
@@ -23,7 +23,8 @@ void LoadProtoFromPath(const std::string proto_path, T& proto) {
   std::string data{std::istreambuf_iterator<char>{proto_stream}, std::istreambuf_iterator<char>{}};
   if (!ParseProtoFromBytes(&proto, data.c_str(), data.size())) {
     fail_check(
-        "Unable to parse proto from file: ", proto_path, ". Please check if it is a valid protobuf file of proto. ");
+        "Unable to parse proto from file: ", proto_path, ". Please check if it is a valid protobuf file of proto. "
+    );
   }
 }
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/common/graph_node_list.h
+++ b/onnx/common/graph_node_list.h
@@ -97,7 +97,7 @@ struct generic_graph_node_list_iterator final {
     return d == kNextDirection ? kPrevDirection : kNextDirection;
   }
   T* cur;
-  size_t d; // direction 0 is forward 1 is reverse, see next_in_graph
+  size_t d;  // direction 0 is forward 1 is reverse, see next_in_graph
 };
 
 template <typename T>
@@ -151,7 +151,7 @@ static inline bool operator!=(generic_graph_node_list_iterator<T> a, generic_gra
   return *a != *b;
 }
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE
 
 namespace std {
 
@@ -164,4 +164,4 @@ struct iterator_traits<ONNX_NAMESPACE::generic_graph_node_list_iterator<T>> {
   using iterator_category = bidirectional_iterator_tag;
 };
 
-} // namespace std
+}  // namespace std

--- a/onnx/common/interned_strings.cc
+++ b/onnx/common/interned_strings.cc
@@ -78,4 +78,4 @@ const char* Symbol::toString() const {
 
 Symbol::Symbol(const std::string& s) : value(globalStrings().symbol(s)) {}
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/common/interned_strings.h
+++ b/onnx/common/interned_strings.h
@@ -191,7 +191,7 @@ enum BuiltinSymbol {
 #define DEFINE_SYMBOL(s) k##s,
   FORALL_BUILTIN_SYMBOLS(DEFINE_SYMBOL)
 #undef DEFINE_SYMBOL
-      kLastSymbol, // where we start counting for new symbols
+  kLastSymbol,  // where we start counting for new symbols
 };
 
 struct Symbol {
@@ -224,7 +224,7 @@ inline Symbol operator"" _sym(const char* s, size_t) {
   return Symbol(s);
 }
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE
 
 // make symbol behave like an integer in hash tables
 namespace std {
@@ -235,4 +235,4 @@ struct hash<ONNX_NAMESPACE::Symbol> {
   }
 };
 
-} // namespace std
+}  // namespace std

--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -39,7 +39,7 @@
 
 namespace ONNX_NAMESPACE {
 
-namespace { // internal/private API
+namespace {  // internal/private API
 
 std::string toVarName(size_t i) {
   std::ostringstream oss;
@@ -47,7 +47,7 @@ std::string toVarName(size_t i) {
   return oss.str();
 }
 
-} // namespace
+}  // namespace
 
 // Graph represents one "function" of computation.
 // It uses a simple ownership model where the graph owns all the nodes inside it.
@@ -85,8 +85,8 @@ class ResourceGuard final {
 
 struct Dimension final {
   Dimension() : is_unknown(true), is_int(false), dim(-1) {}
-  Dimension(std::string param) : is_unknown(false), is_int(false), dim(-1), param(std::move(param)) {} // NOLINT
-  Dimension(int64_t dim) : is_unknown(false), is_int(true), dim(dim) {} // NOLINT
+  Dimension(std::string param) : is_unknown(false), is_int(false), dim(-1), param(std::move(param)) {}  // NOLINT
+  Dimension(int64_t dim) : is_unknown(false), is_int(true), dim(dim) {}  // NOLINT
 
   bool is_unknown;
   bool is_int;
@@ -277,7 +277,8 @@ struct Attributes {
         __FILE__,
         __LINE__,
         __func__,
-        name.toString());
+        name.toString()
+    );
     return it;
   }
 };
@@ -314,8 +315,8 @@ struct Value final {
   friend struct Graph;
   Node* node_;
   size_t offset_;
-  size_t unique_ = 0; // unique id
-  size_t stage_ = 0; // 0-forward, 1-backward, 2-double-backward,...
+  size_t unique_ = 0;  // unique id
+  size_t stage_ = 0;  // 0-forward, 1-backward, 2-double-backward,...
   use_list uses_in_current_graph_;
   bool has_unique_name_;
   std::string unique_name_;
@@ -446,7 +447,7 @@ struct Node : public Attributes<Node> {
   std::string doc_string_;
 
  protected:
-  Node(Graph* graph_, NodeKind kind_); // defined after graph
+  Node(Graph* graph_, NodeKind kind_);  // defined after graph
 
  public:
   bool has_name() const {
@@ -987,10 +988,13 @@ struct Graph final {
         std::remove_if(
             initializers_.begin(),
             initializers_.end(),
-            [&name](Tensor& initializer) { return initializer.name() == name; }),
-        initializers_.end());
+            [&name](Tensor& initializer) { return initializer.name() == name; }
+        ),
+        initializers_.end()
+    );
     initializer_names_.erase(
-        std::remove(initializer_names_.begin(), initializer_names_.end(), name), initializer_names_.end());
+        std::remove(initializer_names_.begin(), initializer_names_.end(), name), initializer_names_.end()
+    );
     for (size_t i = 0; i < initializer_node_->outputs().size(); i++) {
       if (initializer_node_->outputs()[i]->uniqueName() == name) {
         initializer_node_->eraseOutput(i);
@@ -1433,4 +1437,4 @@ inline const use_list Value::uses() const {
   return all_uses;
 }
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/common/ir_pb_converter.cc
+++ b/onnx/common/ir_pb_converter.cc
@@ -216,9 +216,8 @@ std::vector<Dimension> tensorShapeProtoToDimensions(const ONNX_NAMESPACE::Tensor
 }
 
 void createDummyValue(
-    std::unique_ptr<Graph>& g,
-    const std::string& name,
-    std::unordered_map<std::string, Value*>& value_by_name_of) {
+    std::unique_ptr<Graph>& g, const std::string& name, std::unordered_map<std::string, Value*>& value_by_name_of
+) {
   auto* undef = g->create(kCaptured, 1);
   g->appendNode(undef);
   undef->outputs()[0]->setUniqueName(name);
@@ -395,8 +394,9 @@ std::unique_ptr<Graph> ImportModelProto(const ModelProto& mp) {
   std::unique_ptr<Graph> g(graphProtoToGraph(mp.graph(), false, mp.ir_version()));
   for (int i = 0; i < mp.opset_import_size(); i++) {
     OpSetID new_opset_version(mp.opset_import(i).domain(), mp.opset_import(i).version());
-    g->forSelfAndEachSubGraph(
-        [&new_opset_version](Graph* graph) { graph->opset_versions_mutable().emplace_back(new_opset_version); });
+    g->forSelfAndEachSubGraph([&new_opset_version](Graph* graph) {
+      graph->opset_versions_mutable().emplace_back(new_opset_version);
+    });
   }
   return g;
 }
@@ -709,7 +709,8 @@ void assertNonNull(const std::shared_ptr<Graph>& g) {
   ONNX_ASSERTM(
       g.get() != nullptr,
       "Warning: onnx version converter is unable to parse input model. "
-      "(The IR version of the ONNX model may be too old.)");
+      "(The IR version of the ONNX model may be too old.)"
+  );
 }
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/common/ir_pb_converter.h
+++ b/onnx/common/ir_pb_converter.h
@@ -47,4 +47,4 @@ std::unique_ptr<Graph> ImportModelProto(const ModelProto& mp);
 ModelProto PrepareOutput(const ModelProto& mp_in);
 
 void assertNonNull(const std::shared_ptr<Graph>& g);
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/common/model_helpers.cc
+++ b/onnx/common/model_helpers.cc
@@ -17,7 +17,8 @@ Common::Status BuildNode(
     const std::string& op_type,
     std::vector<std::string> const& inputs,
     std::vector<std::string> const& outputs,
-    NodeProto* node) {
+    NodeProto* node
+) {
   if (node == NULL) {
     return Common::Status(Common::CHECKER, Common::INVALID_ARGUMENT, "node_proto should not be nullptr.");
   }
@@ -34,4 +35,4 @@ Common::Status BuildNode(
 
   return Common::Status::OK();
 }
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/common/model_helpers.h
+++ b/onnx/common/model_helpers.h
@@ -22,5 +22,6 @@ Common::Status BuildNode(
     const std::string& op_type,
     std::vector<std::string> const& inputs,
     std::vector<std::string> const& outputs,
-    /*OUT*/ NodeProto* node);
-} // namespace ONNX_NAMESPACE
+    /*OUT*/ NodeProto* node
+);
+}  // namespace ONNX_NAMESPACE

--- a/onnx/common/path.cc
+++ b/onnx/common/path.cc
@@ -79,4 +79,4 @@ std::string clean_relative_path(const std::string& path) {
 }
 #endif
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/common/path.h
+++ b/onnx/common/path.h
@@ -19,7 +19,7 @@ namespace ONNX_NAMESPACE {
 
 #ifdef _WIN32
 constexpr const char k_preferred_path_separator = '\\';
-#else // POSIX
+#else  // POSIX
 constexpr const char k_preferred_path_separator = '/';
 #endif
 
@@ -45,4 +45,4 @@ std::string path_join(const std::string& origin, const std::string& append);
 std::string clean_relative_path(const std::string& path);
 #endif
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/common/platform_helpers.h
+++ b/onnx/common/platform_helpers.h
@@ -16,4 +16,4 @@ inline bool is_processor_little_endian() {
   return reinterpret_cast<const std::uint8_t*>(&value)[0] == 1;
 }
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/common/status.cc
+++ b/onnx/common/status.cc
@@ -85,5 +85,5 @@ const std::string& Status::EmptyString() {
   return empty_str;
 }
 
-} // namespace Common
-} // namespace ONNX_NAMESPACE
+}  // namespace Common
+}  // namespace ONNX_NAMESPACE

--- a/onnx/common/status.h
+++ b/onnx/common/status.h
@@ -92,5 +92,5 @@ inline std::ostream& operator<<(std::ostream& out, const Status& status) {
   return out << status.ToString();
 }
 
-} // namespace Common
-} // namespace ONNX_NAMESPACE
+}  // namespace Common
+}  // namespace ONNX_NAMESPACE

--- a/onnx/common/tensor.h
+++ b/onnx/common/tensor.h
@@ -230,7 +230,8 @@ inline std::string* Tensor::data<std::string>() {
   ONNX_ASSERTM(
       !is_raw_data(),
       "data type is string. string content is required to be stored in repeated bytes string_data field."
-      "raw_data type cannot be string.");
+      "raw_data type cannot be string."
+  );
   return string_data_.data();
 }
 template <>
@@ -238,7 +239,8 @@ inline const std::string* Tensor::data<std::string>() const {
   ONNX_ASSERTM(
       !is_raw_data(),
       "data type is string. string content is required to be stored in repeated bytes string_data field."
-      "raw_data type cannot be string.");
+      "raw_data type cannot be string."
+  );
   return string_data_.data();
 }
 
@@ -268,4 +270,4 @@ define_data(int64_t, int64_data_);
 define_data(uint64_t, uint64_data_);
 #undef define_data
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/common/version.h
+++ b/onnx/common/version.h
@@ -11,4 +11,4 @@ namespace ONNX_NAMESPACE {
 // Represents the most recent release version. Updated with every release.
 constexpr const char* LAST_RELEASE_VERSION = "1.15.0";
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/common/visitor.h
+++ b/onnx/common/visitor.h
@@ -125,5 +125,5 @@ struct MutableVisitor {
   virtual ~MutableVisitor() {}
 };
 
-} // namespace internal
-} // namespace ONNX_NAMESPACE
+}  // namespace internal
+}  // namespace ONNX_NAMESPACE

--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -43,7 +43,8 @@ static std::string ProtoBytesToText(const py::bytes& bytes) {
 
 template <typename T, typename Ts = typename std::remove_const<T>::type>
 std::pair<std::unique_ptr<Ts[]>, std::unordered_map<std::string, T*>> ParseProtoFromBytesMap(
-    std::unordered_map<std::string, py::bytes> bytesMap) {
+    std::unordered_map<std::string, py::bytes> bytesMap
+) {
   std::unique_ptr<Ts[]> values(new Ts[bytesMap.size()]);
   std::unordered_map<std::string, T*> result;
   size_t i = 0;
@@ -62,7 +63,8 @@ std::unordered_map<std::string, py::bytes> CallNodeInferenceFunction(
     std::unordered_map<std::string, py::bytes> inputDataByNameBytes,
     std::unordered_map<std::string, py::bytes> inputSparseDataByNameBytes,
     std::unordered_map<std::string, int> opsetImports,
-    const int irVersion) {
+    const int irVersion
+) {
   NodeProto node{};
   ParseProtoFromPyBytes(&node, nodeBytes);
   // Early fail if node is badly defined - may throw ValidationError
@@ -77,13 +79,15 @@ std::unordered_map<std::string, py::bytes> CallNodeInferenceFunction(
   }
 
   shape_inference::GraphInferenceContext graphInferenceContext(
-      valueTypes.second, opsetImports, nullptr, {}, OpSchemaRegistry::Instance(), nullptr, irVersion);
+      valueTypes.second, opsetImports, nullptr, {}, OpSchemaRegistry::Instance(), nullptr, irVersion
+  );
   // Construct inference context and get results - may throw InferenceError
   // TODO: if it is desirable for infer_node_outputs to provide check_type, strict_mode, data_prop,
   // we can add them to the Python API. For now we just assume the default options.
   ShapeInferenceOptions options{false, 0, false};
   shape_inference::InferenceContextImpl ctx(
-      node, valueTypes.second, inputData.second, inputSparseData.second, options, nullptr, &graphInferenceContext);
+      node, valueTypes.second, inputData.second, inputSparseData.second, options, nullptr, &graphInferenceContext
+  );
   schema->GetTypeAndShapeInferenceFunction()(ctx);
   // Verify the inference succeeded - may also throw ValidationError
   // Note that input types were not validated until now (except that their count was correct)
@@ -109,9 +113,9 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
   onnx_cpp2py_export.attr("ONNX_ML") = py::bool_(
 #ifdef ONNX_ML
       true
-#else // ONNX_ML
+#else  // ONNX_ML
       false
-#endif // ONNX_ML
+#endif  // ONNX_ML
   );
 
   // Submodule `schema`
@@ -163,7 +167,8 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
           py::arg("type"),
           py::arg("description") = "",
           py::kw_only(),
-          py::arg("required") = true)
+          py::arg("required") = true
+      )
       .def(
           py::init([](std::string name, const py::object& default_value, std::string description) {
             // Construct an attribute with a default value.
@@ -174,8 +179,9 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
             return OpSchema::Attribute(std::move(name), std::move(description), std::move(proto));
           }),
           py::arg("name"),
-          py::arg("default_value"), // type: onnx.AttributeProto
-          py::arg("description") = "")
+          py::arg("default_value"),  // type: onnx.AttributeProto
+          py::arg("description") = ""
+      )
       .def_readonly("name", &OpSchema::Attribute::name)
       .def_readonly("description", &OpSchema::Attribute::description)
       .def_readonly("type", &OpSchema::Attribute::type)
@@ -185,7 +191,8 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
             std::string out;
             attr->default_value.SerializeToString(&out);
             return out;
-          })
+          }
+      )
       .def_readonly("required", &OpSchema::Attribute::required);
 
   py::class_<OpSchema::TypeConstraintParam>(op_schema, "TypeConstraintParam")
@@ -193,7 +200,8 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
           py::init<std::string, std::vector<std::string>, std::string>(),
           py::arg("type_param_str"),
           py::arg("allowed_type_strs"),
-          py::arg("description") = "")
+          py::arg("description") = ""
+      )
       .def_readonly("type_param_str", &OpSchema::TypeConstraintParam::type_param_str)
       .def_readonly("allowed_type_strs", &OpSchema::TypeConstraintParam::allowed_type_strs)
       .def_readonly("description", &OpSchema::TypeConstraintParam::description);
@@ -215,7 +223,8 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
                 param_option,
                 is_homogeneous,
                 min_arity,
-                differentiation_category);
+                differentiation_category
+            );
           }),
           py::arg("name"),
           py::arg("type_str"),
@@ -224,7 +233,8 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
           py::arg("param_option") = OpSchema::Single,
           py::arg("is_homogeneous") = true,
           py::arg("min_arity") = 1,
-          py::arg("differentiation_category") = OpSchema::DifferentiationCategory::Unknown)
+          py::arg("differentiation_category") = OpSchema::DifferentiationCategory::Unknown
+      )
 
       .def_property_readonly("name", &OpSchema::FormalParameter::GetName)
       .def_property_readonly("types", &OpSchema::FormalParameter::GetTypes)
@@ -242,23 +252,28 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
             auto warnings = py::module::import("warnings");
             warnings.attr("warn")(
                 "OpSchema.FormalParameter.typeStr is deprecated and will be removed in 1.16. "
-                "Use OpSchema.FormalParameter.type_str instead.");
+                "Use OpSchema.FormalParameter.type_str instead."
+            );
             return self.GetTypeStr();
-          })
+          }
+      )
       .def_property_readonly(
           "isHomogeneous",
           [](const OpSchema::FormalParameter& self) {
             auto warnings = py::module::import("warnings");
             warnings.attr("warn")(
                 "OpSchema.FormalParameter.isHomogeneous is deprecated and will be removed in 1.16. "
-                "Use OpSchema.FormalParameter.is_homogeneous instead.");
+                "Use OpSchema.FormalParameter.is_homogeneous instead."
+            );
             return self.GetIsHomogeneous();
-          })
+          }
+      )
       .def_property_readonly("differentiationCategory", [](const OpSchema::FormalParameter& self) {
         auto warnings = py::module::import("warnings");
         warnings.attr("warn")(
             "OpSchema.FormalParameter.differentiationCategory is deprecated and will be removed in 1.16. "
-            "Use OpSchema.FormalParameter.differentiation_category instead.");
+            "Use OpSchema.FormalParameter.differentiation_category instead."
+        );
         return self.GetDifferentiationCategory();
       });
 
@@ -310,10 +325,12 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
               std::string /* type_str */,
               std::vector<std::string> /* constraints */,
               std::string /* description */>>{},
-          py::arg("attributes") = std::vector<OpSchema::Attribute>{})
+          py::arg("attributes") = std::vector<OpSchema::Attribute>{}
+      )
       .def_property("name", &OpSchema::Name, [](OpSchema& self, const std::string& name) { self.SetName(name); })
       .def_property(
-          "domain", &OpSchema::domain, [](OpSchema& self, const std::string& domain) { self.SetDomain(domain); })
+          "domain", &OpSchema::domain, [](OpSchema& self, const std::string& domain) { self.SetDomain(domain); }
+      )
       .def_property("doc", &OpSchema::doc, [](OpSchema& self, const std::string& doc) { self.SetDoc(doc); })
       .def_property_readonly("file", &OpSchema::file)
       .def_property_readonly("line", &OpSchema::line)
@@ -322,7 +339,8 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
       .def_property_readonly("deprecated", &OpSchema::deprecated)
       .def_property_readonly("function_opset_versions", &OpSchema::function_opset_versions)
       .def_property_readonly(
-          "context_dependent_function_opset_versions", &OpSchema::context_dependent_function_opset_versions)
+          "context_dependent_function_opset_versions", &OpSchema::context_dependent_function_opset_versions
+      )
       .def_property_readonly(
           "all_function_opset_versions",
           [](OpSchema* op) -> std::vector<int> {
@@ -332,13 +350,16 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
             all_function_opset_versions.insert(
                 all_function_opset_versions.end(),
                 context_dependent_function_opset_versions.begin(),
-                context_dependent_function_opset_versions.end());
+                context_dependent_function_opset_versions.end()
+            );
             std::sort(all_function_opset_versions.begin(), all_function_opset_versions.end());
             all_function_opset_versions.erase(
                 std::unique(all_function_opset_versions.begin(), all_function_opset_versions.end()),
-                all_function_opset_versions.end());
+                all_function_opset_versions.end()
+            );
             return all_function_opset_versions;
-          })
+          }
+      )
       .def_property_readonly("min_input", &OpSchema::min_input)
       .def_property_readonly("max_input", &OpSchema::max_input)
       .def_property_readonly("min_output", &OpSchema::min_output)
@@ -358,7 +379,8 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
           py::arg("inputDataByNameBytes") = std::unordered_map<std::string, py::bytes>{},
           py::arg("inputSparseDataByNameBytes") = std::unordered_map<std::string, py::bytes>{},
           py::arg("opsetImports") = std::unordered_map<std::string, int>{},
-          py::arg("irVersion") = int(IR_VERSION))
+          py::arg("irVersion") = int(IR_VERSION)
+      )
       .def_property_readonly("has_function", &OpSchema::HasFunction)
       .def_property_readonly(
           "_function_body",
@@ -367,7 +389,8 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
             if (op->HasFunction())
               op->GetFunction()->SerializeToString(&bytes);
             return py::bytes(bytes);
-          })
+          }
+      )
       .def(
           "get_function_with_opset_version",
           [](OpSchema* op, int opset_version) -> py::bytes {
@@ -377,7 +400,8 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
               function_proto->SerializeToString(&bytes);
             }
             return py::bytes(bytes);
-          })
+          }
+      )
       .def_property_readonly("has_context_dependent_function", &OpSchema::HasContextDependentFunction)
       .def(
           "get_context_dependent_function",
@@ -399,11 +423,12 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
               func_proto.SerializeToString(&func_bytes);
             }
             return py::bytes(func_bytes);
-          })
+          }
+      )
       .def(
           "get_context_dependent_function_with_opset_version",
-          [](OpSchema* op, int opset_version, const py::bytes& bytes, const std::vector<py::bytes>& input_types_bytes)
-              -> py::bytes {
+          [](OpSchema* op, int opset_version, const py::bytes& bytes, const std::vector<py::bytes>& input_types_bytes
+          ) -> py::bytes {
             NodeProto proto{};
             ParseProtoFromPyBytes(&proto, bytes);
             std::string func_bytes = "";
@@ -421,7 +446,8 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
               func_proto.SerializeToString(&func_bytes);
             }
             return py::bytes(func_bytes);
-          });
+          }
+      );
 
   defs.def(
           "has_schema",
@@ -429,12 +455,14 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
             return OpSchemaRegistry::Schema(op_type, domain) != nullptr;
           },
           "op_type"_a,
-          "domain"_a = ONNX_DOMAIN)
+          "domain"_a = ONNX_DOMAIN
+  )
       .def(
           "schema_version_map",
           []() -> std::unordered_map<std::string, std::pair<int, int>> {
             return OpSchemaRegistry::DomainToVersionRange::Instance().Map();
-          })
+          }
+      )
       .def(
           "get_schema",
           [](const std::string& op_type, const int max_inclusive_version, const std::string& domain) -> OpSchema {
@@ -442,14 +470,16 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
             if (!schema) {
               fail_schema(
                   "No schema registered for '" + op_type + "' version '" + std::to_string(max_inclusive_version) +
-                  "' and domain '" + domain + "'!");
+                  "' and domain '" + domain + "'!"
+              );
             }
             return *schema;
           },
           "op_type"_a,
           "max_inclusive_version"_a,
           "domain"_a = ONNX_DOMAIN,
-          "Return the schema of the operator *op_type* and for a specific version.")
+          "Return the schema of the operator *op_type* and for a specific version."
+      )
       .def(
           "get_schema",
           [](const std::string& op_type, const std::string& domain) -> OpSchema {
@@ -461,15 +491,18 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
           },
           "op_type"_a,
           "domain"_a = ONNX_DOMAIN,
-          "Return the schema of the operator *op_type* and for a specific version.")
+          "Return the schema of the operator *op_type* and for a specific version."
+      )
       .def(
           "get_all_schemas",
           []() -> const std::vector<OpSchema> { return OpSchemaRegistry::get_all_schemas(); },
-          "Return the schema of all existing operators for the latest version.")
+          "Return the schema of all existing operators for the latest version."
+      )
       .def(
           "get_all_schemas_with_history",
           []() -> const std::vector<OpSchema> { return OpSchemaRegistry::get_all_schemas_with_history(); },
-          "Return the schema of all existing operators and all versions.");
+          "Return the schema of all existing operators and all versions."
+      );
 
   // Submodule `checker`
   auto checker = onnx_cpp2py_export.def_submodule("checker");
@@ -479,7 +512,8 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
   checker_context.def(py::init<>())
       .def_property("ir_version", &checker::CheckerContext::get_ir_version, &checker::CheckerContext::set_ir_version)
       .def_property(
-          "opset_imports", &checker::CheckerContext::get_opset_imports, &checker::CheckerContext::set_opset_imports);
+          "opset_imports", &checker::CheckerContext::get_opset_imports, &checker::CheckerContext::set_opset_imports
+      );
 
   py::register_exception<checker::ValidationError>(checker, "ValidationError");
 
@@ -536,14 +570,16 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
       },
       "bytes"_a,
       "full_check"_a = false,
-      "skip_opset_compatibility_check"_a = false);
+      "skip_opset_compatibility_check"_a = false
+  );
 
   checker.def(
       "check_model_path",
       (void (*)(const std::string& path, bool full_check, bool skip_opset_compatibility_check)) & checker::check_model,
       "path"_a,
       "full_check"_a = false,
-      "skip_opset_compatibility_check"_a = false);
+      "skip_opset_compatibility_check"_a = false
+  );
 
   // Submodule `version_converter`
   auto version_converter = onnx_cpp2py_export.def_submodule("version_converter");
@@ -586,7 +622,8 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
         std::string out;
         model.SerializeToString(&out);
         return py::bytes(out);
-      });
+      }
+  );
 
   // Submodule `shape_inference`
   auto shape_inference = onnx_cpp2py_export.def_submodule("shape_inference");
@@ -607,7 +644,8 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
       "bytes"_a,
       "check_type"_a = false,
       "strict_mode"_a = false,
-      "data_prop"_a = false);
+      "data_prop"_a = false
+  );
 
   shape_inference.def(
       "infer_shapes_path",
@@ -618,7 +656,8 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
          bool data_prop) -> void {
         ShapeInferenceOptions options{check_type, strict_mode == true ? 1 : 0, data_prop};
         shape_inference::InferShapes(model_path, output_path, OpSchemaRegistry::Instance(), options);
-      });
+      }
+  );
 
   shape_inference.def(
       "infer_function_output_types",
@@ -653,7 +692,8 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
           result.push_back(py::bytes(out));
         }
         return result;
-      });
+      }
+  );
 
   // Submodule `parser`
   auto parser = onnx_cpp2py_export.def_submodule("parser");
@@ -673,4 +713,4 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
   printer.def("graph_to_text", ProtoBytesToText<GraphProto>);
 }
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/attr_proto_util.cc
+++ b/onnx/defs/attr_proto_util.cc
@@ -58,9 +58,8 @@ AttributeProto MakeRefAttribute(const std::string& attr_name, AttributeProto_Att
 }
 
 AttributeProto MakeRefAttribute(
-    const std::string& attr_name,
-    const std::string& referred_attr_name,
-    AttributeProto_AttributeType type) {
+    const std::string& attr_name, const std::string& referred_attr_name, AttributeProto_AttributeType type
+) {
   AttributeProto a;
   a.set_name(attr_name);
   a.set_ref_attr_name(referred_attr_name);
@@ -68,4 +67,4 @@ AttributeProto MakeRefAttribute(
   return a;
 }
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/attr_proto_util.h
+++ b/onnx/defs/attr_proto_util.h
@@ -36,8 +36,7 @@ AttributeProto MakeRefAttribute(const std::string& attr_name, AttributeProto_Att
 // node.
 // <type> specifies the attribute type.
 AttributeProto MakeRefAttribute(
-    const std::string& attr_name,
-    const std::string& referred_attr_name,
-    AttributeProto_AttributeType type);
+    const std::string& attr_name, const std::string& referred_attr_name, AttributeProto_AttributeType type
+);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/controlflow/defs.cc
+++ b/onnx/defs/controlflow/defs.cc
@@ -48,25 +48,30 @@ ONNX_OPERATOR_SET_SCHEMA(
             "[3] are not compatible.",
             "V",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Attr(
             "then_branch",
             "Graph to run if condition is true. Has N outputs: values you wish to "
             "be live-out to the enclosing scope. The number of outputs must match"
             " the number of outputs in the else_branch.",
-            AttributeProto::GRAPH)
+            AttributeProto::GRAPH
+        )
         .Attr(
             "else_branch",
             "Graph to run if condition is false. Has N outputs: values you wish to"
             " be live-out to the enclosing scope. The number of outputs must match"
             " the number of outputs in the then_branch.",
-            AttributeProto::GRAPH)
+            AttributeProto::GRAPH
+        )
         .TypeConstraint(
             "V",
             control_flow_types_ir9(),
-            "All Tensor, Sequence(Tensor), Optional(Tensor), and Optional(Sequence(Tensor)) types up to IRv9.")
+            "All Tensor, Sequence(Tensor), Optional(Tensor), and Optional(Sequence(Tensor)) types up to IRv9."
+        )
         .TypeConstraint("B", {"tensor(bool)"}, "Only bool")
-        .TypeAndShapeInferenceFunction(IfInferenceFunction));
+        .TypeAndShapeInferenceFunction(IfInferenceFunction)
+);
 
 static const char* Loop_ver19_doc = R"DOC(
 Generic Looping construct. This loop has multiple termination conditions:
@@ -217,13 +222,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             "A maximum trip-count for the loop specified at runtime. Optional."
             " Pass empty string to skip.",
             "I",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Input(
-            1,
-            "cond",
-            "A boolean termination condition. Optional. Pass empty string to skip.",
-            "B",
-            OpSchema::Optional)
+            1, "cond", "A boolean termination condition. Optional. Pass empty string to skip.", "B", OpSchema::Optional
+        )
         .Input(
             2,
             "v_initial",
@@ -232,7 +235,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "V",
             OpSchema::Variadic,
             false,
-            0)
+            0
+        )
         .Output(
             0,
             "v_final_and_scan_outputs",
@@ -240,7 +244,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Scan outputs must be Tensors.",
             "V",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Attr(
             "body",
             "The graph run each iteration. It has 2+N inputs: (iteration_num, "
@@ -250,14 +255,17 @@ ONNX_OPERATOR_SET_SCHEMA(
             "output value at the end of each iteration of the loop. It is an error"
             " if the dimensions or data type of these scan_outputs change across loop"
             " iterations.",
-            AttributeProto::GRAPH)
+            AttributeProto::GRAPH
+        )
         .TypeConstraint(
             "V",
             control_flow_types_ir9(),
-            "All Tensor, Sequence(Tensor), Optional(Tensor), and Optional(Sequence(Tensor)) types up to IRv9.")
+            "All Tensor, Sequence(Tensor), Optional(Tensor), and Optional(Sequence(Tensor)) types up to IRv9."
+        )
         .TypeConstraint("I", {"tensor(int64)"}, "tensor of int64, which should be a scalar.")
         .TypeConstraint("B", {"tensor(bool)"}, "tensor of bool, which should be a scalar.")
-        .TypeAndShapeInferenceFunction(LoopInferenceFunction));
+        .TypeAndShapeInferenceFunction(LoopInferenceFunction)
+);
 
 static const char* scan_19_doc = R"DOC(
 Scan can be used to iterate over one or more scan_input tensors,
@@ -394,14 +402,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Initial values of the loop's N state variables followed by M scan_inputs",
             "V",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Output(
             0,
             "final_state_and_scan_outputs",
             "Final values of the loop's N state variables followed by K scan_outputs",
             "V",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Attr(
             "body",
             "The graph run each iteration. It has N+M inputs: "
@@ -411,7 +421,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "scan_output_elt value at the end of each iteration of the loop. It is an error"
             " if the dimensions of these values change across loop iterations.",
             AttributeProto::GRAPH,
-            true)
+            true
+        )
         .Attr("num_scan_inputs", "An attribute specifying the number of scan_inputs M. ", AttributeProto::INT, true)
         .Attr(
             "scan_input_directions",
@@ -420,7 +431,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "indicates reverse direction. "
             "If omitted, all scan_input tensors will be scanned in the forward direction.",
             AttributeProto::INTS,
-            false)
+            false
+        )
         .Attr(
             "scan_output_directions",
             "An optional list of K flags, one for each scan_output. The i-th element of the list "
@@ -430,7 +442,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "If omitted, all scan_output tensors will be produced by appending a value "
             "in each iteration.",
             AttributeProto::INTS,
-            false)
+            false
+        )
         .Attr(
             "scan_input_axes",
             "An optional list of M flags. The i-th element of the list specifies the axis "
@@ -438,7 +451,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "be used as the scan axis for every scan_input. Negative value for an axis means "
             "counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(input).",
             AttributeProto::INTS,
-            false)
+            false
+        )
         .Attr(
             "scan_output_axes",
             "An optional list of K flags. The i-th element of the list specifies the axis "
@@ -447,8 +461,10 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Negative value for an axis means counting dimensions from the back. Accepted "
             "range is [-r, r-1].",
             AttributeProto::INTS,
-            false)
+            false
+        )
         .TypeConstraint("V", OpSchema::all_tensor_types_ir9(), "All Tensor types up to IRv9.")
-        .TypeAndShapeInferenceFunction(ScanInferenceFunction)); // Shares same shape inference as opset 11
+        .TypeAndShapeInferenceFunction(ScanInferenceFunction)
+);  // Shares same shape inference as opset 11
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/controlflow/old.cc
+++ b/onnx/defs/controlflow/old.cc
@@ -47,25 +47,30 @@ ONNX_OPERATOR_SET_SCHEMA(
             "[3] are not compatible.",
             "V",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Attr(
             "then_branch",
             "Graph to run if condition is true. Has N outputs: values you wish to "
             "be live-out to the enclosing scope. The number of outputs must match"
             " the number of outputs in the else_branch.",
-            AttributeProto::GRAPH)
+            AttributeProto::GRAPH
+        )
         .Attr(
             "else_branch",
             "Graph to run if condition is false. Has N outputs: values you wish to"
             " be live-out to the enclosing scope. The number of outputs must match"
             " the number of outputs in the then_branch.",
-            AttributeProto::GRAPH)
+            AttributeProto::GRAPH
+        )
         .TypeConstraint(
             "V",
             control_flow_types_ir4(),
-            "All Tensor, Sequence(Tensor), Optional(Tensor), and Optional(Sequence(Tensor)) types up to IRv4.")
+            "All Tensor, Sequence(Tensor), Optional(Tensor), and Optional(Sequence(Tensor)) types up to IRv4."
+        )
         .TypeConstraint("B", {"tensor(bool)"}, "Only bool")
-        .TypeAndShapeInferenceFunction(IfInferenceFunction));
+        .TypeAndShapeInferenceFunction(IfInferenceFunction)
+);
 
 static const char* Loop_ver16_doc = R"DOC(
 Generic Looping construct. This loop has multiple termination conditions:
@@ -216,13 +221,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             "A maximum trip-count for the loop specified at runtime. Optional."
             " Pass empty string to skip.",
             "I",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Input(
-            1,
-            "cond",
-            "A boolean termination condition. Optional. Pass empty string to skip.",
-            "B",
-            OpSchema::Optional)
+            1, "cond", "A boolean termination condition. Optional. Pass empty string to skip.", "B", OpSchema::Optional
+        )
         .Input(
             2,
             "v_initial",
@@ -231,7 +234,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "V",
             OpSchema::Variadic,
             false,
-            0)
+            0
+        )
         .Output(
             0,
             "v_final_and_scan_outputs",
@@ -239,7 +243,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Scan outputs must be Tensors.",
             "V",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Attr(
             "body",
             "The graph run each iteration. It has 2+N inputs: (iteration_num, "
@@ -249,14 +254,17 @@ ONNX_OPERATOR_SET_SCHEMA(
             "output value at the end of each iteration of the loop. It is an error"
             " if the dimensions or data type of these scan_outputs change across loop"
             " iterations.",
-            AttributeProto::GRAPH)
+            AttributeProto::GRAPH
+        )
         .TypeConstraint(
             "V",
             control_flow_types_ir4(),
-            "All Tensor, Sequence(Tensor), Optional(Tensor), and Optional(Sequence(Tensor)) types up to IRv4.")
+            "All Tensor, Sequence(Tensor), Optional(Tensor), and Optional(Sequence(Tensor)) types up to IRv4."
+        )
         .TypeConstraint("I", {"tensor(int64)"}, "tensor of int64, which should be a scalar.")
         .TypeConstraint("B", {"tensor(bool)"}, "tensor of bool, which should be a scalar.")
-        .TypeAndShapeInferenceFunction(LoopInferenceFunction));
+        .TypeAndShapeInferenceFunction(LoopInferenceFunction)
+);
 
 static const char* scan_16_doc = R"DOC(
 Scan can be used to iterate over one or more scan_input tensors,
@@ -393,14 +401,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Initial values of the loop's N state variables followed by M scan_inputs",
             "V",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Output(
             0,
             "final_state_and_scan_outputs",
             "Final values of the loop's N state variables followed by K scan_outputs",
             "V",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Attr(
             "body",
             "The graph run each iteration. It has N+M inputs: "
@@ -410,7 +420,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "scan_output_elt value at the end of each iteration of the loop. It is an error"
             " if the dimensions of these values change across loop iterations.",
             AttributeProto::GRAPH,
-            true)
+            true
+        )
         .Attr("num_scan_inputs", "An attribute specifying the number of scan_inputs M. ", AttributeProto::INT, true)
         .Attr(
             "scan_input_directions",
@@ -419,7 +430,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "indicates reverse direction. "
             "If omitted, all scan_input tensors will be scanned in the forward direction.",
             AttributeProto::INTS,
-            false)
+            false
+        )
         .Attr(
             "scan_output_directions",
             "An optional list of K flags, one for each scan_output. The i-th element of the list "
@@ -429,7 +441,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "If omitted, all scan_output tensors will be produced by appending a value "
             "in each iteration.",
             AttributeProto::INTS,
-            false)
+            false
+        )
         .Attr(
             "scan_input_axes",
             "An optional list of M flags. The i-th element of the list specifies the axis "
@@ -437,7 +450,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "be used as the scan axis for every scan_input. Negative value for an axis means "
             "counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(input).",
             AttributeProto::INTS,
-            false)
+            false
+        )
         .Attr(
             "scan_output_axes",
             "An optional list of K flags. The i-th element of the list specifies the axis "
@@ -446,9 +460,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Negative value for an axis means counting dimensions from the back. Accepted "
             "range is [-r, r-1].",
             AttributeProto::INTS,
-            false)
+            false
+        )
         .TypeConstraint("V", OpSchema::all_tensor_types_ir4(), "All Tensor types up to IRv4.")
-        .TypeAndShapeInferenceFunction(ScanInferenceFunction)); // Shares same shape inference as opset 11
+        .TypeAndShapeInferenceFunction(ScanInferenceFunction)
+);  // Shares same shape inference as opset 11
 
 void ScanInferenceFunctionOpset8(InferenceContext& ctx) {
   // NOTE:
@@ -537,7 +553,8 @@ void ScanInferenceFunctionOpset8(InferenceContext& ctx) {
           "Graph attribute inferencing returned type information for ",
           output_types.size(),
           " outputs. Expected ",
-          num_outputs);
+          num_outputs
+      );
     }
 
     // propagate type/shape information for loop state variables and outputs
@@ -605,7 +622,8 @@ void ScanInferenceFunctionOpset9(InferenceContext& ctx) {
           axes.size(),
           ") is not equal to number of scan inputs (",
           num_scan_inputs,
-          ").");
+          ")."
+      );
     }
   } else {
     axes.insert(axes.end(), num_scan_inputs, 0);
@@ -618,7 +636,8 @@ void ScanInferenceFunctionOpset9(InferenceContext& ctx) {
           output_axes.size(),
           ") is not equal to number of scan outputs (",
           num_scan_outputs,
-          ").");
+          ")."
+      );
     }
   } else {
     output_axes.insert(output_axes.end(), num_scan_outputs, 0);
@@ -699,7 +718,8 @@ void ScanInferenceFunctionOpset9(InferenceContext& ctx) {
           "Graph attribute inferencing returned type information for ",
           output_types.size(),
           " outputs. Expected ",
-          num_outputs);
+          num_outputs
+      );
     }
 
     // propagate type/shape information for loop state variables and outputs
@@ -887,21 +907,24 @@ ONNX_OPERATOR_SET_SCHEMA(
             "the maximum sequence length (the dimension of the sequence axis of "
             "the scan_input tensors).",
             "I",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Input(
             1,
             "initial_state_and_scan_inputs",
             "Initial values of the loop's N state variables followed by M scan_inputs",
             "V",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Output(
             0,
             "final_state_and_scan_outputs",
             "Final values of the loop's N state variables followed by K scan_outputs",
             "V",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Attr(
             "body",
             "The graph run each iteration. It has N+M inputs: "
@@ -911,7 +934,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "scan_output_elt value at the end of each iteration of the loop. It is an error"
             " if the dimensions of these values change across loop iterations.",
             AttributeProto::GRAPH,
-            true)
+            true
+        )
         .Attr("num_scan_inputs", "An attribute specifying the number of scan_inputs M. ", AttributeProto::INT, true)
         .Attr(
             "directions",
@@ -920,14 +944,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "indicates reverse direction. "
             "If omitted, all scan_input tensors will be scanned in the forward direction.",
             AttributeProto::INTS,
-            false)
+            false
+        )
         .TypeConstraint("I", {"tensor(int64)"}, "Int64 tensor")
         .TypeConstraint("V", OpSchema::all_tensor_types(), "All Tensor types")
-        .TypeAndShapeInferenceFunction(ScanInferenceFunctionOpset8));
+        .TypeAndShapeInferenceFunction(ScanInferenceFunctionOpset8)
+);
 
 void LoopInferenceFunctionOpset8(InferenceContext& ctx) {
   auto num_inputs = ctx.getNumInputs();
-  auto num_loop_state_vars = num_inputs - 2; // skip 'M' and 'cond'
+  auto num_loop_state_vars = num_inputs - 2;  // skip 'M' and 'cond'
 
   std::vector<const TypeProto*> subgraph_input_types;
 
@@ -964,7 +990,7 @@ void LoopInferenceFunctionOpset8(InferenceContext& ctx) {
   GraphInferencer* graphInferencer = ctx.getGraphAttributeInferencer("body");
   if (graphInferencer) {
     std::vector<const TensorProto*> input_data;
-    input_data.push_back(nullptr); // iteration number
+    input_data.push_back(nullptr);  // iteration number
     for (size_t i = 1; i < num_inputs; ++i) {
       input_data.push_back(ctx.getInputData(i));
     }
@@ -983,12 +1009,13 @@ void LoopInferenceFunctionOpset8(InferenceContext& ctx) {
           "Graph attribute inferencing returned type information for ",
           subgraph_output_types.size(),
           " outputs. Expected ",
-          num_outputs + 1);
+          num_outputs + 1
+      );
     }
 
     // check loop state values match. we should already have type/shape info
     for (size_t i = 0; i < num_outputs; ++i) {
-      auto* subgraph_output_type = subgraph_output_types[i + 1]; // skip 'cond'
+      auto* subgraph_output_type = subgraph_output_types[i + 1];  // skip 'cond'
       auto* loop_output_type = ctx.getOutputType(i);
 
       const bool is_loop_state_var = i < num_loop_state_vars;
@@ -998,7 +1025,8 @@ void LoopInferenceFunctionOpset8(InferenceContext& ctx) {
             "Loop 'body' subgraph outputs should all be tensors but output ",
             i,
             " was ",
-            subgraph_output_type->value_case());
+            subgraph_output_type->value_case()
+        );
       }
 
       // if there's an existing type check it matches. otherwise propagate
@@ -1159,13 +1187,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             "A maximum trip-count for the loop specified at runtime. Optional."
             " Pass empty string to skip.",
             "I",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Input(
-            1,
-            "cond",
-            "A boolean termination condition. Optional. Pass empty string to skip.",
-            "B",
-            OpSchema::Optional)
+            1, "cond", "A boolean termination condition. Optional. Pass empty string to skip.", "B", OpSchema::Optional
+        )
         .Input(
             2,
             "v_initial",
@@ -1173,14 +1199,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "change across loop iterations)",
             "V",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Output(
             0,
             "v_final_and_scan_outputs",
             "Final N loop carried dependency values then K scan_outputs",
             "V",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Attr(
             "body",
             "The graph run each iteration. It has 2+N inputs: (iteration_num, "
@@ -1190,15 +1218,17 @@ ONNX_OPERATOR_SET_SCHEMA(
             "output value at the end of each iteration of the loop. It is an error"
             " if the dimensions or data type of these scan_outputs change across loop"
             " iterations.",
-            AttributeProto::GRAPH)
+            AttributeProto::GRAPH
+        )
         .TypeConstraint("V", OpSchema::all_tensor_types(), "All Tensor types")
         .TypeConstraint("I", {"tensor(int64)"}, "tensor of int64, which should be a scalar.")
         .TypeConstraint("B", {"tensor(bool)"}, "tensor of bool, which should be a scalar.")
-        .TypeAndShapeInferenceFunction(LoopInferenceFunctionOpset8));
+        .TypeAndShapeInferenceFunction(LoopInferenceFunctionOpset8)
+);
 
 void LoopInferenceFunctionOpset11(InferenceContext& ctx) {
   auto num_inputs = ctx.getNumInputs();
-  auto num_loop_state_vars = num_inputs - 2; // skip 'M' and 'cond'
+  auto num_loop_state_vars = num_inputs - 2;  // skip 'M' and 'cond'
 
   std::vector<const TypeProto*> subgraph_input_types;
 
@@ -1235,7 +1265,7 @@ void LoopInferenceFunctionOpset11(InferenceContext& ctx) {
   GraphInferencer* graphInferencer = ctx.getGraphAttributeInferencer("body");
   if (graphInferencer) {
     std::vector<const TensorProto*> input_data;
-    input_data.push_back(nullptr); // iteration number
+    input_data.push_back(nullptr);  // iteration number
     for (size_t i = 1; i < num_inputs; ++i) {
       input_data.push_back(ctx.getInputData(i));
     }
@@ -1254,12 +1284,13 @@ void LoopInferenceFunctionOpset11(InferenceContext& ctx) {
           "Graph attribute inferencing returned type information for ",
           subgraph_output_types.size(),
           " outputs. Expected ",
-          num_outputs + 1);
+          num_outputs + 1
+      );
     }
 
     // check loop state values match. we should already have type/shape info
     for (size_t i = 0; i < num_outputs; ++i) {
-      auto* subgraph_output_type = subgraph_output_types[i + 1]; // skip 'cond'
+      auto* subgraph_output_type = subgraph_output_types[i + 1];  // skip 'cond'
       auto* loop_output_type = ctx.getOutputType(i);
 
       const bool is_loop_state_var = i < num_loop_state_vars;
@@ -1269,7 +1300,8 @@ void LoopInferenceFunctionOpset11(InferenceContext& ctx) {
             "Loop 'body' subgraph outputs should all be tensors but output ",
             i,
             " was ",
-            subgraph_output_type->value_case());
+            subgraph_output_type->value_case()
+        );
       }
 
       // if there's an existing type check it matches. otherwise propagate
@@ -1450,13 +1482,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             "A maximum trip-count for the loop specified at runtime. Optional."
             " Pass empty string to skip.",
             "I",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Input(
-            1,
-            "cond",
-            "A boolean termination condition. Optional. Pass empty string to skip.",
-            "B",
-            OpSchema::Optional)
+            1, "cond", "A boolean termination condition. Optional. Pass empty string to skip.", "B", OpSchema::Optional
+        )
         .Input(
             2,
             "v_initial",
@@ -1465,14 +1495,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "V",
             OpSchema::Variadic,
             false,
-            0)
+            0
+        )
         .Output(
             0,
             "v_final_and_scan_outputs",
             "Final N loop carried dependency values then K scan_outputs",
             "V",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Attr(
             "body",
             "The graph run each iteration. It has 2+N inputs: (iteration_num, "
@@ -1482,11 +1514,13 @@ ONNX_OPERATOR_SET_SCHEMA(
             "output value at the end of each iteration of the loop. It is an error"
             " if the dimensions or data type of these scan_outputs change across loop"
             " iterations.",
-            AttributeProto::GRAPH)
+            AttributeProto::GRAPH
+        )
         .TypeConstraint("V", OpSchema::all_tensor_types(), "All Tensor types")
         .TypeConstraint("I", {"tensor(int64)"}, "tensor of int64, which should be a scalar.")
         .TypeConstraint("B", {"tensor(bool)"}, "tensor of bool, which should be a scalar.")
-        .TypeAndShapeInferenceFunction(LoopInferenceFunctionOpset11));
+        .TypeAndShapeInferenceFunction(LoopInferenceFunctionOpset11)
+);
 
 static const char* scan_9_doc = R"DOC(
 Scan can be used to iterate over one or more scan_input tensors,
@@ -1623,14 +1657,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Initial values of the loop's N state variables followed by M scan_inputs",
             "V",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Output(
             0,
             "final_state_and_scan_outputs",
             "Final values of the loop's N state variables followed by K scan_outputs",
             "V",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Attr(
             "body",
             "The graph run each iteration. It has N+M inputs: "
@@ -1640,7 +1676,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "scan_output_elt value at the end of each iteration of the loop. It is an error"
             " if the dimensions of these values change across loop iterations.",
             AttributeProto::GRAPH,
-            true)
+            true
+        )
         .Attr("num_scan_inputs", "An attribute specifying the number of scan_inputs M. ", AttributeProto::INT, true)
         .Attr(
             "scan_input_directions",
@@ -1649,7 +1686,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "indicates reverse direction. "
             "If omitted, all scan_input tensors will be scanned in the forward direction.",
             AttributeProto::INTS,
-            false)
+            false
+        )
         .Attr(
             "scan_output_directions",
             "An optional list of K flags, one for each scan_output. The i-th element of the list "
@@ -1659,29 +1697,33 @@ ONNX_OPERATOR_SET_SCHEMA(
             "If omitted, all scan_output tensors will be produced by appending a value "
             "in each iteration.",
             AttributeProto::INTS,
-            false)
+            false
+        )
         .Attr(
             "scan_input_axes",
             "An optional list of M flags. The i-th element of the list specifies the axis "
             "to be scanned (the sequence axis) for the i-th scan_input. If omitted, 0 will "
             "be used as the scan axis for every scan_input.",
             AttributeProto::INTS,
-            false)
+            false
+        )
         .Attr(
             "scan_output_axes",
             "An optional list of K flags. The i-th element of the list specifies the axis "
             "for the i-th scan_output. The scan outputs are accumulated along the specified "
             "axis. If omitted, 0 will be used as the scan axis for every scan_output.",
             AttributeProto::INTS,
-            false)
+            false
+        )
         .TypeConstraint("V", OpSchema::all_tensor_types(), "All Tensor types")
-        .TypeAndShapeInferenceFunction(ScanInferenceFunctionOpset9));
+        .TypeAndShapeInferenceFunction(ScanInferenceFunctionOpset9)
+);
 
 void IfInferenceFunction1(InferenceContext& ctx) {
   // there are no inputs so we just need to run the subgraph inferencing for
   // then/else subgraphs and apply those to the outputs.
-  std::vector<const TypeProto*> subgraph_input_types; // none
-  std::vector<const TensorProto*> input_data; // none
+  std::vector<const TypeProto*> subgraph_input_types;  // none
+  std::vector<const TensorProto*> input_data;  // none
 
   std::vector<const TypeProto*> then_output_types;
   std::vector<const TypeProto*> else_output_types;
@@ -1704,10 +1746,8 @@ void IfInferenceFunction1(InferenceContext& ctx) {
   // the output types for then and else should be the same
   if (num_then_outputs != num_else_outputs) {
     fail_type_inference(
-        "then_branch and else_branch produce different number of outputs. ",
-        num_then_outputs,
-        " != ",
-        num_else_outputs);
+        "then_branch and else_branch produce different number of outputs. ", num_then_outputs, " != ", num_else_outputs
+    );
   }
 
   if (num_then_outputs != num_outputs) {
@@ -1720,7 +1760,8 @@ void IfInferenceFunction1(InferenceContext& ctx) {
 
     if (then_output->value_case() != else_output->value_case()) {
       fail_type_inference(
-          "Mismatched type for output ", i, " then=", then_output->value_case(), " else=", else_output->value_case());
+          "Mismatched type for output ", i, " then=", then_output->value_case(), " else=", else_output->value_case()
+      );
     }
 
     auto* if_output = ctx.getOutputType(i);
@@ -1732,7 +1773,8 @@ void IfInferenceFunction1(InferenceContext& ctx) {
 
       if (then_elem_type != else_elem_type) {
         fail_type_inference(
-            "Mismatched tensor element type for output ", i, " then=", then_elem_type, " else=", else_elem_type);
+            "Mismatched tensor element type for output ", i, " then=", then_elem_type, " else=", else_elem_type
+        );
       }
 
       // merge the 'else' shape information to check it's consistent and
@@ -1756,28 +1798,32 @@ ONNX_OPERATOR_SET_SCHEMA(
             "data type.",
             "V",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Attr(
             "then_branch",
             "Graph to run if condition is true. Has N outputs: values you wish to "
             "be live-out to the enclosing scope. The number of outputs must match"
             " the number of outputs in the else_branch.",
-            AttributeProto::GRAPH)
+            AttributeProto::GRAPH
+        )
         .Attr(
             "else_branch",
             "Graph to run if condition is false. Has N outputs: values you wish to"
             " be live-out to the enclosing scope. The number of outputs must match"
             " the number of outputs in the then_branch.",
-            AttributeProto::GRAPH)
+            AttributeProto::GRAPH
+        )
         .TypeConstraint("V", OpSchema::all_tensor_types(), "All Tensor types")
         .TypeConstraint("B", {"tensor(bool)"}, "Only bool")
-        .TypeAndShapeInferenceFunction(IfInferenceFunction1));
+        .TypeAndShapeInferenceFunction(IfInferenceFunction1)
+);
 
 void IfInferenceFunction_11(InferenceContext& ctx) {
   // there are no inputs so we just need to run the subgraph inferencing for
   // then/else subgraphs and apply those to the outputs.
-  std::vector<const TypeProto*> subgraph_input_types; // none
-  std::vector<const TensorProto*> input_data; // none
+  std::vector<const TypeProto*> subgraph_input_types;  // none
+  std::vector<const TensorProto*> input_data;  // none
 
   std::vector<const TypeProto*> then_output_types;
   std::vector<const TypeProto*> else_output_types;
@@ -1800,10 +1846,8 @@ void IfInferenceFunction_11(InferenceContext& ctx) {
   // the output types for then and else should be the same
   if (num_then_outputs != num_else_outputs) {
     fail_type_inference(
-        "then_branch and else_branch produce different number of outputs. ",
-        num_then_outputs,
-        " != ",
-        num_else_outputs);
+        "then_branch and else_branch produce different number of outputs. ", num_then_outputs, " != ", num_else_outputs
+    );
   }
 
   if (num_then_outputs != num_outputs) {
@@ -1816,7 +1860,8 @@ void IfInferenceFunction_11(InferenceContext& ctx) {
 
     if (then_output->value_case() != else_output->value_case()) {
       fail_type_inference(
-          "Mismatched type for output ", i, " then=", then_output->value_case(), " else=", else_output->value_case());
+          "Mismatched type for output ", i, " then=", then_output->value_case(), " else=", else_output->value_case()
+      );
     }
 
     auto* if_output = ctx.getOutputType(i);
@@ -1828,7 +1873,8 @@ void IfInferenceFunction_11(InferenceContext& ctx) {
 
       if (then_elem_type != else_elem_type) {
         fail_type_inference(
-            "Mismatched tensor element type for output ", i, " then=", then_elem_type, " else=", else_elem_type);
+            "Mismatched tensor element type for output ", i, " then=", then_elem_type, " else=", else_elem_type
+        );
       }
 
       UnionShapeInfo(else_output->tensor_type().shape(), *if_output->mutable_tensor_type());
@@ -1863,28 +1909,32 @@ ONNX_OPERATOR_SET_SCHEMA(
             "[3] are not compatible.",
             "V",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Attr(
             "then_branch",
             "Graph to run if condition is true. Has N outputs: values you wish to "
             "be live-out to the enclosing scope. The number of outputs must match"
             " the number of outputs in the else_branch.",
-            AttributeProto::GRAPH)
+            AttributeProto::GRAPH
+        )
         .Attr(
             "else_branch",
             "Graph to run if condition is false. Has N outputs: values you wish to"
             " be live-out to the enclosing scope. The number of outputs must match"
             " the number of outputs in the then_branch.",
-            AttributeProto::GRAPH)
+            AttributeProto::GRAPH
+        )
         .TypeConstraint("V", OpSchema::all_tensor_types(), "All Tensor types")
         .TypeConstraint("B", {"tensor(bool)"}, "Only bool")
-        .TypeAndShapeInferenceFunction(IfInferenceFunction_11));
+        .TypeAndShapeInferenceFunction(IfInferenceFunction_11)
+);
 
 void IfInferenceFunction_13(InferenceContext& ctx) {
   // there are no inputs so we just need to run the subgraph inferencing for
   // then/else subgraphs and apply those to the outputs.
-  std::vector<const TypeProto*> subgraph_input_types; // none
-  std::vector<const TensorProto*> input_data; // none
+  std::vector<const TypeProto*> subgraph_input_types;  // none
+  std::vector<const TensorProto*> input_data;  // none
 
   std::vector<const TypeProto*> then_output_types;
   std::vector<const TypeProto*> else_output_types;
@@ -1907,10 +1957,8 @@ void IfInferenceFunction_13(InferenceContext& ctx) {
   // the output types for then and else should be the same
   if (num_then_outputs != num_else_outputs) {
     fail_type_inference(
-        "then_branch and else_branch produce different number of outputs. ",
-        num_then_outputs,
-        " != ",
-        num_else_outputs);
+        "then_branch and else_branch produce different number of outputs. ", num_then_outputs, " != ", num_else_outputs
+    );
   }
 
   if (num_then_outputs != num_outputs) {
@@ -1955,19 +2003,22 @@ ONNX_OPERATOR_SET_SCHEMA(
             "[3] are not compatible.",
             "V",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Attr(
             "then_branch",
             "Graph to run if condition is true. Has N outputs: values you wish to "
             "be live-out to the enclosing scope. The number of outputs must match"
             " the number of outputs in the else_branch.",
-            AttributeProto::GRAPH)
+            AttributeProto::GRAPH
+        )
         .Attr(
             "else_branch",
             "Graph to run if condition is false. Has N outputs: values you wish to"
             " be live-out to the enclosing scope. The number of outputs must match"
             " the number of outputs in the then_branch.",
-            AttributeProto::GRAPH)
+            AttributeProto::GRAPH
+        )
         .TypeConstraint(
             "V",
             []() {
@@ -1976,14 +2027,16 @@ ONNX_OPERATOR_SET_SCHEMA(
               t.insert(t.end(), s.begin(), s.end());
               return t;
             }(),
-            "All Tensor and Sequence types")
+            "All Tensor and Sequence types"
+        )
         .TypeConstraint("B", {"tensor(bool)"}, "Only bool")
-        .TypeAndShapeInferenceFunction(IfInferenceFunction_13));
+        .TypeAndShapeInferenceFunction(IfInferenceFunction_13)
+);
 
 void LoopInferenceFunction_13(InferenceContext& ctx) {
   auto num_inputs = ctx.getNumInputs();
   assert(num_inputs >= 2);
-  auto num_loop_state_vars = num_inputs - 2; // skip 'M' and 'cond'
+  auto num_loop_state_vars = num_inputs - 2;  // skip 'M' and 'cond'
 
   std::vector<const TypeProto*> subgraph_input_types;
   subgraph_input_types.reserve(num_inputs);
@@ -2029,7 +2082,7 @@ void LoopInferenceFunction_13(InferenceContext& ctx) {
   GraphInferencer* graphInferencer = ctx.getGraphAttributeInferencer("body");
   if (graphInferencer) {
     std::vector<const TensorProto*> input_data;
-    input_data.push_back(nullptr); // iteration number
+    input_data.push_back(nullptr);  // iteration number
     for (size_t i = 1; i < num_inputs; ++i) {
       input_data.push_back(ctx.getInputData(i));
     }
@@ -2048,12 +2101,13 @@ void LoopInferenceFunction_13(InferenceContext& ctx) {
           "Graph attribute inferencing returned type information for ",
           subgraph_output_types.size(),
           " outputs. Expected ",
-          num_outputs + 1);
+          num_outputs + 1
+      );
     }
 
     // check loop state values match. we should already have type/shape info
     for (size_t i = 0; i < num_outputs; ++i) {
-      auto* subgraph_output_type = subgraph_output_types[i + 1]; // skip 'cond'
+      auto* subgraph_output_type = subgraph_output_types[i + 1];  // skip 'cond'
       auto* loop_output_type = ctx.getOutputType(i);
 
       const bool is_loop_state_var = i < num_loop_state_vars;
@@ -2063,7 +2117,8 @@ void LoopInferenceFunction_13(InferenceContext& ctx) {
             "Loop 'body' subgraph outputs should all be tensors or sequences but output ",
             i,
             " was ",
-            subgraph_output_type->value_case());
+            subgraph_output_type->value_case()
+        );
       }
 
       if (!is_loop_state_var && !subgraph_output_type->has_tensor_type()) {
@@ -2071,7 +2126,8 @@ void LoopInferenceFunction_13(InferenceContext& ctx) {
             "Loop 'body' subgraph scan outputs should all be tensors but output ",
             i,
             " was ",
-            subgraph_output_type->value_case());
+            subgraph_output_type->value_case()
+        );
       }
 
       // if there's an existing type check it matches. otherwise propagate
@@ -2254,13 +2310,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             "A maximum trip-count for the loop specified at runtime. Optional."
             " Pass empty string to skip.",
             "I",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Input(
-            1,
-            "cond",
-            "A boolean termination condition. Optional. Pass empty string to skip.",
-            "B",
-            OpSchema::Optional)
+            1, "cond", "A boolean termination condition. Optional. Pass empty string to skip.", "B", OpSchema::Optional
+        )
         .Input(
             2,
             "v_initial",
@@ -2269,7 +2323,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "V",
             OpSchema::Variadic,
             false,
-            0)
+            0
+        )
         .Output(
             0,
             "v_final_and_scan_outputs",
@@ -2277,7 +2332,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Scan outputs must be Tensors.",
             "V",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Attr(
             "body",
             "The graph run each iteration. It has 2+N inputs: (iteration_num, "
@@ -2287,7 +2343,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "output value at the end of each iteration of the loop. It is an error"
             " if the dimensions or data type of these scan_outputs change across loop"
             " iterations.",
-            AttributeProto::GRAPH)
+            AttributeProto::GRAPH
+        )
         .TypeConstraint(
             "V",
             []() {
@@ -2296,10 +2353,12 @@ ONNX_OPERATOR_SET_SCHEMA(
               t.insert(t.end(), s.begin(), s.end());
               return t;
             }(),
-            "All Tensor and Sequence types")
+            "All Tensor and Sequence types"
+        )
         .TypeConstraint("I", {"tensor(int64)"}, "tensor of int64, which should be a scalar.")
         .TypeConstraint("B", {"tensor(bool)"}, "tensor of bool, which should be a scalar.")
-        .TypeAndShapeInferenceFunction(LoopInferenceFunction_13));
+        .TypeAndShapeInferenceFunction(LoopInferenceFunction_13)
+);
 
 static const char* scan_11_doc = R"DOC(
 Scan can be used to iterate over one or more scan_input tensors,
@@ -2438,14 +2497,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Initial values of the loop's N state variables followed by M scan_inputs",
             "V",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Output(
             0,
             "final_state_and_scan_outputs",
             "Final values of the loop's N state variables followed by K scan_outputs",
             "V",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Attr(
             "body",
             "The graph run each iteration. It has N+M inputs: "
@@ -2455,7 +2516,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "scan_output_elt value at the end of each iteration of the loop. It is an error"
             " if the dimensions of these values change across loop iterations.",
             AttributeProto::GRAPH,
-            true)
+            true
+        )
         .Attr("num_scan_inputs", "An attribute specifying the number of scan_inputs M. ", AttributeProto::INT, true)
         .Attr(
             "scan_input_directions",
@@ -2464,7 +2526,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "indicates reverse direction. "
             "If omitted, all scan_input tensors will be scanned in the forward direction.",
             AttributeProto::INTS,
-            false)
+            false
+        )
         .Attr(
             "scan_output_directions",
             "An optional list of K flags, one for each scan_output. The i-th element of the list "
@@ -2474,7 +2537,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "If omitted, all scan_output tensors will be produced by appending a value "
             "in each iteration.",
             AttributeProto::INTS,
-            false)
+            false
+        )
         .Attr(
             "scan_input_axes",
             "An optional list of M flags. The i-th element of the list specifies the axis "
@@ -2482,7 +2546,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "be used as the scan axis for every scan_input. Negative value for an axis means "
             "counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(input).",
             AttributeProto::INTS,
-            false)
+            false
+        )
         .Attr(
             "scan_output_axes",
             "An optional list of K flags. The i-th element of the list specifies the axis "
@@ -2491,8 +2556,10 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Negative value for an axis means counting dimensions from the back. Accepted "
             "range is [-r, r-1].",
             AttributeProto::INTS,
-            false)
+            false
+        )
         .TypeConstraint("V", OpSchema::all_tensor_types(), "All Tensor types")
-        .TypeAndShapeInferenceFunction(ScanInferenceFunction));
+        .TypeAndShapeInferenceFunction(ScanInferenceFunction)
+);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/controlflow/utils.cc
+++ b/onnx/defs/controlflow/utils.cc
@@ -28,8 +28,8 @@ void ClearShape(TypeProto& input_type) {
 void IfInferenceFunction(InferenceContext& ctx) {
   // there are no inputs so we just need to run the subgraph inferencing for
   // then/else subgraphs and apply those to the outputs.
-  std::vector<const TypeProto*> subgraph_input_types; // none
-  std::vector<const TensorProto*> input_data; // none
+  std::vector<const TypeProto*> subgraph_input_types;  // none
+  std::vector<const TensorProto*> input_data;  // none
 
   std::vector<const TypeProto*> then_output_types;
   std::vector<const TypeProto*> else_output_types;
@@ -52,10 +52,8 @@ void IfInferenceFunction(InferenceContext& ctx) {
   // the output types for then and else should be the same
   if (num_then_outputs != num_else_outputs) {
     fail_type_inference(
-        "then_branch and else_branch produce different number of outputs. ",
-        num_then_outputs,
-        " != ",
-        num_else_outputs);
+        "then_branch and else_branch produce different number of outputs. ", num_then_outputs, " != ", num_else_outputs
+    );
   }
 
   if (num_then_outputs != num_outputs) {
@@ -76,7 +74,7 @@ void IfInferenceFunction(InferenceContext& ctx) {
 void LoopInferenceFunction(InferenceContext& ctx) {
   auto num_inputs = ctx.getNumInputs();
   assert(num_inputs >= 2);
-  auto num_loop_state_vars = num_inputs - 2; // skip 'M' and 'cond'
+  auto num_loop_state_vars = num_inputs - 2;  // skip 'M' and 'cond'
 
   std::vector<const TypeProto*> subgraph_input_types;
   subgraph_input_types.reserve(num_inputs);
@@ -114,7 +112,7 @@ void LoopInferenceFunction(InferenceContext& ctx) {
   GraphInferencer* graphInferencer = ctx.getGraphAttributeInferencer("body");
   if (graphInferencer) {
     std::vector<const TensorProto*> input_data;
-    input_data.push_back(nullptr); // iteration number
+    input_data.push_back(nullptr);  // iteration number
     for (size_t i = 1; i < num_inputs; ++i) {
       input_data.push_back(ctx.getInputData(i));
     }
@@ -133,12 +131,13 @@ void LoopInferenceFunction(InferenceContext& ctx) {
           "Graph attribute inferencing returned type information for ",
           subgraph_output_types.size(),
           " outputs. Expected ",
-          num_outputs + 1);
+          num_outputs + 1
+      );
     }
 
     // check loop state values match. we should already have type/shape info
     for (size_t i = 0; i < num_outputs; ++i) {
-      auto* subgraph_output_type = subgraph_output_types[i + 1]; // skip 'cond'
+      auto* subgraph_output_type = subgraph_output_types[i + 1];  // skip 'cond'
       auto* loop_output_type = ctx.getOutputType(i);
 
       const bool is_loop_state_var = i < num_loop_state_vars;
@@ -149,7 +148,8 @@ void LoopInferenceFunction(InferenceContext& ctx) {
             "Loop 'body' subgraph outputs should all be tensors or sequences or optionals, but output ",
             i,
             " was ",
-            subgraph_output_type->value_case());
+            subgraph_output_type->value_case()
+        );
       }
 
       if (!is_loop_state_var && !subgraph_output_type->has_tensor_type()) {
@@ -157,7 +157,8 @@ void LoopInferenceFunction(InferenceContext& ctx) {
             "Loop 'body' subgraph scan outputs should all be tensors but output ",
             i,
             " was ",
-            subgraph_output_type->value_case());
+            subgraph_output_type->value_case()
+        );
       }
 
       // if there's an existing type check it matches. otherwise propagate
@@ -213,7 +214,8 @@ void ScanInferenceFunction(InferenceContext& ctx) {
           axes.size(),
           ") is not equal to number of scan inputs (",
           num_scan_inputs,
-          ").");
+          ")."
+      );
     }
   } else {
     axes.insert(axes.end(), num_scan_inputs, 0);
@@ -226,7 +228,8 @@ void ScanInferenceFunction(InferenceContext& ctx) {
           output_axes.size(),
           ") is not equal to number of scan outputs (",
           num_scan_outputs,
-          ").");
+          ")."
+      );
     }
   } else {
     output_axes.insert(output_axes.end(), num_scan_outputs, 0);
@@ -309,7 +312,8 @@ void ScanInferenceFunction(InferenceContext& ctx) {
           "Graph attribute inferencing returned type information for ",
           output_types.size(),
           " outputs. Expected ",
-          num_outputs);
+          num_outputs
+      );
     }
 
     // propagate type/shape information for loop state variables and outputs
@@ -356,4 +360,4 @@ void ScanInferenceFunction(InferenceContext& ctx) {
   }
 }
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/controlflow/utils.h
+++ b/onnx/defs/controlflow/utils.h
@@ -20,4 +20,4 @@ void LoopInferenceFunction(InferenceContext& ctx);
 
 void ScanInferenceFunction(InferenceContext& ctx);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/data_propagators.h
+++ b/onnx/defs/data_propagators.h
@@ -82,4 +82,4 @@ inline void GatherOp13DataPropagator(DataPropagationContext& ctx) {
   }
 }
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/data_type_utils.cc
+++ b/onnx/defs/data_type_utils.cc
@@ -204,7 +204,7 @@ void DataTypeUtils::FromString(const std::string& type_str, TypeProto& type_prot
         if (cm > 0) {
           opaque_type->mutable_domain()->assign(s.Data(), cm);
         }
-        s.LStrip(cm + 1); // skip comma
+        s.LStrip(cm + 1);  // skip comma
       }
       if (!s.Empty()) {
         opaque_type->mutable_name()->assign(s.Data(), s.Size());
@@ -231,7 +231,7 @@ void DataTypeUtils::FromString(const std::string& type_str, TypeProto& type_prot
     // Call mutable_shape() to initialize a shape with no dimension.
     t->mutable_shape();
   }
-} // namespace Utils
+}  // namespace Utils
 
 bool DataTypeUtils::IsValidDataTypeString(const std::string& type_str) {
   TypesWrapper& t = TypesWrapper::GetTypesWrapper();
@@ -242,7 +242,8 @@ bool DataTypeUtils::IsValidDataTypeString(const std::string& type_str) {
 void DataTypeUtils::FromDataTypeString(const std::string& type_str, int32_t& tensor_data_type) {
   if (!IsValidDataTypeString(type_str)) {
     ONNX_THROW_EX(std::invalid_argument(
-        "DataTypeUtils::FromDataTypeString - Received invalid data type string '" + type_str + "'."));
+        "DataTypeUtils::FromDataTypeString - Received invalid data type string '" + type_str + "'."
+    ));
   }
 
   TypesWrapper& t = TypesWrapper::GetTypesWrapper();
@@ -446,5 +447,5 @@ TypesWrapper::TypesWrapper() {
     allowed_data_types_.insert(str_type_pair.first);
   }
 }
-} // namespace Utils
-} // namespace ONNX_NAMESPACE
+}  // namespace Utils
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/data_type_utils.h
+++ b/onnx/defs/data_type_utils.h
@@ -67,7 +67,7 @@ class DataTypeUtils final {
   // Returns lock used for concurrent updates to TypeStrToProtoMap.
   static std::mutex& GetTypeStrLock();
 };
-} // namespace Utils
-} // namespace ONNX_NAMESPACE
+}  // namespace Utils
+}  // namespace ONNX_NAMESPACE
 
-#endif // ! ONNX_DATA_TYPE_UTILS_H
+#endif  // ! ONNX_DATA_TYPE_UTILS_H

--- a/onnx/defs/function.cc
+++ b/onnx/defs/function.cc
@@ -16,10 +16,8 @@ std::string InteralTensorNameGenerator(const std::string& node_name, const std::
 }
 
 void FunctionExpandHelper(
-    const NodeProto& node,
-    const FunctionProto& func,
-    GraphProto& g,
-    const std::string& node_prefix) {
+    const NodeProto& node, const FunctionProto& func, GraphProto& g, const std::string& node_prefix
+) {
   // Create a temporary unique node prefix for tensor names
   std::string uniq_prefix = node_prefix;
   if (uniq_prefix.empty()) {
@@ -161,7 +159,8 @@ bool FunctionBodyHelper::BuildFunctionProto(
     FunctionProto& functionProto,
     const OpSchema& schema,
     const std::vector<NodeDef>& node_defs,
-    const std::vector<OperatorSetIdProto>& relied_opsets) {
+    const std::vector<OperatorSetIdProto>& relied_opsets
+) {
   BuildNodes(functionProto, node_defs);
 
   for (auto& relied_opset : relied_opsets) {
@@ -172,4 +171,4 @@ bool FunctionBodyHelper::BuildFunctionProto(
   return true;
 }
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/function.h
+++ b/onnx/defs/function.h
@@ -20,10 +20,8 @@
 namespace ONNX_NAMESPACE {
 // Helper function to expand a function node given the function proto
 void FunctionExpandHelper(
-    const NodeProto& node,
-    const FunctionProto& func,
-    GraphProto& g,
-    const std::string& node_prefix = "");
+    const NodeProto& node, const FunctionProto& func, GraphProto& g, const std::string& node_prefix = ""
+);
 
 class FunctionBodyHelper {
  public:
@@ -48,7 +46,8 @@ class FunctionBodyHelper {
         std::string op_type,
         std::vector<std::string> inputs,
         std::vector<AttributeProtoWrapper> attributes = {},
-        std::string domain = "")
+        std::string domain = ""
+    )
         : outputs(std::move(outputs)),
           op_type(std::move(op_type)),
           inputs(std::move(inputs)),
@@ -95,7 +94,8 @@ class FunctionBodyHelper {
       FunctionProto& functionProto,
       const OpSchema& schema,
       const std::vector<NodeDef>& node_defs,
-      const std::vector<OperatorSetIdProto>& relied_opsets);
+      const std::vector<OperatorSetIdProto>& relied_opsets
+  );
 
   template <typename T>
   static NodeDef Const(const std::string& name, const T& value) {
@@ -177,7 +177,7 @@ class FunctionBuilder {
     std::string constant_op(name);
     constant_op += " = Constant()";
     auto tensor = ToTensor(values);
-    tensor.add_dims(values.size()); // Treat as 1D tensor.
+    tensor.add_dims(values.size());  // Treat as 1D tensor.
 
     return Add(constant_op.c_str(), MakeAttribute("value", tensor));
   }
@@ -193,4 +193,4 @@ class FunctionBuilder {
   FunctionProto& funProto;
 };
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -25,40 +25,45 @@ ONNX_OPERATOR_SET_SCHEMA(
             "sparse_value",
             "The value for the elements of the output tensor in sparse format.",
             AttributeProto::SPARSE_TENSOR,
-            false)
+            false
+        )
         .Attr(
             "value_int",
             "The value for the sole element for the scalar, int64, output tensor.",
             AttributeProto::INT,
-            false)
+            false
+        )
         .Attr(
-            "value_ints",
-            "The values for the elements for the 1D, int64, output tensor.",
-            AttributeProto::INTS,
-            false)
+            "value_ints", "The values for the elements for the 1D, int64, output tensor.", AttributeProto::INTS, false
+        )
         .Attr(
             "value_float",
             "The value for the sole element for the scalar, float32, output tensor.",
             AttributeProto::FLOAT,
-            false)
+            false
+        )
         .Attr(
             "value_floats",
             "The values for the elements for the 1D, float32, output tensor.",
             AttributeProto::FLOATS,
-            false)
+            false
+        )
         .Attr(
             "value_string",
             "The value for the sole element for the scalar, UTF-8 string, output tensor.",
             AttributeProto::STRING,
-            false)
+            false
+        )
         .Attr(
             "value_strings",
             "The values for the elements for the 1D, UTF-8 string, output tensor.",
             AttributeProto::STRINGS,
-            false)
+            false
+        )
         .Output(0, "output", "Output tensor containing the same value of the provided tensor.", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types_ir9(), "Constrain input and output types to all tensor types.")
-        .TypeAndShapeInferenceFunction(ConstantOpInference));
+        .TypeAndShapeInferenceFunction(ConstantOpInference)
+);
 
 static const char* ConstantOfShape_ver20_doc = R"DOC(
 Generate a tensor with given value and shape.
@@ -74,13 +79,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "(Optional) The value of the output elements."
             "Should be a one-element tensor. If not specified, it defaults to a tensor of value 0 and datatype float32",
             AttributeProto::TENSOR,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Input(
             0,
             "input",
             "1D tensor. The shape of the expected output tensor. If empty tensor is given, the output would be a scalar."
             " All values must be >= 0.",
-            "T1")
+            "T1"
+        )
         .Output(
             0,
             "output",
@@ -88,7 +95,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "If attribute 'value' is specified, the value and datatype of the output tensor is taken from 'value'."
             "If attribute 'value' is not specified, the value in the output defaults to 0, and the datatype "
             "defaults to float32.",
-            "T2")
+            "T2"
+        )
         .TypeConstraint("T1", {"tensor(int64)"}, "Constrain input types.")
         .TypeConstraint(
             "T2",
@@ -109,7 +117,8 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(float8e4m3fnuz)",
              "tensor(float8e5m2)",
              "tensor(float8e5m2fnuz)"},
-            "Constrain output types to be numerics.")
+            "Constrain output types to be numerics."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           if (ctx.getAttribute("value") != nullptr) {
             propagateElemTypeFromDtypeToOutput(ctx, ctx.getAttribute("value"), 0);
@@ -122,7 +131,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (found) {
             *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape() = output_shape;
           }
-        }));
+        })
+);
 
 static const char* EyeLike_ver9_doc = R"DOC(
 Generate a 2D tensor (matrix) with ones on the diagonal and zeros everywhere else. Only 2D
@@ -145,14 +155,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             " If T2 is the output, this op sets T2[i, i+k] = 1. k = 0 populates the main diagonal, "
             "k > 0 populates an upper diagonal,  and k < 0 populates a lower diagonal.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "dtype",
             "(Optional) The data type for the elements of the output tensor. If not specified,"
             "the data type of the input tensor T1 is used. If input tensor T1 is also not"
             "specified, then type defaults to 'float'.",
             AttributeProto::INT,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Input(0, "input", "2D input tensor to copy shape, and optionally, type information from.", "T1")
         .Output(0, "output", "Output tensor, same shape as input tensor T1.", "T2")
         .TypeConstraint(
@@ -169,7 +181,8 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(uint32)",
              "tensor(uint64)",
              "tensor(bool)"},
-            "Constrain input types. Strings and complex are not supported.")
+            "Constrain input types. Strings and complex are not supported."
+        )
         .TypeConstraint(
             "T2",
             {"tensor(float16)",
@@ -184,7 +197,8 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(uint32)",
              "tensor(uint64)",
              "tensor(bool)"},
-            "Constrain output types. Strings and complex are not supported.")
+            "Constrain output types. Strings and complex are not supported."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           if (ctx.getAttribute("dtype") != nullptr) {
             propagateElemTypeFromAttributeToOutput(ctx, "dtype", 0);
@@ -198,7 +212,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
           }
           propagateShapeFromInputToOutput(ctx, 0, 0);
-        }));
+        })
+);
 
 static const char* RandomUniform_ver1_doc = R"DOC(
 Generate a tensor with random values drawn from a uniform distribution. The shape
@@ -220,22 +235,24 @@ ONNX_OPERATOR_SET_SCHEMA(
             "seed",
             "(Optional) Seed to the random generator, if not specified we will auto generate one.",
             AttributeProto::FLOAT,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "dtype",
             "The data type for the elements of the output tensor. If not specified, default is TensorProto::FLOAT.",
             AttributeProto::INT,
-            static_cast<int64_t>(TensorProto::FLOAT))
+            static_cast<int64_t>(TensorProto::FLOAT)
+        )
         .Attr("shape", "The shape of the output tensor.", AttributeProto::INTS)
         .Output(0, "output", "Output tensor of random values drawn from uniform distribution", "T")
         .TypeConstraint(
-            "T",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain output types to float tensors.")
+            "T", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain output types to float tensors."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromAttributeToOutput(ctx, "dtype", 0, TensorProto::FLOAT);
           propagateShapeFromAttributeToOutput(ctx, "shape", 0);
-        }));
+        })
+);
 
 static const char* RandomNormal_ver1_doc = R"DOC(
 Generate a tensor with random values drawn from a normal distribution. The shape
@@ -258,22 +275,24 @@ ONNX_OPERATOR_SET_SCHEMA(
             "seed",
             "(Optional) Seed to the random generator, if not specified we will auto generate one.",
             AttributeProto::FLOAT,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "dtype",
             "The data type for the elements of the output tensor. Default is TensorProto::FLOAT.",
             AttributeProto::INT,
-            static_cast<int64_t>(TensorProto::FLOAT))
+            static_cast<int64_t>(TensorProto::FLOAT)
+        )
         .Attr("shape", "The shape of the output tensor.", AttributeProto::INTS)
         .Output(0, "output", "Output tensor of random values drawn from normal distribution", "T")
         .TypeConstraint(
-            "T",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain output types to float tensors.")
+            "T", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain output types to float tensors."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromAttributeToOutput(ctx, "dtype", 0, TensorProto::FLOAT);
           propagateShapeFromAttributeToOutput(ctx, "shape", 0);
-        }));
+        })
+);
 
 static const char* RandomUniformLike_ver1_doc = R"DOC(
 Generate a tensor with random values drawn from a uniform distribution.
@@ -296,23 +315,25 @@ ONNX_OPERATOR_SET_SCHEMA(
             "seed",
             "(Optional) Seed to the random generator, if not specified we will auto generate one.",
             AttributeProto::FLOAT,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "dtype",
             "(Optional) The data type for the elements of the output tensor, if not specified, we will use "
             "the data type of the input tensor.",
             AttributeProto::INT,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Input(0, "input", "Input tensor to copy shape and optionally type information from.", "T1")
         .Output(0, "output", "Output tensor of random values drawn from uniform distribution", "T2")
         .TypeConstraint(
             "T1",
             OpSchema::all_tensor_types(),
-            "Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type.")
+            "Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type."
+        )
         .TypeConstraint(
-            "T2",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain output types to float tensors.")
+            "T2", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain output types to float tensors."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           if (ctx.getAttribute("dtype") != nullptr)
             propagateElemTypeFromAttributeToOutput(ctx, "dtype", 0);
@@ -322,7 +343,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             return;
           }
           propagateShapeFromInputToOutput(ctx, 0, 0);
-        }));
+        })
+);
 
 static const char* RandomNormalLike_ver1_doc = R"DOC(
 Generate a tensor with random values drawn from a normal distribution.
@@ -345,23 +367,25 @@ ONNX_OPERATOR_SET_SCHEMA(
             "seed",
             "(Optional) Seed to the random generator, if not specified we will auto generate one.",
             AttributeProto::FLOAT,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "dtype",
             "(Optional) The data type for the elements of the output tensor, if not specified, we will use "
             "the data type of the input tensor.",
             AttributeProto::INT,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Input(0, "input", "Input tensor to copy shape and optionally type information from.", "T1")
         .Output(0, "output", "Output tensor of random values drawn from normal distribution", "T2")
         .TypeConstraint(
             "T1",
             OpSchema::all_tensor_types(),
-            "Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type.")
+            "Constrain to any tensor type. If the dtype attribute is not provided this must be a valid output type."
+        )
         .TypeConstraint(
-            "T2",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain output types to float tensors.")
+            "T2", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain output types to float tensors."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           if (ctx.getAttribute("dtype") != nullptr)
             propagateElemTypeFromAttributeToOutput(ctx, "dtype", 0);
@@ -371,7 +395,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             return;
           }
           propagateShapeFromInputToOutput(ctx, 0, 0);
-        }));
+        })
+);
 
 static const char* Multinomial_ver7_doc = R"DOC(
 Generate a tensor of samples from a multinomial distribution according to the probabilities
@@ -388,26 +413,29 @@ ONNX_OPERATOR_SET_SCHEMA(
             "seed",
             "(Optional) Seed to the random generator, if not specified we will auto generate one.",
             AttributeProto::FLOAT,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "dtype",
             "(Optional) The data type for the elements of the output tensor, if not specified, we will use int32.",
             AttributeProto::INT,
-            static_cast<int64_t>(TensorProto::INT32))
+            static_cast<int64_t>(TensorProto::INT32)
+        )
         .Input(
             0,
             "input",
             "Input tensor with shape [batch_size, class_size], where class_size is the number of all possible outcomes. Each value along the axis zero represents the unnormalized log-probability of each corresponding outcome in a batch.",
-            "T1")
+            "T1"
+        )
         .Output(
             0,
             "output",
             "Output tensor with shape [batch_size, sample_size], where sample_size is the number of times to sample. Each value along the axis zero represents the outcome of the corresponding sample in a batch.",
-            "T2")
+            "T2"
+        )
         .TypeConstraint(
-            "T1",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input types to float tensors.")
+            "T1", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain input types to float tensors."
+        )
         .TypeConstraint("T2", {"tensor(int32)", "tensor(int64)"}, "Constrain output types to integral tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           auto dtype = ctx.getAttribute("dtype");
@@ -428,10 +456,11 @@ ONNX_OPERATOR_SET_SCHEMA(
               fail_shape_inference("Input tensor must have rank 2");
             }
             batch_size = input_shape.dim(0);
-          } // else statically-unknown batch-size
+          }  // else statically-unknown batch-size
           sample_size.set_dim_value(getAttribute(ctx, "sample_size", 1));
           updateOutputShape(ctx, 0, {batch_size, sample_size});
-        }));
+        })
+);
 
 static const char* Range_ver11_doc = R"DOC(
 Generate a tensor containing a sequence of numbers that begin at `start` and extends by increments of `delta`
@@ -467,8 +496,9 @@ Output: [10, 8, 6]
 )DOC";
 
 template <typename T>
-inline int64_t
-compute_output_dim_for_range(const TensorProto* start, const TensorProto* limit, const TensorProto* delta) {
+inline int64_t compute_output_dim_for_range(
+    const TensorProto* start, const TensorProto* limit, const TensorProto* delta
+) {
   if (start->dims().size() != 0 || limit->dims().size() != 0 || delta->dims().size() != 0) {
     fail_shape_inference("Input to 'Range' op should be scalars (Tensor with only one element and shape empty)");
   }
@@ -497,7 +527,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float)", "tensor(double)", "tensor(int16)", "tensor(int32)", "tensor(int64)"},
-            "Constrain input types to common numeric type tensors.")
+            "Constrain input types to common numeric type tensors."
+        )
         .FunctionBody(R"ONNX(
           {
             sub_result = Sub (limit, start)
@@ -541,16 +572,20 @@ ONNX_OPERATOR_SET_SCHEMA(
             // stored in initializer list.
             if (start_initializer->data_type() == TensorProto::FLOAT) {
               output_dim->set_dim_value(
-                  compute_output_dim_for_range<float>(start_initializer, limit_initializer, delta_initializer));
+                  compute_output_dim_for_range<float>(start_initializer, limit_initializer, delta_initializer)
+              );
             } else if (start_initializer->data_type() == TensorProto::INT32) {
               output_dim->set_dim_value(
-                  compute_output_dim_for_range<int32_t>(start_initializer, limit_initializer, delta_initializer));
+                  compute_output_dim_for_range<int32_t>(start_initializer, limit_initializer, delta_initializer)
+              );
             } else if (start_initializer->data_type() == TensorProto::INT64) {
               output_dim->set_dim_value(
-                  compute_output_dim_for_range<int64_t>(start_initializer, limit_initializer, delta_initializer));
+                  compute_output_dim_for_range<int64_t>(start_initializer, limit_initializer, delta_initializer)
+              );
             } else if (start_initializer->data_type() == TensorProto::DOUBLE) {
               output_dim->set_dim_value(
-                  compute_output_dim_for_range<double>(start_initializer, limit_initializer, delta_initializer));
+                  compute_output_dim_for_range<double>(start_initializer, limit_initializer, delta_initializer)
+              );
             } else {
               // 'float16' has no native CPU type -
               // stop with rank inference, no action here
@@ -558,7 +593,8 @@ ONNX_OPERATOR_SET_SCHEMA(
 
             return;
           }
-        }));
+        })
+);
 
 static const char* Bernoulli_ver15_doc = R"DOC(
 Draws binary random numbers (0 or 1) from a Bernoulli distribution. The input tensor should be a tensor
@@ -578,19 +614,20 @@ ONNX_OPERATOR_SET_SCHEMA(
             "seed",
             "(Optional) Seed to the random generator, if not specified we will auto generate one.",
             AttributeProto::FLOAT,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "dtype",
             "The data type for the elements of the output tensor. if not specified, we will use "
             "the data type of the input tensor.",
             AttributeProto::INT,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Input(0, "input", "All values in input have to be in the range:[0, 1].", "T1")
         .Output(0, "output", "The returned output tensor only has values 0 or 1, same shape as input tensor.", "T2")
         .TypeConstraint(
-            "T1",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input types to float tensors.")
+            "T1", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain input types to float tensors."
+        )
         .TypeConstraint(
             "T2",
             {"tensor(float16)",
@@ -606,7 +643,8 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(int32)",
              "tensor(int64)",
              "tensor(bool)"},
-            "Constrain output types to all numeric tensors and bool tensors.")
+            "Constrain output types to all numeric tensors and bool tensors."
+        )
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
           if (ctx.getAttribute("dtype") != nullptr)
             propagateElemTypeFromAttributeToOutput(ctx, "dtype", 0);
@@ -632,10 +670,13 @@ ONNX_OPERATOR_SET_SCHEMA(
                   .Add(
                       "X_random = RandomUniformLike <low = 0.0, high = 1.0, seed = @seed> (input)",
                       "dtype",
-                      int64_t(input_type))
+                      int64_t(input_type)
+                  )
                   .Add("X_greater = Greater (X_random, input)")
                   .Add("output = Cast (X_greater)", "to", int64_t(dtype));
               schema.BuildFunction(functionProto);
               return true;
-            }));
-} // namespace ONNX_NAMESPACE
+            }
+        )
+);
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/generator/old.cc
+++ b/onnx/defs/generator/old.cc
@@ -24,40 +24,45 @@ ONNX_OPERATOR_SET_SCHEMA(
             "sparse_value",
             "The value for the elements of the output tensor in sparse format.",
             AttributeProto::SPARSE_TENSOR,
-            false)
+            false
+        )
         .Attr(
             "value_int",
             "The value for the sole element for the scalar, int64, output tensor.",
             AttributeProto::INT,
-            false)
+            false
+        )
         .Attr(
-            "value_ints",
-            "The values for the elements for the 1D, int64, output tensor.",
-            AttributeProto::INTS,
-            false)
+            "value_ints", "The values for the elements for the 1D, int64, output tensor.", AttributeProto::INTS, false
+        )
         .Attr(
             "value_float",
             "The value for the sole element for the scalar, float32, output tensor.",
             AttributeProto::FLOAT,
-            false)
+            false
+        )
         .Attr(
             "value_floats",
             "The values for the elements for the 1D, float32, output tensor.",
             AttributeProto::FLOATS,
-            false)
+            false
+        )
         .Attr(
             "value_string",
             "The value for the sole element for the scalar, UTF-8 string, output tensor.",
             AttributeProto::STRING,
-            false)
+            false
+        )
         .Attr(
             "value_strings",
             "The values for the elements for the 1D, UTF-8 string, output tensor.",
             AttributeProto::STRINGS,
-            false)
+            false
+        )
         .Output(0, "output", "Output tensor containing the same value of the provided tensor.", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to all tensor types.")
-        .TypeAndShapeInferenceFunction(ConstantOpInference));
+        .TypeAndShapeInferenceFunction(ConstantOpInference)
+);
 
 static const char* Constant_ver12_doc = R"DOC(
 This operator produces a constant tensor. Exactly one of the provided attributes, either value, sparse_value,
@@ -74,40 +79,45 @@ ONNX_OPERATOR_SET_SCHEMA(
             "sparse_value",
             "The value for the elements of the output tensor in sparse format.",
             AttributeProto::SPARSE_TENSOR,
-            false)
+            false
+        )
         .Attr(
             "value_int",
             "The value for the sole element for the scalar, int64, output tensor.",
             AttributeProto::INT,
-            false)
+            false
+        )
         .Attr(
-            "value_ints",
-            "The values for the elements for the 1D, int64, output tensor.",
-            AttributeProto::INTS,
-            false)
+            "value_ints", "The values for the elements for the 1D, int64, output tensor.", AttributeProto::INTS, false
+        )
         .Attr(
             "value_float",
             "The value for the sole element for the scalar, float32, output tensor.",
             AttributeProto::FLOAT,
-            false)
+            false
+        )
         .Attr(
             "value_floats",
             "The values for the elements for the 1D, float32, output tensor.",
             AttributeProto::FLOATS,
-            false)
+            false
+        )
         .Attr(
             "value_string",
             "The value for the sole element for the scalar, UTF-8 string, output tensor.",
             AttributeProto::STRING,
-            false)
+            false
+        )
         .Attr(
             "value_strings",
             "The values for the elements for the 1D, UTF-8 string, output tensor.",
             AttributeProto::STRINGS,
-            false)
+            false
+        )
         .Output(0, "output", "Output tensor containing the same value of the provided tensor.", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to all tensor types.")
-        .TypeAndShapeInferenceFunction(ConstantOpInference));
+        .TypeAndShapeInferenceFunction(ConstantOpInference)
+);
 
 static const char* Constant_ver1_doc = R"DOC(A constant tensor.)DOC";
 
@@ -121,17 +131,19 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           auto attr_proto = ctx.getAttribute("value");
           if (nullptr == attr_proto)
-            return; // attribute not present
+            return;  // attribute not present
           if (!attr_proto->has_t())
-            return; // attribute has no tensor value
+            return;  // attribute has no tensor value
           const TensorProto& tensor_proto = attr_proto->t();
           updateOutputElemType(ctx, 0, tensor_proto.data_type());
           updateOutputShape(ctx, 0, tensor_proto);
-        }));
+        })
+);
 
 static const char* Constant_ver9_doc = R"DOC(A constant tensor.)DOC";
 
@@ -150,7 +162,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           const TensorProto& tensor_proto = attr_proto->t();
           updateOutputElemType(ctx, 0, tensor_proto.data_type());
           updateOutputShape(ctx, 0, tensor_proto);
-        }));
+        })
+);
 
 static const char* Constant_ver11_doc = R"DOC(
 A constant tensor. Exactly one of the two attributes, either value or sparse_value,
@@ -167,7 +180,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "sparse_value",
             "The value for the elements of the output tensor in sparse format.",
             AttributeProto::SPARSE_TENSOR,
-            false)
+            false
+        )
         .Output(0, "output", "Output tensor containing the same value of the provided tensor.", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to all tensor types.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -176,7 +190,8 @@ ONNX_OPERATOR_SET_SCHEMA(
 
           if ((nullptr != value) && (nullptr != sparse_value))
             fail_shape_inference(
-                "Only one of the attributes 'value' or 'sparse_value' must be specified for a Constant node.");
+                "Only one of the attributes 'value' or 'sparse_value' must be specified for a Constant node."
+            );
 
           if (nullptr != value) {
             // OpSchema::Verify check ensures that the attribute value has_t():
@@ -198,9 +213,10 @@ ONNX_OPERATOR_SET_SCHEMA(
               appendDim(output_shape, sparse.dims(i));
             return;
           }
-          fail_shape_inference(
-              "One of the attributes 'value' or 'sparse_value' must be specified for a Constant node.");
-        }));
+          fail_shape_inference("One of the attributes 'value' or 'sparse_value' must be specified for a Constant node."
+          );
+        })
+);
 
 static const char* ConstantOfShape_ver9_doc = R"DOC(
 Generate a tensor with given value and shape.
@@ -216,13 +232,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "(Optional) The value of the output elements."
             "Should be a one-element tensor. If not specified, it defaults to a tensor of value 0 and datatype float32",
             AttributeProto::TENSOR,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Input(
             0,
             "input",
             "1D tensor. The shape of the expected output tensor. If empty tensor is given, the output would be a scalar."
             " All values must be >= 0.",
-            "T1")
+            "T1"
+        )
         .Output(
             0,
             "output",
@@ -230,7 +248,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "If attribute 'value' is specified, the value and datatype of the output tensor is taken from 'value'."
             "If attribute 'value' is not specified, the value in the output defaults to 0, and the datatype "
             "defaults to float32.",
-            "T2")
+            "T2"
+        )
         .TypeConstraint("T1", {"tensor(int64)"}, "Constrain input types.")
         .TypeConstraint(
             "T2",
@@ -246,7 +265,8 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(uint32)",
              "tensor(uint64)",
              "tensor(bool)"},
-            "Constrain output types to be numerics.")
+            "Constrain output types to be numerics."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           if (ctx.getAttribute("value") != nullptr) {
             propagateElemTypeFromDtypeToOutput(ctx, ctx.getAttribute("value"), 0);
@@ -259,6 +279,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (found) {
             *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape() = output_shape;
           }
-        }));
+        })
+);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/generator/utils.cc
+++ b/onnx/defs/generator/utils.cc
@@ -27,11 +27,13 @@ void ConstantOpInference(InferenceContext& ctx) {
       (nullptr != value_float),
       (nullptr != value_floats),
       (nullptr != value_string),
-      (nullptr != value_strings)};
+      (nullptr != value_strings)
+  };
 
   if (std::count(non_null_attr.begin(), non_null_attr.end(), true) != 1) {
     fail_shape_inference(
-        "One and only one of the attributes 'value', 'value_*' or 'sparse_value' must be specified for a Constant node.");
+        "One and only one of the attributes 'value', 'value_*' or 'sparse_value' must be specified for a Constant node."
+    );
   }
 
   if (nullptr != value) {
@@ -105,7 +107,8 @@ void ConstantOpInference(InferenceContext& ctx) {
 
   fail_shape_inference(
       "TypeAndShapeInferenceFunction implementation incomplete: "
-      "this line should never be reached.");
+      "this line should never be reached."
+  );
 }
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/generator/utils.h
+++ b/onnx/defs/generator/utils.h
@@ -10,4 +10,4 @@ namespace ONNX_NAMESPACE {
 
 void ConstantOpInference(InferenceContext& ctx);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/image/defs.cc
+++ b/onnx/defs/image/defs.cc
@@ -45,7 +45,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "pixel_format",
             "Pixel format. Can be one of \"RGB\", \"BGR\", or \"Grayscale\".",
             AttributeProto::STRING,
-            std::string("RGB"))
+            std::string("RGB")
+        )
         .Input(0, "encoded_stream", "Encoded stream", "T1", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
         .Output(0, "image", "Decoded image", "T2", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
         .TypeConstraint("T1", {"tensor(uint8)"}, "Constrain input types to 8-bit unsigned integer tensor.")
@@ -64,6 +65,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           sh->add_dim();
           sh->add_dim();
           sh->add_dim();
-        }));
+        })
+);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/logical/defs.cc
+++ b/onnx/defs/logical/defs.cc
@@ -36,7 +36,8 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
         OpSchema::Single,
         true,
         1,
-        OpSchema::NonDifferentiable);
+        OpSchema::NonDifferentiable
+    );
     schema.Input(
         1,
         "B",
@@ -45,7 +46,8 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
         OpSchema::Single,
         true,
         1,
-        OpSchema::NonDifferentiable);
+        OpSchema::NonDifferentiable
+    );
     schema.Output(0, "C", "Result tensor.", "T1", OpSchema::Single, true, 1, OpSchema::NonDifferentiable);
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       // Type inference
@@ -55,7 +57,8 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
         bidirectionalBroadcastShapeInference(
             ctx.getInputType(0)->tensor_type().shape(),
             ctx.getInputType(1)->tensor_type().shape(),
-            *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
+            *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()
+        );
     });
   };
 }
@@ -66,7 +69,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator("and"))
         .TypeConstraint("T", {"tensor(bool)"}, "Constrain input to boolean tensor.")
-        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor."));
+        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor.")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Or,
@@ -74,7 +78,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator("or"))
         .TypeConstraint("T", {"tensor(bool)"}, "Constrain input to boolean tensor.")
-        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor."));
+        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor.")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Xor,
@@ -82,7 +87,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator("xor"))
         .TypeConstraint("T", {"tensor(bool)"}, "Constrain input to boolean tensor.")
-        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor."));
+        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor.")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Greater,
@@ -90,7 +96,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator("greater"))
         .TypeConstraint("T", OpSchema::all_numeric_types_ir4(), "Constrain input types to all numeric tensors.")
-        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor."));
+        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor.")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Less,
@@ -98,7 +105,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator("less"))
         .TypeConstraint("T", OpSchema::all_numeric_types_ir4(), "Constrain input types to all numeric tensors.")
-        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor."));
+        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor.")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Equal,
@@ -121,8 +129,10 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(double)",
              "tensor(bfloat16)",
              "tensor(string)"},
-            "Constrain input types to all (non-complex) tensors.")
-        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor."));
+            "Constrain input types to all (non-complex) tensors."
+        )
+        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor.")
+);
 
 static const char* Not_ver1_doc = R"DOC(
 Returns the negation of the input tensor element-wise.
@@ -136,7 +146,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Input(0, "X", "Input tensor", "T", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
         .Output(0, "Y", "Output tensor", "T", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
         .TypeConstraint("T", {"tensor(bool)"}, "Constrain input/output to boolean tensors.")
-        .TypeAndShapeInferenceFunction(unaryLogicalOpInference));
+        .TypeAndShapeInferenceFunction(unaryLogicalOpInference)
+);
 
 static const char* BitShift_ver11_doc = R"DOC(
 Bitwise shift operator performs element-wise operation. For each input element, if the
@@ -158,25 +169,21 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .SetDoc(GET_OP_DOC_STR(std::string(BitShift_ver11_doc) + GenerateBroadcastingDocMul()))
         .Input(
-            0,
-            "X",
-            "First operand, input to be shifted.",
-            "T",
-            OpSchema::Single,
-            true,
-            1,
-            OpSchema::NonDifferentiable)
+            0, "X", "First operand, input to be shifted.", "T", OpSchema::Single, true, 1, OpSchema::NonDifferentiable
+        )
         .Input(1, "Y", "Second operand, amounts of shift.", "T", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
         .Output(0, "Z", "Output tensor", "T", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
         .TypeConstraint(
             "T",
             {"tensor(uint8)", "tensor(uint16)", "tensor(uint32)", "tensor(uint64)"},
-            "Constrain input and output types to integer tensors.")
+            "Constrain input and output types to integer tensors."
+        )
         .Attr(
             "direction",
             "Direction of moving bits. It can be either \"RIGHT\" (for right shift) "
             "or \"LEFT\" (for left shift).",
-            AttributeProto::STRING)
+            AttributeProto::STRING
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           // Type inference
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
@@ -185,8 +192,10 @@ ONNX_OPERATOR_SET_SCHEMA(
             bidirectionalBroadcastShapeInference(
                 ctx.getInputType(0)->tensor_type().shape(),
                 ctx.getInputType(1)->tensor_type().shape(),
-                *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
-        }));
+                *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()
+            );
+        })
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     LessOrEqual,
@@ -202,7 +211,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             O2 = Equal (A, B)
             C = Or (O1, O2)
         }
-        )ONNX"));
+        )ONNX")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     GreaterOrEqual,
@@ -218,7 +228,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             O2 = Equal (A, B)
             C = Or (O1, O2)
         }
-        )ONNX"));
+        )ONNX")
+);
 
 static const char* BitwiseNot_ver18_doc = R"DOC(
 Returns the bitwise not of the input tensor element-wise.
@@ -241,8 +252,10 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(int16)",
              "tensor(int32)",
              "tensor(int64)"},
-            "Constrain input/output to integer tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input/output to integer tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 std::function<void(OpSchema&)> BinaryBitwiseDocGenerator(const char* name) {
   return [=](OpSchema& schema) {
@@ -264,7 +277,8 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
         OpSchema::Single,
         true,
         1,
-        OpSchema::NonDifferentiable);
+        OpSchema::NonDifferentiable
+    );
     schema.Input(
         1,
         "B",
@@ -273,7 +287,8 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
         OpSchema::Single,
         true,
         1,
-        OpSchema::NonDifferentiable);
+        OpSchema::NonDifferentiable
+    );
     schema.Output(0, "C", "Result tensor.", "T", OpSchema::Single, true, 1, OpSchema::NonDifferentiable);
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       // Type inference
@@ -283,7 +298,8 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
         bidirectionalBroadcastShapeInference(
             ctx.getInputType(0)->tensor_type().shape(),
             ctx.getInputType(1)->tensor_type().shape(),
-            *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
+            *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()
+        );
     });
   };
 }
@@ -303,7 +319,9 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(int16)",
              "tensor(int32)",
              "tensor(int64)"},
-            "Constrain input to integer tensors."));
+            "Constrain input to integer tensors."
+        )
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     BitwiseOr,
@@ -320,7 +338,9 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(int16)",
              "tensor(int32)",
              "tensor(int64)"},
-            "Constrain input to integer tensors."));
+            "Constrain input to integer tensors."
+        )
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     BitwiseXor,
@@ -337,6 +357,8 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(int16)",
              "tensor(int32)",
              "tensor(int64)"},
-            "Constrain input to integer tensors."));
+            "Constrain input to integer tensors."
+        )
+);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/logical/old.cc
+++ b/onnx/defs/logical/old.cc
@@ -31,7 +31,8 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
         bidirectionalBroadcastShapeInference(
             ctx.getInputType(0)->tensor_type().shape(),
             ctx.getInputType(1)->tensor_type().shape(),
-            *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
+            *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()
+        );
     });
   };
 }
@@ -42,7 +43,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator_opset12("greater"))
         .TypeConstraint("T", OpSchema::all_numeric_types(), "Constrain input types to all numeric tensors.")
-        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor."));
+        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor.")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Less,
@@ -50,7 +52,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator_opset12("less"))
         .TypeConstraint("T", OpSchema::all_numeric_types(), "Constrain input types to all numeric tensors.")
-        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor."));
+        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor.")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Equal,
@@ -71,8 +74,10 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(float16)",
              "tensor(float)",
              "tensor(double)"},
-            "Constrain input types to all numeric tensors.")
-        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor."));
+            "Constrain input types to all numeric tensors."
+        )
+        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor.")
+);
 
 inline void logicalOpInference_opset1(InferenceContext& ctx) {
   updateOutputElemType(ctx, 0, TensorProto::BOOL);
@@ -124,7 +129,8 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
         bidirectionalBroadcastShapeInference(
             ctx.getInputType(0)->tensor_type().shape(),
             ctx.getInputType(1)->tensor_type().shape(),
-            *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
+            *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()
+        );
     });
   };
 }
@@ -135,7 +141,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator_opset1("and"))
         .TypeConstraint("T", {"tensor(bool)"}, "Constrain input to boolean tensor.")
-        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor."));
+        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor.")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Or,
@@ -143,7 +150,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator_opset1("or"))
         .TypeConstraint("T", {"tensor(bool)"}, "Constrain input to boolean tensor.")
-        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor."));
+        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor.")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Xor,
@@ -151,7 +159,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator_opset1("xor"))
         .TypeConstraint("T", {"tensor(bool)"}, "Constrain input to boolean tensor.")
-        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor."));
+        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor.")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Greater,
@@ -159,10 +168,10 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator_opset1("greater"))
         .TypeConstraint(
-            "T",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input to float tensors.")
-        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor."));
+            "T", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain input to float tensors."
+        )
+        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor.")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Less,
@@ -170,10 +179,10 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator_opset1("less"))
         .TypeConstraint(
-            "T",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input to float tensors.")
-        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor."));
+            "T", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain input to float tensors."
+        )
+        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor.")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Equal,
@@ -181,7 +190,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator_opset1("equal"))
         .TypeConstraint("T", {"tensor(bool)", "tensor(int32)", "tensor(int64)"}, "Constrain input to integral tensors.")
-        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor."));
+        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor.")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Equal,
@@ -189,7 +199,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator_opset7("equal"))
         .TypeConstraint("T", {"tensor(bool)", "tensor(int32)", "tensor(int64)"}, "Constrain input to integral tensors.")
-        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor."));
+        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor.")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Greater,
@@ -197,10 +208,10 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator_opset7("greater"))
         .TypeConstraint(
-            "T",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input to float tensors.")
-        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor."));
+            "T", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain input to float tensors."
+        )
+        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor.")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Less,
@@ -208,10 +219,10 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator_opset7("less"))
         .TypeConstraint(
-            "T",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input to float tensors.")
-        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor."));
+            "T", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain input to float tensors."
+        )
+        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor.")
+);
 
 // Shares same doc generator as newer opset 16 version.
 extern std::function<void(OpSchema&)> BinaryLogicDocGenerator(const char* name);
@@ -230,7 +241,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             O2 = Equal (A, B)
             C = Or (O1, O2)
         }
-        )ONNX"));
+        )ONNX")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     GreaterOrEqual,
@@ -246,7 +258,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             O2 = Equal (A, B)
             C = Or (O1, O2)
         }
-        )ONNX"));
+        )ONNX")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Equal,
@@ -268,7 +281,9 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(float)",
              "tensor(double)",
              "tensor(bfloat16)"},
-            "Constrain input types to all numeric tensors.")
-        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor."));
+            "Constrain input types to all numeric tensors."
+        )
+        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output to boolean tensor.")
+);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -43,7 +43,8 @@ inline void MathOpDataPropagator(DataPropagationContext& ctx, std::string op_typ
     auto& input_dim_1 = input_1->dim(size_1 == 1 ? 0 : i);
     if (input_dim_0.has_dim_value() && input_dim_1.has_dim_value()) {
       tsp.mutable_dim()->Add()->set_dim_value(
-          MathOpTwoIntegers(op_type, input_dim_0.dim_value(), input_dim_1.dim_value()));
+          MathOpTwoIntegers(op_type, input_dim_0.dim_value(), input_dim_1.dim_value())
+      );
     } else {
       // Cannot compute the value; simply add an empty dim without value and param
       tsp.mutable_dim()->Add();
@@ -68,23 +69,19 @@ Performs element-wise binary {name} (with Numpy-style broadcasting support).
     schema.Input(0, "A", "First operand.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable);
     schema.Input(1, "B", "Second operand.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable);
     schema.Output(
-        0,
-        "C",
-        "Result, has same element type as two inputs",
-        "T",
-        OpSchema::Single,
-        true,
-        1,
-        OpSchema::Differentiable);
+        0, "C", "Result, has same element type as two inputs", "T", OpSchema::Single, true, 1, OpSchema::Differentiable
+    );
     schema.TypeConstraint(
-        "T", OpSchema::all_numeric_types_ir4(), "Constrain input and output types to all numeric tensors.");
+        "T", OpSchema::all_numeric_types_ir4(), "Constrain input and output types to all numeric tensors."
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       propagateElemTypeFromInputToOutput(ctx, 0, 0);
       if (hasNInputShapes(ctx, 2))
         bidirectionalBroadcastShapeInference(
             ctx.getInputType(0)->tensor_type().shape(),
             ctx.getInputType(1)->tensor_type().shape(),
-            *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
+            *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()
+        );
     });
   };
 }
@@ -94,14 +91,16 @@ ONNX_OPERATOR_SET_SCHEMA(
     14,
     OpSchema().FillUsing(MathDocGenerator("addition")).PartialDataPropagationFunction([](DataPropagationContext& ctx) {
       MathOpDataPropagator(ctx, "Add");
-    }));
+    })
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Sub,
     14,
     OpSchema()
         .FillUsing(MathDocGenerator("subtraction"))
-        .PartialDataPropagationFunction([](DataPropagationContext& ctx) { MathOpDataPropagator(ctx, "Sub"); }));
+        .PartialDataPropagationFunction([](DataPropagationContext& ctx) { MathOpDataPropagator(ctx, "Sub"); })
+);
 
 static const char* Mod_doc = R"DOC(
   Performs element-wise binary modulus (with Numpy-style broadcasting support).
@@ -128,29 +127,34 @@ ONNX_OPERATOR_SET_SCHEMA(
             "fmod",
             "Whether the operator should behave like fmod (default=0 meaning it will do integer mods); Set this to 1 to force fmod treatment",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(0, "A", "Dividend tensor", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(1, "B", "Divisor tensor", "T", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
         .Output(0, "C", "Remainder tensor", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint(
             "T",
             OpSchema::all_numeric_types_ir4(),
-            "Constrain input and output types to high-precision numeric tensors.")
+            "Constrain input and output types to high-precision numeric tensors."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
           if (hasNInputShapes(ctx, 2))
             bidirectionalBroadcastShapeInference(
                 ctx.getInputType(0)->tensor_type().shape(),
                 ctx.getInputType(1)->tensor_type().shape(),
-                *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
-        }));
+                *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()
+            );
+        })
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Mul,
     14,
     OpSchema()
         .FillUsing(MathDocGenerator("multiplication"))
-        .PartialDataPropagationFunction([](DataPropagationContext& ctx) { MathOpDataPropagator(ctx, "Mul"); }));
+        .PartialDataPropagationFunction([](DataPropagationContext& ctx) { MathOpDataPropagator(ctx, "Mul"); })
+);
 
 ONNX_OPERATOR_SET_SCHEMA(Div, 14, OpSchema().FillUsing(MathDocGenerator("division")));
 
@@ -177,8 +181,10 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(float16)",
              "tensor(double)",
              "tensor(bfloat16)"},
-            "Constrain input and output types to signed numeric tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to signed numeric tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Abs_ver13_doc = R"DOC(
 Absolute takes one input data (Tensor<T>) and produces one output data
@@ -194,10 +200,10 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Input(0, "X", "Input tensor", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Output(0, "Y", "Output tensor", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint(
-            "T",
-            OpSchema::all_numeric_types_ir4(),
-            "Constrain input and output types to all numeric tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "T", OpSchema::all_numeric_types_ir4(), "Constrain input and output types to all numeric tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Reciprocal_ver13_doc = R"DOC(
 Reciprocal takes one input data (Tensor<T>) and produces one output data
@@ -215,8 +221,10 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Floor_ver13_doc = R"DOC(
 Floor takes one input data (Tensor<T>) and produces one output data
@@ -234,8 +242,10 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Ceil_ver13_doc = R"DOC(
 Ceil takes one input data (Tensor<T>) and produces one output data
@@ -253,8 +263,10 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Sqrt_ver13_doc = R"DOC(
 Square root takes one input data (Tensor<T>) and produces one output data
@@ -272,8 +284,10 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Relu_ver14_doc = R"DOC(
 Relu takes one input data (Tensor<T>) and produces one output data
@@ -298,7 +312,8 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(float16)",
              "tensor(double)",
              "tensor(bfloat16)"},
-            "Constrain input and output types to signed numeric tensors.")
+            "Constrain input and output types to signed numeric tensors."
+        )
         .FunctionBody(
             R"ONNX(
           {
@@ -307,8 +322,10 @@ ONNX_OPERATOR_SET_SCHEMA(
             Y = Max (X, ZeroCast)
           }
         )ONNX",
-            18)
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            18
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* LeakyRelu_ver16_doc = R"DOC(
 LeakyRelu takes input data (Tensor<T>) and an argument alpha, and produces one
@@ -327,7 +344,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(bfloat16)", "tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
         .FunctionBody(R"ONNX(
           {
@@ -339,7 +357,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             AlphaMulX = Mul (AlphaCast, X)
             Y = Where (XLessThanZero, AlphaMulX, X)
           }
-        )ONNX"));
+        )ONNX")
+);
 
 static const char* ThresholdedRelu_ver10_doc = R"DOC(
 ThresholdedRelu takes one input data (Tensor<T>) and produces one output data
@@ -358,7 +377,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
         .FunctionBody(
             R"ONNX(
@@ -371,7 +391,9 @@ ONNX_OPERATOR_SET_SCHEMA(
             Y = Where(AlphaLessThanX, X, ZeroCast)
           }
         )ONNX",
-            18));
+            18
+        )
+);
 
 static const char* Selu_ver6_doc = R"DOC(
 Selu takes one input data (Tensor<T>) and produces one output data
@@ -389,20 +411,23 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Coefficient of SELU default to 1.67326319217681884765625 "
             "(i.e., float32 approximation of 1.6732632423543772848170429916717).",
             AttributeProto::FLOAT,
-            1.67326319217681884765625f)
+            1.67326319217681884765625f
+        )
         .Attr(
             "gamma",
             "Coefficient of SELU default to 1.05070102214813232421875 "
             "(i.e., float32 approximation of 1.0507009873554804934193349852946).",
             AttributeProto::FLOAT,
-            1.05070102214813232421875f)
+            1.05070102214813232421875f
+        )
         .SetDoc(Selu_ver6_doc)
         .Input(0, "X", "Input tensor", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Output(0, "Y", "Output tensor", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
         .FunctionBody(
             R"ONNX(
@@ -422,7 +447,9 @@ ONNX_OPERATOR_SET_SCHEMA(
             Y = Where(XLessThanZero, Neg, Pos)
           }
         )ONNX",
-            18));
+            18
+        )
+);
 
 static const char* Elu_ver6_doc = R"DOC(
 Elu takes one input data (Tensor<T>) and produces one output data
@@ -442,7 +469,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
         .FunctionBody(
             R"ONNX(
@@ -460,7 +488,9 @@ ONNX_OPERATOR_SET_SCHEMA(
             Y = Where(XLessThanZero, AlphaMulExpXSubOne, X)
           }
         )ONNX",
-            18));
+            18
+        )
+);
 
 static const char* mish_ver18_doc = R"DOC(
 Mish: A Self Regularized Non-Monotonic Neural Activation Function.
@@ -482,7 +512,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input X and output types to float tensors.")
+            "Constrain input X and output types to float tensors."
+        )
         .FunctionBody(R"ONNX(
           {
             Softplus_X = Softplus (X)
@@ -490,7 +521,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             Y = Mul (X, TanHSoftplusX)
            }
         )ONNX")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* celu_ver12_doc = R"DOC(
 Continuously Differentiable Exponential Linear Units:
@@ -529,9 +561,8 @@ TensorProto ToDimensionOneInt64Tensor(std::vector<int64_t> value) {
 }
 
 bool BuildContextDependentFunctionBodyCelu(
-    const FunctionBodyBuildContext& ctx,
-    const OpSchema& schema,
-    FunctionProto& functionProto) {
+    const FunctionBodyBuildContext& ctx, const OpSchema& schema, FunctionProto& functionProto
+) {
   float alpha = ctx.getAttribute("alpha") != nullptr ? ctx.getAttribute("alpha")->f() : celu_default_alpha;
   FunctionBuilder builder(functionProto);
   builder.Const("alpha", std::vector<float>{alpha}).Add(R"(
@@ -555,10 +586,12 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The Alpha value in Celu formula which control the shape of "
             "the unit. The default value is 1.0.",
             AttributeProto::FLOAT,
-            celu_default_alpha)
+            celu_default_alpha
+        )
         .TypeConstraint("T", {"tensor(float)"}, "Constrain input and output types to float32 tensors.")
         .SetContextDependentFunctionBodyBuilder(BuildContextDependentFunctionBodyCelu)
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* gelu_ver20_doc = R"DOC(
 Gelu takes one input data (Tensor<T>) and produces one
@@ -573,9 +606,8 @@ to the tensor elementwise.
 static std::string gelu_default_approx = "none";
 
 bool BuildContextDependentFunctionBodyGelu(
-    const FunctionBodyBuildContext& ctx,
-    const OpSchema& schema,
-    FunctionProto& functionProto) {
+    const FunctionBodyBuildContext& ctx, const OpSchema& schema, FunctionProto& functionProto
+) {
   auto approx_attr_proto = ctx.getAttribute("approximate");
   std::string approximate =
       approx_attr_proto != nullptr && approx_attr_proto->has_s() ? approx_attr_proto->s() : gelu_default_approx;
@@ -636,13 +668,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "`\"none\"`: do not use approximation."
             "`\"tanh\"`: use tanh approximation.",
             AttributeProto::STRING,
-            gelu_default_approx)
+            gelu_default_approx
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .SetContextDependentFunctionBodyBuilder(BuildContextDependentFunctionBodyGelu)
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Exp_ver13_doc = R"DOC(
 Calculates the exponential of the given input tensor, element-wise.
@@ -663,12 +698,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Log_ver13_doc = R"DOC(
 Calculates the natural log of the given input tensor, element-wise.
@@ -689,12 +727,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Tanh_ver13_doc = R"DOC(
 Calculates the hyperbolic tangent of the given input tensor element-wise.
@@ -715,12 +756,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Pow_ver15_doc = R"DOC(
 Pow takes input data (Tensor<T>) and exponent Tensor, and
@@ -735,24 +779,15 @@ ONNX_OPERATOR_SET_SCHEMA(
         .SetDoc(GET_OP_DOC_STR(std::string(Pow_ver15_doc) + GenerateBroadcastingDocMul()))
         .Input(0, "X", "First operand, base of the exponent.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
-            1,
-            "Y",
-            "Second operand, power of the exponent.",
-            "T1",
-            OpSchema::Single,
-            true,
-            1,
-            OpSchema::Differentiable)
+            1, "Y", "Second operand, power of the exponent.", "T1", OpSchema::Single, true, 1, OpSchema::Differentiable
+        )
         .Output(0, "Z", "Output tensor", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint(
             "T",
-            {"tensor(int32)",
-             "tensor(int64)",
-             "tensor(float16)",
-             "tensor(float)",
-             "tensor(double)",
-             "tensor(bfloat16)"},
-            "Constrain input X and output types to float/int tensors.")
+            {"tensor(int32)", "tensor(int64)", "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"
+            },
+            "Constrain input X and output types to float/int tensors."
+        )
         .TypeConstraint(
             "T1",
             {"tensor(uint8)",
@@ -767,15 +802,18 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(float)",
              "tensor(double)",
              "tensor(bfloat16)"},
-            "Constrain input Y types to float/int tensors.")
+            "Constrain input Y types to float/int tensors."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
           if (hasNInputShapes(ctx, 2))
             bidirectionalBroadcastShapeInference(
                 ctx.getInputType(0)->tensor_type().shape(),
                 ctx.getInputType(1)->tensor_type().shape(),
-                *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
-        }));
+                *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()
+            );
+        })
+);
 
 static const char* PRelu_ver16_doc = R"DOC(
 PRelu takes input data (Tensor<T>) and slope tensor as input, and produces one
@@ -788,7 +826,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     16,
     OpSchema()
         .SetDoc(
-            GET_OP_DOC_STR(std::string(PRelu_ver16_doc) + GenerateBroadcastingDocUni("tensor slope", "input tensor X")))
+            GET_OP_DOC_STR(std::string(PRelu_ver16_doc) + GenerateBroadcastingDocUni("tensor slope", "input tensor X"))
+        )
         .Input(0, "X", "Input tensor", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
             1,
@@ -799,7 +838,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Output(0, "Y", "Output tensor (same size as X)", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint(
             "T",
@@ -811,7 +851,8 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(uint64)",
              "tensor(int32)",
              "tensor(int64)"},
-            "Constrain input and output types to float/int tensors.")
+            "Constrain input and output types to float/int tensors."
+        )
         .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
         .FunctionBody(R"ONNX(
         {
@@ -821,7 +862,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           SlopeMulX = Mul (slope, X)
           Y = Where(XLessThanZero, SlopeMulX, X)
         }
-        )ONNX"));
+        )ONNX")
+);
 
 static const char* Sigmoid_ver13_doc = R"DOC(
 Sigmoid takes one input data (Tensor<T>) and produces one output data
@@ -839,8 +881,10 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* HardSigmoid_ver6_doc = R"DOC(
 HardSigmoid takes one input data (Tensor<T>) and produces one output data
@@ -860,7 +904,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
         .FunctionBody(
             R"ONNX(
@@ -879,7 +924,9 @@ ONNX_OPERATOR_SET_SCHEMA(
             Y = Max(MinOneOrAlphaMulXAddBeta, ZeroCast)
           }
         )ONNX",
-            18));
+            18
+        )
+);
 
 static const char* HardSwish_ver14_doc = R"DOC(
 HardSwish takes one input data (Tensor<T>) and produces one output data (Tensor<T>) where
@@ -897,14 +944,16 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
         .FunctionBody(R"ONNX(
           {
             HS_X = HardSigmoid<alpha = 0.16666667163372, beta = 0.5>(X)
             Y = Mul (X, HS_X)
           }
-        )ONNX"));
+        )ONNX")
+);
 
 // Generate opschema for element-wise ops. Leaves type constraint "T"
 // unspecified.
@@ -927,7 +976,8 @@ All inputs and outputs must have the same data type.
         OpSchema::Variadic,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.Output(0, name, "Output tensor.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable);
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       propagateElemTypeFromInputToOutput(ctx, 0, 0);
@@ -952,20 +1002,16 @@ ONNX_OPERATOR_SET_SCHEMA(
     13,
     OpSchema()
         .FillUsing(ElementwiseMultiOpDocGenerator("max"))
-        .TypeConstraint(
-            "T",
-            OpSchema::all_numeric_types_ir4(),
-            "Constrain input and output types to numeric tensors."));
+        .TypeConstraint("T", OpSchema::all_numeric_types_ir4(), "Constrain input and output types to numeric tensors.")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Min,
     13,
     OpSchema()
         .FillUsing(ElementwiseMultiOpDocGenerator("min"))
-        .TypeConstraint(
-            "T",
-            OpSchema::all_numeric_types_ir4(),
-            "Constrain input and output types to numeric tensors."));
+        .TypeConstraint("T", OpSchema::all_numeric_types_ir4(), "Constrain input and output types to numeric tensors.")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Sum,
@@ -975,7 +1021,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Mean,
@@ -985,7 +1033,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* Clip_ver13_doc = R"DOC(
 Clip operator limits the given input within an interval. The interval is
@@ -994,9 +1044,8 @@ numeric_limits::lowest() and numeric_limits::max(), respectively.
 )DOC";
 
 bool BuildContextDependentFunctionBodyClip(
-    const FunctionBodyBuildContext& ctx,
-    const OpSchema& schema,
-    FunctionProto& functionProto) {
+    const FunctionBodyBuildContext& ctx, const OpSchema& schema, FunctionProto& functionProto
+) {
   bool has_min = ctx.hasInput(1);
   bool has_max = ctx.hasInput(2);
 
@@ -1033,7 +1082,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             1,
             "min",
@@ -1043,7 +1093,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "max",
@@ -1053,7 +1104,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "output",
@@ -1062,16 +1114,18 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
-            "T",
-            OpSchema::all_numeric_types_ir4(),
-            "Constrain input and output types to all numeric tensors.")
+            "T", OpSchema::all_numeric_types_ir4(), "Constrain input and output types to all numeric tensors."
+        )
         .SetContextDependentFunctionBodyBuilder(BuildContextDependentFunctionBodyClip)
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
-std::function<void(OpSchema&)>
-SoftmaxFamilyDocGenerator(const char* name, const char* description, const char* equation) {
+std::function<void(OpSchema&)> SoftmaxFamilyDocGenerator(
+    const char* name, const char* description, const char* equation
+) {
   return [=](OpSchema& schema) {
     std::string doc;
     POPULATE_OP_DOC_STR(doc = R"DOC(
@@ -1096,7 +1150,8 @@ from the back. Accepted range is [-r, r-1] where r = rank(input).
     schema.SetDoc(doc);
     schema.Attr("axis", axis_attr, AttributeProto::INT, static_cast<int64_t>(-1));
     schema.Input(
-        0, "input", "The input tensor of rank >= axis.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable);
+        0, "input", "The input tensor of rank >= axis.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable
+    );
     schema.Output(
         0,
         "output",
@@ -1105,11 +1160,13 @@ from the back. Accepted range is [-r, r-1] where r = rank(input).
         OpSchema::Single,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       // Type inference
       propagateElemTypeFromInputToOutput(ctx, 0, 0);
@@ -1140,7 +1197,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .FillUsing(SoftmaxFamilyDocGenerator(
             "Softmax",
             "normalized exponential",
-            "Softmax(input, axis) = Exp(input) / ReduceSum(Exp(input), axis=axis, keepdims=1) "))
+            "Softmax(input, axis) = Exp(input) / ReduceSum(Exp(input), axis=axis, keepdims=1) "
+        ))
         // function body builder for opset version 13 (the default opset version is the same
         // as the operator's since_version.
         .SetContextDependentFunctionBodyBuilder(
@@ -1158,7 +1216,8 @@ ONNX_OPERATOR_SET_SCHEMA(
 
               schema.BuildFunction(functionProto);
               return true;
-            })
+            }
+        )
         // function body builder for opset version 18.
         // ReduceSum is updated in opset 18 to have axes as the second input.
         // Therefore function body for opset version 18
@@ -1177,16 +1236,17 @@ ONNX_OPERATOR_SET_SCHEMA(
               schema.BuildFunction(functionProto);
               return true;
             },
-            18));
+            18
+        )
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     LogSoftmax,
     13,
     OpSchema()
         .FillUsing(SoftmaxFamilyDocGenerator(
-            "LogSoftmax",
-            "log of softmax",
-            "LogSoftmax(input, axis) = Log(Softmax(input, axis=axis))"))
+            "LogSoftmax", "log of softmax", "LogSoftmax(input, axis) = Log(Softmax(input, axis=axis))"
+        ))
         // Function for opset 13
         .SetContextDependentFunctionBodyBuilder(
             [](const FunctionBodyBuildContext& ctx, const OpSchema& schema, FunctionProto& functionProto) -> bool {
@@ -1205,7 +1265,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               schema.BuildFunction(functionProto);
               return true;
             },
-            13)
+            13
+        )
         // Function for opset 18
         .SetContextDependentFunctionBodyBuilder(
             [](const FunctionBodyBuildContext& ctx, const OpSchema& schema, FunctionProto& functionProto) -> bool {
@@ -1222,7 +1283,9 @@ ONNX_OPERATOR_SET_SCHEMA(
               schema.BuildFunction(functionProto);
               return true;
             },
-            18));
+            18
+        )
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Hardmax,
@@ -1230,7 +1293,9 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema().FillUsing(SoftmaxFamilyDocGenerator(
         "Hardmax",
         "hardmax",
-        "Hardmax(element in input, axis) = 1 if the element is the first maximum value along the specified axis, 0 otherwise")));
+        "Hardmax(element in input, axis) = 1 if the element is the first maximum value along the specified axis, 0 otherwise"
+    ))
+);
 
 static const char* Softsign_ver1_doc = R"DOC(
 Calculates the softsign (x/(1+|x|)) of the given input tensor element-wise.
@@ -1250,11 +1315,13 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
         .FunctionBody(
             R"ONNX(
@@ -1266,7 +1333,9 @@ ONNX_OPERATOR_SET_SCHEMA(
             output = Div(input, OneAddAbsInput)
           }
         )ONNX",
-            18));
+            18
+        )
+);
 
 static const char* Softplus_ver1_doc = R"DOC(
 Softplus takes one input data (Tensor<T>) and produces one output data
@@ -1284,7 +1353,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
         .FunctionBody(
             R"ONNX(
@@ -1296,7 +1366,9 @@ ONNX_OPERATOR_SET_SCHEMA(
               Y = Log (exp_x_add_one)
             }
             )ONNX",
-            18));
+            18
+        )
+);
 
 static const char* Gemm_ver13_doc = R"DOC(General Matrix multiplication:
 https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms#Level_3
@@ -1316,7 +1388,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .SetDoc(GET_OP_DOC_STR(
             std::string(Gemm_ver13_doc) + GenerateBroadcastingDocUni("tensor C", "tensor A * B") + "\n" +
-            GenerateOptionalArgumentsDoc()))
+            GenerateOptionalArgumentsDoc()
+        ))
         .Input(
             0,
             "A",
@@ -1327,7 +1400,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             1,
             "B",
@@ -1338,7 +1412,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             2,
             "C",
@@ -1349,7 +1424,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Output(0, "Y", "Output tensor of shape (M, N).", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint(
             "T",
@@ -1361,7 +1437,8 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(int32)",
              "tensor(int64)",
              "tensor(bfloat16)"},
-            "Constrain input and output types to float/int tensors.")
+            "Constrain input and output types to float/int tensors."
+        )
         .Attr("transA", "Whether A should be transposed", AttributeProto::INT, static_cast<int64_t>(0))
         .Attr("transB", "Whether B should be transposed", AttributeProto::INT, static_cast<int64_t>(0))
         .Attr("alpha", "Scalar multiplier for the product of input tensors A * B.", AttributeProto::FLOAT, 1.0f)
@@ -1383,7 +1460,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
             updateOutputShape(ctx, 0, {first_input_shape.dim(transA ? 1 : 0), second_input_shape.dim(transB ? 0 : 1)});
           }
-        }));
+        })
+);
 
 void matmulShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, int input1Idx, int input2Idx) {
   if (!hasInputShape(ctx, input1Idx) || !hasInputShape(ctx, input2Idx)) {
@@ -1474,12 +1552,14 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(int32)",
              "tensor(int64)",
              "tensor(bfloat16)"},
-            "Constrain input and output types to float/int tensors.")
+            "Constrain input and output types to float/int tensors."
+        )
         .SetDoc(MatMul_ver13_doc)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
           matmulShapeInference(ctx, 0, 1);
-        }));
+        })
+);
 
 static const char* TopK_ver11_doc = R"DOC(
 Retrieve the top-K largest or smallest elements along a specified axis. Given an input tensor of
@@ -1505,14 +1585,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .SetDoc(TopK_ver11_doc)
         .Input(
-            0,
-            "X",
-            "Tensor of shape [a_1, a_2, ..., a_n, r]",
-            "T",
-            OpSchema::Single,
-            true,
-            1,
-            OpSchema::Differentiable)
+            0, "X", "Tensor of shape [a_1, a_2, ..., a_n, r]", "T", OpSchema::Single, true, 1, OpSchema::Differentiable
+        )
         .Input(
             1,
             "K",
@@ -1521,7 +1595,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "Values",
@@ -1531,7 +1606,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Output(
             1,
             "Indices",
@@ -1542,7 +1618,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .TypeConstraint("T", OpSchema::all_numeric_types(), "Constrain input and output types to numeric tensors.")
         .TypeConstraint("I", {"tensor(int64)"}, "Constrain index tensor to int64")
         .Attr(
@@ -1550,12 +1627,14 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Dimension on which to do the sort. Negative value means counting dimensions "
             "from the back. Accepted range is [-r, r-1] where r = rank(input).",
             AttributeProto::INT,
-            static_cast<int64_t>(-1))
+            static_cast<int64_t>(-1)
+        )
         .Attr(
             "largest",
             "Whether to return the top-K largest or smallest elements.",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .Attr("sorted", "Whether to return the elements in sorted order.", AttributeProto::INT, static_cast<int64_t>(1))
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           // Type inference:
@@ -1615,7 +1694,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
 
           return;
-        }));
+        })
+);
 
 static const char* Sin_ver7_doc = R"DOC(
 Calculates the sine of the given input tensor, element-wise.
@@ -1636,12 +1716,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Cos_ver7_doc = R"DOC(
 Calculates the cosine of the given input tensor, element-wise.
@@ -1662,12 +1745,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Tan_ver7_doc = R"DOC(
 Calculates the tangent of the given input tensor, element-wise.
@@ -1688,12 +1774,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Asin_ver7_doc = R"DOC(
 Calculates the arcsine (inverse of sine) of the given input tensor, element-wise.
@@ -1714,12 +1803,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Acos_ver7_doc = R"DOC(
 Calculates the arccosine (inverse of cosine) of the given input tensor, element-wise.
@@ -1740,12 +1832,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Atan_ver7_doc = R"DOC(
 Calculates the arctangent (inverse of tangent) of the given input tensor, element-wise.
@@ -1766,12 +1861,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Expand_ver13_doc = R"DOC(
 Broadcast the input tensor following the given shape and the broadcast rule.
@@ -1798,7 +1896,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(0, "output", "Output tensor", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to all tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -1815,7 +1914,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               bidirectionalBroadcastShapeInference(input_shape, second_shape, *getOutputShape(ctx, 0));
             }
           }
-        }));
+        })
+);
 
 static const char* Sinh_ver9_doc = R"DOC(
 Calculates the hyperbolic sine of the given input tensor element-wise.
@@ -1836,12 +1936,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Cosh_ver9_doc = R"DOC(
 Calculates the hyperbolic cosine of the given input tensor element-wise.
@@ -1862,12 +1965,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Asinh_ver9_doc = R"DOC(
 Calculates the hyperbolic arcsine of the given input tensor element-wise.
@@ -1888,12 +1994,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Acosh_ver9_doc = R"DOC(
 Calculates the hyperbolic arccosine of the given input tensor element-wise.
@@ -1914,12 +2023,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Atanh_ver9_doc = R"DOC(
 Calculates the hyperbolic arctangent of the given input tensor element-wise.
@@ -1940,12 +2052,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Sign_ver13_doc = R"DOC(
 Calculate the sign of the given input tensor element-wise.
@@ -1967,12 +2082,13 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .TypeConstraint(
-            "T",
-            OpSchema::all_numeric_types_ir4(),
-            "Constrain input and output types to all numeric tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "T", OpSchema::all_numeric_types_ir4(), "Constrain input and output types to all numeric tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Erf_ver13_doc = R"DOC(
 Computes the error function of the given input tensor element-wise.
@@ -1993,12 +2109,13 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
-            "T",
-            OpSchema::all_numeric_types_ir4(),
-            "Constrain input and output types to all numeric tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "T", OpSchema::all_numeric_types_ir4(), "Constrain input and output types to all numeric tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* QLinearMatMul_ver10_doc = R"DOC(
 Matrix product that behaves like numpy.matmul: https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.matmul.html.
@@ -2028,7 +2145,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "a_zero_point",
@@ -2037,7 +2155,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(3, "b", "N-dimensional quantized matrix b", "T2", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
         .Input(
             4,
@@ -2047,7 +2166,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             5,
             "b_zero_point",
@@ -2056,7 +2176,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             6,
             "y_scale",
@@ -2065,7 +2186,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             7,
             "y_zero_point",
@@ -2074,7 +2196,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "y",
@@ -2083,19 +2206,23 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .TypeConstraint(
             "T1",
             {"tensor(int8)", "tensor(uint8)"},
-            "Constrain input a and its zero point data type to 8-bit integer tensor.")
+            "Constrain input a and its zero point data type to 8-bit integer tensor."
+        )
         .TypeConstraint(
             "T2",
             {"tensor(int8)", "tensor(uint8)"},
-            "Constrain input b and its zero point data type to 8-bit integer tensor.")
+            "Constrain input b and its zero point data type to 8-bit integer tensor."
+        )
         .TypeConstraint(
             "T3",
             {"tensor(int8)", "tensor(uint8)"},
-            "Constrain output y and its zero point data type to 8-bit integer tensor.")
+            "Constrain output y and its zero point data type to 8-bit integer tensor."
+        )
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
           auto a_type = ctx.getInputType(0);
           auto b_type = ctx.getInputType(3);
@@ -2120,7 +2247,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           propagateElemTypeFromInputToOutput(ctx, 7, 0);
 
           matmulShapeInference(ctx, 0, 3);
-        }));
+        })
+);
 
 static const char* MatMulInteger_ver10_doc = R"DOC(
 Matrix product that behaves like numpy.matmul: https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.matmul.html.
@@ -2145,7 +2273,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             3,
             "b_zero_point",
@@ -2157,16 +2286,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
-            0,
-            "Y",
-            "Matrix multiply results from A * B",
-            "T3",
-            OpSchema::Single,
-            true,
-            1,
-            OpSchema::NonDifferentiable)
+            0, "Y", "Matrix multiply results from A * B", "T3", OpSchema::Single, true, 1, OpSchema::NonDifferentiable
+        )
         .TypeConstraint("T1", {"tensor(int8)", "tensor(uint8)"}, "Constrain input A data type to 8-bit integer tensor.")
         .TypeConstraint("T2", {"tensor(int8)", "tensor(uint8)"}, "Constrain input B data type to 8-bit integer tensor.")
         .TypeConstraint("T3", {"tensor(int32)"}, "Constrain output Y data type as 32-bit integer tensor.")
@@ -2184,7 +2308,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           y_type->mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto::INT32);
 
           matmulShapeInference(ctx, 0, 1);
-        }));
+        })
+);
 static const char* CumSum_ver14_doc = R"DOC(
 Performs cumulative sum of the input elements along the given axis.
 By default, it will do the sum inclusively meaning the first element is copied as is.
@@ -2218,21 +2343,17 @@ ONNX_OPERATOR_SET_SCHEMA(
             " In other terms, if set to 1, the j-th output element would be the sum of the first (j-1) elements."
             " Otherwise, it would be the sum of the first j elements.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "reverse",
             "If set to 1 will perform the sums in reverse direction.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(
-            0,
-            "x",
-            "An input tensor that is to be processed.",
-            "T",
-            OpSchema::Single,
-            true,
-            1,
-            OpSchema::Differentiable)
+            0, "x", "An input tensor that is to be processed.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable
+        )
         .Input(
             1,
             "axis",
@@ -2242,7 +2363,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "y",
@@ -2251,13 +2373,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T",
             OpSchema::numeric_types_for_math_reduction_ir4(),
-            "Constrain input and output types to high-precision numeric tensors.")
+            "Constrain input and output types to high-precision numeric tensors."
+        )
         .TypeConstraint("T2", {"tensor(int32)", "tensor(int64)"}, "axis tensor can be int32 or int64 only")
-        .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput));
+        .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Round_ver11_doc = R"DOC(
 Round takes one input Tensor and rounds the values, element-wise, meaning
@@ -2286,8 +2411,10 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Det_ver11_doc = R"DOC(
 Det calculates determinant of a square matrix or batches of square matrices.
@@ -2307,7 +2434,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to floating-point tensors.")
+            "Constrain input and output types to floating-point tensors."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           // Type inference
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
@@ -2330,7 +2458,8 @@ ONNX_OPERATOR_SET_SCHEMA(
                   mat_w.dim_value(),
                   " != mat_h:",
                   mat_h.dim_value(),
-                  ").");
+                  ")."
+              );
             }
 
             for (int i = 0; i < rank - 2; ++i) {
@@ -2338,7 +2467,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               *dim = input_shape.dim(i);
             }
           }
-        }));
+        })
+);
 
 static const char* NegativeLogLikelihoodLoss_ver13_doc = R"DOC(
 A NegativeLogLikelihoodLoss operator computes (weighted) negative log likelihood loss.
@@ -2445,9 +2575,8 @@ loss = np.sum(loss) / weight_total
 )DOC";
 
 bool BuildContextDependentFunctionBody(
-    const FunctionBodyBuildContext& ctx,
-    const OpSchema& schema,
-    FunctionProto& functionProto) {
+    const FunctionBodyBuildContext& ctx, const OpSchema& schema, FunctionProto& functionProto
+) {
   if (ctx.getInputType(0) == nullptr) {
     // we cannot create a correct function body without knowing the input type
     return false;
@@ -2531,7 +2660,8 @@ bool BuildContextDependentFunctionBody(
       builder.Add("weight_gather_temp = Gather (weight, transform_targets)");
       builder.Add(
           float_input ? "weight_gather_temp_1 = Where (mask, const_zero_float, weight_gather_temp)"
-                      : "weight_gather_temp_1 = Where (mask, const_zero_casted, weight_gather_temp)");
+                      : "weight_gather_temp_1 = Where (mask, const_zero_casted, weight_gather_temp)"
+      );
       builder.Add("weight_gather = Squeeze (weight_gather_temp_1, axes)");
     }
 
@@ -2569,7 +2699,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             1,
             "target",
@@ -2580,7 +2711,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "weight",
@@ -2590,7 +2722,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(0, "loss", "The negative log likelihood loss", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Attr(
             "reduction",
@@ -2599,16 +2732,19 @@ ONNX_OPERATOR_SET_SCHEMA(
             "'sum': the output will be summed. "
             "'mean': the sum of the output will be divided by the sum of applied weights.",
             AttributeProto::STRING,
-            std::string("mean"))
+            std::string("mean")
+        )
         .Attr(
             "ignore_index",
             "Specifies a target value that is ignored and does not contribute to the input gradient. It's an optional value.",
             AttributeProto::INT,
-            false)
+            false
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input, weight, and output types to floating-point tensors.")
+            "Constrain input, weight, and output types to floating-point tensors."
+        )
         .TypeConstraint("Tind", {"tensor(int32)", "tensor(int64)"}, "Constrain target to integer types")
         .SetContextDependentFunctionBodyBuilder(BuildContextDependentFunctionBody)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -2662,7 +2798,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
             // otherwise output is a scalar.
           }
-        }));
+        })
+);
 
 void einsumRankInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string equation) {
   const size_t numInputs = ctx.getNumInputs();
@@ -2674,7 +2811,7 @@ void einsumRankInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string equa
   std::string left_equation;
 
   equation.erase(std::remove(equation.begin(), equation.end(), ' '),
-                 equation.end()); // Remove space char
+                 equation.end());  // Remove space char
   auto mid_index = equation.find("->");
   if (mid_index != std::string::npos) {
     // Separate right and left hand sides of the equation
@@ -2706,8 +2843,8 @@ void einsumRankInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string equa
           fail_shape_inference("Ellipsis represents incompatible dimensions.");
         }
         num_ellipsis_indices = rank - term.size() + 3;
-      } else { // ellipsis has been seen before. Check that if dimensions
-               // are compatible
+      } else {  // ellipsis has been seen before. Check that if dimensions
+                // are compatible
         if (num_ellipsis_indices != rank - term.size() + 3) {
           fail_shape_inference("Ellipsis represents incompatible dimensions.");
         }
@@ -2731,23 +2868,23 @@ void einsumRankInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string equa
   if (mid_index != std::string::npos) {
     std::string right_equation = equation.substr(mid_index + 2);
     auto right_ellipsis_index = right_equation.find("...");
-    if (right_ellipsis_index != std::string::npos) { // Right-hand side contains ellipsis
+    if (right_ellipsis_index != std::string::npos) {  // Right-hand side contains ellipsis
       for (size_t i = 0; i < num_ellipsis_indices; ++i) {
         output_shape->add_dim();
       }
     }
-    for (char c : right_equation) { // Add a dimension per each character
-                                    // in right hand equation
+    for (char c : right_equation) {  // Add a dimension per each character
+                                     // in right hand equation
       if (c != '.') {
         output_shape->add_dim();
       }
     }
-  } else { // Infer the dimension for right-hand side
+  } else {  // Infer the dimension for right-hand side
     // If there's an ellipsis, add it's corresponding dimensions
     for (size_t i = 0; i < num_ellipsis_indices; i++) {
       output_shape->add_dim();
     }
-    for (size_t i = 0; i < left_equation.size(); i++) { // Count chars that appear exactly once on left hand side
+    for (size_t i = 0; i < left_equation.size(); i++) {  // Count chars that appear exactly once on left hand side
       if ((left_equation.at(i) != ',') && (left_equation.at(i) != '.')) {
         num_letter_occurrences[left_equation.at(i) - 'a']++;
       }
@@ -2797,9 +2934,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Input(0, "Inputs", "Operands", "T", OpSchema::Variadic, true, 1, OpSchema::Differentiable)
         .Output(0, "Output", "Output tensor", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint(
-            "T",
-            OpSchema::all_numeric_types(),
-            "Constrain input and output types to all numerical tensor types.")
+            "T", OpSchema::all_numeric_types(), "Constrain input and output types to all numerical tensor types."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           // Type inference
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
@@ -2808,7 +2944,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             return;
           }
           einsumRankInference(ctx, equation);
-        }));
+        })
+);
 
 const char* reduction_doc_sce =
     "Type of reduction to apply to loss: none, sum, mean(default). "
@@ -2861,13 +2998,12 @@ Finally, L is optionally reduced:
 )DOC";
 
 bool BuildContextDependentFunctionBodySCE(
-    const FunctionBodyBuildContext& ctx,
-    const OpSchema& schema,
-    FunctionProto& functionProto) {
+    const FunctionBodyBuildContext& ctx, const OpSchema& schema, FunctionProto& functionProto
+) {
   FunctionBuilder builder(functionProto);
   // Using stable implementation of LogSoftmax
-  builder //
-      .Const("Shape3D", std::vector<int64_t>({0, 0, -1})) //
+  builder  //
+      .Const("Shape3D", std::vector<int64_t>({0, 0, -1}))  //
       .Add(R"(
         X_NCD = Reshape (scores, Shape3D)
         X_NDC = Transpose <perm = [0, 2, 1]> (X_NCD)
@@ -2891,7 +3027,8 @@ bool BuildContextDependentFunctionBodySCE(
   builder.Add(
       ctx.hasInput(2)
           ? "output = NegativeLogLikelihoodLoss <reduction : string = @reduction, ignore_index : int = @ignore_index> (X_Log, labels, weights)"
-          : "output = NegativeLogLikelihoodLoss <reduction : string = @reduction, ignore_index : int = @ignore_index> (X_Log, labels)");
+          : "output = NegativeLogLikelihoodLoss <reduction : string = @reduction, ignore_index : int = @ignore_index> (X_Log, labels)"
+  );
 
   schema.BuildFunction(functionProto);
   return true;
@@ -2907,7 +3044,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "ignore_index",
             "Specifies a target value that is ignored and does not contribute to the input gradient. It's an optional value.",
             AttributeProto::INT,
-            false)
+            false
+        )
         .Input(
             0,
             "scores",
@@ -2917,7 +3055,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             1,
             "labels",
@@ -2930,7 +3069,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "weights",
@@ -2941,7 +3081,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "output",
@@ -2952,7 +3093,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Output(
             1,
             "log_prob",
@@ -2961,11 +3103,13 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeConstraint("Tind", {"tensor(int32)", "tensor(int64)"}, "Constrain target to integer types")
         .SetContextDependentFunctionBodyBuilder(BuildContextDependentFunctionBodySCE)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -2983,7 +3127,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             propagateElemTypeFromInputToOutput(ctx, 0, 1);
             propagateShapeFromInputToOutput(ctx, 0, 1);
           }
-        }));
+        })
+);
 
 static const char* DFT_ver20_doc =
     R"DOC(Computes the discrete Fourier Transform (DFT) of the input.
@@ -3018,12 +3163,14 @@ ONNX_OPERATOR_SET_SCHEMA(
             "If the input tensor is complex, onesided output is not possible. "
             "Value can be `0` or `1`. Default is `0`.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "inverse",
             "Whether to perform the inverse discrete Fourier Transform. Default is 0, which corresponds to `false`.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(
             0,
             "input",
@@ -3034,7 +3181,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             1,
             "dft_length",
@@ -3045,7 +3193,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "axis",
@@ -3056,7 +3205,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "output",
@@ -3066,7 +3216,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "If `axis=1` and `onesided` is `1`, the following shape is expected: `[signal_dim0][floor(signal_dim1/2)+1][signal_dim2]...[signal_dimN][2]`. "
             "If `axis=N` and `onesided` is `1`, the following shape is expected: `[signal_dim0][signal_dim1][signal_dim2]...[floor(signal_dimN/2)+1][2]`. "
             "The `signal_dim` at the specified `axis` is equal to the `dft_length`.",
-            "T1")
+            "T1"
+        )
         .TypeConstraint("T1", OpSchema::all_float_types_ir4(), "Constrain input and output types to float tensors.")
         .TypeConstraint("T2", {"tensor(int32)", "tensor(int64)"}, "Constrain scalar length types to integers.")
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
@@ -3113,7 +3264,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               // Coerce the last dimension to 2.
               ONNX_ASSERTM(
                   rank == static_cast<int64_t>(new_shape_proto.dim_size()),
-                  "rank should be equal to new_shape_proto.dim_size()");
+                  "rank should be equal to new_shape_proto.dim_size()"
+              );
               new_shape_proto.mutable_dim(rank - 1)->set_dim_value(2);
               updateOutputShape(ctx, output_index, new_shape_proto);
               return;
@@ -3148,7 +3300,8 @@ ONNX_OPERATOR_SET_SCHEMA(
                 axis,
                 " is invalid for a tensor of rank ",
                 rank,
-                ". Valid values are '-rank <= axis && axis != -1 && axis < rank - 1'");
+                ". Valid values are '-rank <= axis && axis != -1 && axis < rank - 1'"
+            );
           }
 
           auto axis_idx = (axis >= 0 ? axis : axis + rank);
@@ -3193,7 +3346,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           result_shape_proto.mutable_dim(static_cast<int>(rank - 1))->set_dim_value(2);
 
           updateOutputShape(ctx, output_index, result_shape_proto);
-        }));
+        })
+);
 
 std::function<void(OpSchema&)> CosineSumWindowOpDocGenerator(const char* name) {
   return [=](OpSchema& schema) {
@@ -3210,14 +3364,16 @@ Generates a {name} window as described in the paper https://ieeexplore.ieee.org/
         "Strictly must be one of the values from DataType enum in TensorProto whose values correspond to T2. "
         "The default value is 1 = FLOAT. ",
         AttributeProto::INT,
-        static_cast<int64_t>(TensorProto_DataType_FLOAT));
+        static_cast<int64_t>(TensorProto_DataType_FLOAT)
+    );
     schema.Attr(
         "periodic",
         "If 1, returns a window to be used as periodic function. If 0, return a symmetric window. "
         "When 'periodic' is specified, hann computes a window of length size + 1 and returns the first size points. "
         "The default value is 1. ",
         AttributeProto::INT,
-        static_cast<int64_t>(1));
+        static_cast<int64_t>(1)
+    );
     schema.Input(
         0,
         "size",
@@ -3226,7 +3382,8 @@ Generates a {name} window as described in the paper https://ieeexplore.ieee.org/
         OpSchema::Single,
         true,
         1,
-        OpSchema::NonDifferentiable);
+        OpSchema::NonDifferentiable
+    );
     std::string output_doc("A {name} window with length: size. The output has the shape: [size].");
     ReplaceAll(output_doc, "{name}", name);
     schema.Output(0, "output", output_doc, "T2", OpSchema::Single, true, 1, OpSchema::NonDifferentiable);
@@ -3298,7 +3455,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           Temp1 = Add (Temp0, A2_Component)
           output = Cast <to : int = @output_datatype> (Temp1)
         }
-        )ONNX"));
+        )ONNX")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     HammingWindow,
@@ -3336,7 +3494,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           Temp1 = Add (Temp0, A2_Component)
           output = Cast <to : int = @output_datatype> (Temp1)
         }
-        )ONNX"));
+        )ONNX")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     BlackmanWindow,
@@ -3374,7 +3533,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           Temp1 = Add (Temp0, A2_Component)
           output = Cast <to : int = @output_datatype> (Temp1)
         }
-        )ONNX"));
+        )ONNX")
+);
 
 static const char* MelWeightMatrix_ver17_doc = R"DOC(
 Generate a MelWeightMatrix that can be used to re-weight a Tensor containing a linearly sampled frequency spectra (from DFT or STFT) into num_mel_bins frequency information based on the [lower_edge_hertz, upper_edge_hertz] range on the mel scale.
@@ -3398,7 +3558,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Strictly must be one of the values from DataType enum in TensorProto whose values correspond to T3. "
             "The default value is 1 = FLOAT. ",
             AttributeProto::INT,
-            static_cast<int64_t>(TensorProto_DataType_FLOAT))
+            static_cast<int64_t>(TensorProto_DataType_FLOAT)
+        )
         .Input(
             0,
             "num_mel_bins",
@@ -3407,7 +3568,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             1,
             "dft_length",
@@ -3417,7 +3579,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "sample_rate",
@@ -3426,7 +3589,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             3,
             "lower_edge_hertz",
@@ -3435,7 +3599,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             4,
             "upper_edge_hertz",
@@ -3444,7 +3609,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "output",
@@ -3454,12 +3620,14 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .TypeConstraint("T1", {"tensor(int32)", "tensor(int64)"}, "Constrain to integer tensors.")
         .TypeConstraint(
             "T2",
             {"tensor(float)", "tensor(float16)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain to float tensors")
+            "Constrain to float tensors"
+        )
         .TypeConstraint("T3", OpSchema::all_numeric_types_ir4(), "Constrain to any numerical types.")
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
           auto output_datatype = getAttribute(ctx, "output_datatype", static_cast<int64_t>(TensorProto_DataType_FLOAT));
@@ -3493,7 +3661,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             result_shape.add_dim()->set_dim_value(num_mel_bins_value);
             updateOutputShape(ctx, 0, result_shape);
           }
-        }));
+        })
+);
 
 static const char* STFT_ver17_doc = R"DOC(Computes the Short-time Fourier Transform of the signal.)DOC";
 
@@ -3511,7 +3680,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "When invoked with real or complex valued input, the default value is 1. "
             "Values can be 0 or 1.",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .Input(
             0,
             "signal",
@@ -3523,7 +3693,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             1,
             "frame_step",
@@ -3532,7 +3703,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "window",
@@ -3543,7 +3715,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             3,
             "frame_length",
@@ -3553,7 +3726,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "output",
@@ -3564,11 +3738,13 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .TypeConstraint(
             "T1",
             {"tensor(float)", "tensor(float16)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain signal and output to float tensors.")
+            "Constrain signal and output to float tensors."
+        )
         .TypeConstraint("T2", {"tensor(int32)", "tensor(int64)"}, "Constrain scalar length types to int64_t.")
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
@@ -3637,7 +3813,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               auto window_length = window_shape->dim(0).dim_value();
               if (window_length != frame_length_value) {
                 fail_type_inference(
-                    "If STFT has both a window input and frame_length specified, the dimension of the window must match the frame_length specified!");
+                    "If STFT has both a window input and frame_length specified, the dimension of the window must match the frame_length specified!"
+                );
               }
             }
 
@@ -3671,12 +3848,13 @@ ONNX_OPERATOR_SET_SCHEMA(
           auto batch_dim = result_shape_proto.add_dim();
 
           if (input_shape.dim(0).has_dim_value()) {
-            batch_dim->set_dim_value(input_shape.dim(0).dim_value()); // batch size
+            batch_dim->set_dim_value(input_shape.dim(0).dim_value());  // batch size
           }
 
           result_shape_proto.add_dim()->set_dim_value(n_dfts);
           result_shape_proto.add_dim()->set_dim_value(dft_unique_bins);
           result_shape_proto.add_dim()->set_dim_value(2);
           updateOutputShape(ctx, 0, result_shape_proto);
-        }));
-} // namespace ONNX_NAMESPACE
+        })
+);
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/math/old.cc
+++ b/onnx/defs/math/old.cc
@@ -25,25 +25,21 @@ Performs element-wise binary {name} (with Numpy-style broadcasting support).
     schema.Input(0, "A", "First operand.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable);
     schema.Input(1, "B", "Second operand.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable);
     schema.Output(
-        0,
-        "C",
-        "Result, has same element type as two inputs",
-        "T",
-        OpSchema::Single,
-        true,
-        1,
-        OpSchema::Differentiable);
+        0, "C", "Result, has same element type as two inputs", "T", OpSchema::Single, true, 1, OpSchema::Differentiable
+    );
     schema.TypeConstraint(
         "T",
         OpSchema::numeric_types_for_math_reduction_ir4(),
-        "Constrain input and output types to high-precision numeric tensors.");
+        "Constrain input and output types to high-precision numeric tensors."
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       propagateElemTypeFromInputToOutput(ctx, 0, 0);
       if (hasNInputShapes(ctx, 2))
         bidirectionalBroadcastShapeInference(
             ctx.getInputType(0)->tensor_type().shape(),
             ctx.getInputType(1)->tensor_type().shape(),
-            *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
+            *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()
+        );
     });
   };
 }
@@ -73,14 +69,16 @@ Performs element-wise binary {name} (with Numpy-style broadcasting support).
     schema.TypeConstraint(
         "T",
         OpSchema::numeric_types_for_math_reduction(),
-        "Constrain input and output types to high-precision numeric tensors.");
+        "Constrain input and output types to high-precision numeric tensors."
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       propagateElemTypeFromInputToOutput(ctx, 0, 0);
       if (hasNInputShapes(ctx, 2))
         bidirectionalBroadcastShapeInference(
             ctx.getInputType(0)->tensor_type().shape(),
             ctx.getInputType(1)->tensor_type().shape(),
-            *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
+            *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()
+        );
     });
   };
 }
@@ -122,23 +120,27 @@ and contains the {name} values of the corresponding input.
         "the batch_size. Negative value means counting dimensions "
         "from the back. Accepted range is [-r, r-1] where r = rank(input).",
         AttributeProto::INT,
-        static_cast<int64_t>(1));
+        static_cast<int64_t>(1)
+    );
     schema.Input(
         0,
         "input",
         "The input tensor that's coerced into a 2D matrix of size (NxD) "
         "as described above.",
-        "T");
+        "T"
+    );
     schema.Output(
         0,
         "output",
         "The output values with the same "
         "shape as input tensor (the original size without coercion).",
-        "T");
+        "T"
+    );
     schema.TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       // Type inference
       propagateElemTypeFromInputToOutput(ctx, 0, 0);
@@ -163,20 +165,19 @@ and contains the {name} values of the corresponding input.
 }
 
 ONNX_OPERATOR_SET_SCHEMA(
-    Softmax,
-    11,
-    OpSchema().FillUsing(SoftmaxFamilyDocGenerator_opset_11("softmax", "normalized exponential")));
+    Softmax, 11, OpSchema().FillUsing(SoftmaxFamilyDocGenerator_opset_11("softmax", "normalized exponential"))
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
-    LogSoftmax,
-    11,
-    OpSchema().FillUsing(SoftmaxFamilyDocGenerator_opset_11("logsoftmax", "log of softmax")));
+    LogSoftmax, 11, OpSchema().FillUsing(SoftmaxFamilyDocGenerator_opset_11("logsoftmax", "log of softmax"))
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Hardmax,
     11,
-    OpSchema().FillUsing(
-        SoftmaxFamilyDocGenerator_opset_11("hardmax", "1 for the first maximum value, and 0 for all others")));
+    OpSchema()
+        .FillUsing(SoftmaxFamilyDocGenerator_opset_11("hardmax", "1 for the first maximum value, and 0 for all others"))
+);
 
 static const char* Mod_doc_10 = R"DOC(
   Performs element-wise binary modulus (with Numpy-style broadcasting support).
@@ -203,22 +204,24 @@ ONNX_OPERATOR_SET_SCHEMA(
             "fmod",
             "Whether the operator should behave like fmod (default=0 meaning it will do integer mods); Set this to 1 to force fmod treatment",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(0, "A", "Dividend tensor", "T")
         .Input(1, "B", "Divisor tensor", "T")
         .Output(0, "C", "Remainder tensor", "T")
         .TypeConstraint(
-            "T",
-            OpSchema::all_numeric_types(),
-            "Constrain input and output types to high-precision numeric tensors.")
+            "T", OpSchema::all_numeric_types(), "Constrain input and output types to high-precision numeric tensors."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
           if (hasNInputShapes(ctx, 2))
             bidirectionalBroadcastShapeInference(
                 ctx.getInputType(0)->tensor_type().shape(),
                 ctx.getInputType(1)->tensor_type().shape(),
-                *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
-        }));
+                *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()
+            );
+        })
+);
 
 static const char* Neg_ver6_doc = R"DOC(
 Neg takes one input data (Tensor<T>) and produces one output data
@@ -242,8 +245,10 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(int64)",
              "tensor(float16)",
              "tensor(double)"},
-            "Constrain input and output types to signed numeric tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to signed numeric tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Abs_ver6_doc = R"DOC(
 Absolute takes one input data (Tensor<T>) and produces one output data
@@ -259,7 +264,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Input(0, "X", "Input tensor", "T")
         .Output(0, "Y", "Output tensor", "T")
         .TypeConstraint("T", OpSchema::all_numeric_types(), "Constrain input and output types to all numeric tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Reciprocal_ver6_doc = R"DOC(
 Reciprocal takes one input data (Tensor<T>) and produces one output data
@@ -277,8 +283,10 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Floor_ver6_doc = R"DOC(
 Floor takes one input data (Tensor<T>) and produces one output data
@@ -296,8 +304,10 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Ceil_ver6_doc = R"DOC(
 Ceil takes one input data (Tensor<T>) and produces one output data
@@ -315,8 +325,10 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Sqrt_ver6_doc = R"DOC(
 Square root takes one input data (Tensor<T>) and produces one output data
@@ -334,8 +346,10 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Relu_ver6_doc = R"DOC(
 Relu takes one input data (Tensor<T>) and produces one output data
@@ -353,8 +367,10 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Relu_ver13_doc = R"DOC(
 Relu takes one input data (Tensor<T>) and produces one output data
@@ -372,8 +388,10 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Exp_ver6_doc = R"DOC(
 Calculates the exponential of the given input tensor, element-wise.
@@ -390,12 +408,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "output",
             "The exponential of the input tensor computed "
             "element-wise",
-            "T")
+            "T"
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Log_ver6_doc = R"DOC(
 Calculates the natural log of the given input tensor, element-wise.
@@ -412,12 +433,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "output",
             "The natural log of the input tensor computed "
             "element-wise",
-            "T")
+            "T"
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Tanh_ver6_doc = R"DOC(
 Calculates the hyperbolic tangent of the given input tensor element-wise.
@@ -434,12 +458,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "output",
             "The hyperbolic tangent values of the input tensor "
             "computed element-wise",
-            "T")
+            "T"
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Pow_ver13_doc = R"DOC(
 Pow takes input data (Tensor<T>) and exponent Tensor, and
@@ -454,24 +481,15 @@ ONNX_OPERATOR_SET_SCHEMA(
         .SetDoc(GET_OP_DOC_STR(std::string(Pow_ver13_doc) + GenerateBroadcastingDocMul()))
         .Input(0, "X", "First operand, base of the exponent.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
-            1,
-            "Y",
-            "Second operand, power of the exponent.",
-            "T1",
-            OpSchema::Single,
-            true,
-            1,
-            OpSchema::Differentiable)
+            1, "Y", "Second operand, power of the exponent.", "T1", OpSchema::Single, true, 1, OpSchema::Differentiable
+        )
         .Output(0, "Z", "Output tensor", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint(
             "T",
-            {"tensor(int32)",
-             "tensor(int64)",
-             "tensor(float16)",
-             "tensor(float)",
-             "tensor(double)",
-             "tensor(bfloat16)"},
-            "Constrain input X and output types to float/int tensors.")
+            {"tensor(int32)", "tensor(int64)", "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"
+            },
+            "Constrain input X and output types to float/int tensors."
+        )
         .TypeConstraint(
             "T1",
             {"tensor(uint8)",
@@ -485,15 +503,18 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(float16)",
              "tensor(float)",
              "tensor(double)"},
-            "Constrain input Y types to float/int tensors.")
+            "Constrain input Y types to float/int tensors."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
           if (hasNInputShapes(ctx, 2))
             bidirectionalBroadcastShapeInference(
                 ctx.getInputType(0)->tensor_type().shape(),
                 ctx.getInputType(1)->tensor_type().shape(),
-                *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
-        }));
+                *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()
+            );
+        })
+);
 
 static const char* Pow_ver12_doc = R"DOC(
 Pow takes input data (Tensor<T>) and exponent Tensor, and
@@ -512,7 +533,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(int32)", "tensor(int64)", "tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input X and output types to float/int tensors.")
+            "Constrain input X and output types to float/int tensors."
+        )
         .TypeConstraint(
             "T1",
             {"tensor(uint8)",
@@ -526,15 +548,18 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(float16)",
              "tensor(float)",
              "tensor(double)"},
-            "Constrain input Y types to float/int tensors.")
+            "Constrain input Y types to float/int tensors."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
           if (hasNInputShapes(ctx, 2))
             bidirectionalBroadcastShapeInference(
                 ctx.getInputType(0)->tensor_type().shape(),
                 ctx.getInputType(1)->tensor_type().shape(),
-                *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
-        }));
+                *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()
+            );
+        })
+);
 
 static const char* Sigmoid_ver6_doc = R"DOC(
 Sigmoid takes one input data (Tensor<T>) and produces one output data
@@ -552,8 +577,10 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 // Generate opschema for element-wise ops. Leaves type constraint "T"
 // unspecified.
@@ -592,14 +619,16 @@ ONNX_OPERATOR_SET_SCHEMA(
     12,
     OpSchema()
         .FillUsing(ElementwiseMultiOpDocGenerator_opset8("max"))
-        .TypeConstraint("T", OpSchema::all_numeric_types(), "Constrain input and output types to numeric tensors."));
+        .TypeConstraint("T", OpSchema::all_numeric_types(), "Constrain input and output types to numeric tensors.")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Min,
     12,
     OpSchema()
         .FillUsing(ElementwiseMultiOpDocGenerator_opset8("min"))
-        .TypeConstraint("T", OpSchema::all_numeric_types(), "Constrain input and output types to numeric tensors."));
+        .TypeConstraint("T", OpSchema::all_numeric_types(), "Constrain input and output types to numeric tensors.")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Sum,
@@ -609,7 +638,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Mean,
@@ -619,7 +650,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* Clip_ver12_doc = R"DOC(
 Clip operator limits the given input within an interval. The interval is
@@ -639,17 +672,20 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Minimum value, under which element is replaced by min. "
             "It must be a scalar(tensor of empty shape).",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Input(
             2,
             "max",
             "Maximum value, above which element is replaced by max. "
             "It must be a scalar(tensor of empty shape).",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(0, "output", "Output tensor with clipped input elements", "T")
         .TypeConstraint("T", OpSchema::all_numeric_types(), "Constrain input and output types to all numeric tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Gemm_ver11_doc = R"DOC(General Matrix multiplication:
 https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms#Level_3
@@ -670,21 +706,24 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .SetDoc(GET_OP_DOC_STR(
             std::string(Gemm_ver11_doc) + GenerateBroadcastingDocUni("tensor C", "tensor A * B") + "\n" +
-            GenerateOptionalArgumentsDoc()))
+            GenerateOptionalArgumentsDoc()
+        ))
         .Input(
             0,
             "A",
             "Input tensor A. "
             "The shape of A should be (M, K) if transA is 0, "
             "or (K, M) if transA is non-zero.",
-            "T")
+            "T"
+        )
         .Input(
             1,
             "B",
             "Input tensor B. "
             "The shape of B should be (K, N) if transB is 0, "
             "or (N, K) if transB is non-zero.",
-            "T")
+            "T"
+        )
         .Input(
             2,
             "C",
@@ -692,7 +731,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "If not specified, the computation is done as if C is a scalar 0. "
             "The shape of C should be unidirectional broadcastable to (M, N).",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(0, "Y", "Output tensor of shape (M, N).", "T")
         .TypeConstraint(
             "T",
@@ -703,7 +743,8 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(uint64)",
              "tensor(int32)",
              "tensor(int64)"},
-            "Constrain input and output types to float/int tensors.")
+            "Constrain input and output types to float/int tensors."
+        )
         .Attr("transA", "Whether A should be transposed", AttributeProto::INT, static_cast<int64_t>(0))
         .Attr("transB", "Whether B should be transposed", AttributeProto::INT, static_cast<int64_t>(0))
         .Attr("alpha", "Scalar multiplier for the product of input tensors A * B.", AttributeProto::FLOAT, 1.0f)
@@ -725,7 +766,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
             updateOutputShape(ctx, 0, {first_input_shape.dim(transA ? 1 : 0), second_input_shape.dim(transB ? 0 : 1)});
           }
-        }));
+        })
+);
 
 void matmulShapeInference_opset_9(ONNX_NAMESPACE::InferenceContext& ctx, int input1Idx, int input2Idx) {
   if (!hasInputShape(ctx, input1Idx) || !hasInputShape(ctx, input2Idx)) {
@@ -815,12 +857,14 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(uint64)",
              "tensor(int32)",
              "tensor(int64)"},
-            "Constrain input and output types to float/int tensors.")
+            "Constrain input and output types to float/int tensors."
+        )
         .SetDoc(MatMul_ver9_doc)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
           matmulShapeInference_opset_9(ctx, 0, 1);
-        }));
+        })
+);
 
 static const char* Expand_ver8_doc = R"DOC(
 Broadcast the input tensor following the given shape and the broadcast rule.
@@ -843,7 +887,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             1,
             "shape",
             "A 1-D tensor indicates the shape you want to expand to, following the broadcast rule",
-            "tensor(int64)")
+            "tensor(int64)"
+        )
         .Output(0, "output", "Output tensor", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to all tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -879,7 +924,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
             bidirectionalBroadcastShapeInference(input_shape, second_shape, *getOutputShape(ctx, 0));
           }
-        }));
+        })
+);
 
 static const char* Sign_ver9_doc = R"DOC(
 Calculate the sign of the given input tensor element-wise.
@@ -897,9 +943,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             "output",
             "The sign of the input tensor "
             "computed element-wise. It has the same shape and type of the input.",
-            "T")
+            "T"
+        )
         .TypeConstraint("T", OpSchema::all_numeric_types(), "Constrain input and output types to all numeric tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Erf_ver9_doc = R"DOC(
 Computes the error function of the given input tensor element-wise.
@@ -916,9 +964,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             "output",
             "The error function of the input tensor "
             "computed element-wise. It has the same shape and type of the input.",
-            "T")
+            "T"
+        )
         .TypeConstraint("T", OpSchema::all_numeric_types(), "Constrain input and output types to all numeric tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* CumSum_ver11_doc = R"DOC(
 Performs cumulative sum of the input elements along the given axis.
@@ -953,21 +1003,17 @@ ONNX_OPERATOR_SET_SCHEMA(
             " In other terms, if set to 1, the j-th output element would be the sum of the first (j-1) elements."
             " Otherwise, it would be the sum of the first j elements.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "reverse",
             "If set to 1 will perform the sums in reverse direction.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(
-            0,
-            "x",
-            "An input tensor that is to be processed.",
-            "T",
-            OpSchema::Single,
-            true,
-            1,
-            OpSchema::Differentiable)
+            0, "x", "An input tensor that is to be processed.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable
+        )
         .Input(
             1,
             "axis",
@@ -977,7 +1023,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "y",
@@ -986,13 +1033,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(uint32)", "tensor(uint64)", "tensor(int32)", "tensor(int64)", "tensor(float)", "tensor(double)"},
-            "Input can be of any tensor type.")
+            "Input can be of any tensor type."
+        )
         .TypeConstraint("T2", {"tensor(int32)", "tensor(int64)"}, "axis tensor can be int32 or int64 only")
-        .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput));
+        .TypeAndShapeInferenceFunction(ONNX_NAMESPACE::propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* NegativeLogLikelihoodLoss_ver12_doc = R"DOC(
 A NegativeLogLikelihoodLoss operator computes (weighted) negative log likelihood loss.
@@ -1088,9 +1138,8 @@ TensorProto ToDimensionOneInt64Tensor_old(std::vector<int64_t> value) {
 }
 
 bool BuildContextDependentFunctionBody_opset12(
-    const FunctionBodyBuildContext& ctx,
-    const OpSchema& schema,
-    FunctionProto& functionProto) {
+    const FunctionBodyBuildContext& ctx, const OpSchema& schema, FunctionProto& functionProto
+) {
   if (ctx.getInputType(0) == nullptr) {
     // we cannot create a correct function body without knowing the input type
     return false;
@@ -1109,10 +1158,8 @@ bool BuildContextDependentFunctionBody_opset12(
 
   if (ctx.getAttribute("ignore_index") == nullptr) {
     body.push_back(
-        {{"input_gather_element"},
-         "GatherElements",
-         {"input", "expanded_target"},
-         {MakeAttribute("axis", (int64_t)1)}});
+        {{"input_gather_element"}, "GatherElements", {"input", "expanded_target"}, {MakeAttribute("axis", (int64_t)1)}}
+    );
 
     body.push_back({{"loss_NCdd"}, "Neg", {"input_gather_element"}});
 
@@ -1131,8 +1178,8 @@ bool BuildContextDependentFunctionBody_opset12(
       }
     } else {
       body.push_back({{"weight_gather"}, "Gather", {"weight", "target"}});
-      body.push_back(
-          {{"loss_unweighted"}, "Squeeze", {"loss_N1dd"}, {MakeAttribute("axes", std::vector<int64_t>({1}))}});
+      body.push_back({{"loss_unweighted"}, "Squeeze", {"loss_N1dd"}, {MakeAttribute("axes", std::vector<int64_t>({1}))}}
+      );
       if (reduction_attr == "none") {
         body.push_back({{"loss"}, "Mul", {"loss_unweighted", "weight_gather"}});
       } else {
@@ -1140,7 +1187,8 @@ bool BuildContextDependentFunctionBody_opset12(
         if (reduction_attr == "mean") {
           body.push_back({{"loss_sum"}, "ReduceSum", {"loss_Ndd"}, {MakeAttribute("keepdims", (int64_t)0)}});
           body.push_back(
-              {{"weight_gather_sum"}, "ReduceSum", {"weight_gather"}, {MakeAttribute("keepdims", (int64_t)0)}});
+              {{"weight_gather_sum"}, "ReduceSum", {"weight_gather"}, {MakeAttribute("keepdims", (int64_t)0)}}
+          );
           body.push_back({{"loss"}, "Div", {"loss_sum", "weight_gather_sum"}});
         } else {
           body.push_back({{"loss"}, "ReduceSum", {"loss_Ndd"}, {MakeAttribute("keepdims", (int64_t)0)}});
@@ -1152,35 +1200,35 @@ bool BuildContextDependentFunctionBody_opset12(
         {{"const_ignore_index"},
          "Constant",
          {},
-         {MakeAttribute("value", ToDimensionOneInt64Tensor_old(ctx.getAttribute("ignore_index")->i()))}});
+         {MakeAttribute("value", ToDimensionOneInt64Tensor_old(ctx.getAttribute("ignore_index")->i()))}}
+    );
 
     body.push_back({{"const_zero_target_typed"}, "Sub", {"expanded_target", "expanded_target"}});
     body.push_back(
         {{"expanded_target_int64"},
          "Cast",
          {"expanded_target"},
-         {MakeAttribute("to", (int64_t)TensorProto_DataType::TensorProto_DataType_INT64)}});
+         {MakeAttribute("to", (int64_t)TensorProto_DataType::TensorProto_DataType_INT64)}}
+    );
 
     body.push_back({{"mask"}, "Equal", {"expanded_target_int64", "const_ignore_index"}});
     body.push_back({{"transform_targets"}, "Where", {"mask", "const_zero_target_typed", "expanded_target"}});
     body.push_back(
-        {{"input_gather_element"},
-         "GatherElements",
-         {"input", "transform_targets"},
-         {MakeAttribute("axis", (int64_t)1)}});
-    body.push_back(
-        {{"const_zero_float"}, "Constant", {}, {MakeAttribute("value", ToDimensionOneFloatTensor_old(0.0f))}});
+        {{"input_gather_element"}, "GatherElements", {"input", "transform_targets"}, {MakeAttribute("axis", (int64_t)1)}
+        }
+    );
+    body.push_back({{"const_zero_float"}, "Constant", {}, {MakeAttribute("value", ToDimensionOneFloatTensor_old(0.0f))}}
+    );
     if (!float_input) {
       body.push_back(
-          {{"const_zero_casted"},
-           "Cast",
-           {"const_zero_float"},
-           {MakeAttribute("to", static_cast<int64_t>(input_type))}});
+          {{"const_zero_casted"}, "Cast", {"const_zero_float"}, {MakeAttribute("to", static_cast<int64_t>(input_type))}}
+      );
     }
     body.push_back(
         {{"input_gather_element_transform"},
          "Where",
-         {"mask", float_input ? "const_zero_float" : "const_zero_casted", "input_gather_element"}});
+         {"mask", float_input ? "const_zero_float" : "const_zero_casted", "input_gather_element"}}
+    );
     body.push_back({{"loss_NCdd"}, "Neg", {"input_gather_element_transform"}});
     body.push_back({{"loss_N1dd"}, "Slice", {"loss_NCdd", "const_zero", "const_one", "const_one"}});
 
@@ -1188,20 +1236,20 @@ bool BuildContextDependentFunctionBody_opset12(
       body.push_back({{"squeeze_mask"}, "Squeeze", {"mask"}, {MakeAttribute("axes", std::vector<int64_t>({1}))}});
 
       body.push_back(
-          {{"const_one_float"}, "Constant", {}, {MakeAttribute("value", ToDimensionOneFloatTensor_old(1.0f))}});
+          {{"const_one_float"}, "Constant", {}, {MakeAttribute("value", ToDimensionOneFloatTensor_old(1.0f))}}
+      );
       if (!float_input) {
         body.push_back(
-            {{"const_one_casted"},
-             "Cast",
-             {"const_one_float"},
-             {MakeAttribute("to", static_cast<int64_t>(input_type))}});
+            {{"const_one_casted"}, "Cast", {"const_one_float"}, {MakeAttribute("to", static_cast<int64_t>(input_type))}}
+        );
       }
       body.push_back(
           {{"weight_gather"},
            "Where",
            {"squeeze_mask",
             float_input ? "const_zero_float" : "const_zero_casted",
-            float_input ? "const_one_float" : "const_one_casted"}});
+            float_input ? "const_one_float" : "const_one_casted"}}
+      );
 
     } else {
       body.push_back({{"weight_gather_temp"}, "Gather", {"weight", "transform_targets"}});
@@ -1209,10 +1257,12 @@ bool BuildContextDependentFunctionBody_opset12(
       body.push_back(
           {{"weight_gather_temp_1"},
            "Where",
-           {"mask", float_input ? "const_zero_float" : "const_zero_casted", "weight_gather_temp"}});
+           {"mask", float_input ? "const_zero_float" : "const_zero_casted", "weight_gather_temp"}}
+      );
 
       body.push_back(
-          {{"weight_gather"}, "Squeeze", {"weight_gather_temp_1"}, {MakeAttribute("axes", std::vector<int64_t>({1}))}});
+          {{"weight_gather"}, "Squeeze", {"weight_gather_temp_1"}, {MakeAttribute("axes", std::vector<int64_t>({1}))}}
+      );
     }
 
     body.push_back({{"loss_unweighted"}, "Squeeze", {"loss_N1dd"}, {MakeAttribute("axes", std::vector<int64_t>({1}))}});
@@ -1222,8 +1272,8 @@ bool BuildContextDependentFunctionBody_opset12(
       body.push_back({{"loss_Ndd"}, "Mul", {"loss_unweighted", "weight_gather"}});
       if (reduction_attr == "mean") {
         body.push_back({{"loss_sum"}, "ReduceSum", {"loss_Ndd"}, {MakeAttribute("keepdims", (int64_t)0)}});
-        body.push_back(
-            {{"weight_gather_sum"}, "ReduceSum", {"weight_gather"}, {MakeAttribute("keepdims", (int64_t)0)}});
+        body.push_back({{"weight_gather_sum"}, "ReduceSum", {"weight_gather"}, {MakeAttribute("keepdims", (int64_t)0)}}
+        );
         body.push_back({{"loss"}, "Div", {"loss_sum", "weight_gather_sum"}});
       } else {
         body.push_back({{"loss"}, "ReduceSum", {"loss_Ndd"}, {MakeAttribute("keepdims", (int64_t)0)}});
@@ -1253,14 +1303,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Target tensor of shape (N) or (N, d1, d2, ..., dk). Target element value shall be in range of [0, C). "
             "If ignore_index is specified, it may have a value outside [0, C) and the target values should either be "
             "in the range [0, C) or have the value ignore_index.",
-            "Tind")
+            "Tind"
+        )
         .Input(
             2,
             "weight",
             "Optional rescaling weight tensor. "
             "If given, it has to be a tensor of size C. Otherwise, it is treated as if having all ones.",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(0, "loss", "The negative log likelihood loss", "T")
         .Attr(
             "reduction",
@@ -1269,16 +1321,19 @@ ONNX_OPERATOR_SET_SCHEMA(
             "'sum': the output will be summed. "
             "'mean': the sum of the output will be divided by the sum of applied weights.",
             AttributeProto::STRING,
-            std::string("mean"))
+            std::string("mean")
+        )
         .Attr(
             "ignore_index",
             "Specifies a target value that is ignored and does not contribute to the input gradient. It's an optional value.",
             AttributeProto::INT,
-            false)
+            false
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input, weight, and output types to floating-point tensors.")
+            "Constrain input, weight, and output types to floating-point tensors."
+        )
         .TypeConstraint("Tind", {"tensor(int32)", "tensor(int64)"}, "Constrain target to integer types")
         .SetContextDependentFunctionBodyBuilder(BuildContextDependentFunctionBody_opset12)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -1331,7 +1386,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
             // otherwise output is a scalar.
           }
-        }));
+        })
+);
 
 const char* reduction_doc_sce_opset12 =
     "Type of reduction to apply to loss: none, sum, mean(default). "
@@ -1375,9 +1431,8 @@ where tensor W is of shape (N, D1, D2, ..., Dk) and W[n][d1][d2]...[dk] = weight
 )DOC";
 
 bool BuildContextDependentFunctionBodySCE_opset12(
-    const FunctionBodyBuildContext& ctx,
-    const OpSchema& schema,
-    FunctionProto& functionProto) {
+    const FunctionBodyBuildContext& ctx, const OpSchema& schema, FunctionProto& functionProto
+) {
   std::vector<FunctionBodyHelper::NodeDef> body;
 
   // Using stable implementation of LogSoftmax
@@ -1402,7 +1457,8 @@ bool BuildContextDependentFunctionBodySCE_opset12(
 
   std::vector<std::string> input_tensor_names{"X_Log", "labels"};
   std::vector<FunctionBodyHelper::AttributeProtoWrapper> attributes{
-      MakeRefAttribute("reduction", AttributeProto::STRING)};
+      MakeRefAttribute("reduction", AttributeProto::STRING)
+  };
   // Add weights as input if needed.
   if (ctx.hasInput(2)) {
     input_tensor_names.push_back("weights");
@@ -1435,13 +1491,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "ignore_index",
             "Specifies a target value that is ignored and does not contribute to the input gradient. It's an optional value.",
             AttributeProto::INT,
-            false)
+            false
+        )
         .Input(
             0,
             "scores",
             "The predicted outputs with shape [batch_size, class_size], or "
             "[batch_size, class_size, D1, D2 , ..., Dk], where K is the number of dimensions.",
-            "T")
+            "T"
+        )
         .Input(
             1,
             "labels",
@@ -1450,7 +1508,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Labels element value shall be in range of [0, C). "
             "If ignore_index is specified, it may have a value outside [0, C) and the label values should either be "
             "in the range [0, C) or have the value ignore_index.",
-            "Tind")
+            "Tind"
+        )
         .Input(
             2,
             "weights",
@@ -1458,24 +1517,28 @@ ONNX_OPERATOR_SET_SCHEMA(
             "be a 1D Tensor assigning weight to each of the classes. Otherwise, "
             "it is treated as if having all ones.",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(
             0,
             "output",
             "Weighted loss float Tensor. If reduction is 'none', this has the "
             "shape of [batch_size], or [batch_size, D1, D2, ..., Dk] in case of "
             "K-dimensional loss. Otherwise, it is a scalar.",
-            "T")
+            "T"
+        )
         .Output(
             1,
             "log_prob",
             "Log probability tensor. If the output of softmax is prob, its value is log(prob).",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeConstraint("Tind", {"tensor(int32)", "tensor(int64)"}, "Constrain target to integer types")
         .SetContextDependentFunctionBodyBuilder(BuildContextDependentFunctionBodySCE_opset12)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -1493,7 +1556,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             propagateElemTypeFromInputToOutput(ctx, 0, 1);
             propagateShapeFromInputToOutput(ctx, 0, 1);
           }
-        }));
+        })
+);
 
 std::function<void(OpSchema&)> SoftmaxFamilyDocGenerator_opset1(const char* name, const char* description) {
   return [=](OpSchema& schema) {
@@ -1524,42 +1588,45 @@ will throw errors.
         "to 2D; defaults to one because the 0th axis most likely describes "
         "the batch_size",
         AttributeProto::INT,
-        static_cast<int64_t>(1));
+        static_cast<int64_t>(1)
+    );
     schema.Input(
         0,
         "input",
         "The input tensor that's coerced into a 2D matrix of size (NxD) "
         "as described above.",
-        "T");
+        "T"
+    );
     schema.Output(
         0,
         "output",
         "The output values with the same "
         "shape as input tensor (the original size without coercion).",
-        "T");
+        "T"
+    );
     schema.TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."
+    );
     schema.TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
   };
 }
 
 ONNX_OPERATOR_SET_SCHEMA(
-    Softmax,
-    1,
-    OpSchema().FillUsing(SoftmaxFamilyDocGenerator_opset1("softmax", "normalized exponential")));
+    Softmax, 1, OpSchema().FillUsing(SoftmaxFamilyDocGenerator_opset1("softmax", "normalized exponential"))
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
-    LogSoftmax,
-    1,
-    OpSchema().FillUsing(SoftmaxFamilyDocGenerator_opset1("logsoftmax", "log of softmax")));
+    LogSoftmax, 1, OpSchema().FillUsing(SoftmaxFamilyDocGenerator_opset1("logsoftmax", "log of softmax"))
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Hardmax,
     1,
-    OpSchema().FillUsing(
-        SoftmaxFamilyDocGenerator_opset1("hardmax", "1 for the first maximum value, and 0 for all others")));
+    OpSchema()
+        .FillUsing(SoftmaxFamilyDocGenerator_opset1("hardmax", "1 for the first maximum value, and 0 for all others"))
+);
 
 const char* kBroadcastDoc_old = R"DOC(
 If necessary the right-hand-side argument will be broadcasted to match the
@@ -1598,19 +1665,22 @@ Performs element-wise binary {name} (with limited broadcast support).
     // definition.
     schema.Attr("consumed_inputs", "legacy optimization attribute.", AttributeProto::INTS, OPTIONAL_VALUE);
     schema.Attr(
-        "axis", "If set, defines the broadcast dimensions. See doc for details.", AttributeProto::INT, OPTIONAL_VALUE);
+        "axis", "If set, defines the broadcast dimensions. See doc for details.", AttributeProto::INT, OPTIONAL_VALUE
+    );
     schema.Input(0, "A", "First operand, should share the type with the second operand.", "T");
     schema.Input(
         1,
         "B",
         "Second operand. With broadcasting can be of smaller size than A. "
         "If broadcasting is disabled it should be of the same size.",
-        "T");
+        "T"
+    );
     schema.Output(0, "C", "Result, has same dimensions and type as A", "T");
     schema.TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."
+    );
   };
 }
 
@@ -1625,19 +1695,22 @@ Performs element-wise binary {name} (with limited broadcast support).
     schema.SetDoc(doc);
     schema.Attr("broadcast", "Pass 1 to enable broadcasting", AttributeProto::INT, static_cast<int64_t>(0));
     schema.Attr(
-        "axis", "If set, defines the broadcast dimensions. See doc for details.", AttributeProto::INT, OPTIONAL_VALUE);
+        "axis", "If set, defines the broadcast dimensions. See doc for details.", AttributeProto::INT, OPTIONAL_VALUE
+    );
     schema.Input(0, "A", "First operand, should share the type with the second operand.", "T");
     schema.Input(
         1,
         "B",
         "Second operand. With broadcasting can be of smaller size than A. "
         "If broadcasting is disabled it should be of the same size.",
-        "T");
+        "T"
+    );
     schema.Output(0, "C", "Result, has same dimensions and type as A", "T");
     schema.TypeConstraint(
         "T",
         OpSchema::numeric_types_for_math_reduction(),
-        "Constrain input and output types to high-precision numeric tensors.");
+        "Constrain input and output types to high-precision numeric tensors."
+    );
     schema.TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput);
   };
 }
@@ -1675,19 +1748,23 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Y",
             "Input tensor of any shape broadcastable to X shape, "
             "the exponent component.",
-            "T")
+            "T"
+        )
         .Attr("broadcast", "Pass 1 to enable broadcasting", AttributeProto::INT, static_cast<int64_t>(0))
         .Attr(
             "axis",
             "If set, defines the broadcast dimensions. See doc for details.",
             AttributeProto::INT,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Output(0, "Z", "Output tensor (same size as X)", "T")
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Pow_ver7_doc = R"DOC(
 Pow takes input data (Tensor<T>) and exponent Tensor, and
@@ -1706,15 +1783,18 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
           if (hasNInputShapes(ctx, 2))
             bidirectionalBroadcastShapeInference(
                 ctx.getInputType(0)->tensor_type().shape(),
                 ctx.getInputType(1)->tensor_type().shape(),
-                *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
-        }));
+                *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()
+            );
+        })
+);
 
 static const char* Neg_ver1_doc = R"DOC(
 Neg takes one input data (Tensor<T>) and produces one output data
@@ -1736,7 +1816,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* Abs_ver1_doc = R"DOC(
 Absolute takes one input data (Tensor<T>) and produces one output data
@@ -1758,7 +1840,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* Reciprocal_ver1_doc = R"DOC(
 Reciprocal takes one input data (Tensor<T>) and produces one output data
@@ -1780,7 +1864,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* Floor_ver1_doc = R"DOC(
 Floor takes one input data (Tensor<T>) and produces one output data
@@ -1802,7 +1888,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* Ceil_ver1_doc = R"DOC(
 Ceil takes one input data (Tensor<T>) and produces one output data
@@ -1824,7 +1912,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* Sqrt_ver1_doc = R"DOC(
 Square root takes one input data (Tensor<T>) and produces one output data
@@ -1846,7 +1936,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* Relu_ver1_doc = R"DOC(
 Relu takes one input data (Tensor<T>) and produces one output data
@@ -1868,7 +1960,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* LeakyRelu_ver1_doc = R"DOC(
 LeakyRelu takes input data (Tensor<T>) and an argument alpha, and produces one
@@ -1891,7 +1985,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* Selu_ver1_doc = R"DOC(
 Selu takes one input data (Tensor<T>) and produces one output data
@@ -1916,7 +2012,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* Elu_ver1_doc = R"DOC(
 Elu takes one input data (Tensor<T>) and produces one output data
@@ -1940,7 +2038,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* Exp_ver1_doc = R"DOC(
 Calculates the exponential of the given input tensor, element-wise.
@@ -1957,7 +2057,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "output",
             "The exponential of the input tensor computed "
             "element-wise",
-            "T")
+            "T"
+        )
         // This attribute was added via AllowConsumed API in OpSchema.
         // After removing the API, we're now using the Attr API to simulate the
         // old definition.
@@ -1965,7 +2066,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* Log_ver1_doc = R"DOC(
 Calculates the natural log of the given input tensor, element-wise.
@@ -1982,7 +2085,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "output",
             "The natural log of the input tensor computed "
             "element-wise",
-            "T")
+            "T"
+        )
         // This attribute was added via AllowConsumed API in OpSchema.
         // After removing the API, we're now using the Attr API to simulate the
         // old definition.
@@ -1990,7 +2094,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* Tanh_ver1_doc = R"DOC(
 Calculates the hyperbolic tangent of the given input tensor element-wise.
@@ -2007,7 +2113,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "output",
             "The hyperbolic tangent values of the input tensor "
             "computed element-wise",
-            "T")
+            "T"
+        )
         // This attribute was added via AllowConsumed API in OpSchema.
         // After removing the API, we're now using the Attr API to simulate the
         // old definition.
@@ -2015,7 +2122,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* PRelu_ver1_doc = R"DOC(
 
@@ -2036,7 +2145,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "slope",
             "Slope tensor. If `Slope` is of size 1, the value is shared"
             "across different channels",
-            "T")
+            "T"
+        )
         .Output(0, "Y", "Output tensor", "T")
         // This attribute was added via AllowConsumed API in OpSchema.
         // After removing the API, we're now using the Attr API to simulate the
@@ -2045,7 +2155,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     PRelu,
@@ -2058,13 +2170,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "slope",
             "Slope tensor. If `Slope` is of size 1, the value is shared"
             "across different channels",
-            "T")
+            "T"
+        )
         .Output(0, "Y", "Output tensor", "T")
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* PRelu_ver7_doc = R"DOC(
 PRelu takes input data (Tensor<T>) and slope tensor as input, and produces one
@@ -2077,20 +2192,24 @@ ONNX_OPERATOR_SET_SCHEMA(
     7,
     OpSchema()
         .SetDoc(
-            GET_OP_DOC_STR(std::string(PRelu_ver7_doc) + GenerateBroadcastingDocUni("tensor slope", "input tensor X")))
+            GET_OP_DOC_STR(std::string(PRelu_ver7_doc) + GenerateBroadcastingDocUni("tensor slope", "input tensor X"))
+        )
         .Input(0, "X", "Input tensor", "T")
         .Input(
             1,
             "slope",
             "Slope tensor. The shape of slope can be smaller than first input X; "
             "if so, its shape must be unidirectional broadcastable to X",
-            "T")
+            "T"
+        )
         .Output(0, "Y", "Output tensor (same size as X)", "T")
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Sigmoid_ver1_doc = R"DOC(
 Sigmoid takes one input data (Tensor<T>) and produces one output data
@@ -2112,7 +2231,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* HardSigmoid_ver1_doc = R"DOC(
 HardSigmoid takes one input data (Tensor<T>) and produces one output data
@@ -2136,7 +2257,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* Max_ver1_doc = R"DOC(
 Element-wise max of each of the input tensors. All inputs and outputs must
@@ -2157,7 +2280,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* Min_ver1_doc = R"DOC(
 Element-wise min of each of the input tensors. All inputs and outputs must
@@ -2178,7 +2303,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* Sum_ver1_doc = R"DOC(
 Element-wise sum of each of the input tensors. All inputs and outputs must
@@ -2199,7 +2326,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* Mean_ver1_doc = R"DOC(
 Element-wise mean of each of the input tensors. All inputs and outputs must
@@ -2220,7 +2349,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* Clip_ver1_doc = R"DOC(
 Clip operator limits the given input within an interval. The interval is
@@ -2244,7 +2375,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* Gemm_ver1_doc = R"DOC(General Matrix multiplication:
 https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms#Level_3
@@ -2268,7 +2401,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         // This attribute was added via AllowConsumed API in OpSchema.
         // After removing the API, we're now using the Attr API to simulate the
         // old definition.
@@ -2279,8 +2413,10 @@ ONNX_OPERATOR_SET_SCHEMA(
             "alpha",
             "Scalar multiplier for the product of input tensors A * B, the default value is 1.0.",
             AttributeProto::FLOAT,
-            1.0f)
-        .Attr("beta", "Scalar multiplier for input tensor C, the default value is 1.0.", AttributeProto::FLOAT, 1.0f));
+            1.0f
+        )
+        .Attr("beta", "Scalar multiplier for input tensor C, the default value is 1.0.", AttributeProto::FLOAT, 1.0f)
+);
 
 static const char* Gemm_ver6_doc = R"DOC(General Matrix multiplication:
 https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms#Level_3
@@ -2304,7 +2440,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .Attr("transA", "Whether A should be transposed", AttributeProto::INT, static_cast<int64_t>(0))
         .Attr("transB", "Whether B should be transposed", AttributeProto::INT, static_cast<int64_t>(0))
         .Attr("broadcast", "Whether C should be broadcasted", AttributeProto::INT, static_cast<int64_t>(0))
@@ -2312,7 +2449,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "alpha",
             "Scalar multiplier for the product of input tensors A * B, the default value is 1.0.",
             AttributeProto::FLOAT,
-            1.0f)
+            1.0f
+        )
         .Attr("beta", "Scalar multiplier for input tensor C, the default value is 1.0.", AttributeProto::FLOAT, 1.0f)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
@@ -2331,7 +2469,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               (!ctx.getAttribute("broadcast") || static_cast<int>(ctx.getAttribute("broadcast")->i()) == 0)) {
             *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape() = ctx.getInputType(2)->tensor_type().shape();
           }
-        }));
+        })
+);
 
 static const char* Gemm_ver7_doc = R"DOC(General Matrix multiplication:
 https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms#Level_3
@@ -2357,25 +2496,29 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Input tensor A. "
             "The shape of A should be (M, K) if transA is 0, "
             "or (K, M) if transA is non-zero.",
-            "T")
+            "T"
+        )
         .Input(
             1,
             "B",
             "Input tensor B. "
             "The shape of B should be (K, N) if transB is 0, "
             "or (N, K) if transB is non-zero.",
-            "T")
+            "T"
+        )
         .Input(
             2,
             "C",
             "Input tensor C. "
             "The shape of C should be unidirectional broadcastable to (M, N).",
-            "T")
+            "T"
+        )
         .Output(0, "Y", "Output tensor of shape (M, N).", "T")
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .Attr("transA", "Whether A should be transposed", AttributeProto::INT, static_cast<int64_t>(0))
         .Attr("transB", "Whether B should be transposed", AttributeProto::INT, static_cast<int64_t>(0))
         .Attr("alpha", "Scalar multiplier for the product of input tensors A * B.", AttributeProto::FLOAT, 1.0f)
@@ -2397,7 +2540,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
             updateOutputShape(ctx, 0, {first_input_shape.dim(transA ? 1 : 0), second_input_shape.dim(transB ? 0 : 1)});
           }
-        }));
+        })
+);
 
 static const char* Gemm_ver9_doc = R"DOC(General Matrix multiplication:
 https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms#Level_3
@@ -2423,20 +2567,23 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Input tensor A. "
             "The shape of A should be (M, K) if transA is 0, "
             "or (K, M) if transA is non-zero.",
-            "T")
+            "T"
+        )
         .Input(
             1,
             "B",
             "Input tensor B. "
             "The shape of B should be (K, N) if transB is 0, "
             "or (N, K) if transB is non-zero.",
-            "T")
+            "T"
+        )
         .Input(
             2,
             "C",
             "Input tensor C. "
             "The shape of C should be unidirectional broadcastable to (M, N).",
-            "T")
+            "T"
+        )
         .Output(0, "Y", "Output tensor of shape (M, N).", "T")
         .TypeConstraint(
             "T",
@@ -2447,7 +2594,8 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(uint64)",
              "tensor(int32)",
              "tensor(int64)"},
-            "Constrain input and output types to float/int tensors.")
+            "Constrain input and output types to float/int tensors."
+        )
         .Attr("transA", "Whether A should be transposed", AttributeProto::INT, static_cast<int64_t>(0))
         .Attr("transB", "Whether B should be transposed", AttributeProto::INT, static_cast<int64_t>(0))
         .Attr("alpha", "Scalar multiplier for the product of input tensors A * B.", AttributeProto::FLOAT, 1.0f)
@@ -2469,7 +2617,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
             updateOutputShape(ctx, 0, {first_input_shape.dim(transA ? 1 : 0), second_input_shape.dim(transB ? 0 : 1)});
           }
-        }));
+        })
+);
 
 static const char* Max_ver6_doc = R"DOC(
 Element-wise max of each of the input tensors. All inputs and outputs must
@@ -2486,8 +2635,10 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Min_ver6_doc = R"DOC(
 Element-wise min of each of the input tensors. All inputs and outputs must
@@ -2504,8 +2655,10 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Sum_ver6_doc = R"DOC(
 Element-wise sum of each of the input tensors. All inputs and outputs must
@@ -2522,8 +2675,10 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Mean_ver6_doc = R"DOC(
 Element-wise mean of each of the input tensors. All inputs and outputs must
@@ -2540,8 +2695,10 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* MatMul_ver1_doc = R"DOC(
 Matrix product that behaves like numpy.matmul: https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.matmul.html
@@ -2557,7 +2714,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .SetDoc(MatMul_ver1_doc)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
@@ -2627,7 +2785,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
 
           *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape() = resultShape;
-        }));
+        })
+);
 
 static const char* TopK_ver1_doc = R"DOC(
 Retrieve the top-K elements along a specified axis. Given an input tensor of
@@ -2652,18 +2811,21 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Values",
             "Tensor of shape [a_1, a_2, ..., a_{axis-1}, k, a_{axis+1}, ... a_n] "
             "containing top K values from the input tensor",
-            "T")
+            "T"
+        )
         .Output(
             1,
             "Indices",
             "Tensor of shape [a_1, a_2, ..., a_{axis-1}, k, a_{axis+1}, ... a_n] "
             "containing the corresponding input tensor indices for the top K "
             "values.",
-            "I")
+            "I"
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeConstraint("I", {"tensor(int64)"}, "Constrain index tensor to int64")
         .Attr("k", "Number of top elements to retrieve", AttributeProto::INT, true)
         .Attr("axis", "Dimension on which to do the sort.", AttributeProto::INT, static_cast<int64_t>(-1))
@@ -2693,7 +2855,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           result_shape.mutable_dim(static_cast<int>(axis))->set_dim_value(k);
           updateOutputShape(ctx, 0, result_shape);
           updateOutputShape(ctx, 1, result_shape);
-        }));
+        })
+);
 
 static const char* TopK_ver10_doc = R"DOC(
 Retrieve the top-K elements along a specified axis. Given an input tensor of
@@ -2718,24 +2881,28 @@ ONNX_OPERATOR_SET_SCHEMA(
             1,
             "K",
             "A 1-D tensor containing a single positive value corresponding to the number of top elements to retrieve",
-            "tensor(int64)")
+            "tensor(int64)"
+        )
         .Output(
             0,
             "Values",
             "Tensor of shape [a_1, a_2, ..., a_{axis-1}, k, a_{axis+1}, ... a_n] "
             "containing top K values from the input tensor",
-            "T")
+            "T"
+        )
         .Output(
             1,
             "Indices",
             "Tensor of shape [a_1, a_2, ..., a_{axis-1}, k, a_{axis+1}, ... a_n] "
             "containing the corresponding input tensor indices for the top K "
             "values.",
-            "I")
+            "I"
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeConstraint("I", {"tensor(int64)"}, "Constrain index tensor to int64")
         .Attr("axis", "Dimension on which to do the sort.", AttributeProto::INT, static_cast<int64_t>(-1))
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -2798,7 +2965,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
 
           return;
-        }));
+        })
+);
 
 static const char* Clip_ver6_doc = R"DOC(
 Clip operator limits the given input within an interval. The interval is
@@ -2815,19 +2983,23 @@ ONNX_OPERATOR_SET_SCHEMA(
             "min",
             "Minimum value, under which element is replaced by min",
             AttributeProto::FLOAT,
-            std::numeric_limits<float>::lowest())
+            std::numeric_limits<float>::lowest()
+        )
         .Attr(
             "max",
             "Maximum value, above which element is replaced by max",
             AttributeProto::FLOAT,
-            std::numeric_limits<float>::max())
+            std::numeric_limits<float>::max()
+        )
         .Input(0, "input", "Input tensor whose elements to be clipped", "T")
         .Output(0, "output", "Output tensor with clipped input elements", "T")
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Clip_ver11_doc = R"DOC(
 Clip operator limits the given input within an interval. The interval is
@@ -2847,20 +3019,24 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Minimum value, under which element is replaced by min. "
             "It must be a scalar(tensor of empty shape).",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Input(
             2,
             "max",
             "Maximum value, above which element is replaced by max. "
             "It must be a scalar(tensor of empty shape).",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(0, "output", "Output tensor with clipped input elements", "T")
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 std::function<void(OpSchema&)> ElementwiseMultiOpDocGenerator_old(const char* name) {
   return [=](OpSchema& schema) {
@@ -2878,7 +3054,8 @@ All inputs and outputs must have the same data type.
     schema.TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       propagateElemTypeFromInputToOutput(ctx, 0, 0);
       int num_inputs = static_cast<int>(ctx.getNumInputs());
@@ -2917,8 +3094,10 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* PRelu_ver9_doc = R"DOC(
 PRelu takes input data (Tensor<T>) and slope tensor as input, and produces one
@@ -2931,7 +3110,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     9,
     OpSchema()
         .SetDoc(
-            GET_OP_DOC_STR(std::string(PRelu_ver9_doc) + GenerateBroadcastingDocUni("tensor slope", "input tensor X")))
+            GET_OP_DOC_STR(std::string(PRelu_ver9_doc) + GenerateBroadcastingDocUni("tensor slope", "input tensor X"))
+        )
         .Input(0, "X", "Input tensor", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
             1,
@@ -2942,7 +3122,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Output(0, "Y", "Output tensor (same size as X)", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint(
             "T",
@@ -2953,8 +3134,10 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(uint64)",
              "tensor(int32)",
              "tensor(int64)"},
-            "Constrain input and output types to float/int tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float/int tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* DFT_ver17_doc = R"DOC(Computes the discrete Fourier transform of input.)DOC";
 
@@ -2972,19 +3155,22 @@ ONNX_OPERATOR_SET_SCHEMA(
             "When invoked with real or complex valued input, the default value is 0. "
             "Values can be 0 or 1.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "axis",
             "The axis on which to perform the DFT. By default this value is set to 1, which corresponds to the first dimension after the batch index. "
             "Negative value means counting dimensions from the back. Accepted range is $[-r, -2] \\cup [0, r-2]$ where `r = rank(input)`. "
             "The last dimension is for representing complex numbers and thus is an invalid axis.",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .Attr(
             "inverse",
             "Whether to perform the inverse discrete fourier transform. By default this value is set to 0, which corresponds to false.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(
             0,
             "input",
@@ -2997,7 +3183,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             1,
             "dft_length",
@@ -3009,7 +3196,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "output",
@@ -3019,11 +3207,13 @@ ONNX_OPERATOR_SET_SCHEMA(
             "If axis=2 and onesided is 1, the following shape is expected: [batch_idx][signal_dim1][floor(signal_dim2/2)+1]...[signal_dimN][2]. "
             "If axis=N and onesided is 1, the following shape is expected: [batch_idx][signal_dim1][signal_dim2]...[floor(signal_dimN/2)+1][2]. "
             "The signal_dim at the specified axis is equal to the dft_length.",
-            "T1")
+            "T1"
+        )
         .TypeConstraint(
             "T1",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeConstraint("T2", {"tensor(int32)", "tensor(int64)"}, "Constrain scalar length types to int64_t.")
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
           bool is_onesided = static_cast<bool>(getAttribute(ctx, "onesided", 0));
@@ -3057,7 +3247,8 @@ ONNX_OPERATOR_SET_SCHEMA(
                 axis,
                 " is invalid for a tensor of rank ",
                 rank,
-                ". Valid values are '-rank <= axis && axis != -1 && axis < rank - 1'");
+                ". Valid values are '-rank <= axis && axis != -1 && axis < rank - 1'"
+            );
           }
 
           auto axis_idx = (axis >= 0 ? axis : axis + rank);
@@ -3105,6 +3296,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           result_shape_proto.mutable_dim(static_cast<int>(dim_size - 1))->set_dim_value(2);
 
           updateOutputShape(ctx, 0, result_shape_proto);
-        }));
+        })
+);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/math/utils.h
+++ b/onnx/defs/math/utils.h
@@ -32,7 +32,7 @@ T GetScalarValueFromTensor(const ONNX_NAMESPACE::TensorProto* t) {
       fail_shape_inference("Unsupported input data type of ", data_type);
   }
 }
-} // namespace utils
-} // namespace math
-} // namespace defs
-} // namespace ONNX_NAMESPACE
+}  // namespace utils
+}  // namespace math
+}  // namespace defs
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -36,11 +36,8 @@ const char* conv_transpose_auto_pad_doc =
     "padding is added at the end for SAME_UPPER and at the beginning for SAME_LOWER.";
 
 void convPoolShapeInference(
-    InferenceContext& ctx,
-    bool use_dilation,
-    bool require_kernel_shape,
-    int input1Idx,
-    int input2Idx) {
+    InferenceContext& ctx, bool use_dilation, bool require_kernel_shape, int input1Idx, int input2Idx
+) {
   // we need the first input shape for this inference.
   if (!hasInputShape(ctx, input1Idx)) {
     return;
@@ -204,11 +201,11 @@ std::function<void(OpSchema&)> PoolOpSchemaGenerator(
     const char* opName,
     const char* additionalDescription,
     bool use_dilation,
-    bool supports8bit = false) {
+    bool supports8bit = false
+) {
   return [=](OpSchema& schema) {
     std::string doc;
-    POPULATE_OP_DOC_STR(
-        doc = R"DOC(
+    POPULATE_OP_DOC_STR(doc = R"DOC(
  {name} consumes an input tensor X and applies {opName} pooling across
  the tensor according to kernel sizes, stride sizes, and pad lengths.
  {opName} pooling consisting of computing the {opName} on all values of a
@@ -241,27 +238,31 @@ std::function<void(OpSchema&)> PoolOpSchemaGenerator(
  ```
  {additionalDescription}
  )DOC";
-        ReplaceAll(doc, "{name}", name);
-        ReplaceAll(doc, "{opName}", opName);
-        ReplaceAll(doc, "{additionalDescription}", additionalDescription);
-        ReplaceAll(
-            doc,
-            "{kernelSpatialShape}",
-            use_dilation ? "((kernel_spatial_shape[i] - 1) * dilations[i] + 1)" : "kernel_spatial_shape[i]"););
+                        ReplaceAll(doc, "{name}", name);
+                        ReplaceAll(doc, "{opName}", opName);
+                        ReplaceAll(doc, "{additionalDescription}", additionalDescription);
+                        ReplaceAll(
+                            doc,
+                            "{kernelSpatialShape}",
+                            use_dilation ? "((kernel_spatial_shape[i] - 1) * dilations[i] + 1)"
+                                         : "kernel_spatial_shape[i]"
+                        ););
     schema.SetDoc(doc);
     schema.Attr("kernel_shape", "The size of the kernel along each axis.", AttributeProto::INTS);
     schema.Attr(
         "strides",
         "Stride along each spatial axis. If not present, the stride defaults to 1 along each spatial axis.",
         AttributeProto::INTS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr("auto_pad", conv_auto_pad_doc, AttributeProto::STRING, std::string("NOTSET"));
     schema.Attr("pads", pads_doc, AttributeProto::INTS, OPTIONAL_VALUE);
     schema.Attr(
         "ceil_mode",
         "Whether to use ceil or floor (default) to compute the output shape.",
         AttributeProto::INT,
-        static_cast<int64_t>(0));
+        static_cast<int64_t>(0)
+    );
     schema.Input(
         0,
         "X",
@@ -280,7 +281,8 @@ std::function<void(OpSchema&)> PoolOpSchemaGenerator(
         OpSchema::Single,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.Output(
         0,
         "Y",
@@ -292,12 +294,14 @@ std::function<void(OpSchema&)> PoolOpSchemaGenerator(
         OpSchema::Single,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.TypeConstraint(
         "T",
         GetSupportedDataTypesForPoolingOps(supports8bit),
         supports8bit ? "Constrain input and output types to float and 8 bit tensors."
-                     : "Constrain input and output types to float tensors.");
+                     : "Constrain input and output types to float tensors."
+    );
     schema.TypeAndShapeInferenceFunction([use_dilation](InferenceContext& ctx) {
       propagateElemTypeFromInputToOutput(ctx, 0, 0);
       if (ctx.getNumOutputs() > 1) {
@@ -322,17 +326,21 @@ ONNX_OPERATOR_SET_SCHEMA(
             "average",
             "The output of each pooling window is divided by the number of elements (exclude pad when attribute count_include_pad is zero).",
             true, /* use_dilation: dilations attribute has been added in opset 19. */
-            false /* supports8bit: does not support 8bit. */))
+            false /* supports8bit: does not support 8bit. */
+        ))
         .Attr(
             "dilations",
             "Dilation value along each spatial axis of filter. If not present, the dilation defaults to 1 along each spatial axis.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "count_include_pad",
             "Whether include pad pixels when calculating values for the edges. Default is 0, doesn't count include pad.",
             AttributeProto::INT,
-            static_cast<int64_t>(0)));
+            static_cast<int64_t>(0)
+        )
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     MaxPool,
@@ -343,19 +351,22 @@ ONNX_OPERATOR_SET_SCHEMA(
             "max",
             "The output of each pooling window is maximum number of elements exclude pad. ",
             true,
-            true))
+            true
+        ))
         .Attr(
             "storage_order",
             "The storage order of the tensor. 0 is row major, and 1 is column major. "
             "This attribute is used only to convert an n-tuple index value into "
             "a single integer value for producing the second output. ",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "dilations",
             "Dilation value along each spatial axis of filter. If not present, the dilation defaults to 1 along each spatial axis.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Output(
             1,
             "Indices",
@@ -369,8 +380,10 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
-        .TypeConstraint("I", {"tensor(int64)"}, "Constrain index tensor to int64"));
+            OpSchema::NonDifferentiable
+        )
+        .TypeConstraint("I", {"tensor(int64)"}, "Constrain index tensor to int64")
+);
 
 void maxUnpoolShapeInference(InferenceContext& ctx) {
   // we need at least two inputs to have a shape for this inference.
@@ -379,7 +392,7 @@ void maxUnpoolShapeInference(InferenceContext& ctx) {
   }
   propagateElemTypeFromInputToOutput(ctx, 0, 0);
   if (!hasInputShape(ctx, 0)) {
-    return; // If first input does not have shape, we cannot infer much.
+    return;  // If first input does not have shape, we cannot infer much.
   }
   auto input_shape = ctx.getInputType(0)->tensor_type().shape();
   if (input_shape.dim_size() < 2) {
@@ -429,15 +442,15 @@ void maxUnpoolShapeInference(InferenceContext& ctx) {
         fail_shape_inference("'output_shape' must have same number of elements as the shape of input tensor X.");
       }
     }
-    return; // 'output_shape' is specified as input. Actual shape will be
-            // determined at runtime.
+    return;  // 'output_shape' is specified as input. Actual shape will be
+             // determined at runtime.
   }
 
   auto final_output_shape = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
 
   *final_output_shape->add_dim() = input_shape.dim(0);
   *final_output_shape->add_dim() =
-      ctx.getInputType(1)->tensor_type().shape().dim(1); // channels should be the second dim of second input.
+      ctx.getInputType(1)->tensor_type().shape().dim(1);  // channels should be the second dim of second input.
 
   int kernel_shape_size = static_cast<int>(kernel_shape.size());
   for (int i = 0; i < kernel_shape_size; ++i) {
@@ -487,7 +500,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "strides",
             "Stride along each spatial axis. If not present, the stride defaults to 1 along each spatial axis.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr("pads", pads_doc, AttributeProto::INTS, OPTIONAL_VALUE)
         .Input(
             0,
@@ -508,7 +522,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             1,
             "I",
@@ -523,7 +538,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "output_shape",
@@ -533,7 +549,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "output",
@@ -542,13 +559,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T1",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeConstraint("T2", {"tensor(int64)"}, "Constrain index tensor to int64")
-        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { maxUnpoolShapeInference(ctx); }));
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { maxUnpoolShapeInference(ctx); })
+);
 
 std::function<void(OpSchema&)> LpPoolOpSchemaGenerator(const char* name) {
   return [=](OpSchema& schema) {
@@ -584,21 +604,25 @@ std::function<void(OpSchema&)> LpPoolOpSchemaGenerator(const char* name) {
         "strides",
         "Stride along each spatial axis. If not present, the stride defaults to 1 along each spatial axis.",
         AttributeProto::INTS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr(
         "dilations",
         "dilation value along each spatial axis of the filter. If not present, the dilation defaults is 1 along each spatial axis.",
         AttributeProto::INTS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr("auto_pad", conv_auto_pad_doc, AttributeProto::STRING, std::string("NOTSET"));
     schema.Attr("pads", pads_doc, AttributeProto::INTS, OPTIONAL_VALUE);
     schema.Attr(
-        "p", "p value of the Lp norm used to pool over the input data.", AttributeProto::INT, static_cast<int64_t>(2));
+        "p", "p value of the Lp norm used to pool over the input data.", AttributeProto::INT, static_cast<int64_t>(2)
+    );
     schema.Attr(
         "ceil_mode",
         "Whether to use ceil or floor (default) to compute the output shape.",
         AttributeProto::INT,
-        static_cast<int64_t>(0));
+        static_cast<int64_t>(0)
+    );
     schema.Input(
         0,
         "X",
@@ -614,7 +638,8 @@ std::function<void(OpSchema&)> LpPoolOpSchemaGenerator(const char* name) {
         OpSchema::Single,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.Output(
         0,
         "Y",
@@ -625,11 +650,13 @@ std::function<void(OpSchema&)> LpPoolOpSchemaGenerator(const char* name) {
         OpSchema::Single,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       propagateElemTypeFromInputToOutput(ctx, 0, 0);
       convPoolShapeInference(ctx, true, true, 0, 1);
@@ -693,7 +720,8 @@ std::function<void(OpSchema&)> RoiPoolOpSchemaGenerator(const char* name) {
         "spatial_scale",
         "Multiplicative spatial scale factor to translate ROI coordinates from their input scale to the scale used when pooling.",
         AttributeProto::FLOAT,
-        1.f);
+        1.f
+    );
     schema.Input(
         0,
         "X",
@@ -706,7 +734,8 @@ std::function<void(OpSchema&)> RoiPoolOpSchemaGenerator(const char* name) {
         OpSchema::Single,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.Input(
         1,
         "rois",
@@ -717,7 +746,8 @@ std::function<void(OpSchema&)> RoiPoolOpSchemaGenerator(const char* name) {
         OpSchema::Single,
         true,
         1,
-        OpSchema::NonDifferentiable);
+        OpSchema::NonDifferentiable
+    );
     schema.Output(
         0,
         "Y",
@@ -726,11 +756,13 @@ std::function<void(OpSchema&)> RoiPoolOpSchemaGenerator(const char* name) {
         OpSchema::Single,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) { roiPoolTypeShapeInference(ctx); });
   };
 }
@@ -761,7 +793,8 @@ computes the output.)DOC";
         OpSchema::Single,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.Input(
         1,
         "W",
@@ -787,7 +820,8 @@ computes the output.)DOC";
         OpSchema::Single,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.Input(
         2,
         "B",
@@ -796,7 +830,8 @@ computes the output.)DOC";
         OpSchema::Optional,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.Output(
         0,
         "Y",
@@ -807,33 +842,39 @@ computes the output.)DOC";
         OpSchema::Single,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."
+    );
     schema.Attr(
         "kernel_shape",
         "The shape of the convolution kernel. If not present, should be inferred from input W.",
         AttributeProto::INTS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr(
         "dilations",
         "dilation value along each spatial axis of the filter. If not present, the dilation defaults is 1 along each spatial axis.",
         AttributeProto::INTS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr(
         "strides",
         "Stride along each spatial axis. If not present, the stride defaults is 1 along each spatial axis.",
         AttributeProto::INTS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr("auto_pad", conv_auto_pad_doc, AttributeProto::STRING, std::string("NOTSET"));
     schema.Attr("pads", pads_doc, AttributeProto::INTS, OPTIONAL_VALUE);
     schema.Attr(
         "group",
         "number of groups input channels and output channels are divided into.",
         AttributeProto::INT,
-        static_cast<int64_t>(1));
+        static_cast<int64_t>(1)
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       propagateElemTypeFromInputToOutput(ctx, 0, 0);
       convPoolShapeInference(ctx, true, false, 0, 1);
@@ -870,17 +911,20 @@ ONNX_OPERATOR_SET_SCHEMA(
             "in effect, the operation expects input data tensor "
             "to arrive with the dimension denotation of [DATA_BATCH, "
             "DATA_CHANNEL, DATA_FEATURE, DATA_FEATURE ...].",
-            "T1")
+            "T1"
+        )
         .Input(
             1,
             "x_scale",
             "Scale tensor for input 'x'. It's a scalar, which means a per-tensor/layer quantization.",
-            "tensor(float)")
+            "tensor(float)"
+        )
         .Input(
             2,
             "x_zero_point",
             "Zero point tensor for input 'x'. It's a scalar, which means a per-tensor/layer quantization.",
-            "T1")
+            "T1"
+        )
         .Input(
             3,
             "w",
@@ -898,41 +942,48 @@ ONNX_OPERATOR_SET_SCHEMA(
             "X.shape[1] == (W.shape[1] * group) == C "
             "(assuming zero based indices for the shape array). "
             "Or in other words FILTER_IN_CHANNEL should be equal to DATA_CHANNEL. ",
-            "T2")
+            "T2"
+        )
         .Input(
             4,
             "w_scale",
             "Scale tensor for input 'w'. It could be a scalar or a 1-D tensor, which means a per-tensor/layer or per output channel quantization. If it's a 1-D tensor, its number of elements should be equal to the number of output channels (M).",
-            "tensor(float)")
+            "tensor(float)"
+        )
         .Input(
             5,
             "w_zero_point",
             "Zero point tensor for input 'w'. It could be a scalar or a 1-D tensor, which means a per-tensor/layer or per output channel quantization. If it's a 1-D tensor, its number of elements should be equal to the number of output channels (M).",
-            "T2")
+            "T2"
+        )
         .Input(
             6,
             "y_scale",
             "Scale tensor for output 'y'. It's a scalar, which means a per-tensor/layer quantization.",
-            "tensor(float)")
+            "tensor(float)"
+        )
         .Input(
             7,
             "y_zero_point",
             "Zero point tensor for output 'y'. It's a scalar, which means a per-tensor/layer quantization.",
-            "T3")
+            "T3"
+        )
         .Input(
             8,
             "B",
             "Optional 1D bias to be added to the convolution, has size of M. "
             "Bias must be quantized using scale = x_scale * w_scale and zero_point = 0",
             "T4",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(
             0,
             "y",
             "Output data tensor that contains the result of the "
             "convolution. The output dimensions are functions "
             "of the kernel size, stride size, and pad lengths.",
-            "T3")
+            "T3"
+        )
         .TypeConstraint("T1", {"tensor(int8)", "tensor(uint8)"}, "Constrain input type to 8-bit integer tensor.")
         .TypeConstraint("T2", {"tensor(int8)", "tensor(uint8)"}, "Constrain filter type to 8-bit integer tensor.")
         .TypeConstraint("T3", {"tensor(int8)", "tensor(uint8)"}, "Constrain output type to 8-bit integer tensor.")
@@ -942,17 +993,20 @@ ONNX_OPERATOR_SET_SCHEMA(
             "kernel_shape",
             "The shape of the convolution kernel. If not present, should be inferred from input 'w'.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "dilations",
             "dilation value along each spatial axis of the filter. If not present, the dilation defaults to 1 along each spatial axis.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "strides",
             "Stride along each spatial axis. If not present, the stride defaults to 1 along each spatial axis.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "pads",
             "Padding for the beginning and ending along each spatial axis, it can take any value greater than or equal to 0."
@@ -962,12 +1016,14 @@ ONNX_OPERATOR_SET_SCHEMA(
             "This attribute cannot be used simultaneously with auto_pad attribute. If not present, the padding defaults"
             "to 0 along start and end of each spatial axis.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "group",
             "number of groups input channels and output channels are divided into. default is 1.",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           auto x_type = ctx.getInputType(0);
           auto w_type = ctx.getInputType(3);
@@ -991,7 +1047,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           propagateElemTypeFromInputToOutput(ctx, 7, 0);
 
           convPoolShapeInference(ctx, true, false, 0, 3);
-        }));
+        })
+);
 
 static const char* ConvInteger_ver10_doc = R"DOC(
 The integer convolution operator consumes an input tensor, its zero-point, a filter, and its zero-point,
@@ -1015,7 +1072,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "in effect, the operation expects input data tensor "
             "to arrive with the dimension denotation of [DATA_BATCH, "
             "DATA_CHANNEL, DATA_FEATURE, DATA_FEATURE ...].",
-            "T1")
+            "T1"
+        )
         .Input(
             1,
             "w",
@@ -1033,13 +1091,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "X.shape[1] == (W.shape[1] * group) == C "
             "(assuming zero based indices for the shape array). "
             "Or in other words FILTER_IN_CHANNEL should be equal to DATA_CHANNEL. ",
-            "T2")
+            "T2"
+        )
         .Input(
             2,
             "x_zero_point",
             "Zero point tensor for input 'x'. It's optional and default value is 0. It's a scalar, which means a per-tensor/layer quantization.",
             "T1",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Input(
             3,
             "w_zero_point",
@@ -1047,39 +1107,46 @@ ONNX_OPERATOR_SET_SCHEMA(
             "which means a per-tensor/layer or per output channel quantization. If it's a 1-D tensor, its number "
             "of elements should be equal to the number of output channels (M)",
             "T2",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(
             0,
             "y",
             "Output data tensor that contains the result of the "
             "convolution. The output dimensions are functions "
             "of the kernel size, stride size, and pad lengths.",
-            "T3")
+            "T3"
+        )
         .TypeConstraint(
             "T1",
             {"tensor(int8)", "tensor(uint8)"},
-            "Constrain input x and its zero point data type to 8-bit integer tensor.")
+            "Constrain input x and its zero point data type to 8-bit integer tensor."
+        )
         .TypeConstraint(
             "T2",
             {"tensor(int8)", "tensor(uint8)"},
-            "Constrain input w and its zero point data type to 8-bit integer tensor.")
+            "Constrain input w and its zero point data type to 8-bit integer tensor."
+        )
         .TypeConstraint("T3", {"tensor(int32)"}, "Constrain output y data type to 32-bit integer tensor.")
         .Attr("auto_pad", conv_auto_pad_doc, AttributeProto::STRING, std::string("NOTSET"))
         .Attr(
             "kernel_shape",
             "The shape of the convolution kernel. If not present, should be inferred from input 'w'.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "dilations",
             "dilation value along each spatial axis of the filter. If not present, the dilation defaults to 1 along each axis.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "strides",
             "Stride along each spatial axis. If not present, the stride defaults to 1 along each axis.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "pads",
             "Padding for the beginning and ending along each spatial axis, it can take any value greater than or equal to 0."
@@ -1089,12 +1156,14 @@ ONNX_OPERATOR_SET_SCHEMA(
             "This attribute cannot be used simultaneously with auto_pad attribute. If not present, the padding defaults"
             "to 0 along start and end of each spatial axis.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "group",
             "number of groups input channels and output channels are divided into. default is 1.",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           auto x_type = ctx.getInputType(0);
           auto w_type = ctx.getInputType(1);
@@ -1108,7 +1177,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           y_type->mutable_tensor_type()->set_elem_type(TensorProto::INT32);
 
           convPoolShapeInference(ctx, true, false, 0, 1);
-        }));
+        })
+);
 
 void convTransposeShapeInference(InferenceContext& ctx) {
   propagateElemTypeFromInputToOutput(ctx, 0, 0);
@@ -1122,7 +1192,7 @@ void convTransposeShapeInference(InferenceContext& ctx) {
 
   auto input_shape = ctx.getInputType(0)->tensor_type().shape();
   if (input_shape.dim_size() < 2) {
-    return; // Input tensor should have at least two dimensions.
+    return;  // Input tensor should have at least two dimensions.
   }
 
   // first dim is the batch axis and the next is the number of channels.
@@ -1210,7 +1280,7 @@ void convTransposeShapeInference(InferenceContext& ctx) {
 
   std::vector<int64_t> output_padding;
   if (getRepeatedAttribute(ctx, "output_padding", output_padding)) {
-    if (output_padding.size() != n_input_dims) { // Added only to one side.
+    if (output_padding.size() != n_input_dims) {  // Added only to one side.
       return;
     }
   } else {
@@ -1221,8 +1291,8 @@ void convTransposeShapeInference(InferenceContext& ctx) {
 
   *final_output_shape->add_dim() = input_shape.dim(0);
   *final_output_shape->add_dim() =
-      ctx.getInputType(1)->tensor_type().shape().dim(1) * group; // channels should be the second dim of second input
-                                                                 // multiply group.
+      ctx.getInputType(1)->tensor_type().shape().dim(1) * group;  // channels should be the second dim of second input
+                                                                  // multiply group.
 
   int size_of_output;
   if (output_shape_presented) {
@@ -1231,8 +1301,8 @@ void convTransposeShapeInference(InferenceContext& ctx) {
       if (input_shape.dim(i + 2).has_dim_value()) {
         if (output_shape[i] < input_shape.dim(i + 2).dim_value()) {
           // TODO: throw exception?
-          return; // output shape value cannot be smaller than the input shape
-                  // value
+          return;  // output shape value cannot be smaller than the input shape
+                   // value
         }
       }
       final_output_shape->add_dim()->set_dim_value(output_shape[i]);
@@ -1284,7 +1354,8 @@ output_shape can also be explicitly specified in which case pads values are auto
         OpSchema::Single,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.Input(
         1,
         "W",
@@ -1301,7 +1372,8 @@ output_shape can also be explicitly specified in which case pads values are auto
         OpSchema::Single,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.Input(
         2,
         "B",
@@ -1310,7 +1382,8 @@ output_shape can also be explicitly specified in which case pads values are auto
         OpSchema::Optional,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.Output(
         0,
         "Y",
@@ -1323,23 +1396,27 @@ output_shape can also be explicitly specified in which case pads values are auto
         OpSchema::Single,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."
+    );
     schema.Attr(
         "kernel_shape",
         "The shape of the convolution kernel. If not present, should be inferred from input W.",
         AttributeProto::INTS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr(
         "output_shape",
         "The shape of the output can be explicitly set which will cause pads values to be auto generated. If output_shape is specified "
         "pads values are ignored. See doc for details for equations to generate pads. Note that the output_shape attribute value "
         "should not include dimensions for batch size and channels, which are automatically inferred.",
         AttributeProto::INTS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr(
         "output_padding",
         "Additional elements added to the side with higher coordinate indices in the output. "
@@ -1353,24 +1430,28 @@ output_shape can also be explicitly specified in which case pads values are auto
         "participates in the computation of the needed padding amount. "
         "This is also called adjs or adjustment in some frameworks.",
         AttributeProto::INTS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr(
         "dilations",
         "dilation value along each spatial axis of the filter. If not present, the dilation defaults to 1 along each spatial axis.",
         AttributeProto::INTS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr(
         "strides",
         "Stride along each spatial axis. If not present, the stride defaults to 1 along each spatial axis.",
         AttributeProto::INTS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr("auto_pad", conv_transpose_auto_pad_doc, AttributeProto::STRING, std::string("NOTSET"));
     schema.Attr("pads", pads_doc, AttributeProto::INTS, OPTIONAL_VALUE);
     schema.Attr(
         "group",
         "number of groups input channels and output channels are divided into.",
         AttributeProto::INT,
-        static_cast<int64_t>(1));
+        static_cast<int64_t>(1)
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) { convTransposeShapeInference(ctx); });
   };
 }
@@ -1394,14 +1475,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "C is the number of input channels, and H and W are the height and width. "
             "In general, the shape is (N, C, D1, D2, ... , Dn) for n-dimensional data, where "
             "D1 to Dn are the spatial dimension sizes. Most common use cases have n = 2 or 3.",
-            "T")
+            "T"
+        )
         .Input(
             1,
             "W",
             "Weight tensor that will be used in the convolutions. It has shape (oC, C/group, kH, kW), "
             "where oC is the number of output channels and kH and kW are the kernel height and width. "
             "For more than 2 dimensions, it has shape (oC, C/group, k1, k2, ... , kn).",
-            "T")
+            "T"
+        )
         .Input(
             2,
             "offset",
@@ -1409,13 +1492,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "It has shape (N, offset_group * kH * kW * 2, oH, oW) for 2D data or "
             "(N, offset_group * k1 * k2 * ... * kn * n, o1, o2, ... , on) for nD data. Use linear interpolation"
             "for fractional offset values. Sampling locations outside of the padded input tensor gives zero.",
-            "T")
+            "T"
+        )
         .Input(
             3,
             "B",
             "Optional 1D bias of length oC to be added to the convolution. Default is a tensor of zeros.",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Input(
             4,
             "mask",
@@ -1424,38 +1509,45 @@ ONNX_OPERATOR_SET_SCHEMA(
             "(N, offset_group * k1 * k2 * ... * kn * n, o1, o2, ... , on) for nD data. Default is a "
             "tensor of ones.",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(
             0,
             "Y",
             "Output data tensor that contains the result of convolution. It has shape (N, oC, oH, oW) "
             "for 2D data or (N, oC, o1, o2, ..., on) for nD data",
-            "T")
+            "T"
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .Attr(
             "dilations",
             "Dilation value along each spatial axis of the kernel. Default is 1 along each axis.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "group",
             "Number of groups the input and output channels, C and oC, are divided into. C and oC must both "
             "be divisible by group. Default is 1.",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .Attr(
             "kernel_shape",
             "Shape of the convolution kernel. If not present, it is inferred from the shape of input W.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "offset_group",
             "Number of groups of offset. C must be divisible by offset_group. Default is 1.",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .Attr(
             "pads",
             "Padding for the beginning and end along each spatial axis. The values represent the number of pixels "
@@ -1464,16 +1556,19 @@ ONNX_OPERATOR_SET_SCHEMA(
             "is the number of pixels added at the beginning of axis `i` and xi_end is the number of pixels "
             "added at the end of axis `i`. Default is 0 along each axis.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "strides",
             "Stride along each spatial axis. Default is 1 along each axis.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
           convPoolShapeInference(ctx, true, false, 0, 1);
-        }));
+        })
+);
 
 // For GlobalPool operations.
 void globalPoolTypeShapeInference(InferenceContext& ctx) {
@@ -1526,7 +1621,8 @@ std::function<void(OpSchema&)> GlobalPoolingOpSchemaGenerator(const char* op_typ
         OpSchema::Single,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.Output(
         0,
         "Y",
@@ -1538,18 +1634,19 @@ std::function<void(OpSchema&)> GlobalPoolingOpSchemaGenerator(const char* op_typ
         OpSchema::Single,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) { globalPoolTypeShapeInference(ctx); });
   };
 }
 ONNX_OPERATOR_SET_SCHEMA(
-    GlobalAveragePool,
-    1,
-    OpSchema().FillUsing(GlobalPoolingOpSchemaGenerator("AveragePool", "average")));
+    GlobalAveragePool, 1, OpSchema().FillUsing(GlobalPoolingOpSchemaGenerator("AveragePool", "average"))
+);
 ONNX_OPERATOR_SET_SCHEMA(GlobalMaxPool, 1, OpSchema().FillUsing(GlobalPoolingOpSchemaGenerator("MaxPool", "max")));
 
 std::function<void(OpSchema&)> GlobalLpPoolingOpSchemaGenerator(const char* op_type, const char* op) {
@@ -1563,7 +1660,8 @@ std::function<void(OpSchema&)> GlobalLpPoolingOpSchemaGenerator(const char* op_t
                         ReplaceAll(doc, "{op}", op););
     schema.SetDoc(doc);
     schema.Attr(
-        "p", "p value of the Lp norm used to pool over the input data.", AttributeProto::INT, static_cast<int64_t>(2));
+        "p", "p value of the Lp norm used to pool over the input data.", AttributeProto::INT, static_cast<int64_t>(2)
+    );
     schema.Input(
         0,
         "X",
@@ -1578,7 +1676,8 @@ std::function<void(OpSchema&)> GlobalLpPoolingOpSchemaGenerator(const char* op_t
         OpSchema::Single,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.Output(
         0,
         "Y",
@@ -1590,11 +1689,13 @@ std::function<void(OpSchema&)> GlobalLpPoolingOpSchemaGenerator(const char* op_t
         OpSchema::Single,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) { globalPoolTypeShapeInference(ctx); });
   };
 }
@@ -1654,13 +1755,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Factor used in computing the running mean and variance."
             "e.g., running_mean = running_mean * momentum + mean * (1 - momentum).",
             AttributeProto::FLOAT,
-            0.9f)
+            0.9f
+        )
         .Attr(
             "training_mode",
             "If set to true, it indicates BatchNormalization is being used for training, and outputs 1, "
             "2, 3, and 4 would be populated.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(
             0,
             "X",
@@ -1674,7 +1777,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(1, "scale", "Scale tensor of shape (C).", "T1", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(2, "B", "Bias tensor of shape (C).", "T1", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
@@ -1685,7 +1789,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             4,
             "input_var",
@@ -1694,16 +1799,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Output(
-            0,
-            "Y",
-            "The output tensor of the same shape as X",
-            "T",
-            OpSchema::Single,
-            true,
-            1,
-            OpSchema::Differentiable)
+            0, "Y", "The output tensor of the same shape as X", "T", OpSchema::Single, true, 1, OpSchema::Differentiable
+        )
         .Output(
             1,
             "running_mean",
@@ -1712,7 +1812,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             2,
             "running_var",
@@ -1722,19 +1823,23 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeConstraint(
             "T1",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain scale and bias types to float tensors.")
+            "Constrain scale and bias types to float tensors."
+        )
         .TypeConstraint(
             "T2",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain mean and variance types to float tensors.")
+            "Constrain mean and variance types to float tensors."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateShapeAndTypeFromFirstInput(ctx);
           propagateShapeFromInputToOutput(ctx, 0, 0);
@@ -1769,7 +1874,7 @@ ONNX_OPERATOR_SET_SCHEMA(
 
           if (ctx.getNumOutputs() > 1) {
             TensorShapeProto outputs_shape;
-            *outputs_shape.add_dim() = num_channels; // channel
+            *outputs_shape.add_dim() = num_channels;  // channel
 
             propagateElemTypeFromInputToOutput(ctx, 3, 1);
             updateOutputShape(ctx, 1, outputs_shape);
@@ -1779,7 +1884,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               updateOutputShape(ctx, 2, outputs_shape);
             }
           }
-        }));
+        })
+);
 
 static const char* InstanceNormalization_ver6_doc = R"DOC(
 Carries out instance normalization as described in the paper
@@ -1811,7 +1917,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             1,
             "scale",
@@ -1820,7 +1927,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             2,
             "B",
@@ -1829,7 +1937,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Output(
             0,
             "output",
@@ -1838,12 +1947,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { propagateShapeAndTypeFromFirstInput(ctx); }));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { propagateShapeAndTypeFromFirstInput(ctx); })
+);
 
 static const char* LpNormalization_ver1_doc = R"DOC(
 Given a matrix, apply Lp-normalization along the provided axis.
@@ -1858,19 +1970,23 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .SetDoc(LpNormalization_ver1_doc)
         .Attr(
             "axis",
             "The axis on which to apply normalization, -1 mean last axis.",
             AttributeProto::INT,
-            static_cast<int64_t>(-1))
+            static_cast<int64_t>(-1)
+        )
         .Attr(
             "p",
             "The order of the normalization, only 1 or 2 are supported.",
             AttributeProto::INT,
-            static_cast<int64_t>(2))
-        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { propagateShapeAndTypeFromFirstInput(ctx); }));
+            static_cast<int64_t>(2)
+        )
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { propagateShapeAndTypeFromFirstInput(ctx); })
+);
 
 static const char* Dropout_ver13_doc = R"DOC(
 Dropout takes an input floating-point tensor, an optional input ratio (floating-point scalar) and an optional input training_mode (boolean scalar). It produces two tensor outputs,
@@ -1895,7 +2011,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "seed",
             "(Optional) Seed to the random generator, if not specified we will auto generate one.",
             AttributeProto::INT,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Input(0, "data", "The input data as Tensor.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
             1,
@@ -1908,7 +2025,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "training_mode",
@@ -1919,17 +2037,20 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(0, "output", "The output.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Output(1, "mask", "The output mask.", "T2", OpSchema::Optional, true, 1, OpSchema::NonDifferentiable)
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeConstraint(
             "T1",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input 'ratio' types to float tensors.")
+            "Constrain input 'ratio' types to float tensors."
+        )
         .TypeConstraint("T2", {"tensor(bool)"}, "Constrain output 'mask' types to boolean tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
@@ -1957,7 +2078,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               propagateShapeFromInputToOutput(ctx, 0, 1);
             }
           }
-        }));
+        })
+);
 
 static const char* Shrink_ver9_doc = R"DOC(
 Shrink takes one input data (Tensor<numeric>) and produces one Tensor output,
@@ -1995,7 +2117,9 @@ ONNX_OPERATOR_SET_SCHEMA(
             output = Where(InputLessThanNegLambda, InputAddBias, InputSubBiasOrZero)
 		      }
         )ONNX",
-            18));
+            18
+        )
+);
 
 static const char* Flatten_ver13_doc = R"DOC(
 Flattens the input tensor into a 2D matrix. If input tensor has shape
@@ -2020,7 +2144,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output to all tensor types.")
         .Attr(
             "axis",
@@ -2031,7 +2156,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "When axis = 0, the shape of the output tensor is (1, (d_0 X d_1 ... d_n), "
             "where the shape of the input tensor is (d_0, d_1, ... d_n). ",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
           if (!hasInputShape(ctx, 0))
@@ -2047,7 +2173,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
           // TODO: is the operation defined for input-rank < 2?
           updateOutputShape(ctx, 0, {multiplyDims(input_shape, 0, axis), multiplyDims(input_shape, axis, rank)});
-        }));
+        })
+);
 
 static const char* LRN_ver13_doc = R"DOC(
 Local Response Normalization proposed in the [AlexNet paper](https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf).
@@ -2088,7 +2215,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Output(
             0,
             "Y",
@@ -2097,14 +2225,17 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
             "Constrain input and output "
-            " types to float tensors.")
+            " types to float tensors."
+        )
         .SetDoc(LRN_ver13_doc)
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* TfIdfVectorizer_ver9_doc = R"DOC(
 This transform extracts n-grams from the input sequence and save them as a vector. Input can
@@ -2143,38 +2274,42 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Input(0, "X", "Input for n-gram extraction", "T", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
         .Output(0, "Y", "Ngram results", "T1", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
         .TypeConstraint(
-            "T",
-            {"tensor(string)", "tensor(int32)", "tensor(int64)"},
-            "Input is ether string UTF-8 or int32/int64")
+            "T", {"tensor(string)", "tensor(int32)", "tensor(int64)"}, "Input is ether string UTF-8 or int32/int64"
+        )
         .TypeConstraint("T1", {"tensor(float)"}, "1-D tensor of floats")
         .Attr(
             "max_gram_length",
             "Maximum n-gram length. If this value is 3, 3-grams will be used to generate the output.",
-            AttributeProto::INT)
+            AttributeProto::INT
+        )
         .Attr(
             "min_gram_length",
             "Minimum n-gram length. If this value is 2 and max_gram_length is 3, output may contain counts of 2-grams and 3-grams.",
-            AttributeProto::INT)
+            AttributeProto::INT
+        )
         .Attr(
             "max_skip_count",
             "Maximum number of items (integers/strings) to be skipped when constructing an n-gram from X. "
             "If max_skip_count=1, min_gram_length=2, max_gram_length=3, this operator may generate 2-grams "
             "with skip_count=0 and skip_count=1, and 3-grams with skip_count=0 and skip_count=1",
-            AttributeProto::INT)
+            AttributeProto::INT
+        )
         .Attr(
             "pool_strings",
             "List of strings n-grams learned from the training set. Either this or pool_int64s attributes must be present but not both. "
             "It's an 1-D tensor starting with the collections of all 1-grams and ending with the collections of n-grams. "
             "The i-th element in pool stores the n-gram that should be mapped to coordinate ngram_indexes[i] in the output vector.",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "pool_int64s",
             "List of int64 n-grams learned from the training set. Either this or pool_strings attributes must be present but not both. "
             "It's an 1-D tensor starting with the collections of all 1-grams and ending with the collections of n-grams. "
             "The i-th element in pool stores the n-gram that should be mapped to coordinate ngram_indexes[i] in the output vector.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "ngram_counts",
             "The starting indexes of 1-grams, 2-grams, and so on in pool. "
@@ -2182,12 +2317,14 @@ ONNX_OPERATOR_SET_SCHEMA(
             "For example, if ngram_counts is [0, 17, 36], the first index (zero-based) of 1-gram/2-gram/3-gram "
             "in pool are 0/17/36. This format is essentially identical to CSR (or CSC) sparse matrix format, "
             "and we choose to use this due to its popularity.",
-            AttributeProto::INTS)
+            AttributeProto::INTS
+        )
         .Attr(
             "ngram_indexes",
             "list of int64s (type: AttributeProto::INTS). This list is parallel to the specified 'pool_*' attribute. "
             "The i-th element in ngram_indexes indicate the coordinate of the i-th n-gram in the output tensor.",
-            AttributeProto::INTS)
+            AttributeProto::INTS
+        )
         .Attr(
             "weights",
             "list of floats. This attribute stores the weight of each n-gram in pool. The i-th element in weights "
@@ -2195,12 +2332,14 @@ ONNX_OPERATOR_SET_SCHEMA(
             "By default, weights is an all-one tensor.This attribute is used when mode is \"IDF\" or \"TFIDF\" "
             "to scale the associated word counts.",
             AttributeProto::FLOATS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "mode",
             "The weighting criteria. It can be one of \"TF\" (term frequency), "
             "\"IDF\" (inverse document frequency), and \"TFIDF\" (the combination of TF and IDF)",
-            AttributeProto::STRING)
+            AttributeProto::STRING
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           auto output_elem_type = ctx.getOutputType(0)->mutable_tensor_type();
           output_elem_type->set_elem_type(TensorProto::FLOAT);
@@ -2230,7 +2369,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             updateOutputShape(ctx, 0, output_shape);
           }
         })
-        .SetDoc(TfIdfVectorizer_ver9_doc));
+        .SetDoc(TfIdfVectorizer_ver9_doc)
+);
 
 static const char* mvn_ver13_doc = R"DOC(
       A MeanVarianceNormalization Function: Perform mean variance normalization
@@ -2253,11 +2393,13 @@ ONNX_OPERATOR_SET_SCHEMA(
             "along each channel. Two variables with the same C-coordinate "
             "are associated with the same mean and variance.",
             AttributeProto::INTS,
-            mvn_default_axes)
+            mvn_default_axes
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain input and output types to all numeric tensors.")
+            "Constrain input and output types to all numeric tensors."
+        )
         .FunctionBody(R"ONNX(
         {
           Exponent = Constant <value = float {2.0}>()
@@ -2290,7 +2432,9 @@ ONNX_OPERATOR_SET_SCHEMA(
           Y = Div (X_variance, Processed_STD)
         }
         )ONNX",
-            18));
+            18
+        )
+);
 
 void col2imShapeInference(InferenceContext& ctx) {
   propagateElemTypeFromInputToOutput(ctx, 0, 0);
@@ -2364,12 +2508,12 @@ void col2imShapeInference(InferenceContext& ctx) {
   // Dimensions N and C are always present
   Dim N, C;
   if (ctx.getInputType(0)->tensor_type().shape().dim(0).has_dim_value()) {
-    N = input_shape.dim(0); // Otherwise, N is unknown.
+    N = input_shape.dim(0);  // Otherwise, N is unknown.
   }
   *final_image_shape->add_dim() = N;
 
   if (block_shape_size > 0) {
-    C = input_shape.dim(1) / block_shape_size; // Otherwise, C is unknown.
+    C = input_shape.dim(1) / block_shape_size;  // Otherwise, C is unknown.
   }
   *final_image_shape->add_dim() = C;
 
@@ -2377,7 +2521,7 @@ void col2imShapeInference(InferenceContext& ctx) {
   for (auto i = 0; i < n_input_dims.dim_value(); ++i) {
     Dim image_dim_i;
     if (image_shape.size() > 0) {
-      image_dim_i.set_dim_value(image_shape[i]); // Otherwise, spatial dimensions are unknown
+      image_dim_i.set_dim_value(image_shape[i]);  // Otherwise, spatial dimensions are unknown
     }
     *final_image_shape->add_dim() = image_dim_i;
   }
@@ -2406,7 +2550,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "1-dimensional tensor with dilation value along each spatial axis of the image. "
             "If not present, the dilation defaults to 1 along each spatial axis of the image.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "pads",
             "1-dimensional tensor with padding value for the beginning and ending along each spatial axis, "
@@ -2417,13 +2562,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "added at the beginning of axis `i` and xi_end is the number of pixels added at the end of axis `i`. "
             "If not present, the padding defaults to 0 along start and end of each spatial axis.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "strides",
             "1-dimensional tensor with stride value along each spatial axis. "
             "If not present, the stride defaults to 1 along each spatial axis.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .SetDoc(Col2Im_ver18_doc)
         .Input(
             0,
@@ -2438,7 +2585,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             1,
             "image_shape",
@@ -2449,7 +2597,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "block_shape",
@@ -2461,7 +2610,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "output",
@@ -2470,12 +2620,13 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
-            "T",
-            OpSchema::all_tensor_types_ir4(),
-            "Constrain input and output types to all numeric tensor types.")
-        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { col2imShapeInference(ctx); }));
+            "T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to all numeric tensor types."
+        )
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { col2imShapeInference(ctx); })
+);
 
 static const char* LayerNormalization_ver17_doc = R"DOC(
       This is layer normalization defined in ONNX as function.
@@ -2520,10 +2671,8 @@ static const char* LayerNormalization_ver17_doc = R"DOC(
 )DOC";
 
 bool BuildContextDependentFunctionBodyLayerNormalization(
-    const FunctionBodyBuildContext& ctx,
-    const OpSchema& schema,
-    FunctionProto& functionProto,
-    int sinceVersion) {
+    const FunctionBodyBuildContext& ctx, const OpSchema& schema, FunctionProto& functionProto, int sinceVersion
+) {
   ONNX_ASSERT(sinceVersion == 17 || sinceVersion == 18);
   // LayerNormalization <axis, epsilon, stash_type> (X, Scale, B) => (Y, Mean?, InvStdDev?)
   auto* tp = ctx.getInputType(0);
@@ -2535,7 +2684,7 @@ bool BuildContextDependentFunctionBodyLayerNormalization(
   int64_t U =
       (type_attr != nullptr) ? type_attr->i() : static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
   if ((U != ONNX_NAMESPACE::TensorProto_DataType_FLOAT) && (U != ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16))
-    return false; // Error
+    return false;  // Error
 
   auto* axis_attr = ctx.getAttribute("axis");
   int64_t axis = (axis_attr != nullptr) ? axis_attr->i() : -1;
@@ -2557,20 +2706,22 @@ bool BuildContextDependentFunctionBodyLayerNormalization(
   FunctionBuilder builder(functionProto);
   builder.Const("FloatEpsilon", ToTensor<float>(epsilon))
       .Add("Epsilon = Cast (FloatEpsilon)", "to", U)
-      .Add("XShape = Shape (X)") // shape of input tensor: 1D tensor
-      .Add("Rank = Size (XShape)") // rank of input tensor: scalar
-      .Add("Zero1D = Constant()", "value", mktensor(0)) // [0] : 1D tensor
-      .Add("Axis1D = Constant()", "value", mktensor(axis)) // [axis] : 1D tensor
-      .Add("PrefixShape = Slice (XShape, Zero1D, Axis1D)") // [d[0], ..., d[axis-1]]
+      .Add("XShape = Shape (X)")  // shape of input tensor: 1D tensor
+      .Add("Rank = Size (XShape)")  // rank of input tensor: scalar
+      .Add("Zero1D = Constant()", "value", mktensor(0))  // [0] : 1D tensor
+      .Add("Axis1D = Constant()", "value", mktensor(axis))  // [axis] : 1D tensor
+      .Add("PrefixShape = Slice (XShape, Zero1D, Axis1D)")  // [d[0], ..., d[axis-1]]
       .Add(
-          axis >= 0 // number of axes that are reduced =
-              ? "NumReducedAxes = Sub (Rank, Axis1D)" // [rank - axis]: 1D tensor
-              : "NumReducedAxes = Neg (Axis1D)") // [-axis] : 1D tensor
+          axis >= 0  // number of axes that are reduced =
+              ? "NumReducedAxes = Sub (Rank, Axis1D)"  // [rank - axis]: 1D tensor
+              : "NumReducedAxes = Neg (Axis1D)"
+      )  // [-axis] : 1D tensor
       .Add(
           "SuffixShape = ConstantOfShape (NumReducedAxes)",
           "value",
-          mktensor(1)) // [1, ..., 1] for reduced axes
-      .Add("ReducedShape = Concat <axis = 0> (PrefixShape, SuffixShape)") // [d[0], ..., d[axis-1], 1, ..., 1]
+          mktensor(1)
+      )  // [1, ..., 1] for reduced axes
+      .Add("ReducedShape = Concat <axis = 0> (PrefixShape, SuffixShape)")  // [d[0], ..., d[axis-1], 1, ..., 1]
       .Add("X2D = Flatten (X)", "axis", axis)
       .Add("XU = Cast (X2D)", "to", U);
   if (sinceVersion == 17) {
@@ -2610,16 +2761,14 @@ bool BuildContextDependentFunctionBodyLayerNormalization(
 }
 
 bool BuildContextDependentFunctionBodyLayerNormalizationVer17(
-    const FunctionBodyBuildContext& ctx,
-    const OpSchema& schema,
-    FunctionProto& functionProto) {
+    const FunctionBodyBuildContext& ctx, const OpSchema& schema, FunctionProto& functionProto
+) {
   return BuildContextDependentFunctionBodyLayerNormalization(ctx, schema, functionProto, 17);
 }
 
 bool BuildContextDependentFunctionBodyLayerNormalizationVer18(
-    const FunctionBodyBuildContext& ctx,
-    const OpSchema& schema,
-    FunctionProto& functionProto) {
+    const FunctionBodyBuildContext& ctx, const OpSchema& schema, FunctionProto& functionProto
+) {
   return BuildContextDependentFunctionBodyLayerNormalization(ctx, schema, functionProto, 18);
 }
 
@@ -2633,13 +2782,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The first normalization dimension. If rank(X) is r, axis' allowed range is [-r, r). "
             "Negative value means counting dimensions from the back.",
             AttributeProto::INT,
-            static_cast<int64_t>(-1))
+            static_cast<int64_t>(-1)
+        )
         .Attr("epsilon", "The epsilon value to use to avoid division by zero.", AttributeProto::FLOAT, 1e-5f)
         .Attr(
             "stash_type",
             "Type of Mean and InvStdDev. This also specifies stage one's computation precision.",
             AttributeProto::INT,
-            static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT))
+            static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT)
+        )
         .AllowUncheckedAttributes()
         .Input(0, "X", "Tensor to be normalized.", "T")
         .Input(1, "Scale", "Scale tensor.", "T")
@@ -2651,11 +2802,13 @@ ONNX_OPERATOR_SET_SCHEMA(
             "InvStdDev",
             "Saved inverse standard deviation used during training to speed up gradient computation.",
             "U",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain input types and output Y type to float tensors.")
+            "Constrain input types and output Y type to float tensors."
+        )
         .TypeConstraint("U", {"tensor(float)", "tensor(bfloat16)"}, "Type of Mean and InvStdDev tensors.")
         .SetContextDependentFunctionBodyBuilder(BuildContextDependentFunctionBodyLayerNormalizationVer17, 17)
         .SetContextDependentFunctionBodyBuilder(BuildContextDependentFunctionBodyLayerNormalizationVer18, 18)
@@ -2703,7 +2856,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             for (int d = static_cast<int>(axis); d < input_ndim; ++d)
               inv_std_dev_shape->mutable_dim(d)->set_dim_value(1);
           }
-        }));
+        })
+);
 
 static const char* GroupNormalization_ver18_doc = R"DOC(
 A GroupNormalization function. Carries out group normalization as described in
@@ -2733,7 +2887,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "num_groups",
             "The number of groups of channels. It should be a divisor of the number of channels `C`.",
             AttributeProto::INT,
-            true)
+            true
+        )
         .Input(
             0,
             "X",
@@ -2745,7 +2900,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             1,
             "scale",
@@ -2754,16 +2910,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
-            2,
-            "bias",
-            "Bias tensor of shape `(num_groups)`.",
-            "T",
-            OpSchema::Single,
-            true,
-            1,
-            OpSchema::Differentiable)
+            2, "bias", "Bias tensor of shape `(num_groups)`.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable
+        )
         .Output(
             0,
             "Y",
@@ -2772,69 +2923,73 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain input and output types to float tensors.")
-        .SetContextDependentFunctionBodyBuilder(
-            [](const FunctionBodyBuildContext& ctx, const OpSchema& schema, FunctionProto& functionProto) {
-              // GroupNormalization <epsilon, num_groups> (X, scale, bias) => (Y)
-              auto* tp = ctx.getInputType(0);
-              if ((tp == nullptr) || (!tp->has_tensor_type()))
-                return false;
-              int64_t T = tp->tensor_type().elem_type();
+            "Constrain input and output types to float tensors."
+        )
+        .SetContextDependentFunctionBodyBuilder([](const FunctionBodyBuildContext& ctx,
+                                                   const OpSchema& schema,
+                                                   FunctionProto& functionProto) {
+          // GroupNormalization <epsilon, num_groups> (X, scale, bias) => (Y)
+          auto* tp = ctx.getInputType(0);
+          if ((tp == nullptr) || (!tp->has_tensor_type()))
+            return false;
+          int64_t T = tp->tensor_type().elem_type();
 
-              auto* epsilon_attr = ctx.getAttribute("epsilon");
-              float epsilon = (epsilon_attr != nullptr) ? epsilon_attr->f() : 1e-5f;
-              auto* num_groups_attr = ctx.getAttribute("num_groups");
-              if (num_groups_attr == nullptr)
-                return false;
-              int64_t num_groups = num_groups_attr->i();
+          auto* epsilon_attr = ctx.getAttribute("epsilon");
+          float epsilon = (epsilon_attr != nullptr) ? epsilon_attr->f() : 1e-5f;
+          auto* num_groups_attr = ctx.getAttribute("num_groups");
+          if (num_groups_attr == nullptr)
+            return false;
+          int64_t num_groups = num_groups_attr->i();
 
-              FunctionBuilder builder(functionProto);
-              builder.Const1D("FloatEpsilon", epsilon)
-                  .Add("Epsilon = Cast (FloatEpsilon)", "to", T)
-                  .Add("XShape = Shape (X)") // shape of input tensor: 1D tensor
-                  .Add("C = Shape <start = 1, end = 2> (X)")
-                  .Const1D("NumGroups", num_groups)
-                  .Add("GroupSize = Div (C, NumGroups)")
-                  .Add("N = Shape <start = 0, end = 1> (X)") // batch size
-                  .Add("InstanceShape = Shape <start = 2> (X)") // data instance shape
+          FunctionBuilder builder(functionProto);
+          builder.Const1D("FloatEpsilon", epsilon)
+              .Add("Epsilon = Cast (FloatEpsilon)", "to", T)
+              .Add("XShape = Shape (X)")  // shape of input tensor: 1D tensor
+              .Add("C = Shape <start = 1, end = 2> (X)")
+              .Const1D("NumGroups", num_groups)
+              .Add("GroupSize = Div (C, NumGroups)")
+              .Add("N = Shape <start = 0, end = 1> (X)")  // batch size
+              .Add("InstanceShape = Shape <start = 2> (X)")  // data instance shape
 
-                  // NewShape = [N, num_groups, group_size, H, W, (...)]
-                  .Add("NewShape = Concat <axis = 0> (N, NumGroups, GroupSize, InstanceShape)")
-                  .Add("XReshaped = Reshape (X, NewShape)")
+              // NewShape = [N, num_groups, group_size, H, W, (...)]
+              .Add("NewShape = Concat <axis = 0> (N, NumGroups, GroupSize, InstanceShape)")
+              .Add("XReshaped = Reshape (X, NewShape)")
 
-                  // Flatten into 3D tensor: [N, num_groups, group_size x H x W (x ...)]
-                  .Add("Shape3D = Constant <value_ints = [0, 0, -1]> ()")
-                  .Add("X3D = Reshape(XReshaped, Shape3D)")
+              // Flatten into 3D tensor: [N, num_groups, group_size x H x W (x ...)]
+              .Add("Shape3D = Constant <value_ints = [0, 0, -1]> ()")
+              .Add("X3D = Reshape(XReshaped, Shape3D)")
 
-                  // Calculate statistics
-                  .Const1D("Axes2", (int64_t)2)
-                  .Add("Mean = ReduceMean (X3D, Axes2)")
-                  .Add("Square = Mul (X3D, X3D)")
-                  .Add("MeanOfSquare = ReduceMean (Square, Axes2)")
-                  .Add("SquareOfMean = Mul (Mean, Mean)")
-                  .Add("Var = Sub (MeanOfSquare, SquareOfMean)")
-                  .Add("VarPlusEpsilon = Add (Var, Epsilon)")
-                  .Add("StdDev = Sqrt (VarPlusEpsilon)")
-                  .Add("Deviation = Sub (X3D, Mean)")
-                  .Add("Normalized = Div (Deviation, StdDev)")
+              // Calculate statistics
+              .Const1D("Axes2", (int64_t)2)
+              .Add("Mean = ReduceMean (X3D, Axes2)")
+              .Add("Square = Mul (X3D, X3D)")
+              .Add("MeanOfSquare = ReduceMean (Square, Axes2)")
+              .Add("SquareOfMean = Mul (Mean, Mean)")
+              .Add("Var = Sub (MeanOfSquare, SquareOfMean)")
+              .Add("VarPlusEpsilon = Add (Var, Epsilon)")
+              .Add("StdDev = Sqrt (VarPlusEpsilon)")
+              .Add("Deviation = Sub (X3D, Mean)")
+              .Add("Normalized = Div (Deviation, StdDev)")
 
-                  // Reshape scale and bias for broadcasting
-                  .Add("ScaleShape = Constant <value_ints = [1, -1, 1]> ()")
-                  .Add("ScaleT = Cast (scale)", "to", T)
-                  .Add("BiasT = Cast (bias)", "to", T)
-                  .Add("ScaleReshaped = Reshape (ScaleT, ScaleShape)")
-                  .Add("BiasReshaped = Reshape (BiasT, ScaleShape)")
+              // Reshape scale and bias for broadcasting
+              .Add("ScaleShape = Constant <value_ints = [1, -1, 1]> ()")
+              .Add("ScaleT = Cast (scale)", "to", T)
+              .Add("BiasT = Cast (bias)", "to", T)
+              .Add("ScaleReshaped = Reshape (ScaleT, ScaleShape)")
+              .Add("BiasReshaped = Reshape (BiasT, ScaleShape)")
 
-                  // Calculate scaled and biased output
-                  .Add("Scaled = Mul (ScaleReshaped, Normalized)")
-                  .Add("Biased = Add (Scaled, BiasReshaped)")
-                  .Add("Y = Reshape (Biased, XShape)");
+              // Calculate scaled and biased output
+              .Add("Scaled = Mul (ScaleReshaped, Normalized)")
+              .Add("Biased = Add (Scaled, BiasReshaped)")
+              .Add("Y = Reshape (Biased, XShape)");
 
-              schema.BuildFunction(functionProto);
-              return true;
-            }));
-} // namespace ONNX_NAMESPACE
+          schema.BuildFunction(functionProto);
+          return true;
+        })
+);
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/nn/old.cc
+++ b/onnx/defs/nn/old.cc
@@ -32,7 +32,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "seed",
             "(Optional) Seed to the random generator, if not specified we will auto generate one.",
             AttributeProto::INT,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Input(0, "data", "The input data as Tensor.", "T")
         .Input(
             1,
@@ -42,7 +43,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "If it's non-zero, output will be a random dropout of the scaled input, which is typically "
             "the case during training. It is an optional value, if not specified it will default to 0.5.",
             "T1",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Input(
             2,
             "training_mode",
@@ -50,17 +52,20 @@ ONNX_OPERATOR_SET_SCHEMA(
             "specified explicitly, it is false. If it is false, ratio is ignored and the operation mimics inference mode where "
             "nothing will be dropped from the input data and if mask is requested as output it will contain all ones.",
             "T2",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(0, "output", "The output.", "T")
         .Output(1, "mask", "The output mask.", "T2", OpSchema::Optional)
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeConstraint(
             "T1",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input 'ratio' types to float tensors.")
+            "Constrain input 'ratio' types to float tensors."
+        )
         .TypeConstraint("T2", {"tensor(bool)"}, "Constrain output 'mask' types to boolean tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
@@ -88,7 +93,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               propagateShapeFromInputToOutput(ctx, 0, 1);
             }
           }
-        }));
+        })
+);
 
 static const char* Flatten_ver11_doc = R"DOC(
 Flattens the input tensor into a 2D matrix. If input tensor has shape
@@ -109,7 +115,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "with input dimensions up to axis flattened to the outer dimension "
             "of the output and remaining input dimensions flattened into the inner "
             "dimension of the output.",
-            "T")
+            "T"
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output to all tensor types.")
         .Attr(
             "axis",
@@ -120,7 +127,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "When axis = 0, the shape of the output tensor is (1, (d_0 X d_1 ... d_n), "
             "where the shape of the input tensor is (d_0, d_1, ... d_n). ",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
           if (!hasInputShape(ctx, 0))
@@ -136,7 +144,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
           // TODO: is the operation defined for input-rank < 2?
           updateOutputShape(ctx, 0, {multiplyDims(input_shape, 0, axis), multiplyDims(input_shape, axis, rank)});
-        }));
+        })
+);
 
 static const char* LRN_ver1_doc = R"DOC(
 Local Response Normalization proposed in the [AlexNet paper](https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf).
@@ -173,15 +182,18 @@ ONNX_OPERATOR_SET_SCHEMA(
             "in effect, the operation expects the input "
             "data tensor to arrive with the dimension denotation "
             "of [DATA_BATCH, DATA_CHANNEL, DATA_FEATURE, DATA_FEATURE ...].",
-            "T")
+            "T"
+        )
         .Output(0, "Y", "Output tensor, which has the shape and type as input tensor", "T")
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
             "Constrain input and output "
-            " types to float tensors.")
+            " types to float tensors."
+        )
         .SetDoc(LRN_ver1_doc)
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* mvn_ver9_doc = R"DOC(
       A MeanVarianceNormalization Function: Perform mean variance normalization
@@ -204,11 +216,13 @@ ONNX_OPERATOR_SET_SCHEMA(
             "along each channel. Two variables with the same C-coordinate "
             "are associated with the same mean and variance.",
             AttributeProto::INTS,
-            mvn_default_axes)
+            mvn_default_axes
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to all numeric tensors.")
+            "Constrain input and output types to all numeric tensors."
+        )
         .FunctionBody(FunctionBodyHelper::BuildNodes(
             {// nodes: {outputs, op, inputs, attributes}
              FunctionBodyHelper::Const<float>("Exponent", 2.0f),
@@ -221,7 +235,10 @@ ONNX_OPERATOR_SET_SCHEMA(
              {{"STD"}, "Sqrt", {"Variance"}},
              {{"X_variance"}, "Sub", {"X", "X_RM"}},
              {{"Processed_STD"}, "Add", {"STD", "Epsilon"}},
-             {{"Y"}, "Div", {"X_variance", "Processed_STD"}}})));
+             {{"Y"}, "Div", {"X_variance", "Processed_STD"}}
+            }
+        ))
+);
 
 const char* pads_doc2 =
     "Padding for the beginning and ending along each spatial axis, it can take any value greater "
@@ -247,11 +264,8 @@ const char* auto_pad_doc3 =
     "padding is added at the end for SAME_UPPER and at the beginning for SAME_LOWER.";
 
 void convPoolShapeInference1(
-    InferenceContext& ctx,
-    bool use_dilation,
-    bool require_kernel_shape,
-    int input1Idx,
-    int input2Idx) {
+    InferenceContext& ctx, bool use_dilation, bool require_kernel_shape, int input1Idx, int input2Idx
+) {
   // we need the first input shape for this inference.
   if (!hasInputShape(ctx, input1Idx)) {
     return;
@@ -403,8 +417,9 @@ void convPoolShapeInference1(
   }
 }
 
-std::function<void(OpSchema&)>
-PoolOpSchemaGenerator_9(const char* name, const char* opName, const char* additionalDescription) {
+std::function<void(OpSchema&)> PoolOpSchemaGenerator_9(
+    const char* name, const char* opName, const char* additionalDescription
+) {
   return [=](OpSchema& schema) {
     std::string doc;
     POPULATE_OP_DOC_STR(doc = R"DOC(
@@ -452,7 +467,8 @@ PoolOpSchemaGenerator_9(const char* name, const char* opName, const char* additi
         "in effect, the operation expects the input "
         "data tensor to arrive with the dimension denotation "
         "of [DATA_BATCH, DATA_CHANNEL, DATA_FEATURE, DATA_FEATURE ...].",
-        "T");
+        "T"
+    );
     schema.Output(
         0,
         "Y",
@@ -460,11 +476,13 @@ PoolOpSchemaGenerator_9(const char* name, const char* opName, const char* additi
         "the input tensor. Dimensions will vary based "
         "on various kernel, stride, and pad sizes. Floor value of "
         "the dimension is used",
-        "T");
+        "T"
+    );
     schema.TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       propagateElemTypeFromInputToOutput(ctx, 0, 0);
       if (ctx.getNumOutputs() > 1) {
@@ -481,15 +499,11 @@ PoolOpSchemaGenerator_9(const char* name, const char* opName, const char* additi
 }
 
 std::function<void(OpSchema&)> PoolOpSchemaGenerator_10(
-    const char* name,
-    const char* opName,
-    const char* additionalDescription,
-    bool use_dilation,
-    int opsetNum) {
+    const char* name, const char* opName, const char* additionalDescription, bool use_dilation, int opsetNum
+) {
   return [=](OpSchema& schema) {
     std::string doc;
-    POPULATE_OP_DOC_STR(
-        doc = R"DOC(
+    POPULATE_OP_DOC_STR(doc = R"DOC(
  {name} consumes an input tensor X and applies {opName} pooling across
  the tensor according to kernel sizes, stride sizes, and pad lengths.
  {opName} pooling consisting of computing the {opName} on all values of a
@@ -519,13 +533,15 @@ std::function<void(OpSchema&)> PoolOpSchemaGenerator_10(
  ```
  {additionalDescription}
  )DOC";
-        ReplaceAll(doc, "{name}", name);
-        ReplaceAll(doc, "{opName}", opName);
-        ReplaceAll(doc, "{additionalDescription}", additionalDescription);
-        ReplaceAll(
-            doc,
-            "{kernelSpatialShape}",
-            use_dilation ? "((kernel_spatial_shape[i] - 1) * dilations[i] + 1)" : "kernel_spatial_shape[i]"););
+                        ReplaceAll(doc, "{name}", name);
+                        ReplaceAll(doc, "{opName}", opName);
+                        ReplaceAll(doc, "{additionalDescription}", additionalDescription);
+                        ReplaceAll(
+                            doc,
+                            "{kernelSpatialShape}",
+                            use_dilation ? "((kernel_spatial_shape[i] - 1) * dilations[i] + 1)"
+                                         : "kernel_spatial_shape[i]"
+                        ););
     schema.SetDoc(doc);
     schema.Attr("kernel_shape", "The size of the kernel along each axis.", AttributeProto::INTS);
     schema.Attr(
@@ -534,14 +550,16 @@ std::function<void(OpSchema&)> PoolOpSchemaGenerator_10(
             ? "Stride along each spatial axis. If not present, the stride defaults to 1 along each spatial axis."
             : "Stride along each spatial axis.",
         AttributeProto::INTS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr("auto_pad", auto_pad_doc2, AttributeProto::STRING, std::string("NOTSET"));
     schema.Attr("pads", pads_doc2, AttributeProto::INTS, OPTIONAL_VALUE);
     schema.Attr(
         "ceil_mode",
         "Whether to use ceil or floor (default) to compute the output shape.",
         AttributeProto::INT,
-        static_cast<int64_t>(0));
+        static_cast<int64_t>(0)
+    );
     schema.Input(
         0,
         "X",
@@ -556,7 +574,8 @@ std::function<void(OpSchema&)> PoolOpSchemaGenerator_10(
         "in effect, the operation expects the input "
         "data tensor to arrive with the dimension denotation "
         "of [DATA_BATCH, DATA_CHANNEL, DATA_FEATURE, DATA_FEATURE ...].",
-        "T");
+        "T"
+    );
     schema.Output(
         0,
         "Y",
@@ -564,11 +583,13 @@ std::function<void(OpSchema&)> PoolOpSchemaGenerator_10(
         "the input tensor. Dimensions will vary based "
         "on various kernel, stride, and pad sizes. Floor value of "
         "the dimension is used",
-        "T");
+        "T"
+    );
     schema.TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."
+    );
     schema.TypeAndShapeInferenceFunction([use_dilation](InferenceContext& ctx) {
       propagateElemTypeFromInputToOutput(ctx, 0, 0);
       if (ctx.getNumOutputs() > 1) {
@@ -596,11 +617,11 @@ std::function<void(OpSchema&)> PoolOpSchemaGenerator_11(
     const char* opName,
     const char* additionalDescription,
     bool use_dilation,
-    bool supports8bit = false) {
+    bool supports8bit = false
+) {
   return [=](OpSchema& schema) {
     std::string doc;
-    POPULATE_OP_DOC_STR(
-        doc = R"DOC(
+    POPULATE_OP_DOC_STR(doc = R"DOC(
  {name} consumes an input tensor X and applies {opName} pooling across
  the tensor according to kernel sizes, stride sizes, and pad lengths.
  {opName} pooling consisting of computing the {opName} on all values of a
@@ -636,27 +657,31 @@ or when ceil_mode is disabled:
  ```
  {additionalDescription}
  )DOC";
-        ReplaceAll(doc, "{name}", name);
-        ReplaceAll(doc, "{opName}", opName);
-        ReplaceAll(doc, "{additionalDescription}", additionalDescription);
-        ReplaceAll(
-            doc,
-            "{kernelSpatialShape}",
-            use_dilation ? "((kernel_spatial_shape[i] - 1) * dilations[i] + 1)" : "kernel_spatial_shape[i]"););
+                        ReplaceAll(doc, "{name}", name);
+                        ReplaceAll(doc, "{opName}", opName);
+                        ReplaceAll(doc, "{additionalDescription}", additionalDescription);
+                        ReplaceAll(
+                            doc,
+                            "{kernelSpatialShape}",
+                            use_dilation ? "((kernel_spatial_shape[i] - 1) * dilations[i] + 1)"
+                                         : "kernel_spatial_shape[i]"
+                        ););
     schema.SetDoc(doc);
     schema.Attr("kernel_shape", "The size of the kernel along each axis.", AttributeProto::INTS);
     schema.Attr(
         "strides",
         "Stride along each spatial axis. If not present, the stride defaults to 1 along each spatial axis.",
         AttributeProto::INTS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr("auto_pad", auto_pad_doc3, AttributeProto::STRING, std::string("NOTSET"));
     schema.Attr("pads", pads_doc2, AttributeProto::INTS, OPTIONAL_VALUE);
     schema.Attr(
         "ceil_mode",
         "Whether to use ceil or floor (default) to compute the output shape.",
         AttributeProto::INT,
-        static_cast<int64_t>(0));
+        static_cast<int64_t>(0)
+    );
     schema.Input(
         0,
         "X",
@@ -675,7 +700,8 @@ or when ceil_mode is disabled:
         OpSchema::Single,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.Output(
         0,
         "Y",
@@ -687,12 +713,14 @@ or when ceil_mode is disabled:
         OpSchema::Single,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.TypeConstraint(
         "T",
         GetSupportedDataTypesForPoolingOps_1(supports8bit),
         supports8bit ? "Constrain input and output types to float and 8 bit tensors."
-                     : "Constrain input and output types to float tensors.");
+                     : "Constrain input and output types to float tensors."
+    );
     schema.TypeAndShapeInferenceFunction([use_dilation](InferenceContext& ctx) {
       propagateElemTypeFromInputToOutput(ctx, 0, 0);
       if (ctx.getNumOutputs() > 1) {
@@ -712,9 +740,9 @@ ONNX_OPERATOR_SET_SCHEMA(
     AveragePool,
     1,
     OpSchema().FillUsing(PoolOpSchemaGenerator_9(
-        "AveragePool",
-        "average",
-        "The output of each pooling window is divided by the number of elements exclude pad.")));
+        "AveragePool", "average", "The output of each pooling window is divided by the number of elements exclude pad."
+    ))
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     AveragePool,
@@ -723,12 +751,15 @@ ONNX_OPERATOR_SET_SCHEMA(
         .FillUsing(PoolOpSchemaGenerator_9(
             "AveragePool",
             "average",
-            "The output of each pooling window is divided by the number of elements (exclude pad when attribute count_include_pad is zero)."))
+            "The output of each pooling window is divided by the number of elements (exclude pad when attribute count_include_pad is zero)."
+        ))
         .Attr(
             "count_include_pad",
             "Whether include pad pixels when calculating values for the edges. Default is 0, doesn't count include pad.",
             AttributeProto::INT,
-            static_cast<int64_t>(0)));
+            static_cast<int64_t>(0)
+        )
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     AveragePool,
@@ -739,12 +770,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "average",
             "The output of each pooling window is divided by the number of elements (exclude pad when attribute count_include_pad is zero).",
             false,
-            10))
+            10
+        ))
         .Attr(
             "count_include_pad",
             "Whether include pad pixels when calculating values for the edges. Default is 0, doesn't count include pad.",
             AttributeProto::INT,
-            static_cast<int64_t>(0)));
+            static_cast<int64_t>(0)
+        )
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     AveragePool,
@@ -755,34 +789,37 @@ ONNX_OPERATOR_SET_SCHEMA(
             "average",
             "The output of each pooling window is divided by the number of elements (exclude pad when attribute count_include_pad is zero).",
             true,
-            false))
+            false
+        ))
         .Attr(
             "count_include_pad",
             "Whether include pad pixels when calculating values for the edges. Default is 0, doesn't count include pad.",
             AttributeProto::INT,
-            static_cast<int64_t>(0)));
+            static_cast<int64_t>(0)
+        )
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     MaxPool,
     1,
     OpSchema().FillUsing(PoolOpSchemaGenerator_9(
-        "MaxPool",
-        "max",
-        "The output of each pooling window is maximum number of elements exclude pad.")));
+        "MaxPool", "max", "The output of each pooling window is maximum number of elements exclude pad."
+    ))
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     MaxPool,
     8,
     OpSchema()
         .FillUsing(PoolOpSchemaGenerator_9(
-            "MaxPool",
-            "max",
-            "The output of each pooling window is maximum number of elements exclude pad."))
+            "MaxPool", "max", "The output of each pooling window is maximum number of elements exclude pad."
+        ))
         .Attr(
             "storage_order",
             "The storage order of the tensor. 0 is row major, and 1 is column major.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Output(
             1,
             "Indices",
@@ -793,24 +830,24 @@ ONNX_OPERATOR_SET_SCHEMA(
             "and the indices do not consider padding. "
             "So the values in indices are in [0, N x C x D1 x ... x Dn).",
             "I",
-            OpSchema::Optional)
-        .TypeConstraint("I", {"tensor(int64)"}, "Constrain index tensor to int64"));
+            OpSchema::Optional
+        )
+        .TypeConstraint("I", {"tensor(int64)"}, "Constrain index tensor to int64")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     MaxPool,
     10,
     OpSchema()
         .FillUsing(PoolOpSchemaGenerator_10(
-            "MaxPool",
-            "max",
-            "The output of each pooling window is maximum number of elements exclude pad.",
-            true,
-            10))
+            "MaxPool", "max", "The output of each pooling window is maximum number of elements exclude pad.", true, 10
+        ))
         .Attr(
             "storage_order",
             "The storage order of the tensor. 0 is row major, and 1 is column major.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr("dilations", "Dilation value along each spatial axis of filter.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Output(
             1,
@@ -822,29 +859,30 @@ ONNX_OPERATOR_SET_SCHEMA(
             "and the indices do not consider padding. "
             "So the values in indices are in [0, N x C x D1 x ... x Dn).",
             "I",
-            OpSchema::Optional)
-        .TypeConstraint("I", {"tensor(int64)"}, "Constrain index tensor to int64"));
+            OpSchema::Optional
+        )
+        .TypeConstraint("I", {"tensor(int64)"}, "Constrain index tensor to int64")
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     MaxPool,
     11,
     OpSchema()
         .FillUsing(PoolOpSchemaGenerator_10(
-            "MaxPool",
-            "max",
-            "The output of each pooling window is maximum number of elements exclude pad.",
-            true,
-            11))
+            "MaxPool", "max", "The output of each pooling window is maximum number of elements exclude pad.", true, 11
+        ))
         .Attr(
             "storage_order",
             "The storage order of the tensor. 0 is row major, and 1 is column major.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "dilations",
             "Dilation value along each spatial axis of filter. If not present, the dilation defaults to 1 along each spatial axis.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Output(
             1,
             "Indices",
@@ -855,8 +893,10 @@ ONNX_OPERATOR_SET_SCHEMA(
             "and the indices do not consider padding. "
             "So the values in indices are in [0, N x C x D1 x ... x Dn).",
             "I",
-            OpSchema::Optional)
-        .TypeConstraint("I", {"tensor(int64)"}, "Constrain index tensor to int64"));
+            OpSchema::Optional
+        )
+        .TypeConstraint("I", {"tensor(int64)"}, "Constrain index tensor to int64")
+);
 
 void maxUnpoolShapeInference1(InferenceContext& ctx) {
   // we need at least two inputs to have a shape for this inference.
@@ -865,7 +905,7 @@ void maxUnpoolShapeInference1(InferenceContext& ctx) {
   }
   propagateElemTypeFromInputToOutput(ctx, 0, 0);
   if (!hasInputShape(ctx, 0)) {
-    return; // If first input does not have shape, we cannot infer much.
+    return;  // If first input does not have shape, we cannot infer much.
   }
   auto input_shape = ctx.getInputType(0)->tensor_type().shape();
   if (input_shape.dim_size() < 2) {
@@ -915,15 +955,15 @@ void maxUnpoolShapeInference1(InferenceContext& ctx) {
         fail_shape_inference("'output_shape' must have same number of elements as the shape of input tensor X.");
       }
     }
-    return; // 'output_shape' is specified as input. Actual shape will be
-            // determined at runtime.
+    return;  // 'output_shape' is specified as input. Actual shape will be
+             // determined at runtime.
   }
 
   auto final_output_shape = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
 
   *final_output_shape->add_dim() = input_shape.dim(0);
   *final_output_shape->add_dim() =
-      ctx.getInputType(1)->tensor_type().shape().dim(1); // channels should be the second dim of second input.
+      ctx.getInputType(1)->tensor_type().shape().dim(1);  // channels should be the second dim of second input.
 
   int kernel_shape_size = static_cast<int>(kernel_shape.size());
   for (int i = 0; i < kernel_shape_size; ++i) {
@@ -986,7 +1026,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "in effect, the operation expects the input "
             "data tensor to arrive with the dimension denotation "
             "of [DATA_BATCH, DATA_CHANNEL, DATA_FEATURE, DATA_FEATURE ...].",
-            "T1")
+            "T1"
+        )
         .Input(
             1,
             "I",
@@ -997,21 +1038,25 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The indices are linear, i.e. computed considering the tensor as flattened 1-D tensor, "
             "assuming row-major storage. Also, the linear indices should not consider padding. "
             "So the values in indices are in the range [0, N x C x D1 x ... x Dn).",
-            "T2")
+            "T2"
+        )
         .Input(
             2,
             "output_shape",
             "The shape of the output can be explicitly set which will cause pads values to be auto generated. If 'output_shape' is specified, "
             "'pads' values are ignored.",
             "T2",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(0, "output", "Output data tensor that contains the result of the unpooling.", "T1")
         .TypeConstraint(
             "T1",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeConstraint("T2", {"tensor(int64)"}, "Constrain index tensor to int64")
-        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { maxUnpoolShapeInference1(ctx); }));
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { maxUnpoolShapeInference1(ctx); })
+);
 
 const char* pads_doc1 =
     "Padding for the beginning and ending along each axis, it can take any value greater "
@@ -1047,10 +1092,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Attr("auto_pad", auto_pad_doc1, AttributeProto::STRING, std::string("NOTSET"))
         .Attr("pads", pads_doc1, AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr(
-            "p",
-            "p value of the Lp norm used to pool over the input data, default is 2.0.",
-            AttributeProto::FLOAT,
-            2.0f)
+            "p", "p value of the Lp norm used to pool over the input data, default is 2.0.", AttributeProto::FLOAT, 2.0f
+        )
         .Input(
             0,
             "X",
@@ -1062,18 +1105,22 @@ ONNX_OPERATOR_SET_SCHEMA(
             "dimension are in the form of "
             "(N x C x D1 x D2 ... Dn), where N is the "
             "batch size.",
-            "T")
+            "T"
+        )
         .Output(
             0,
             "Y",
             "Output data tensor from Lp pooling across the input "
             "tensor. Dimensions will vary based on various kernel, stride, and pad "
             "sizes.",
-            "T")
+            "T"
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 std::function<void(OpSchema&)> LpPoolOpSchemaGenerator_10(const char* name) {
   return [=](OpSchema& schema) {
@@ -1091,7 +1138,8 @@ std::function<void(OpSchema&)> LpPoolOpSchemaGenerator_10(const char* name) {
     schema.Attr("auto_pad", auto_pad_doc2, AttributeProto::STRING, std::string("NOTSET"));
     schema.Attr("pads", pads_doc2, AttributeProto::INTS, OPTIONAL_VALUE);
     schema.Attr(
-        "p", "p value of the Lp norm used to pool over the input data.", AttributeProto::INT, static_cast<int64_t>(2));
+        "p", "p value of the Lp norm used to pool over the input data.", AttributeProto::INT, static_cast<int64_t>(2)
+    );
     schema.Input(
         0,
         "X",
@@ -1103,18 +1151,21 @@ std::function<void(OpSchema&)> LpPoolOpSchemaGenerator_10(const char* name) {
         "dimensions are in the form of "
         "(N x C x D1 x D2 ... Dn), where N is the "
         "batch size.",
-        "T");
+        "T"
+    );
     schema.Output(
         0,
         "Y",
         "Output data tensor from Lp pooling across the input "
         "tensor. Dimensions will vary based on various kernel, stride, and pad "
         "sizes.",
-        "T");
+        "T"
+    );
     schema.TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       propagateElemTypeFromInputToOutput(ctx, 0, 0);
       convPoolShapeInference1(ctx, false, true, 0, 1);
@@ -1145,11 +1196,13 @@ std::function<void(OpSchema&)> LpPoolOpSchemaGenerator_11(const char* name) {
         "strides",
         "Stride along each spatial axis. If not present, the stride defaults to 1 along each spatial axis.",
         AttributeProto::INTS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr("auto_pad", auto_pad_doc3, AttributeProto::STRING, std::string("NOTSET"));
     schema.Attr("pads", pads_doc2, AttributeProto::INTS, OPTIONAL_VALUE);
     schema.Attr(
-        "p", "p value of the Lp norm used to pool over the input data.", AttributeProto::INT, static_cast<int64_t>(2));
+        "p", "p value of the Lp norm used to pool over the input data.", AttributeProto::INT, static_cast<int64_t>(2)
+    );
     schema.Input(
         0,
         "X",
@@ -1165,7 +1218,8 @@ std::function<void(OpSchema&)> LpPoolOpSchemaGenerator_11(const char* name) {
         OpSchema::Single,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.Output(
         0,
         "Y",
@@ -1176,11 +1230,13 @@ std::function<void(OpSchema&)> LpPoolOpSchemaGenerator_11(const char* name) {
         OpSchema::Single,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       propagateElemTypeFromInputToOutput(ctx, 0, 0);
       convPoolShapeInference1(ctx, false, true, 0, 1);
@@ -1210,7 +1266,8 @@ computes the output.)DOC";
         "in effect, the operation expects input data tensor "
         "to arrive with the dimension denotation of [DATA_BATCH, "
         "DATA_CHANNEL, DATA_FEATURE, DATA_FEATURE ...].",
-        "T");
+        "T"
+    );
     schema.Input(
         1,
         "W",
@@ -1228,7 +1285,8 @@ computes the output.)DOC";
         "X.shape[1] == (W.shape[1] * group) == C "
         "(assuming zero based indices for the shape array). "
         "Or in other words FILTER_IN_CHANNEL should be equal to DATA_CHANNEL. ",
-        "T");
+        "T"
+    );
     schema.Input(2, "B", "Optional 1D bias to be added to the convolution, has size of M.", "T", OpSchema::Optional);
     schema.Output(
         0,
@@ -1236,18 +1294,22 @@ computes the output.)DOC";
         "Output data tensor that contains the result of the "
         "convolution. The output dimensions are functions "
         "of the kernel size, stride size, and pad lengths.",
-        "T");
+        "T"
+    );
     schema.TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."
+    );
     schema.Attr(
         "kernel_shape",
         "The shape of the convolution kernel. If not present, should be inferred from input W.",
         AttributeProto::INTS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr(
-        "dilations", "dilation value along each spatial axis of the filter.", AttributeProto::INTS, OPTIONAL_VALUE);
+        "dilations", "dilation value along each spatial axis of the filter.", AttributeProto::INTS, OPTIONAL_VALUE
+    );
     schema.Attr("strides", "Stride along each spatial axis.", AttributeProto::INTS, OPTIONAL_VALUE);
     schema.Attr("auto_pad", auto_pad_doc2, AttributeProto::STRING, std::string("NOTSET"));
     schema.Attr("pads", pads_doc2, AttributeProto::INTS, OPTIONAL_VALUE);
@@ -1255,7 +1317,8 @@ computes the output.)DOC";
         "group",
         "number of groups input channels and output channels are divided into.",
         AttributeProto::INT,
-        static_cast<int64_t>(1));
+        static_cast<int64_t>(1)
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       propagateElemTypeFromInputToOutput(ctx, 0, 0);
       convPoolShapeInference1(ctx, true, false, 0, 1);
@@ -1277,7 +1340,7 @@ void convTransposeShapeInference1(InferenceContext& ctx) {
 
   auto input_shape = ctx.getInputType(0)->tensor_type().shape();
   if (input_shape.dim_size() < 2) {
-    return; // Input tensor should have at least two dimensions.
+    return;  // Input tensor should have at least two dimensions.
   }
 
   // first dim is the batch axis and the next is the number of channels.
@@ -1361,7 +1424,7 @@ void convTransposeShapeInference1(InferenceContext& ctx) {
 
   std::vector<int64_t> output_padding;
   if (getRepeatedAttribute(ctx, "output_padding", output_padding)) {
-    if (output_padding.size() != n_input_dims) { // Added only to one side.
+    if (output_padding.size() != n_input_dims) {  // Added only to one side.
       return;
     }
   } else {
@@ -1372,8 +1435,8 @@ void convTransposeShapeInference1(InferenceContext& ctx) {
 
   *final_output_shape->add_dim() = input_shape.dim(0);
   *final_output_shape->add_dim() =
-      ctx.getInputType(1)->tensor_type().shape().dim(1) * group; // channels should be the second dim of second input
-                                                                 // multiply group.
+      ctx.getInputType(1)->tensor_type().shape().dim(1) * group;  // channels should be the second dim of second input
+                                                                  // multiply group.
 
   int size_of_output;
   if (output_shape_presented) {
@@ -1382,8 +1445,8 @@ void convTransposeShapeInference1(InferenceContext& ctx) {
       if (input_shape.dim(i + 2).has_dim_value()) {
         if (output_shape[i] < input_shape.dim(i + 2).dim_value()) {
           // TODO: throw exception?
-          return; // output shape value cannot be smaller than the input shape
-                  // value
+          return;  // output shape value cannot be smaller than the input shape
+                   // value
         }
       }
       final_output_shape->add_dim()->set_dim_value(output_shape[i]);
@@ -1431,7 +1494,8 @@ output_shape can also be explicitly specified in which case pads values are auto
         ", where N is the batch size, C is the number of channels, and"
         " H and W are the height and width. Note that this is for the 2D image. "
         "Otherwise the size is (N x C x D1 x D2 ... x Dn)",
-        "T");
+        "T"
+    );
     schema.Input(
         1,
         "W",
@@ -1444,7 +1508,8 @@ output_shape can also be explicitly specified in which case pads values are auto
         "where (k1 x k2 x ... x kn) is the dimension of the kernel. "
         "The number of channels in the output should be equal to W.shape[1] * group "
         "(assuming zero based indices of the shape array)",
-        "T");
+        "T"
+    );
     schema.Input(2, "B", "Optional 1D bias to be added to the convolution, has size of M.", "T", OpSchema::Optional);
     schema.Output(
         0,
@@ -1454,30 +1519,36 @@ output_shape can also be explicitly specified in which case pads values are auto
         "pad lengths and group count. "
         "The number of channels in the output should be equal to W.shape[1] * group "
         "(assuming zero based indices of the shape array)",
-        "T");
+        "T"
+    );
     schema.TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."
+    );
     schema.Attr(
         "kernel_shape",
         "The shape of the convolution kernel. If not present, should be inferred from input W.",
         AttributeProto::INTS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr(
         "output_shape",
         "The shape of the output can be explicitly set which will cause pads values to be auto generated. If output_shape is specified "
         "pads values are ignored. See doc for details for equations to generate pads",
         AttributeProto::INTS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr(
         "output_padding",
         "The zero-padding added to one side of the output."
         " This is also called adjs/adjustment in some frameworks.",
         AttributeProto::INTS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr(
-        "dilations", "dilation value along each spatial axis of the filter.", AttributeProto::INTS, OPTIONAL_VALUE);
+        "dilations", "dilation value along each spatial axis of the filter.", AttributeProto::INTS, OPTIONAL_VALUE
+    );
     schema.Attr("strides", "Stride along each spatial axis.", AttributeProto::INTS, OPTIONAL_VALUE);
     schema.Attr("auto_pad", auto_pad_doc2, AttributeProto::STRING, std::string("NOTSET"));
     schema.Attr("pads", pads_doc2, AttributeProto::INTS, OPTIONAL_VALUE);
@@ -1485,7 +1556,8 @@ output_shape can also be explicitly specified in which case pads values are auto
         "group",
         "number of groups input channels and output channels are divided into.",
         AttributeProto::INT,
-        static_cast<int64_t>(1));
+        static_cast<int64_t>(1)
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) { convTransposeShapeInference1(ctx); });
   };
 }
@@ -1498,10 +1570,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .SetDoc(GlobalLpPool_ver1_doc)
         .Attr(
-            "p",
-            "p value of the Lp norm used to pool over the input data, default is 2.0.",
-            AttributeProto::FLOAT,
-            2.0f)
+            "p", "p value of the Lp norm used to pool over the input data, default is 2.0.", AttributeProto::FLOAT, 2.0f
+        )
         .Input(
             0,
             "X",
@@ -1512,17 +1582,21 @@ ONNX_OPERATOR_SET_SCHEMA(
             "of the data. For non image case, the dimension are "
             "in the form of (N x C x D1 x D2 ... Dn), "
             "where N is the batch size.",
-            "T")
+            "T"
+        )
         .Output(
             0,
             "Y",
             "Output data tensor from pooling across the input "
             "tensor. Dimensions will be N x C x 1 x 1",
-            "T")
+            "T"
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* BatchNormalization_ver1_doc = R"DOC(
 Carries out batch normalization as described in the paper
@@ -1545,23 +1619,27 @@ ONNX_OPERATOR_SET_SCHEMA(
             "If false, compute the mean and variance across per feature."
             "Default is 1.",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .Attr(
             "is_test",
             "If set to nonzero, run spatial batch normalization in test mode, default is 0.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "epsilon",
             "The epsilon value to use to avoid division by zero, default is 1e-5f.",
             AttributeProto::FLOAT,
-            1e-5f)
+            1e-5f
+        )
         .Attr(
             "momentum",
             "Factor used in computing the running mean and variance."
             "e.g., running_mean = running_mean * momentum + mean * (1 - momentum), default is 0.9f.",
             AttributeProto::FLOAT,
-            0.9f)
+            0.9f
+        )
         // This attribute was added via AllowConsumed API in OpSchema.
         // After removing the API, we're now using the Attr API to simulate the
         // old definition.
@@ -1572,25 +1650,29 @@ ONNX_OPERATOR_SET_SCHEMA(
             "scale",
             "The scale as a 1-dimensional tensor of size C to be applied to the "
             "output.",
-            "T")
+            "T"
+        )
         .Input(
             2,
             "B",
             "The bias as a 1-dimensional tensor of size C to be applied to the "
             "output.",
-            "T")
+            "T"
+        )
         .Input(
             3,
             "mean",
             "The running mean (training) or the estimated mean (testing) "
             "as a 1-dimensional tensor of size C.",
-            "T")
+            "T"
+        )
         .Input(
             4,
             "var",
             "The running variance (training) or the estimated "
             "variance (testing) as a 1-dimensional tensor of size C.",
-            "T")
+            "T"
+        )
         .Output(0, "Y", "The output 4-dimensional tensor of the same shape as X.", "T")
         .Output(
             1,
@@ -1598,32 +1680,38 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The running mean after the BatchNormalization operator. Must be in-place "
             "with the input mean. Should not be used for testing.",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(
             2,
             "var",
             "The running variance after the BatchNormalization operator. Must be "
             "in-place with the input var. Should not be used for testing.",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(
             3,
             "saved_mean",
             "Saved mean used during training to speed up gradient "
             "computation. Should not be used for testing.",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(
             4,
             "saved_var",
             "Saved variance used during training to speed up "
             "gradient computation. Should not be used for testing.",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* BatchNormalization_ver9_doc = R"DOC(
 Carries out batch normalization as described in the paper
@@ -1649,7 +1737,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Factor used in computing the running mean and variance."
             "e.g., running_mean = running_mean * momentum + mean * (1 - momentum).",
             AttributeProto::FLOAT,
-            0.9f)
+            0.9f
+        )
         .Input(
             0,
             "X",
@@ -1663,7 +1752,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(1, "scale", "Scale tensor of shape (C).", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(2, "B", "Bias tensor of shape (C).", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
@@ -1674,7 +1764,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             4,
             "var",
@@ -1683,16 +1774,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Output(
-            0,
-            "Y",
-            "The output tensor of the same shape as X",
-            "T",
-            OpSchema::Single,
-            true,
-            1,
-            OpSchema::Differentiable)
+            0, "Y", "The output tensor of the same shape as X", "T", OpSchema::Single, true, 1, OpSchema::Differentiable
+        )
         .Output(
             1,
             "mean",
@@ -1701,7 +1787,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             2,
             "var",
@@ -1710,7 +1797,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             3,
             "saved_mean",
@@ -1720,7 +1808,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             4,
             "saved_var",
@@ -1730,16 +1819,19 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateShapeAndTypeFromFirstInput(ctx);
           // TODO in training mode, it may be possible to infer some of
           // the other outputs as well.
-        }));
+        })
+);
 
 static const char* BatchNormalization_ver14_doc = R"DOC(
 Carries out batch normalization as described in the paper
@@ -1794,13 +1886,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Factor used in computing the running mean and variance."
             "e.g., running_mean = running_mean * momentum + mean * (1 - momentum).",
             AttributeProto::FLOAT,
-            0.9f)
+            0.9f
+        )
         .Attr(
             "training_mode",
             "If set to true, it indicates BatchNormalization is being used for training, and outputs 1, "
             "2, 3, and 4 would be populated.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(
             0,
             "X",
@@ -1814,7 +1908,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(1, "scale", "Scale tensor of shape (C).", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(2, "B", "Bias tensor of shape (C).", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
@@ -1825,7 +1920,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             4,
             "input_var",
@@ -1834,16 +1930,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Output(
-            0,
-            "Y",
-            "The output tensor of the same shape as X",
-            "T",
-            OpSchema::Single,
-            true,
-            1,
-            OpSchema::Differentiable)
+            0, "Y", "The output tensor of the same shape as X", "T", OpSchema::Single, true, 1, OpSchema::Differentiable
+        )
         .Output(
             1,
             "running_mean",
@@ -1852,7 +1943,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             2,
             "running_var",
@@ -1862,15 +1954,18 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeConstraint(
             "U",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain mean and variance types to float tensors. It allows all float type for U.")
+            "Constrain mean and variance types to float tensors. It allows all float type for U."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateShapeAndTypeFromFirstInput(ctx);
           propagateShapeFromInputToOutput(ctx, 0, 0);
@@ -1905,7 +2000,7 @@ ONNX_OPERATOR_SET_SCHEMA(
 
           if (ctx.getNumOutputs() > 1) {
             TensorShapeProto outputs_shape;
-            *outputs_shape.add_dim() = num_channels; // channel
+            *outputs_shape.add_dim() = num_channels;  // channel
 
             propagateElemTypeFromInputToOutput(ctx, 3, 1);
             updateOutputShape(ctx, 1, outputs_shape);
@@ -1915,7 +2010,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               updateOutputShape(ctx, 2, outputs_shape);
             }
           }
-        }));
+        })
+);
 
 static const char* InstanceNormalization_ver1_doc = R"DOC(
 Carries out instance normalization as described in the paper
@@ -1939,7 +2035,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "epsilon",
             "The epsilon value to use to avoid division by zero, default is 1e-5f.",
             AttributeProto::FLOAT,
-            1e-5f)
+            1e-5f
+        )
         .Input(0, "input", "The input 4-dimensional tensor of shape NCHW.", "T")
         .Input(1, "scale", "The input 1-dimensional scale tensor of size C.", "T")
         .Input(2, "B", "The input 1-dimensional bias tensor of size C.", "T")
@@ -1947,7 +2044,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* Dropout_old_doc = R"DOC(
 Dropout takes one input data (Tensor<float>) and produces two Tensor outputs,
@@ -1972,19 +2071,19 @@ ONNX_OPERATOR_SET_SCHEMA(
             "(int, default 0) if nonzero, run dropout in test mode where "
             "the output is simply Y = X.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(0, "data", "The input data as Tensor.", "T")
         .Output(0, "output", "The output.", "T")
         .Output(
-            1,
-            "mask",
-            "The output mask. If is_test is nonzero, this output is not filled.",
-            "T",
-            OpSchema::Optional)
+            1, "mask", "The output mask. If is_test is nonzero, this output is not filled.", "T", OpSchema::Optional
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Dropout,
@@ -1997,20 +2096,20 @@ ONNX_OPERATOR_SET_SCHEMA(
             "(int, default 0) if nonzero, run dropout in test mode where "
             "the output is simply Y = X.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(0, "data", "The input data as Tensor.", "T")
         .Output(0, "output", "The output.", "T")
         .Output(
-            1,
-            "mask",
-            "The output mask. If is_test is nonzero, this output is not filled.",
-            "T",
-            OpSchema::Optional)
+            1, "mask", "The output mask. If is_test is nonzero, this output is not filled.", "T", OpSchema::Optional
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Dropout_ver7_doc = R"DOC(
 Dropout takes one input data (Tensor<float>) and produces two Tensor outputs,
@@ -2032,8 +2131,10 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to float tensors."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Dropout_ver10_doc = R"DOC(
 Dropout takes one input floating tensor and produces two tensor outputs,
@@ -2055,7 +2156,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeConstraint("T1", {"tensor(bool)"}, "Constrain output mask types to boolean tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateShapeAndTypeFromFirstInput(ctx);
@@ -2065,7 +2167,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               propagateShapeFromInputToOutput(ctx, 0, 1);
             }
           }
-        }));
+        })
+);
 
 static const char* BatchNorm_ver6_doc = R"DOC(
 Carries out batch normalization as described in the paper
@@ -2088,23 +2191,27 @@ ONNX_OPERATOR_SET_SCHEMA(
             "If false, compute the mean and variance across per feature."
             "Default is 1.",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .Attr(
             "is_test",
             "If set to nonzero, run spatial batch normalization in test mode, default is 0.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "epsilon",
             "The epsilon value to use to avoid division by zero, default is 1e-5f.",
             AttributeProto::FLOAT,
-            1e-5f)
+            1e-5f
+        )
         .Attr(
             "momentum",
             "Factor used in computing the running mean and variance."
             "e.g., running_mean = running_mean * momentum + mean * (1 - momentum), default is 0.9f.",
             AttributeProto::FLOAT,
-            0.9f)
+            0.9f
+        )
         .Input(
             0,
             "X",
@@ -2116,31 +2223,36 @@ ONNX_OPERATOR_SET_SCHEMA(
             "dimensions are in the form of "
             "(N x C x D1 x D2 ... Dn), where N is the batch "
             "size.",
-            "T")
+            "T"
+        )
         .Input(
             1,
             "scale",
             "The scale as a 1-dimensional tensor of size C to be applied to the "
             "output.",
-            "T")
+            "T"
+        )
         .Input(
             2,
             "B",
             "The bias as a 1-dimensional tensor of size C to be applied to the "
             "output.",
-            "T")
+            "T"
+        )
         .Input(
             3,
             "mean",
             "The running mean (training) or the estimated mean (testing) "
             "as a 1-dimensional tensor of size C.",
-            "T")
+            "T"
+        )
         .Input(
             4,
             "var",
             "The running variance (training) or the estimated "
             "variance (testing) as a 1-dimensional tensor of size C.",
-            "T")
+            "T"
+        )
         .Output(0, "Y", "The output tensor of the same shape as X.", "T")
         .Output(
             1,
@@ -2148,37 +2260,43 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The running mean after the BatchNormalization operator. Must be in-place "
             "with the input mean. Should not be used for testing.",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(
             2,
             "var",
             "The running variance after the BatchNormalization operator. Must be "
             "in-place with the input var. Should not be used for testing.",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(
             3,
             "saved_mean",
             "Saved mean used during training to speed up gradient "
             "computation. Should not be used for testing.",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(
             4,
             "saved_var",
             "Saved variance used during training to speed up "
             "gradient computation. Should not be used for testing.",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateShapeAndTypeFromFirstInput(ctx);
           // TODO in training mode, it may be possible to infer some of
           // the other outputs as well.
-        }));
+        })
+);
 
 static const char* Flatten_ver1_doc = R"DOC(
 Flattens the input tensor into a 2D matrix. If input tensor has shape
@@ -2199,11 +2317,13 @@ ONNX_OPERATOR_SET_SCHEMA(
             "with input dimensions up to axis flattened to the outer dimension "
             "of the output and remaining input dimensions flattened into the inner "
             "dimension of the output.",
-            "T")
+            "T"
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .Attr(
             "axis",
             "Indicate up to which input dimensions "
@@ -2212,7 +2332,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "When axis = 0, the shape of the output tensor is (1, (d_0 X d_1 ... d_n), "
             "where the shape of the input tensor is (d_0, d_1, ... d_n). ",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
           if (!hasInputShape(ctx, 0))
@@ -2225,7 +2346,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
           // TODO: is the operation defined for input-rank < 2?
           updateOutputShape(ctx, 0, {multiplyDims(input_shape, 0, axis), multiplyDims(input_shape, axis, rank)});
-        }));
+        })
+);
 
 static const char* Flatten_ver9_doc = R"DOC(
 Flattens the input tensor into a 2D matrix. If input tensor has shape
@@ -2246,7 +2368,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "with input dimensions up to axis flattened to the outer dimension "
             "of the output and remaining input dimensions flattened into the inner "
             "dimension of the output.",
-            "T")
+            "T"
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output to all tensor types.")
         .Attr(
             "axis",
@@ -2256,7 +2379,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "When axis = 0, the shape of the output tensor is (1, (d_0 X d_1 ... d_n), "
             "where the shape of the input tensor is (d_0, d_1, ... d_n). ",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
           if (!hasInputShape(ctx, 0))
@@ -2269,7 +2393,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
           // TODO: is the operation defined for input-rank < 2?
           updateOutputShape(ctx, 0, {multiplyDims(input_shape, 0, axis), multiplyDims(input_shape, axis, rank)});
-        }));
+        })
+);
 
 static const char* BatchNormalization_ver7_doc = R"DOC(
     Carries out batch normalization as described in the paper
@@ -2292,14 +2417,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "If false, compute the mean and variance across per feature over "
             "each mini-batch.",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .Attr("epsilon", "The epsilon value to use to avoid division by zero.", AttributeProto::FLOAT, 1e-5f)
         .Attr(
             "momentum",
             "Factor used in computing the running mean and variance."
             "e.g., running_mean = running_mean * momentum + mean * (1 - momentum).",
             AttributeProto::FLOAT,
-            0.9f)
+            0.9f
+        )
         .Input(
             0,
             "X",
@@ -2311,21 +2438,24 @@ ONNX_OPERATOR_SET_SCHEMA(
             "dimensions are in the form of "
             "(N x C x D1 x D2 ... Dn), where N is the batch "
             "size.",
-            "T")
+            "T"
+        )
         .Input(
             1,
             "scale",
             "If spatial is true, the dimension of scale is (C). "
             "If spatial is false, the dimensions of scale are "
             "(C x D1 x ... x Dn)",
-            "T")
+            "T"
+        )
         .Input(
             2,
             "B",
             "If spatial is true, the dimension of bias is (C). "
             "If spatial is false, the dimensions of bias are "
             "(C x D1 x ... x Dn)",
-            "T")
+            "T"
+        )
         .Input(
             3,
             "mean",
@@ -2333,7 +2463,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "(training) or the estimated mean (testing) is (C). "
             "If spatial is false, the dimensions of the running mean "
             "(training) or the estimated mean (testing) are (C x D1 x ... x Dn).",
-            "T")
+            "T"
+        )
         .Input(
             4,
             "var",
@@ -2341,7 +2472,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "(training) or the estimated variance (testing) is (C). "
             "If spatial is false, the dimensions of the running variance"
             "(training) or the estimated variance (testing) are (C x D1 x ... x Dn).",
-            "T")
+            "T"
+        )
         .Output(0, "Y", "The output tensor of the same shape as X", "T")
         .Output(1, "mean", "The running mean after the BatchNormalization operator.", "T", OpSchema::Optional)
         .Output(2, "var", "The running variance after the BatchNormalization operator.", "T", OpSchema::Optional)
@@ -2351,21 +2483,25 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Saved mean used during training to speed up gradient "
             "computation.",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(
             4,
             "saved_var",
             "Saved variance used during training to speed up "
             "gradient computation.",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateShapeAndTypeFromFirstInput(ctx);
           // TODO in training mode, it may be possible to infer some of
           // the other outputs as well.
-        }));
-} // namespace ONNX_NAMESPACE
+        })
+);
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/object_detection/defs.cc
+++ b/onnx/defs/object_detection/defs.cc
@@ -33,7 +33,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "i.e., spatial scale of the input feature map X relative to the "
             "input image. E.g.; default is 1.0f. ",
             AttributeProto::FLOAT,
-            1.f)
+            1.f
+        )
         .Attr("output_height", "default 1; Pooled output Y's height.", AttributeProto::INT, static_cast<int64_t>(1))
         .Attr("output_width", "default 1; Pooled output Y's width.", AttributeProto::INT, static_cast<int64_t>(1))
         .Attr(
@@ -44,13 +45,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "an adaptive number of grid points are used (computed as "
             "ceil(roi_width / output_width), and likewise for height). Default is 0.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "mode",
             "The pooling method. Two modes are supported: 'avg' and 'max'. "
             "Default is 'avg'.",
             AttributeProto::STRING,
-            std::string("avg"))
+            std::string("avg")
+        )
         .Attr(
             "coordinate_transformation_mode",
             "Allowed values are 'half_pixel' and 'output_half_pixel'. "
@@ -58,7 +61,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Use the value 'output_half_pixel' to omit the pixel shift for the input (use this for a "
             "backward-compatible behavior).",
             AttributeProto::STRING,
-            std::string("half_pixel"))
+            std::string("half_pixel")
+        )
         .Input(
             0,
             "X",
@@ -66,7 +70,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "4-D feature map of shape (N, C, H, W), "
             "where N is the batch size, C is the number of channels, "
             "and H and W are the height and the width of the data.",
-            "T1")
+            "T1"
+        )
         .Input(
             1,
             "rois",
@@ -75,24 +80,26 @@ ONNX_OPERATOR_SET_SCHEMA(
             "[[x1, y1, x2, y2], ...]. "
             "The RoIs' coordinates are in the coordinate system of the input image. "
             "Each coordinate set has a 1:1 correspondence with the 'batch_indices' input.",
-            "T1")
+            "T1"
+        )
         .Input(
             2,
             "batch_indices",
             "1-D tensor of shape (num_rois,) with each element denoting "
             "the index of the corresponding image in the batch.",
-            "T2")
+            "T2"
+        )
         .Output(
             0,
             "Y",
             "RoI pooled output, 4-D tensor of shape "
             "(num_rois, C, output_height, output_width). The r-th batch element Y[r-1] "
             "is a pooled feature map corresponding to the r-th RoI X[r-1].",
-            "T1")
+            "T1"
+        )
         .TypeConstraint(
-            "T1",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain types to float tensors.")
+            "T1", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain types to float tensors."
+        )
         .TypeConstraint("T2", {"tensor(int64)"}, "Constrain types to int tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
@@ -122,7 +129,8 @@ ONNX_OPERATOR_SET_SCHEMA(
 
           // set output shape:
           updateOutputShape(ctx, 0, {num_rois, C, ht, width});
-        }));
+        })
+);
 
 static const char* NonMaxSuppression_doc = R"DOC(
 Filter out boxes that have high intersection-over-union (IOU) overlap with previously selected boxes.
@@ -142,31 +150,36 @@ ONNX_OPERATOR_SET_SCHEMA(
             0,
             "boxes",
             "An input tensor with shape [num_batches, spatial_dimension, 4]. The single box data format is indicated by center_point_box.",
-            "tensor(float)")
+            "tensor(float)"
+        )
         .Input(1, "scores", "An input tensor with shape [num_batches, num_classes, spatial_dimension]", "tensor(float)")
         .Input(
             2,
             "max_output_boxes_per_class",
             "Integer representing the maximum number of boxes to be selected per batch per class. It is a scalar. Default to 0, which means no output.",
             "tensor(int64)",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Input(
             3,
             "iou_threshold",
             "Float representing the threshold for deciding whether boxes overlap too much with respect to IOU. It is scalar. Value range [0, 1]. Default to 0.",
             "tensor(float)",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Input(
             4,
             "score_threshold",
             "Float representing the threshold for deciding when to remove boxes based on score. It is a scalar.",
             "tensor(float)",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(
             0,
             "selected_indices",
             "selected indices from the boxes tensor. [num_selected_indices, 3], the selected index format is [batch_index, class_index, box_index].",
-            "tensor(int64)")
+            "tensor(int64)"
+        )
         .Attr(
             "center_point_box",
             "Integer indicate the format of the box data. The default is 0. "
@@ -174,7 +187,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "and the coordinates can be provided as normalized (i.e., lying in the interval [0, 1]) or absolute. Mostly used for TF models. "
             "1 - the box data is supplied as [x_center, y_center, width, height]. Mostly used for Pytorch models.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .SetDoc(NonMaxSuppression_doc)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           // Type inference - Output is always of type INT64
@@ -197,6 +211,7 @@ ONNX_OPERATOR_SET_SCHEMA(
 
           // The value of the second dim is 3
           selected_indices_shape->add_dim()->set_dim_value(3);
-        }));
+        })
+);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/object_detection/old.cc
+++ b/onnx/defs/object_detection/old.cc
@@ -33,7 +33,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "i.e., spatial scale of the input feature map X relative to the "
             "input image. E.g.; default is 1.0f. ",
             AttributeProto::FLOAT,
-            1.f)
+            1.f
+        )
         .Attr("output_height", "default 1; Pooled output Y's height.", AttributeProto::INT, static_cast<int64_t>(1))
         .Attr("output_width", "default 1; Pooled output Y's width.", AttributeProto::INT, static_cast<int64_t>(1))
         .Attr(
@@ -44,13 +45,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "an adaptive number of grid points are used (computed as "
             "ceil(roi_width / output_width), and likewise for height). Default is 0.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "mode",
             "The pooling method. Two modes are supported: 'avg' and 'max'. "
             "Default is 'avg'.",
             AttributeProto::STRING,
-            std::string("avg"))
+            std::string("avg")
+        )
         .Input(
             0,
             "X",
@@ -58,7 +61,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "4-D feature map of shape (N, C, H, W), "
             "where N is the batch size, C is the number of channels, "
             "and H and W are the height and the width of the data.",
-            "T1")
+            "T1"
+        )
         .Input(
             1,
             "rois",
@@ -67,24 +71,26 @@ ONNX_OPERATOR_SET_SCHEMA(
             "[[x1, y1, x2, y2], ...]. "
             "The RoIs' coordinates are in the coordinate system of the input image. "
             "Each coordinate set has a 1:1 correspondence with the 'batch_indices' input.",
-            "T1")
+            "T1"
+        )
         .Input(
             2,
             "batch_indices",
             "1-D tensor of shape (num_rois,) with each element denoting "
             "the index of the corresponding image in the batch.",
-            "T2")
+            "T2"
+        )
         .Output(
             0,
             "Y",
             "RoI pooled output, 4-D tensor of shape "
             "(num_rois, C, output_height, output_width). The r-th batch element Y[r-1] "
             "is a pooled feature map corresponding to the r-th RoI X[r-1].",
-            "T1")
+            "T1"
+        )
         .TypeConstraint(
-            "T1",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain types to float tensors.")
+            "T1", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain types to float tensors."
+        )
         .TypeConstraint("T2", {"tensor(int64)"}, "Constrain types to int tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
@@ -114,7 +120,8 @@ ONNX_OPERATOR_SET_SCHEMA(
 
           // set output shape:
           updateOutputShape(ctx, 0, {num_rois, C, ht, width});
-        }));
+        })
+);
 
 static const char* NonMaxSuppression_doc = R"DOC(
 Filter out boxes that have high intersection-over-union (IOU) overlap with previously selected boxes.
@@ -134,31 +141,36 @@ ONNX_OPERATOR_SET_SCHEMA(
             0,
             "boxes",
             "An input tensor with shape [num_batches, spatial_dimension, 4]. The single box data format is indicated by center_point_box.",
-            "tensor(float)")
+            "tensor(float)"
+        )
         .Input(1, "scores", "An input tensor with shape [num_batches, num_classes, spatial_dimension]", "tensor(float)")
         .Input(
             2,
             "max_output_boxes_per_class",
             "Integer representing the maximum number of boxes to be selected per batch per class. It is a scalar. Default to 0, which means no output.",
             "tensor(int64)",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Input(
             3,
             "iou_threshold",
             "Float representing the threshold for deciding whether boxes overlap too much with respect to IOU. It is scalar. Value range [0, 1]. Default to 0.",
             "tensor(float)",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Input(
             4,
             "score_threshold",
             "Float representing the threshold for deciding when to remove boxes based on score. It is a scalar.",
             "tensor(float)",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(
             0,
             "selected_indices",
             "selected indices from the boxes tensor. [num_selected_indices, 3], the selected index format is [batch_index, class_index, box_index].",
-            "tensor(int64)")
+            "tensor(int64)"
+        )
         .Attr(
             "center_point_box",
             "Integer indicate the format of the box data. The default is 0. "
@@ -166,11 +178,13 @@ ONNX_OPERATOR_SET_SCHEMA(
             "and the coordinates can be provided as normalized (i.e., lying in the interval [0, 1]) or absolute. Mostly used for TF models. "
             "1 - the box data is supplied as [x_center, y_center, width, height]. Mostly used for Pytorch models.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .SetDoc(NonMaxSuppression_doc)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           auto selected_indices_type = ctx.getOutputType(0)->mutable_tensor_type();
           selected_indices_type->set_elem_type(::ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT64);
-        }));
+        })
+);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/operator_sets.h
+++ b/onnx/defs/operator_sets.h
@@ -1204,4 +1204,4 @@ inline bool IsOnnxStaticRegistrationDisabled() {
 #endif
 }
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/operator_sets_ml.h
+++ b/onnx/defs/operator_sets_ml.h
@@ -90,6 +90,6 @@ inline void RegisterOnnxMLOperatorSetSchema() {
   RegisterOpSetSchema<OpSet_OnnxML_ver3>();
   RegisterOpSetSchema<OpSet_OnnxML_ver4>();
 }
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE
 
 #endif

--- a/onnx/defs/operator_sets_preview.h
+++ b/onnx/defs/operator_sets_preview.h
@@ -34,4 +34,4 @@ inline void RegisterOnnxPreviewOperatorSetSchema() {
   RegisterOpSetSchema<OpSet_OnnxPreview_ver1>();
 }
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/operator_sets_training.h
+++ b/onnx/defs/operator_sets_training.h
@@ -21,4 +21,4 @@ inline void RegisterOnnxTrainingOperatorSetSchema() {
   RegisterOpSetSchema<OpSet_OnnxTraining_ver1>();
 }
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/optional/defs.cc
+++ b/onnx/defs/optional/defs.cc
@@ -39,11 +39,13 @@ ONNX_OPERATOR_SET_SCHEMA(
               t.insert(t.end(), s.begin(), s.end());
               return t;
             }(),
-            "Constrain input type to all tensor and sequence types.")
+            "Constrain input type to all tensor and sequence types."
+        )
         .TypeConstraint(
             "O",
             OpSchema::all_optional_types(),
-            "Constrain output type to all optional tensor or optional sequence types.")
+            "Constrain output type to all optional tensor or optional sequence types."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           const size_t numOutputs = ctx.getNumOutputs();
           if (numOutputs != 1) {
@@ -68,7 +70,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           } else {
             fail_type_inference("Optional is expected to have either an input or the type attribute set.");
           }
-        }));
+        })
+);
 
 static const char* OptionalHasElement_ver18_doc = R"DOC(
 Returns true if (1) the input is an optional-type and contains an element,
@@ -86,11 +89,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             0,
             "output",
             "A scalar boolean tensor. If true, it indicates that optional-type input contains an element. Otherwise, it is empty.",
-            "B")
+            "B"
+        )
         .TypeConstraint(
-            "O",
-            optional_and_tensor_types(),
-            "Constrain input type to optional tensor and optional sequence types.")
+            "O", optional_and_tensor_types(), "Constrain input type to optional tensor and optional sequence types."
+        )
         .TypeConstraint("B", {"tensor(bool)"}, "Constrain output to a boolean tensor.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           const size_t numInputs = ctx.getNumInputs();
@@ -104,7 +107,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           auto* output_tensor_type = ctx.getOutputType(0)->mutable_tensor_type();
           output_tensor_type->set_elem_type(TensorProto::BOOL);
           output_tensor_type->mutable_shape()->Clear();
-        }));
+        })
+);
 
 static const char* OptionalGetElement_ver18_doc = R"DOC(
 If the input is a tensor or sequence type, it returns the input.
@@ -120,9 +124,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Input(0, "input", "The optional input.", "O")
         .Output(0, "output", "Output element in the optional input.", "V")
         .TypeConstraint(
-            "O",
-            optional_and_tensor_types(),
-            "Constrain input type to optional tensor and optional sequence types.")
+            "O", optional_and_tensor_types(), "Constrain input type to optional tensor and optional sequence types."
+        )
         .TypeConstraint(
             "V",
             []() {
@@ -131,7 +134,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               t.insert(t.end(), s.begin(), s.end());
               return t;
             }(),
-            "Constrain output type to all tensor or sequence types.")
+            "Constrain output type to all tensor or sequence types."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           const size_t numInputs = ctx.getNumInputs();
           if (numInputs != 1) {
@@ -149,6 +153,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           } else {
             propagateShapeAndTypeFromFirstInput(ctx);
           }
-        }));
+        })
+);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/optional/old.cc
+++ b/onnx/defs/optional/old.cc
@@ -23,11 +23,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             0,
             "output",
             "A scalar boolean tensor. If true, it indicates that optional-type input contains an element. Otherwise, it is empty.",
-            "B")
+            "B"
+        )
         .TypeConstraint(
-            "O",
-            OpSchema::all_optional_types(),
-            "Constrain input type to optional tensor and optional sequence types.")
+            "O", OpSchema::all_optional_types(), "Constrain input type to optional tensor and optional sequence types."
+        )
         .TypeConstraint("B", {"tensor(bool)"}, "Constrain output to a boolean tensor.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           const size_t numInputs = ctx.getNumInputs();
@@ -41,7 +41,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           auto* output_tensor_type = ctx.getOutputType(0)->mutable_tensor_type();
           output_tensor_type->set_elem_type(TensorProto::BOOL);
           output_tensor_type->mutable_shape()->Clear();
-        }));
+        })
+);
 
 static const char* OptionalGetElement_ver1_doc = R"DOC(
 Outputs the element in the optional-type input. It is an error if the input value does not have an element
@@ -56,9 +57,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Input(0, "input", "The optional input.", "O")
         .Output(0, "output", "Output element in the optional input.", "V")
         .TypeConstraint(
-            "O",
-            OpSchema::all_optional_types(),
-            "Constrain input type to optional tensor and optional sequence types.")
+            "O", OpSchema::all_optional_types(), "Constrain input type to optional tensor and optional sequence types."
+        )
         .TypeConstraint(
             "V",
             []() {
@@ -67,7 +67,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               t.insert(t.end(), s.begin(), s.end());
               return t;
             }(),
-            "Constrain output type to all tensor or sequence types.")
+            "Constrain output type to all tensor or sequence types."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           const size_t numInputs = ctx.getNumInputs();
           if (numInputs != 1) {
@@ -81,6 +82,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             fail_type_inference("Input must be an optional-type value containing an element with type information.");
           }
           ctx.getOutputType(0)->CopyFrom(input_type->optional_type().elem_type());
-        }));
+        })
+);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -47,7 +47,7 @@ Status ParserBase::Parse(Literal& result) {
     if (has_escape) {
       std::string& target = result.value;
       target.clear();
-      target.reserve(next_ - from - 2); // upper bound
+      target.reserve(next_ - from - 2);  // upper bound
       // *from is the starting quote. *(next_-1) is the ending quote.
       // Copy what is in-between, except for the escape character
       while (++from < next_ - 1) {
@@ -55,7 +55,7 @@ Status ParserBase::Parse(Literal& result) {
         target.push_back(*from != '\\' ? (*from) : *(++from));
       }
     } else
-      result.value = std::string(from + 1, next_ - from - 2); // skip enclosing quotes
+      result.value = std::string(from + 1, next_ - from - 2);  // skip enclosing quotes
     return Status::OK();
   }
 
@@ -93,7 +93,7 @@ Status ParserBase::Parse(Literal& result) {
     while ((next_ < end_) && (isdigit(*next_) || (*next_ == '.'))) {
       if (*next_ == '.') {
         if (decimal_point)
-          break; // Only one decimal point allowed in numeric literal
+          break;  // Only one decimal point allowed in numeric literal
         decimal_point = true;
       }
       ++next_;
@@ -104,7 +104,7 @@ Status ParserBase::Parse(Literal& result) {
 
     // Optional exponent syntax: (e|E)(+|-)?[0-9]+
     if ((next_ < end_) && ((*next_ == 'e') || (*next_ == 'E'))) {
-      decimal_point = true; // treat as float-literal
+      decimal_point = true;  // treat as float-literal
       ++next_;
       if ((next_ < end_) && ((*next_ == '+') || (*next_ == '-')))
         ++next_;
@@ -128,7 +128,7 @@ bool ParserBase::NextIsValidFloatString() {
       ++next_;
     }
 
-    if (isdigit(*next_)) { // No trailing digits
+    if (isdigit(*next_)) {  // No trailing digits
       next_ = from;
       return false;
     }
@@ -138,8 +138,9 @@ bool ParserBase::NextIsValidFloatString() {
     // Reset parser location before continuing.
     next_ = from;
 
-    std::transform(
-        candidate.begin(), candidate.end(), candidate.begin(), [](unsigned char c) { return std::tolower(c); });
+    std::transform(candidate.begin(), candidate.end(), candidate.begin(), [](unsigned char c) {
+      return std::tolower(c);
+    });
     if (candidate == std::string("inf") || candidate == std::string("infinity") || candidate == std::string("nan")) {
       return true;
     }
@@ -152,7 +153,7 @@ Status OnnxParser::Parse(IdList& idlist) {
   std::string id;
   ParseOptionalIdentifier(id);
   if (id.empty())
-    return Status::OK(); // Treat as empty list of identifiers
+    return Status::OK();  // Treat as empty list of identifiers
   *idlist.Add() = id;
   while (Matches(',')) {
     ParseOptionalIdentifier(id);
@@ -383,7 +384,7 @@ Status OnnxParser::Parse(TensorProto& tensorProto) {
   TypeProto typeProto;
   PARSE(typeProto);
   ParseOptionalIdentifier(*tensorProto.mutable_name());
-  (void)Matches('='); // Optional, to unify handling of initializers as well as tensor-protos in other contexts
+  (void)Matches('=');  // Optional, to unify handling of initializers as well as tensor-protos in other contexts
   return Parse(tensorProto, typeProto);
 }
 
@@ -488,7 +489,7 @@ Status OnnxParser::ParseSingleAttributeValue(AttributeProto& attr, AttributeProt
         attr.set_type(AttributeProto_AttributeType_TENSOR);
         auto& tensorProto = *attr.mutable_t();
         ParseOptionalIdentifier(*tensorProto.mutable_name());
-        (void)Matches('='); // Optional, to unify handling of initializers
+        (void)Matches('=');  // Optional, to unify handling of initializers
         Parse(tensorProto, typeProto);
       } else {
         attr.set_type(AttributeProto_AttributeType_TYPE_PROTO);
@@ -538,7 +539,8 @@ Status OnnxParser::ParseSingleAttributeValue(AttributeProto& attr, AttributeProt
           "Mismatch between expected type ",
           AttributeProto_AttributeType_Name(expected),
           " and specified value's type",
-          AttributeProto_AttributeType_Name(attr.type()));
+          AttributeProto_AttributeType_Name(attr.type())
+      );
     }
   }
   return Status::OK();
@@ -825,4 +827,4 @@ Status OnnxParser::Parse(ModelProto& model) {
   return Status::OK();
 }
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/parser.h
+++ b/onnx/defs/parser.h
@@ -227,7 +227,9 @@ class ParserBase {
         NONE,
         FAIL,
         ONNX_NAMESPACE::MakeString(
-            "[ParseError at position ", GetCurrentPos(), "]\n", "Error context: ", GetErrorContext(), "\n", args...));
+            "[ParseError at position ", GetCurrentPos(), "]\n", "Error context: ", GetErrorContext(), "\n", args...
+        )
+    );
   }
 
   void SkipWhiteSpace() {
@@ -269,7 +271,11 @@ class ParserBase {
     return (next_ >= end_);
   }
 
-  enum class LiteralType { INT_LITERAL, FLOAT_LITERAL, STRING_LITERAL };
+  enum class LiteralType {
+    INT_LITERAL,
+    FLOAT_LITERAL,
+    STRING_LITERAL
+  };
 
   struct Literal {
     LiteralType type;
@@ -442,4 +448,4 @@ class OnnxParser : public ParserBase {
   bool NextIsIdentifier();
 };
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/printer.cc
+++ b/onnx/defs/printer.cc
@@ -213,7 +213,7 @@ void ProtoPrinter::print(const TensorProto& tensor, bool is_initializer) {
         printSet(" {", ",", "}", ParseData<double>(&tensor));
         break;
       default:
-        output_ << "..."; // ParseData not instantiated for other types.
+        output_ << "...";  // ParseData not instantiated for other types.
         break;
     }
   } else {
@@ -463,4 +463,4 @@ DEF_OP(FunctionProto)
 
 DEF_OP(ModelProto)
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/printer.h
+++ b/onnx/defs/printer.h
@@ -47,4 +47,4 @@ std::string ProtoToString(const ProtoType& proto) {
   return ss.str();
 }
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/quantization/defs.cc
+++ b/onnx/defs/quantization/defs.cc
@@ -29,20 +29,23 @@ ONNX_OPERATOR_SET_SCHEMA(
             "y_scale",
             "Scale for doing quantization to get 'y'. It can be a scalar, which means per-tensor/layer quantization, "
             "or a 1-D Tensor for per-axis quantization.",
-            "T1")
+            "T1"
+        )
         .Input(
             2,
             "y_zero_point",
             "Zero point for doing quantization to get 'y'. Shape must match y_scale. "
             "Default is uint8 with zero point of 0 if it's not specified.",
             "T2",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(0, "y", "N-D quantized output tensor. It has same shape as input 'x'.", "T2")
         .Attr(
             "axis",
             "(Optional) The axis of the quantization dimension of the input tensor. Ignored for per-tensor quantization. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(input).",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .Attr(
             "saturate",
             "The parameter defines how the conversion behaves if an input value is out of "
@@ -50,11 +53,13 @@ ONNX_OPERATOR_SET_SCHEMA(
             "(float8e4m3fn, float8e4m3fnuz, float8e5m2, float8e5m2fnuz). It is true by default. "
             "All cases are fully described in two tables inserted in the operator description.",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .TypeConstraint(
             "T1",
             {"tensor(float)", "tensor(float16)", "tensor(bfloat16)", "tensor(int32)"},
-            "Constrain 'x' to float, float16, bfloat16 or int32 tensor.")
+            "Constrain 'x' to float, float16, bfloat16 or int32 tensor."
+        )
         .TypeConstraint(
             "T2",
             {"tensor(int8)",
@@ -63,7 +68,8 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(float8e4m3fnuz)",
              "tensor(float8e5m2)",
              "tensor(float8e5m2fnuz)"},
-            "Constrain 'y_zero_point' and 'y' to 8-bit integer/float tensor.")
+            "Constrain 'y_zero_point' and 'y' to 8-bit integer/float tensor."
+        )
         .SetDoc(QuantizeLinear_ver19_doc)
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
           if (ctx.hasInput(2)) {
@@ -77,7 +83,8 @@ ONNX_OPERATOR_SET_SCHEMA(
 
           auto& input_shape = getInputShape(ctx, 0);
           updateOutputShape(ctx, 0, input_shape);
-        }));
+        })
+);
 
 static const char* DequantizeLinear_ver19_doc = R"DOC(
 The linear dequantization operator. It consumes a quantized tensor, a scale, and a zero point to compute the full precision tensor.
@@ -99,20 +106,23 @@ ONNX_OPERATOR_SET_SCHEMA(
             "x_scale",
             "Scale for input 'x'. It can be a scalar, which means a per-tensor/layer dequantization, "
             "or a 1-D tensor for per-axis dequantization.",
-            "T2")
+            "T2"
+        )
         .Input(
             2,
             "x_zero_point",
             "Zero point for input 'x'. Shape must match x_scale. "
             "It's optional. Zero point is 0 when it's not specified.",
             "T1",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(0, "y", "N-D full precision output tensor. It has same shape as input 'x'.", "T2")
         .Attr(
             "axis",
             "(Optional) The axis of the dequantizing dimension of the input tensor. Ignored for per-tensor quantization. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(input).",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .TypeConstraint(
             "T1",
             {"tensor(int8)",
@@ -122,11 +132,11 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(float8e4m3fnuz)",
              "tensor(float8e5m2)",
              "tensor(float8e5m2fnuz)"},
-            "Constrain 'x_zero_point' and 'x' to 8-bit integer or float, or /32-bit integer tensor.")
+            "Constrain 'x_zero_point' and 'x' to 8-bit integer or float, or /32-bit integer tensor."
+        )
         .TypeConstraint(
-            "T2",
-            {"tensor(float)", "tensor(float16)", "tensor(bfloat16)"},
-            "'x_scale' determines the output type.")
+            "T2", {"tensor(float)", "tensor(float16)", "tensor(bfloat16)"}, "'x_scale' determines the output type."
+        )
         .SetDoc(DequantizeLinear_ver19_doc)
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
           auto y_type = ctx.getOutputType(0);
@@ -138,7 +148,8 @@ ONNX_OPERATOR_SET_SCHEMA(
 
           auto& input_shape = getInputShape(ctx, 0);
           updateOutputShape(ctx, 0, input_shape);
-        }));
+        })
+);
 
 static const char* DynamicQuantizeLinear_ver11_doc = R"DOC(
 A Function to fuse calculation for Scale, Zero Point and FP32->8Bit conversion of FP32 Input data.
@@ -178,15 +189,11 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Input(0, "x", "Input tensor", "T1")
         .Output(0, "y", "Quantized output tensor", "T2")
         .Output(
-            1,
-            "y_scale",
-            "Output scale. It's a scalar, which means a per-tensor/layer quantization.",
-            "tensor(float)")
+            1, "y_scale", "Output scale. It's a scalar, which means a per-tensor/layer quantization.", "tensor(float)"
+        )
         .Output(
-            2,
-            "y_zero_point",
-            "Output zero point. It's a scalar, which means a per-tensor/layer quantization.",
-            "T2")
+            2, "y_zero_point", "Output zero point. It's a scalar, which means a per-tensor/layer quantization.", "T2"
+        )
         .TypeConstraint("T1", {"tensor(float)"}, "Constrain 'x' to float tensor.")
         .TypeConstraint("T2", {"tensor(uint8)"}, "Constrain 'y_zero_point' and 'y' to 8-bit unsigned integer tensor.")
         .FunctionBody(R"ONNX(
@@ -222,6 +229,7 @@ ONNX_OPERATOR_SET_SCHEMA(
 
           auto& input_shape = getInputShape(ctx, 0);
           updateOutputShape(ctx, 0, input_shape);
-        }));
+        })
+);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/quantization/old.cc
+++ b/onnx/defs/quantization/old.cc
@@ -25,25 +25,27 @@ ONNX_OPERATOR_SET_SCHEMA(
             "y_scale",
             "Scale for doing quantization to get 'y'. It can be a scalar, which means per-tensor/layer quantization, "
             "or a 1-D Tensor for per-axis quantization.",
-            "tensor(float)")
+            "tensor(float)"
+        )
         .Input(
             2,
             "y_zero_point",
             "Zero point for doing quantization to get 'y'. Shape must match y_scale. "
             "Default is uint8 with zero point of 0 if it's not specified.",
             "T2",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(0, "y", "N-D quantized output tensor. It has same shape as input 'x'.", "T2")
         .Attr(
             "axis",
             "(Optional) The axis of the quantization dimension of the input tensor. Ignored for per-tensor quantization. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(input).",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .TypeConstraint("T1", {"tensor(float)", "tensor(int32)"}, "Constrain 'x' to float or int32 tensor.")
         .TypeConstraint(
-            "T2",
-            {"tensor(int8)", "tensor(uint8)"},
-            "Constrain 'y_zero_point' and 'y' to 8-bit integer tensor.")
+            "T2", {"tensor(int8)", "tensor(uint8)"}, "Constrain 'y_zero_point' and 'y' to 8-bit integer tensor."
+        )
         .SetDoc(QuantizeLinear_ver13_doc)
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
           if (ctx.hasInput(2)) {
@@ -57,7 +59,8 @@ ONNX_OPERATOR_SET_SCHEMA(
 
           auto& input_shape = getInputShape(ctx, 0);
           updateOutputShape(ctx, 0, input_shape);
-        }));
+        })
+);
 
 static const char* DequantizeLinear_ver13_doc = R"DOC(
 The linear dequantization operator. It consumes a quantized tensor, a scale, and a zero point to compute the full precision tensor.
@@ -77,24 +80,28 @@ ONNX_OPERATOR_SET_SCHEMA(
             "x_scale",
             "Scale for input 'x'. It can be a scalar, which means a per-tensor/layer dequantization, "
             "or a 1-D tensor for per-axis dequantization.",
-            "tensor(float)")
+            "tensor(float)"
+        )
         .Input(
             2,
             "x_zero_point",
             "Zero point for input 'x'. Shape must match x_scale. "
             "It's optional. Zero point is 0 when it's not specified.",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(0, "y", "N-D full precision output tensor. It has same shape as input 'x'.", "tensor(float)")
         .Attr(
             "axis",
             "(Optional) The axis of the dequantizing dimension of the input tensor. Ignored for per-tensor quantization. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(input).",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .TypeConstraint(
             "T",
             {"tensor(int8)", "tensor(uint8)", "tensor(int32)"},
-            "Constrain 'x_zero_point' and 'x' to 8-bit/32-bit integer tensor.")
+            "Constrain 'x_zero_point' and 'x' to 8-bit/32-bit integer tensor."
+        )
         .SetDoc(DequantizeLinear_ver13_doc)
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
           auto y_type = ctx.getOutputType(0);
@@ -106,7 +113,8 @@ ONNX_OPERATOR_SET_SCHEMA(
 
           auto& input_shape = getInputShape(ctx, 0);
           updateOutputShape(ctx, 0, input_shape);
-        }));
+        })
+);
 
 static const char* QuantizeLinear_ver10_doc = R"DOC(
 The linear per-tensor/layer quantization operator. It consumes a high precision tensor, a scale, a zero point to compute the low precision / quantized tensor.
@@ -123,20 +131,21 @@ ONNX_OPERATOR_SET_SCHEMA(
             1,
             "y_scale",
             "Scale for doing quantization to get 'y'. It's a scalar, which means a per-tensor/layer quantization.",
-            "tensor(float)")
+            "tensor(float)"
+        )
         .Input(
             2,
             "y_zero_point",
             "Zero point for doing quantization to get 'y'. It's a scalar, which means a per-tensor/layer quantization. "
             "Default value is uint8 typed 0 if it's not specified.",
             "T2",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(0, "y", "N-D quantized output tensor. It has same shape as input 'x'.", "T2")
         .TypeConstraint("T1", {"tensor(float)", "tensor(int32)"}, "Constrain 'x' to float or int32 tensor.")
         .TypeConstraint(
-            "T2",
-            {"tensor(int8)", "tensor(uint8)"},
-            "Constrain 'y_zero_point' and 'y' to 8-bit integer tensor.")
+            "T2", {"tensor(int8)", "tensor(uint8)"}, "Constrain 'y_zero_point' and 'y' to 8-bit integer tensor."
+        )
         .SetDoc(QuantizeLinear_ver10_doc)
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
           if (ctx.hasInput(2)) {
@@ -150,7 +159,8 @@ ONNX_OPERATOR_SET_SCHEMA(
 
           auto& input_shape = getInputShape(ctx, 0);
           updateOutputShape(ctx, 0, input_shape);
-        }));
+        })
+);
 
 static const char* DequantizeLinear_ver10_doc = R"DOC(
 The linear dequantization operator. It consumes a quantized tensor, a scale, a zero point to compute the full precision tensor.
@@ -168,19 +178,22 @@ ONNX_OPERATOR_SET_SCHEMA(
             1,
             "x_scale",
             "Scale for input 'x'. It's a scalar, which means a per-tensor/layer quantization.",
-            "tensor(float)")
+            "tensor(float)"
+        )
         .Input(
             2,
             "x_zero_point",
             "Zero point for input 'x'. It's a scalar, which means a per-tensor/layer quantization. "
             "It's optional. 0 is the default value when it's not specified.",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(0, "y", "N-D full precision output tensor. It has same shape as input 'x'.", "tensor(float)")
         .TypeConstraint(
             "T",
             {"tensor(int8)", "tensor(uint8)", "tensor(int32)"},
-            "Constrain 'x_zero_point' and 'x' to 8-bit/32-bit integer tensor.")
+            "Constrain 'x_zero_point' and 'x' to 8-bit/32-bit integer tensor."
+        )
         .SetDoc(DequantizeLinear_ver10_doc)
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
           auto y_type = ctx.getOutputType(0);
@@ -192,6 +205,7 @@ ONNX_OPERATOR_SET_SCHEMA(
 
           auto& input_shape = getInputShape(ctx, 0);
           updateOutputShape(ctx, 0, input_shape);
-        }));
+        })
+);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/reduction/defs.cc
+++ b/onnx/defs/reduction/defs.cc
@@ -13,14 +13,12 @@
 namespace ONNX_NAMESPACE {
 
 ONNX_OPERATOR_SET_SCHEMA(
-    ReduceMax,
-    20,
-    OpSchema().FillUsing(ReduceOpGenerator("max", EMPTY_MIN, true, true, nullptr, nullptr, true)));
+    ReduceMax, 20, OpSchema().FillUsing(ReduceOpGenerator("max", EMPTY_MIN, true, true, nullptr, nullptr, true))
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
-    ReduceMin,
-    20,
-    OpSchema().FillUsing(ReduceOpGenerator("min", EMPTY_MAX, true, true, nullptr, nullptr, true)));
+    ReduceMin, 20, OpSchema().FillUsing(ReduceOpGenerator("min", EMPTY_MAX, true, true, nullptr, nullptr, true))
+);
 
 ONNX_OPERATOR_SET_SCHEMA(ReduceSum, 13, OpSchema().FillUsing(ReduceOpDynamicAxes("sum", EMPTY_ZERO)));
 
@@ -32,9 +30,8 @@ const char* reduce_sum_square_func_body = R"ONNX(
   )ONNX";
 
 ONNX_OPERATOR_SET_SCHEMA(
-    ReduceSumSquare,
-    18,
-    OpSchema().FillUsing(ReduceFunctionOp("sum square", EMPTY_ZERO, reduce_sum_square_func_body)));
+    ReduceSumSquare, 18, OpSchema().FillUsing(ReduceFunctionOp("sum square", EMPTY_ZERO, reduce_sum_square_func_body))
+);
 
 ONNX_OPERATOR_SET_SCHEMA(ReduceMean, 18, OpSchema().FillUsing(ReduceOpDynamicAxes("mean", EMPTY_UNDEFINED)));
 
@@ -48,9 +45,8 @@ const char* reduce_log_sum_func_body = R"ONNX(
   )ONNX";
 
 ONNX_OPERATOR_SET_SCHEMA(
-    ReduceLogSum,
-    18,
-    OpSchema().FillUsing(ReduceFunctionOp("log sum", EMPTY_MINUS_INF, reduce_log_sum_func_body)));
+    ReduceLogSum, 18, OpSchema().FillUsing(ReduceFunctionOp("log sum", EMPTY_MINUS_INF, reduce_log_sum_func_body))
+);
 
 const char* reduce_log_sum_exp_func_body = R"ONNX(
   {
@@ -65,7 +61,8 @@ const char* reduce_log_sum_exp_func_body = R"ONNX(
 ONNX_OPERATOR_SET_SCHEMA(
     ReduceLogSumExp,
     18,
-    OpSchema().FillUsing(ReduceFunctionOp("log sum exponent", EMPTY_MINUS_INF, reduce_log_sum_exp_func_body)));
+    OpSchema().FillUsing(ReduceFunctionOp("log sum exponent", EMPTY_MINUS_INF, reduce_log_sum_exp_func_body))
+);
 
 const char* reduce_l1_func_body = R"ONNX(
   {
@@ -75,9 +72,8 @@ const char* reduce_l1_func_body = R"ONNX(
   )ONNX";
 
 ONNX_OPERATOR_SET_SCHEMA(
-    ReduceL1,
-    18,
-    OpSchema().FillUsing(ReduceFunctionOp("L1 norm", EMPTY_ZERO, reduce_l1_func_body)));
+    ReduceL1, 18, OpSchema().FillUsing(ReduceFunctionOp("L1 norm", EMPTY_ZERO, reduce_l1_func_body))
+);
 
 const char* reduce_l2_func_body = R"ONNX(
   {
@@ -90,9 +86,8 @@ const char* reduce_l2_func_body = R"ONNX(
   )ONNX";
 
 ONNX_OPERATOR_SET_SCHEMA(
-    ReduceL2,
-    18,
-    OpSchema().FillUsing(ReduceFunctionOp("L2 norm", EMPTY_ZERO, reduce_l2_func_body)));
+    ReduceL2, 18, OpSchema().FillUsing(ReduceFunctionOp("L2 norm", EMPTY_ZERO, reduce_l2_func_body))
+);
 
 std::function<void(OpSchema&)> ArgReduceDocGenerator(const char* name) {
   return [=](OpSchema& schema) {
@@ -111,17 +106,20 @@ The type of the output tensor is integer.)DOC";
         "axis",
         "The axis in which to compute the arg indices. Accepted range is [-r, r-1] where r = rank(data).",
         AttributeProto::INT,
-        static_cast<int64_t>(0));
+        static_cast<int64_t>(0)
+    );
     schema.Attr(
         "keepdims",
         "Keep the reduced dimension or not, default 1 means keep reduced dimension.",
         AttributeProto::INT,
-        static_cast<int64_t>(1));
+        static_cast<int64_t>(1)
+    );
     schema.Attr(
         "select_last_index",
         "Whether to select the last index or the first index if the {name} appears in multiple indices, default is False (first index).",
         AttributeProto::INT,
-        static_cast<int64_t>(0));
+        static_cast<int64_t>(0)
+    );
     schema.Input(0, "data", "An input tensor.", "T", OpSchema::Single, true, 1, OpSchema::NonDifferentiable);
     schema.Output(
         0,
@@ -131,9 +129,11 @@ The type of the output tensor is integer.)DOC";
         OpSchema::Single,
         true,
         1,
-        OpSchema::NonDifferentiable);
+        OpSchema::NonDifferentiable
+    );
     schema.TypeConstraint(
-        "T", OpSchema::all_numeric_types_ir4(), "Constrain input and output types to all numeric tensors.");
+        "T", OpSchema::all_numeric_types_ir4(), "Constrain input and output types to all numeric tensors."
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       // set output element type to int64
       updateOutputElemType(ctx, 0, TensorProto_DataType_INT64);
@@ -145,7 +145,7 @@ The type of the output tensor is integer.)DOC";
       auto& input_shape = ctx.getInputType(0)->tensor_type().shape();
       auto output_shape = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
       int64_t input_ndim = input_shape.dim_size();
-      int64_t axis = 0; // default to 0
+      int64_t axis = 0;  // default to 0
       auto axis_proto = ctx.getAttribute("axis");
       if (axis_proto) {
         axis = axis_proto->i();
@@ -181,4 +181,4 @@ ONNX_OPERATOR_SET_SCHEMA(ArgMax, 13, OpSchema().FillUsing(ArgReduceDocGenerator(
 
 ONNX_OPERATOR_SET_SCHEMA(ArgMin, 13, OpSchema().FillUsing(ArgReduceDocGenerator("min")));
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/reduction/old.cc
+++ b/onnx/defs/reduction/old.cc
@@ -39,19 +39,22 @@ False instead of True.)DOC";
         "A list of integers, along which to reduce. The default is to reduce over "
         "all the dimensions of the input tensor. Accepted range is [-r, r-1] where r = rank(data).",
         AttributeProto::INTS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr(
         "keepdims",
         "Keep the reduced dimension or not, default 1 means keep reduced dimension.",
         AttributeProto::INT,
-        static_cast<int64_t>(1));
+        static_cast<int64_t>(1)
+    );
     schema.Input(0, "data", "An input tensor.", "T");
     schema.Output(0, "reduced", "Reduced output tensor.", "T");
     schema.TypeConstraint(
         "T",
         GetSupportedDataTypesForReductionOps_opset12(supports_8bit_datatypes),
         supports_8bit_datatypes ? "Constrain input and output types to high-precision and 8 bit numeric tensors."
-                                : "Constrain input and output types to high-precision numeric tensors.");
+                                : "Constrain input and output types to high-precision numeric tensors."
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       propagateElemTypeFromInputToOutput(ctx, 0, 0);
       if (!hasNInputShapes(ctx, 1)) {
@@ -132,21 +135,25 @@ The type of the output tensor is integer.)DOC";
         "axis",
         "The axis in which to compute the arg indices. Accepted range is [-r, r-1] where r = rank(data).",
         AttributeProto::INT,
-        static_cast<int64_t>(0));
+        static_cast<int64_t>(0)
+    );
     schema.Attr(
         "keepdims",
         "Keep the reduced dimension or not, default 1 means keep reduced dimension.",
         AttributeProto::INT,
-        static_cast<int64_t>(1));
+        static_cast<int64_t>(1)
+    );
     schema.Attr(
         "select_last_index",
         "Whether to select the last index or the first index if the {name} appears in multiple indices, default is False (first index).",
         AttributeProto::INT,
-        static_cast<int64_t>(0));
+        static_cast<int64_t>(0)
+    );
     schema.Input(0, "data", "An input tensor.", "T");
     schema.Output(0, "reduced", "Reduced output tensor with integer data type.", "tensor(int64)");
     schema.TypeConstraint(
-        "T", OpSchema::all_numeric_types(), "Constrain input and output types to all numeric tensors.");
+        "T", OpSchema::all_numeric_types(), "Constrain input and output types to all numeric tensors."
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       // set output element type to int64
       updateOutputElemType(ctx, 0, TensorProto_DataType_INT64);
@@ -158,7 +165,7 @@ The type of the output tensor is integer.)DOC";
       auto& input_shape = ctx.getInputType(0)->tensor_type().shape();
       auto output_shape = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
       int64_t input_ndim = input_shape.dim_size();
-      int64_t axis = 0; // default to 0
+      int64_t axis = 0;  // default to 0
       auto axis_proto = ctx.getAttribute("axis");
       if (axis_proto) {
         axis = axis_proto->i();
@@ -188,7 +195,7 @@ The type of the output tensor is integer.)DOC";
       }
     });
   };
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE
 
 ONNX_OPERATOR_SET_SCHEMA(ArgMax, 12, OpSchema().FillUsing(ArgReduceDocGenerator_opset12("max")));
 
@@ -215,18 +222,21 @@ False instead of True.)DOC";
                     : "A list of integers, along which to reduce. The default is to reduce over "
                       "all the dimensions of the input tensor.",
         AttributeProto::INTS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr(
         "keepdims",
         "Keep the reduced dimension or not, default 1 means keep reduced dimension.",
         AttributeProto::INT,
-        static_cast<int64_t>(1));
+        static_cast<int64_t>(1)
+    );
     schema.Input(0, "data", "An input tensor.", "T");
     schema.Output(0, "reduced", "Reduced output tensor.", "T");
     schema.TypeConstraint(
         "T",
         OpSchema::numeric_types_for_math_reduction(),
-        "Constrain input and output types to high-precision numeric tensors.");
+        "Constrain input and output types to high-precision numeric tensors."
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       propagateElemTypeFromInputToOutput(ctx, 0, 0);
       if (!hasNInputShapes(ctx, 1)) {
@@ -282,9 +292,8 @@ ONNX_OPERATOR_SET_SCHEMA(ReduceProd, 1, OpSchema().FillUsing(ReduceDocGenerator_
 ONNX_OPERATOR_SET_SCHEMA(ReduceLogSum, 1, OpSchema().FillUsing(ReduceDocGenerator_opset1("log sum", EMPTY_MINUS_INF)));
 
 ONNX_OPERATOR_SET_SCHEMA(
-    ReduceLogSumExp,
-    1,
-    OpSchema().FillUsing(ReduceDocGenerator_opset1("log sum exponent", EMPTY_MINUS_INF)));
+    ReduceLogSumExp, 1, OpSchema().FillUsing(ReduceDocGenerator_opset1("log sum exponent", EMPTY_MINUS_INF))
+);
 
 ONNX_OPERATOR_SET_SCHEMA(ReduceL1, 1, OpSchema().FillUsing(ReduceDocGenerator_opset1("L1 norm", EMPTY_ZERO)));
 
@@ -309,11 +318,13 @@ The type of the output tensor is integer.)DOC";
         "keepdims",
         "Keep the reduced dimension or not, default 1 means keep reduced dimension.",
         AttributeProto::INT,
-        static_cast<int64_t>(1));
+        static_cast<int64_t>(1)
+    );
     schema.Input(0, "data", "An input tensor.", "T");
     schema.Output(0, "reduced", "Reduced output tensor with integer data type.", "tensor(int64)");
     schema.TypeConstraint(
-        "T", OpSchema::all_numeric_types(), "Constrain input and output types to all numeric tensors.");
+        "T", OpSchema::all_numeric_types(), "Constrain input and output types to all numeric tensors."
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       // set output element type to int64
       updateOutputElemType(ctx, 0, TensorProto_DataType_INT64);
@@ -325,7 +336,7 @@ The type of the output tensor is integer.)DOC";
       auto& input_shape = ctx.getInputType(0)->tensor_type().shape();
       auto output_shape = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
       int64_t input_ndim = input_shape.dim_size();
-      int64_t axis = 0; // default to 0
+      int64_t axis = 0;  // default to 0
       auto axis_proto = ctx.getAttribute("axis");
       if (axis_proto) {
         axis = axis_proto->i();
@@ -352,7 +363,7 @@ The type of the output tensor is integer.)DOC";
       }
     });
   };
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE
 
 ONNX_OPERATOR_SET_SCHEMA(ArgMax, 1, OpSchema().FillUsing(ArgReduceDocGenerator_opset1("max")));
 
@@ -372,16 +383,19 @@ The type of the output tensor is integer.)DOC";
         "axis",
         "The axis in which to compute the arg indices. Accepted range is [-r, r-1] where r = rank(data).",
         AttributeProto::INT,
-        static_cast<int64_t>(0));
+        static_cast<int64_t>(0)
+    );
     schema.Attr(
         "keepdims",
         "Keep the reduced dimension or not, default 1 means keep reduced dimension.",
         AttributeProto::INT,
-        static_cast<int64_t>(1));
+        static_cast<int64_t>(1)
+    );
     schema.Input(0, "data", "An input tensor.", "T");
     schema.Output(0, "reduced", "Reduced output tensor with integer data type.", "tensor(int64)");
     schema.TypeConstraint(
-        "T", OpSchema::all_numeric_types(), "Constrain input and output types to all numeric tensors.");
+        "T", OpSchema::all_numeric_types(), "Constrain input and output types to all numeric tensors."
+    );
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       // set output element type to int64
       updateOutputElemType(ctx, 0, TensorProto_DataType_INT64);
@@ -393,7 +407,7 @@ The type of the output tensor is integer.)DOC";
       auto& input_shape = ctx.getInputType(0)->tensor_type().shape();
       auto output_shape = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
       int64_t input_ndim = input_shape.dim_size();
-      int64_t axis = 0; // default to 0
+      int64_t axis = 0;  // default to 0
       auto axis_proto = ctx.getAttribute("axis");
       if (axis_proto) {
         axis = axis_proto->i();
@@ -423,7 +437,7 @@ The type of the output tensor is integer.)DOC";
       }
     });
   };
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE
 
 ONNX_OPERATOR_SET_SCHEMA(ArgMax, 11, OpSchema().FillUsing(ArgReduceDocGenerator_opset11("max")));
 ONNX_OPERATOR_SET_SCHEMA(ArgMin, 11, OpSchema().FillUsing(ArgReduceDocGenerator_opset11("min")));
@@ -435,12 +449,11 @@ ONNX_OPERATOR_SET_SCHEMA(ReduceMean, 13, OpSchema().FillUsing(ReduceOpGenerator(
 ONNX_OPERATOR_SET_SCHEMA(ReduceProd, 13, OpSchema().FillUsing(ReduceOpGenerator("product", EMPTY_ONE)));
 ONNX_OPERATOR_SET_SCHEMA(ReduceLogSum, 13, OpSchema().FillUsing(ReduceOpGenerator("log sum", EMPTY_MINUS_INF)));
 ONNX_OPERATOR_SET_SCHEMA(
-    ReduceLogSumExp,
-    13,
-    OpSchema().FillUsing(ReduceOpGenerator("log sum exponent", EMPTY_MINUS_INF)));
+    ReduceLogSumExp, 13, OpSchema().FillUsing(ReduceOpGenerator("log sum exponent", EMPTY_MINUS_INF))
+);
 ONNX_OPERATOR_SET_SCHEMA(ReduceL1, 13, OpSchema().FillUsing(ReduceOpGenerator("L1 norm", EMPTY_ZERO)));
 ONNX_OPERATOR_SET_SCHEMA(ReduceL2, 13, OpSchema().FillUsing(ReduceOpGenerator("L2 norm", EMPTY_ZERO)));
 
 ONNX_OPERATOR_SET_SCHEMA(ReduceMax, 18, OpSchema().FillUsing(ReduceOpGenerator("max", EMPTY_MIN, true, true)));
 ONNX_OPERATOR_SET_SCHEMA(ReduceMin, 18, OpSchema().FillUsing(ReduceOpGenerator("min", EMPTY_MAX, true, true)));
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/reduction/utils.cc
+++ b/onnx/defs/reduction/utils.cc
@@ -30,7 +30,8 @@ std::function<void(OpSchema&)> ReduceOpGenerator(
     bool axes_input,
     const char* func_body,
     ContextDependentFunctionBodyBuilder function_builder,
-    bool supports_boolean_datatype /* = false */) {
+    bool supports_boolean_datatype /* = false */
+) {
   return [=](OpSchema& schema) {
     std::string doc = R"DOC(
 Computes the {name} of the input tensor's elements along the provided axes. The resulting
@@ -56,7 +57,8 @@ to `False` instead of `True`.)DOC";
         "keepdims",
         "Keep the reduced dimension or not, default 1 means keep reduced dimension.",
         AttributeProto::INT,
-        static_cast<int64_t>(1));
+        static_cast<int64_t>(1)
+    );
     schema.Input(0, "data", "An input tensor.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable);
     if (axes_input) {
       schema.Attr(
@@ -65,7 +67,8 @@ to `False` instead of `True`.)DOC";
           "When axes is empty and this attribute is set to true, input tensor will not be reduced,"
           "and the output tensor would be equivalent to input tensor.",
           AttributeProto::INT,
-          static_cast<int64_t>(0));
+          static_cast<int64_t>(0)
+      );
       schema.Input(
           1,
           "axes",
@@ -77,21 +80,24 @@ to `False` instead of `True`.)DOC";
           OpSchema::Optional,
           true,
           1,
-          OpSchema::NonDifferentiable);
+          OpSchema::NonDifferentiable
+      );
     } else {
       schema.Attr(
           "axes",
           "A list of integers, along which to reduce. The default is to reduce over "
           "all the dimensions of the input tensor. Accepted range is [-r, r-1] where r = rank(data).",
           AttributeProto::INTS,
-          OPTIONAL_VALUE);
+          OPTIONAL_VALUE
+      );
     }
     schema.Output(0, "reduced", "Reduced output tensor.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable);
     schema.TypeConstraint(
         "T",
         GetSupportedDataTypesForReductionOps(supports_8bit_datatypes, supports_boolean_datatype),
         supports_boolean_datatype ? "Constrain input and output types to numeric and Boolean tensors."
-                                  : "Constrain input and output types to numeric tensors.");
+                                  : "Constrain input and output types to numeric tensors."
+    );
     if (func_body) {
       schema.FunctionBody(func_body);
     } else if (function_builder) {
@@ -113,7 +119,7 @@ to `False` instead of `True`.)DOC";
         noop_with_empty_axes = noop_attr_proto->i();
       }
       std::vector<int64_t> axes;
-      if (ctx.hasInput(1)) { // axes is input
+      if (ctx.hasInput(1)) {  // axes is input
         if (ctx.getAttribute("axes")) {
           fail_shape_inference("axes as an input and attribute cannot be specified at the same time.");
         }
@@ -125,7 +131,7 @@ to `False` instead of `True`.)DOC";
         }
         std::vector<int64_t> axes_values = ParseData<int64_t>(axesInitializer);
         axes.assign(axes_values.begin(), axes_values.end());
-      } else { // axes is attribute
+      } else {  // axes is attribute
         auto axes_proto = ctx.getAttribute("axes");
         if (axes_proto)
           axes.assign(axes_proto->ints().begin(), axes_proto->ints().end());
@@ -160,4 +166,4 @@ to `False` instead of `True`.)DOC";
     });
   };
 }
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/reduction/utils.h
+++ b/onnx/defs/reduction/utils.h
@@ -28,15 +28,17 @@ std::function<void(OpSchema&)> ReduceOpGenerator(
     bool axes_input = false,
     const char* func_body = nullptr,
     ContextDependentFunctionBodyBuilder function_builder = nullptr,
-    bool supports_boolean_datatype = false);
+    bool supports_boolean_datatype = false
+);
 
 inline std::function<void(OpSchema&)> ReduceOpDynamicAxes(const char* name, const char* empty_value) {
   return ReduceOpGenerator(name, empty_value, false, true, nullptr, nullptr, false);
 }
 
-inline std::function<void(OpSchema&)>
-ReduceFunctionOp(const char* name, const char* empty_value, const char* func_body) {
+inline std::function<void(OpSchema&)> ReduceFunctionOp(
+    const char* name, const char* empty_value, const char* func_body
+) {
   return ReduceOpGenerator(name, empty_value, false, true, func_body);
 }
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/rnn/defs.cc
+++ b/onnx/defs/rnn/defs.cc
@@ -79,7 +79,8 @@ std::function<void(OpSchema&)> RNNDocGenerator(const char* /*name*/) {
         "Specify if the RNN is forward, reverse, or bidirectional. "
         "Must be one of forward (default), reverse, or bidirectional.",
         AttributeProto::STRING,
-        std::string("forward"));
+        std::string("forward")
+    );
     schema.Attr(
         "layout",
         "The shape format of inputs X, initial_h and outputs Y, Y_h. "
@@ -92,7 +93,8 @@ std::function<void(OpSchema&)> RNNDocGenerator(const char* /*name*/) {
         "Y.shape = [batch_size, seq_length, num_directions, hidden_size], "
         "initial_h.shape = Y_h.shape = [batch_size, num_directions, hidden_size].",
         AttributeProto::INT,
-        static_cast<int64_t>(0));
+        static_cast<int64_t>(0)
+    );
     schema.Attr("hidden_size", "Number of neurons in the hidden layer", AttributeProto::INT, OPTIONAL_VALUE);
     schema.Attr(
         "activation_alpha",
@@ -101,21 +103,24 @@ std::function<void(OpSchema&)> RNNDocGenerator(const char* /*name*/) {
         "in LSTM. Default values are the same as of corresponding ONNX operators."
         "For example with LeakyRelu, the default alpha is 0.01.",
         AttributeProto::FLOATS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr(
         "activation_beta",
         "Optional scaling values used by some activation functions. The values "
         "are consumed in the order of activation functions, for example (f, g, h) "
         "in LSTM. Default values are the same as of corresponding ONNX operators.",
         AttributeProto::FLOATS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr(
         "clip",
         "Cell clip threshold. Clipping bounds the elements of a tensor "
         "in the range of [-threshold, +threshold] and is applied to the input "
         "of activations. No clip if not specified.",
         AttributeProto::FLOAT,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Input(
         0,
         "X",
@@ -125,7 +130,8 @@ std::function<void(OpSchema&)> RNNDocGenerator(const char* /*name*/) {
         OpSchema::Single,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.Input(
         4,
         "sequence_lens",
@@ -136,7 +142,8 @@ std::function<void(OpSchema&)> RNNDocGenerator(const char* /*name*/) {
         OpSchema::Optional,
         true,
         1,
-        OpSchema::NonDifferentiable);
+        OpSchema::NonDifferentiable
+    );
     schema.Input(
         5,
         "initial_h",
@@ -146,7 +153,8 @@ std::function<void(OpSchema&)> RNNDocGenerator(const char* /*name*/) {
         OpSchema::Optional,
         true,
         1,
-        OpSchema::NonDifferentiable);
+        OpSchema::NonDifferentiable
+    );
     schema.Output(
         0,
         "Y",
@@ -156,7 +164,8 @@ std::function<void(OpSchema&)> RNNDocGenerator(const char* /*name*/) {
         OpSchema::Optional,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.Output(
         1,
         "Y_h",
@@ -166,11 +175,13 @@ std::function<void(OpSchema&)> RNNDocGenerator(const char* /*name*/) {
         OpSchema::Optional,
         true,
         1,
-        OpSchema::Differentiable);
+        OpSchema::Differentiable
+    );
     schema.TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."
+    );
     schema.TypeConstraint("T1", {"tensor(int32)"}, "Constrain seq_lens to integer tensor.");
     schema.TypeAndShapeInferenceFunction(RNNShapeInference);
   };
@@ -229,7 +240,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "input gate. The activation function must be one of the activation "
             "functions specified above. Optional: Default `Tanh` if not specified.",
             AttributeProto::STRINGS,
-            std::vector<std::string>{"Tanh", "Tanh"})
+            std::vector<std::string>{"Tanh", "Tanh"}
+        )
         .Input(
             1,
             "W",
@@ -240,7 +252,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             2,
             "R",
@@ -251,7 +264,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             3,
             "B",
@@ -263,8 +277,10 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::Differentiable)
-        .FillUsing(RNNDocGenerator("RNN")));
+            OpSchema::Differentiable
+        )
+        .FillUsing(RNNDocGenerator("RNN"))
+);
 
 static const char* GRU_ver14_doc = R"DOC(
 Computes an one-layer GRU. This operator is usually supported via some custom
@@ -327,14 +343,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "of the activation functions specified above. Optional: See the equations "
             "for default if not specified.",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "linear_before_reset",
             "When computing the output of the hidden gate, "
             "apply the linear transformation before multiplying by the output of the "
             "reset gate.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(
             1,
             "W",
@@ -345,7 +363,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             2,
             "R",
@@ -356,7 +375,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             3,
             "B",
@@ -368,8 +388,10 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::Differentiable)
-        .FillUsing(RNNDocGenerator("GRU")));
+            OpSchema::Differentiable
+        )
+        .FillUsing(RNNDocGenerator("GRU"))
+);
 
 static const char* LSTM_ver14_doc = R"DOC(
 Computes an one-layer LSTM. This operator is usually supported via some
@@ -435,7 +457,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "be one of the activation functions specified above. Optional: See the equations "
             "for default if not specified.",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "layout",
             "The shape format of inputs X, initial_h, initial_c and outputs Y, Y_h, Y_c. "
@@ -450,7 +473,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "initial_h.shape = Y_h.shape = initial_c.shape = Y_c.shape = "
             "[batch_size, num_directions, hidden_size].",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr("input_forget", "Couple the input and forget gates if 1.", AttributeProto::INT, static_cast<int64_t>(0))
         .Input(
             1,
@@ -462,7 +486,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             2,
             "R",
@@ -473,7 +498,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             3,
             "B",
@@ -485,7 +511,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             6,
             "initial_c",
@@ -495,7 +522,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             7,
             "P",
@@ -507,7 +535,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .FillUsing(RNNDocGenerator("LSTM"))
         .Output(
             2,
@@ -518,5 +547,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::Differentiable));
-} // namespace ONNX_NAMESPACE
+            OpSchema::Differentiable
+        )
+);
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/rnn/old.cc
+++ b/onnx/defs/rnn/old.cc
@@ -12,7 +12,8 @@ std::function<void(OpSchema&)> RNNDocGeneratorOld(const char* /*name*/) {
         "Specify if the RNN is forward, reverse, or bidirectional. "
         "Must be one of forward (default), reverse, or bidirectional.",
         AttributeProto::STRING,
-        std::string("foward"));
+        std::string("foward")
+    );
     schema.Attr("hidden_size", "Number of neurons in the hidden layer", AttributeProto::INT, OPTIONAL_VALUE);
     schema.Attr(
         "activation_alpha",
@@ -20,32 +21,37 @@ std::function<void(OpSchema&)> RNNDocGeneratorOld(const char* /*name*/) {
         "are consumed in the order of activation functions, for example (f, g, h) "
         "in LSTM.",
         AttributeProto::FLOATS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr(
         "activation_beta",
         "Optional scaling values used by some activation functions. The values "
         "are consumed in the order of activation functions, for example (f, g, h) "
         "in LSTM.",
         AttributeProto::FLOATS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr(
         "output_sequence",
         "The sequence output for the hidden is optional if 0. Default 0.",
         AttributeProto::INT,
-        static_cast<int64_t>(0));
+        static_cast<int64_t>(0)
+    );
     schema.Attr(
         "clip",
         "Cell clip threshold. Clipping bounds the elements of a tensor "
         "in the range of [-threshold, +threshold] and is applied to the input "
         "of activations. No clip if not specified.",
         AttributeProto::FLOAT,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Input(
         0,
         "X",
         "The input sequences packed (and potentially padded) into one 3-D "
         "tensor with the shape of `[seq_length, batch_size, input_size]`.",
-        "T");
+        "T"
+    );
     schema.Input(
         4,
         "sequence_lens",
@@ -53,14 +59,16 @@ std::function<void(OpSchema&)> RNNDocGeneratorOld(const char* /*name*/) {
         "If not specified - assumed all sequences in the batch to have "
         "length `seq_length`. It has shape `[batch_size]`.",
         "T1",
-        OpSchema::Optional);
+        OpSchema::Optional
+    );
     schema.Input(
         5,
         "initial_h",
         "Optional initial value of the hidden. If not specified - assumed "
         "to be 0. It has shape `[num_directions, batch_size, hidden_size]`.",
         "T",
-        OpSchema::Optional);
+        OpSchema::Optional
+    );
     schema.Output(
         0,
         "Y",
@@ -68,17 +76,20 @@ std::function<void(OpSchema&)> RNNDocGeneratorOld(const char* /*name*/) {
         "It has shape `[seq_length, num_directions, batch_size, hidden_size]`. "
         "It is optional if `output_sequence` is 0.",
         "T",
-        OpSchema::Optional);
+        OpSchema::Optional
+    );
     schema.Output(
         1,
         "Y_h",
         "The last output value of the hidden. It has shape "
         "`[num_directions, batch_size, hidden_size]`.",
-        "T");
+        "T"
+    );
     schema.TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."
+    );
     schema.TypeConstraint("T1", {"tensor(int32)"}, "Constrain seq_lens to integer tensor.");
   };
 }
@@ -170,21 +181,24 @@ ONNX_OPERATOR_SET_SCHEMA(
             "of the activation functions specified above. Optional: See the equations "
             "for default if not specified.",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Input(
             1,
             "W",
             "The weight tensor for the gates. Concatenation of `W[zrh]` and `WB[zrh]` "
             "(if bidirectional) along dimension 0. This tensor has shape "
             "`[num_directions, 3*hidden_size, input_size]`.",
-            "T")
+            "T"
+        )
         .Input(
             2,
             "R",
             "The recurrence weight tensor. Concatenation of `R[zrh]` and `RB[zrh]` "
             "(if bidirectional) along dimension 0. This tensor has shape "
             "`[num_directions, 3*hidden_size, hidden_size]`.",
-            "T")
+            "T"
+        )
         .Input(
             3,
             "B",
@@ -193,8 +207,10 @@ ONNX_OPERATOR_SET_SCHEMA(
             "has shape `[num_directions, 6*hidden_size]`. Optional: If not specified "
             "- assumed to be 0",
             "T",
-            OpSchema::Optional)
-        .FillUsing(RNNDocGeneratorOld("GRU")));
+            OpSchema::Optional
+        )
+        .FillUsing(RNNDocGeneratorOld("GRU"))
+);
 
 // Versions 1 to 6 of RNN/LSTM and versions 3 to 6 of GRU:
 
@@ -224,7 +240,7 @@ void RNNShapeInference1(InferenceContext& ctx) {
   auto num_outputs = ctx.getNumOutputs();
 
   if (num_outputs == 0)
-    return; // Unlikely, but seems legal.
+    return;  // Unlikely, but seems legal.
 
   propagateElemTypeFromInputToOutput(ctx, 0, 0);
   if (num_outputs > 1)
@@ -234,11 +250,11 @@ void RNNShapeInference1(InferenceContext& ctx) {
 
   if (output_sequence) {
     // No ambiguity in spec
-    updateOutputShape(ctx, 0, {seq_length, num_directions, batch_size, hidden_size}); // Y
+    updateOutputShape(ctx, 0, {seq_length, num_directions, batch_size, hidden_size});  // Y
     if (num_outputs > 1)
-      updateOutputShape(ctx, 1, {num_directions, batch_size, hidden_size}); // Y_h
+      updateOutputShape(ctx, 1, {num_directions, batch_size, hidden_size});  // Y_h
     if (num_outputs > 2)
-      updateOutputShape(ctx, 2, {num_directions, batch_size, hidden_size}); // Y_c
+      updateOutputShape(ctx, 2, {num_directions, batch_size, hidden_size});  // Y_c
   } else {
     // Documentation suggests that the output Y is absent in this case
     // Different tests seem to disagree on whether Y_h and Y_c, if present,
@@ -256,7 +272,8 @@ std::function<void(OpSchema&)> RNNDocGenerator1(const char* /*name*/) {
         "Specify if the RNN is forward, reverse, or bidirectional. "
         "Must be one of forward (default), reverse, or bidirectional.",
         AttributeProto::STRING,
-        std::string("forward"));
+        std::string("forward")
+    );
     schema.Attr("hidden_size", "Number of neurons in the hidden layer", AttributeProto::INT, OPTIONAL_VALUE);
     schema.Attr(
         "activation_alpha",
@@ -265,32 +282,37 @@ std::function<void(OpSchema&)> RNNDocGenerator1(const char* /*name*/) {
         "in LSTM. Default values are the same as of corresponding ONNX operators."
         "For example with LeakyRelu, the default alpha is 0.01.",
         AttributeProto::FLOATS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr(
         "activation_beta",
         "Optional scaling values used by some activation functions. The values "
         "are consumed in the order of activation functions, for example (f, g, h) "
         "in LSTM. Default values are the same as of corresponding ONNX operators.",
         AttributeProto::FLOATS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr(
         "output_sequence",
         "The sequence output for the hidden is optional if 0. Default 0.",
         AttributeProto::INT,
-        static_cast<int64_t>(0));
+        static_cast<int64_t>(0)
+    );
     schema.Attr(
         "clip",
         "Cell clip threshold. Clipping bounds the elements of a tensor "
         "in the range of [-threshold, +threshold] and is applied to the input "
         "of activations. No clip if not specified.",
         AttributeProto::FLOAT,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Input(
         0,
         "X",
         "The input sequences packed (and potentially padded) into one 3-D "
         "tensor with the shape of `[seq_length, batch_size, input_size]`.",
-        "T");
+        "T"
+    );
     schema.Input(
         4,
         "sequence_lens",
@@ -298,14 +320,16 @@ std::function<void(OpSchema&)> RNNDocGenerator1(const char* /*name*/) {
         "If not specified - assumed all sequences in the batch to have "
         "length `seq_length`. It has shape `[batch_size]`.",
         "T1",
-        OpSchema::Optional);
+        OpSchema::Optional
+    );
     schema.Input(
         5,
         "initial_h",
         "Optional initial value of the hidden. If not specified - assumed "
         "to be 0. It has shape `[num_directions, batch_size, hidden_size]`.",
         "T",
-        OpSchema::Optional);
+        OpSchema::Optional
+    );
     schema.Output(
         0,
         "Y",
@@ -313,18 +337,21 @@ std::function<void(OpSchema&)> RNNDocGenerator1(const char* /*name*/) {
         "It has shape `[seq_length, num_directions, batch_size, hidden_size]`. "
         "It is optional if `output_sequence` is 0.",
         "T",
-        OpSchema::Optional);
+        OpSchema::Optional
+    );
     schema.Output(
         1,
         "Y_h",
         "The last output value of the hidden. It has shape "
         "`[num_directions, batch_size, hidden_size]`.",
         "T",
-        OpSchema::Optional);
+        OpSchema::Optional
+    );
     schema.TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."
+    );
     schema.TypeConstraint("T1", {"tensor(int32)"}, "Constrain seq_lens to integer tensor.");
     schema.TypeAndShapeInferenceFunction(RNNShapeInference1);
   };
@@ -404,21 +431,24 @@ ONNX_OPERATOR_SET_SCHEMA(
             "input gate. The activation function must be one of the activation "
             "functions specified above. Optional: Default `Tanh` if not specified.",
             AttributeProto::STRINGS,
-            std::vector<std::string>{"Tanh", "Tanh"})
+            std::vector<std::string>{"Tanh", "Tanh"}
+        )
         .Input(
             1,
             "W",
             "The weight tensor for input gate. Concatenation of `Wi` and `WBi` "
             "(if bidirectional). The tensor has shape "
             "`[num_directions, hidden_size, input_size]`.",
-            "T")
+            "T"
+        )
         .Input(
             2,
             "R",
             "The recurrence weight tensor. Concatenation of `Ri` and `RBi` "
             "(if bidirectional). The tensor has shape "
             "`[num_directions, hidden_size, hidden_size]`.",
-            "T")
+            "T"
+        )
         .Input(
             3,
             "B",
@@ -427,8 +457,10 @@ ONNX_OPERATOR_SET_SCHEMA(
             "`[num_directions, 2*hidden_size]`. Optional: If not specified - assumed "
             "to be 0.",
             "T",
-            OpSchema::Optional)
-        .FillUsing(RNNDocGenerator1("RNN")));
+            OpSchema::Optional
+        )
+        .FillUsing(RNNDocGenerator1("RNN"))
+);
 
 static const char* GRU_ver3_doc = R"DOC(
 Computes an one-layer GRU. This operator is usually supported via some custom
@@ -517,28 +549,32 @@ ONNX_OPERATOR_SET_SCHEMA(
             "of the activation functions specified above. Optional: See the equations "
             "for default if not specified.",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "linear_before_reset",
             "When computing the output of the hidden gate, "
             "apply the linear transformation before multiplying by the output of the "
             "reset gate.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(
             1,
             "W",
             "The weight tensor for the gates. Concatenation of `W[zrh]` and `WB[zrh]` "
             "(if bidirectional) along dimension 0. This tensor has shape "
             "`[num_directions, 3*hidden_size, input_size]`.",
-            "T")
+            "T"
+        )
         .Input(
             2,
             "R",
             "The recurrence weight tensor. Concatenation of `R[zrh]` and `RB[zrh]` "
             "(if bidirectional) along dimension 0. This tensor has shape "
             "`[num_directions, 3*hidden_size, hidden_size]`.",
-            "T")
+            "T"
+        )
         .Input(
             3,
             "B",
@@ -547,8 +583,10 @@ ONNX_OPERATOR_SET_SCHEMA(
             "has shape `[num_directions, 6*hidden_size]`. Optional: If not specified "
             "- assumed to be 0",
             "T",
-            OpSchema::Optional)
-        .FillUsing(RNNDocGenerator1("GRU")));
+            OpSchema::Optional
+        )
+        .FillUsing(RNNDocGenerator1("GRU"))
+);
 
 static const char* LSTM_ver1_doc = R"DOC(
 Computes an one-layer LSTM. This operator is usually supported via some
@@ -645,26 +683,30 @@ ONNX_OPERATOR_SET_SCHEMA(
             "be one of the activation functions specified above. Optional: See the equations "
             "for default if not specified.",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "input_forget",
             "Couple the input and forget gates if 1, default 0.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(
             1,
             "W",
             "The weight tensor for the gates. Concatenation of `W[iofc]` and "
             "`WB[iofc]` (if bidirectional) along dimension 0. The tensor has shape "
             "`[num_directions, 4*hidden_size, input_size]`.",
-            "T")
+            "T"
+        )
         .Input(
             2,
             "R",
             "The recurrence weight tensor. Concatenation of `R[iofc]` and "
             "`RB[iofc]` (if bidirectional) along dimension 0. This tensor has shape "
             "`[num_directions, 4*hidden_size, hidden_size]`.",
-            "T")
+            "T"
+        )
         .Input(
             3,
             "B",
@@ -673,14 +715,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "tensor has shape `[num_directions, 8*hidden_size]`. Optional: If not "
             "specified - assumed to be 0.",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Input(
             6,
             "initial_c",
             "Optional initial value of the cell. If not specified - assumed "
             "to be 0. It has shape `[num_directions, batch_size, hidden_size]`.",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Input(
             7,
             "P",
@@ -689,7 +733,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "`[num_directions, 3*hidde_size]`. Optional: If not specified - "
             "assumed to be 0.",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .FillUsing(RNNDocGenerator1("LSTM"))
         .Output(
             2,
@@ -697,9 +742,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The last output value of the cell. It has shape "
             "`[num_directions, batch_size, hidden_size]`.",
             "T",
-            OpSchema::Optional));
+            OpSchema::Optional
+        )
+);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE
 
 // Versions 7 to 13 of RNN/LSTM/GRU
 
@@ -755,7 +802,8 @@ std::function<void(OpSchema&)> RNNDocGenerator2(const char* /*name*/) {
         "Specify if the RNN is forward, reverse, or bidirectional. "
         "Must be one of forward (default), reverse, or bidirectional.",
         AttributeProto::STRING,
-        std::string("forward"));
+        std::string("forward")
+    );
     schema.Attr("hidden_size", "Number of neurons in the hidden layer", AttributeProto::INT, OPTIONAL_VALUE);
     schema.Attr(
         "activation_alpha",
@@ -764,27 +812,31 @@ std::function<void(OpSchema&)> RNNDocGenerator2(const char* /*name*/) {
         "in LSTM. Default values are the same as of corresponding ONNX operators."
         "For example with LeakyRelu, the default alpha is 0.01.",
         AttributeProto::FLOATS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr(
         "activation_beta",
         "Optional scaling values used by some activation functions. The values "
         "are consumed in the order of activation functions, for example (f, g, h) "
         "in LSTM. Default values are the same as of corresponding ONNX operators.",
         AttributeProto::FLOATS,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Attr(
         "clip",
         "Cell clip threshold. Clipping bounds the elements of a tensor "
         "in the range of [-threshold, +threshold] and is applied to the input "
         "of activations. No clip if not specified.",
         AttributeProto::FLOAT,
-        OPTIONAL_VALUE);
+        OPTIONAL_VALUE
+    );
     schema.Input(
         0,
         "X",
         "The input sequences packed (and potentially padded) into one 3-D "
         "tensor with the shape of `[seq_length, batch_size, input_size]`.",
-        "T");
+        "T"
+    );
     schema.Input(
         4,
         "sequence_lens",
@@ -792,32 +844,37 @@ std::function<void(OpSchema&)> RNNDocGenerator2(const char* /*name*/) {
         "If not specified - assumed all sequences in the batch to have "
         "length `seq_length`. It has shape `[batch_size]`.",
         "T1",
-        OpSchema::Optional);
+        OpSchema::Optional
+    );
     schema.Input(
         5,
         "initial_h",
         "Optional initial value of the hidden. If not specified - assumed "
         "to be 0. It has shape `[num_directions, batch_size, hidden_size]`.",
         "T",
-        OpSchema::Optional);
+        OpSchema::Optional
+    );
     schema.Output(
         0,
         "Y",
         "A tensor that concats all the intermediate output values of the hidden. "
         "It has shape `[seq_length, num_directions, batch_size, hidden_size]`. ",
         "T",
-        OpSchema::Optional);
+        OpSchema::Optional
+    );
     schema.Output(
         1,
         "Y_h",
         "The last output value of the hidden. It has shape "
         "`[num_directions, batch_size, hidden_size]`.",
         "T",
-        OpSchema::Optional);
+        OpSchema::Optional
+    );
     schema.TypeConstraint(
         "T",
         {"tensor(float16)", "tensor(float)", "tensor(double)"},
-        "Constrain input and output types to float tensors.");
+        "Constrain input and output types to float tensors."
+    );
     schema.TypeConstraint("T1", {"tensor(int32)"}, "Constrain seq_lens to integer tensor.");
     schema.TypeAndShapeInferenceFunction(RNNShapeInference2);
   };
@@ -897,21 +954,24 @@ ONNX_OPERATOR_SET_SCHEMA(
             "input gate. The activation function must be one of the activation "
             "functions specified above. Optional: Default `Tanh` if not specified.",
             AttributeProto::STRINGS,
-            std::vector<std::string>{"Tanh", "Tanh"})
+            std::vector<std::string>{"Tanh", "Tanh"}
+        )
         .Input(
             1,
             "W",
             "The weight tensor for input gate. Concatenation of `Wi` and `WBi` "
             "(if bidirectional). The tensor has shape "
             "`[num_directions, hidden_size, input_size]`.",
-            "T")
+            "T"
+        )
         .Input(
             2,
             "R",
             "The recurrence weight tensor. Concatenation of `Ri` and `RBi` "
             "(if bidirectional). The tensor has shape "
             "`[num_directions, hidden_size, hidden_size]`.",
-            "T")
+            "T"
+        )
         .Input(
             3,
             "B",
@@ -920,8 +980,10 @@ ONNX_OPERATOR_SET_SCHEMA(
             "`[num_directions, 2*hidden_size]`. Optional: If not specified - assumed "
             "to be 0.",
             "T",
-            OpSchema::Optional)
-        .FillUsing(RNNDocGenerator2("RNN")));
+            OpSchema::Optional
+        )
+        .FillUsing(RNNDocGenerator2("RNN"))
+);
 
 static const char* GRU_ver7_doc = R"DOC(
 Computes an one-layer GRU. This operator is usually supported via some custom
@@ -1010,28 +1072,32 @@ ONNX_OPERATOR_SET_SCHEMA(
             "of the activation functions specified above. Optional: See the equations "
             "for default if not specified.",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "linear_before_reset",
             "When computing the output of the hidden gate, "
             "apply the linear transformation before multiplying by the output of the "
             "reset gate.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(
             1,
             "W",
             "The weight tensor for the gates. Concatenation of `W[zrh]` and `WB[zrh]` "
             "(if bidirectional) along dimension 0. This tensor has shape "
             "`[num_directions, 3*hidden_size, input_size]`.",
-            "T")
+            "T"
+        )
         .Input(
             2,
             "R",
             "The recurrence weight tensor. Concatenation of `R[zrh]` and `RB[zrh]` "
             "(if bidirectional) along dimension 0. This tensor has shape "
             "`[num_directions, 3*hidden_size, hidden_size]`.",
-            "T")
+            "T"
+        )
         .Input(
             3,
             "B",
@@ -1040,8 +1106,10 @@ ONNX_OPERATOR_SET_SCHEMA(
             "has shape `[num_directions, 6*hidden_size]`. Optional: If not specified "
             "- assumed to be 0",
             "T",
-            OpSchema::Optional)
-        .FillUsing(RNNDocGenerator2("GRU")));
+            OpSchema::Optional
+        )
+        .FillUsing(RNNDocGenerator2("GRU"))
+);
 
 static const char* LSTM_ver7_doc = R"DOC(
 Computes an one-layer LSTM. This operator is usually supported via some
@@ -1138,7 +1206,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "be one of the activation functions specified above. Optional: See the equations "
             "for default if not specified.",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr("input_forget", "Couple the input and forget gates if 1.", AttributeProto::INT, static_cast<int64_t>(0))
         .Input(
             1,
@@ -1146,14 +1215,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The weight tensor for the gates. Concatenation of `W[iofc]` and "
             "`WB[iofc]` (if bidirectional) along dimension 0. The tensor has shape "
             "`[num_directions, 4*hidden_size, input_size]`.",
-            "T")
+            "T"
+        )
         .Input(
             2,
             "R",
             "The recurrence weight tensor. Concatenation of `R[iofc]` and "
             "`RB[iofc]` (if bidirectional) along dimension 0. This tensor has shape "
             "`[num_directions, 4*hidden_size, hidden_size]`.",
-            "T")
+            "T"
+        )
         .Input(
             3,
             "B",
@@ -1162,14 +1233,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "tensor has shape `[num_directions, 8*hidden_size]`. Optional: If not "
             "specified - assumed to be 0.",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Input(
             6,
             "initial_c",
             "Optional initial value of the cell. If not specified - assumed "
             "to be 0. It has shape `[num_directions, batch_size, hidden_size]`.",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Input(
             7,
             "P",
@@ -1178,7 +1251,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "`[num_directions, 3*hidde_size]`. Optional: If not specified - "
             "assumed to be 0.",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .FillUsing(RNNDocGenerator2("LSTM"))
         .Output(
             2,
@@ -1186,5 +1260,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The last output value of the cell. It has shape "
             "`[num_directions, batch_size, hidden_size]`.",
             "T",
-            OpSchema::Optional));
-} // namespace ONNX_NAMESPACE
+            OpSchema::Optional
+        )
+);
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -99,7 +99,8 @@ void OpSchema::CheckInputOutputType(struct InferenceContext& ctx) const {
           " typestr: ",
           type_str,
           ", has unsupported type: ",
-          *Utils::DataTypeUtils::ToType(*param_type));
+          *Utils::DataTypeUtils::ToType(*param_type)
+      );
     }
     if (param.GetIsHomogeneous()) {
       const auto& type_proto = Utils::DataTypeUtils::ToType(*param_type);
@@ -111,7 +112,7 @@ void OpSchema::CheckInputOutputType(struct InferenceContext& ctx) const {
         }
       }
     }
-  } // for inputs
+  }  // for inputs
   // check all output types
   for (size_t out_idx = 0; out_idx < ctx.getNumOutputs(); ++out_idx) {
     // If the last output is Variadic by definition, checker still needs to check the rest of actual output's type
@@ -144,8 +145,8 @@ void OpSchema::CheckInputOutputType(struct InferenceContext& ctx) const {
       } else if (type_constraints[type_str] != *type_proto) {
         fail_check(param.GetName(), " has inconsistent type ", *Utils::DataTypeUtils::ToType(*param_type));
       }
-    } // else
-  } // for outputs
+    }  // else
+  }  // for outputs
 }
 
 void OpSchema::Verify(const NodeProto& node) const {
@@ -164,7 +165,8 @@ void OpSchema::Verify(const NodeProto& node) const {
         min_input_,
         ", max=",
         max_input_,
-        "].");
+        "]."
+    );
   }
 
   if (!num_inputs_allowed_(node.input_size())) {
@@ -182,7 +184,8 @@ void OpSchema::Verify(const NodeProto& node) const {
         min_output_,
         ", max=",
         max_output_,
-        "].");
+        "]."
+    );
   }
 
   if (!num_outputs_allowed_(node.output_size())) {
@@ -203,7 +206,8 @@ void OpSchema::Verify(const NodeProto& node) const {
             node.input_size(),
             ") than declared (",
             inputs_.size(),
-            ") in op definition.");
+            ") in op definition."
+        );
       }
     }
     if (node.input(in_idx).empty() && (Single == inputs_[in_idx].GetOption())) {
@@ -224,13 +228,15 @@ void OpSchema::Verify(const NodeProto& node) const {
             node.output_size(),
             ") than declared (",
             outputs_.size(),
-            ") in op definition.");
+            ") in op definition."
+        );
       }
     }
 
     if (node.output(out_idx).empty() && (Single == outputs_[out_idx].GetOption())) {
       fail_check(
-          "Node (", node.name(), ")'s output ", out_idx, " is marked single but has an empty string in the graph");
+          "Node (", node.name(), ")'s output ", out_idx, " is marked single but has an empty string in the graph"
+      );
     }
   }
 
@@ -428,7 +434,7 @@ OpSchema& OpSchema::SetDomain(const char* domain) {
 }
 
 OpSchema& OpSchema::Attr(Attribute attr) {
-  auto name = attr.name; // copy name so we can move attr in the next line
+  auto name = attr.name;  // copy name so we can move attr in the next line
   attributes_.insert(std::make_pair(std::move(name), std::move(attr)));
   return *this;
 }
@@ -439,10 +445,8 @@ OpSchema& OpSchema::Attr(std::string name, std::string description, AttributePro
 }
 
 OpSchema& OpSchema::Attr(
-    std::string name,
-    std::string description,
-    std::string conditionExplanation,
-    AttributeProto::AttributeType attr_type) {
+    std::string name, std::string description, std::string conditionExplanation, AttributeProto::AttributeType attr_type
+) {
   AttributeProto a;
   a.set_name(name);
   a.set_type(attr_type);
@@ -457,22 +461,24 @@ OpSchema& OpSchema::Attr(const char* name, const char* description, AttributePro
   return Attr(std::string(name), std::string(description), type, required);
 }
 
-#define ATTR_SETTER_WITH_SINGLE_VALUE(type, field, attrtype)                                                           \
-  OpSchema& OpSchema::Attr(                                                                                            \
-      std::string name, std::string description, AttributeProto::AttributeType attr_type, const type& default_value) { \
-    if (attrtype != attr_type) {                                                                                       \
-      fail_schema("Attribute specification type mismatch.");                                                           \
-    }                                                                                                                  \
-    AttributeProto a;                                                                                                  \
-    a.set_name(name);                                                                                                  \
-    a.set_##field(default_value);                                                                                      \
-    a.set_type(attr_type);                                                                                             \
-    Attr(Attribute(std::move(name), std::move(description), std::move(a)));                                            \
-    return *this;                                                                                                      \
-  }                                                                                                                    \
-  OpSchema& OpSchema::Attr(                                                                                            \
-      const char* name, const char* description, AttributeProto::AttributeType attr_type, const type& default_value) { \
-    return Attr(std::string(name), std::string(description), attr_type, default_value);                                \
+#define ATTR_SETTER_WITH_SINGLE_VALUE(type, field, attrtype)                                                        \
+  OpSchema& OpSchema::Attr(                                                                                         \
+      std::string name, std::string description, AttributeProto::AttributeType attr_type, const type& default_value \
+  ) {                                                                                                               \
+    if (attrtype != attr_type) {                                                                                    \
+      fail_schema("Attribute specification type mismatch.");                                                        \
+    }                                                                                                               \
+    AttributeProto a;                                                                                               \
+    a.set_name(name);                                                                                               \
+    a.set_##field(default_value);                                                                                   \
+    a.set_type(attr_type);                                                                                          \
+    Attr(Attribute(std::move(name), std::move(description), std::move(a)));                                         \
+    return *this;                                                                                                   \
+  }                                                                                                                 \
+  OpSchema& OpSchema::Attr(                                                                                         \
+      const char* name, const char* description, AttributeProto::AttributeType attr_type, const type& default_value \
+  ) {                                                                                                               \
+    return Attr(std::string(name), std::string(description), attr_type, default_value);                             \
   }
 
 #define ATTR_SETTER_WITH_LIST_VALUE(type, field, attrtype)                  \
@@ -480,7 +486,8 @@ OpSchema& OpSchema::Attr(const char* name, const char* description, AttributePro
       std::string name,                                                     \
       std::string description,                                              \
       AttributeProto::AttributeType attr_type,                              \
-      const std::vector<type>& default_value) {                             \
+      const std::vector<type>& default_value                                \
+  ) {                                                                       \
     if (attrtype != attr_type) {                                            \
       fail_schema("Attribute specification type mismatch.");                \
     }                                                                       \
@@ -494,18 +501,19 @@ OpSchema& OpSchema::Attr(const char* name, const char* description, AttributePro
     return *this;                                                           \
   }
 
-#define ATTR_SETTER_WITH_SINGLE_COMPLEXVALUE(type, field, attrtype)                                                    \
-  OpSchema& OpSchema::Attr(                                                                                            \
-      std::string name, std::string description, AttributeProto::AttributeType attr_type, const type& default_value) { \
-    if (attrtype != attr_type) {                                                                                       \
-      fail_schema("Attribute specification type mismatch.");                                                           \
-    }                                                                                                                  \
-    AttributeProto a;                                                                                                  \
-    a.set_name(name);                                                                                                  \
-    *(a.mutable_##field()) = default_value;                                                                            \
-    a.set_type(attr_type);                                                                                             \
-    Attr(Attribute(std::move(name), std::move(description), a));                                                       \
-    return *this;                                                                                                      \
+#define ATTR_SETTER_WITH_SINGLE_COMPLEXVALUE(type, field, attrtype)                                                 \
+  OpSchema& OpSchema::Attr(                                                                                         \
+      std::string name, std::string description, AttributeProto::AttributeType attr_type, const type& default_value \
+  ) {                                                                                                               \
+    if (attrtype != attr_type) {                                                                                    \
+      fail_schema("Attribute specification type mismatch.");                                                        \
+    }                                                                                                               \
+    AttributeProto a;                                                                                               \
+    a.set_name(name);                                                                                               \
+    *(a.mutable_##field()) = default_value;                                                                         \
+    a.set_type(attr_type);                                                                                          \
+    Attr(Attribute(std::move(name), std::move(description), a));                                                    \
+    return *this;                                                                                                   \
   }
 
 #define ATTR_SETTER_WITH_LIST_COMPLEXVALUE(type, field, attrtype)           \
@@ -513,7 +521,8 @@ OpSchema& OpSchema::Attr(const char* name, const char* description, AttributePro
       std::string name,                                                     \
       std::string description,                                              \
       AttributeProto::AttributeType attr_type,                              \
-      const std::vector<type>& default_value) {                             \
+      const std::vector<type>& default_value                                \
+  ) {                                                                       \
     if (attrtype != attr_type) {                                            \
       fail_schema("Attribute specification type mismatch.");                \
     }                                                                       \
@@ -561,7 +570,8 @@ OpSchema& OpSchema::Input(
     OpSchema::FormalParameterOption param_option,
     bool is_homogeneous,
     int min_arity,
-    DifferentiationCategory differentiation_category) {
+    DifferentiationCategory differentiation_category
+) {
   return Input(
       n,
       FormalParameter(
@@ -575,7 +585,9 @@ OpSchema& OpSchema::Input(
           param_option,
           is_homogeneous,
           min_arity,
-          differentiation_category));
+          differentiation_category
+      )
+  );
 }
 
 OpSchema& OpSchema::Input(
@@ -586,7 +598,8 @@ OpSchema& OpSchema::Input(
     FormalParameterOption param_option,
     bool is_homogeneous,
     int min_arity,
-    DifferentiationCategory differentiation_category) {
+    DifferentiationCategory differentiation_category
+) {
   return Input(
       n,
       std::string(name),
@@ -599,7 +612,8 @@ OpSchema& OpSchema::Input(
       param_option,
       is_homogeneous,
       min_arity,
-      differentiation_category);
+      differentiation_category
+  );
 }
 
 OpSchema& OpSchema::Output(int n, FormalParameter formal_parameter) {
@@ -618,7 +632,8 @@ OpSchema& OpSchema::Output(
     OpSchema::FormalParameterOption param_option,
     bool is_homogeneous,
     int min_arity,
-    DifferentiationCategory differentiation_category) {
+    DifferentiationCategory differentiation_category
+) {
   return Output(
       n,
       FormalParameter(
@@ -632,7 +647,9 @@ OpSchema& OpSchema::Output(
           param_option,
           is_homogeneous,
           min_arity,
-          differentiation_category));
+          differentiation_category
+      )
+  );
 }
 
 OpSchema& OpSchema::Output(
@@ -643,7 +660,8 @@ OpSchema& OpSchema::Output(
     FormalParameterOption param_option,
     bool is_homogeneous,
     int min_arity,
-    DifferentiationCategory differentiation_category) {
+    DifferentiationCategory differentiation_category
+) {
   return Output(
       n,
       std::string(name),
@@ -656,11 +674,13 @@ OpSchema& OpSchema::Output(
       param_option,
       is_homogeneous,
       min_arity,
-      differentiation_category);
+      differentiation_category
+  );
 }
 
-OpSchema&
-OpSchema::TypeConstraint(std::string type_str, std::vector<std::string> constraints, std::string description) {
+OpSchema& OpSchema::TypeConstraint(
+    std::string type_str, std::vector<std::string> constraints, std::string description
+) {
   if (type_constraints_.end() != type_constraints_.find(type_str)) {
     fail_schema("Duplicate type constraint name");
   }
@@ -671,14 +691,14 @@ OpSchema::TypeConstraint(std::string type_str, std::vector<std::string> constrai
   }
   type_constraints_.insert(std::make_pair(type_str, std::make_pair(d, description)));
   type_constraint_params_.push_back(
-      TypeConstraintParam(std::move(type_str), std::move(constraints), std::move(description)));
+      TypeConstraintParam(std::move(type_str), std::move(constraints), std::move(description))
+  );
   return *this;
 }
 
 OpSchema& OpSchema::TypeConstraint(
-    const char* type_str,
-    std::initializer_list<const char*> constraints,
-    const char* description) {
+    const char* type_str, std::initializer_list<const char*> constraints, const char* description
+) {
   std::vector<std::string> constraints_vector;
   constraints_vector.reserve(constraints.size());
   for (auto iter = constraints.begin(); iter != constraints.end(); ++iter) {
@@ -689,7 +709,8 @@ OpSchema& OpSchema::TypeConstraint(
 }
 
 void OpSchema::ParseAndSetTypes(
-    /*out*/ std::vector<OpSchema::FormalParameter>* formal_parameters) {
+    /*out*/ std::vector<OpSchema::FormalParameter>* formal_parameters
+) {
   for (auto& formal_parameter : *formal_parameters) {
     auto& type = formal_parameter.GetTypeStr();
     DataTypeSet allowed_types;
@@ -705,8 +726,8 @@ void OpSchema::ParseAndSetTypes(
 }
 
 OpSchema& OpSchema::SetContextDependentFunctionBodyBuilder(
-    ContextDependentFunctionBodyBuilder functionBuilder,
-    int opset_version) {
+    ContextDependentFunctionBodyBuilder functionBuilder, int opset_version
+) {
   if (opset_version == OpSchema::kUninitializedSinceVersion && since_version_ != OpSchema::kUninitializedSinceVersion) {
     opset_version_to_function_builder_[since_version_] = std::move(functionBuilder);
   } else {
@@ -716,9 +737,8 @@ OpSchema& OpSchema::SetContextDependentFunctionBodyBuilder(
 }
 
 bool OpSchema::BuildContextDependentFunction(
-    const FunctionBodyBuildContext& ctx,
-    FunctionProto& function_proto,
-    int requested_opset_version) const {
+    const FunctionBodyBuildContext& ctx, FunctionProto& function_proto, int requested_opset_version
+) const {
   if (requested_opset_version == OpSchema::kUninitializedSinceVersion)
     requested_opset_version = since_version_;
 
@@ -727,7 +747,8 @@ bool OpSchema::BuildContextDependentFunction(
   if (opset_version_to_function_builder_.empty() || it == opset_version_to_function_builder_.begin()) {
     ONNX_THROW_EX(std::out_of_range(
         std::string("Cannot find a function builder that satisfies the requested opset version: op_type = ") +
-        this->name_ + ", opset_version = " + std::to_string(requested_opset_version) + "."));
+        this->name_ + ", opset_version = " + std::to_string(requested_opset_version) + "."
+    ));
   } else {
     --it;
     const ContextDependentFunctionBodyBuilder& body_builder = it->second;
@@ -804,9 +825,8 @@ OpSchema& OpSchema::FunctionBody(const std::vector<NodeProto>& func_nodes, int o
 }
 
 OpSchema& OpSchema::FunctionBody(
-    const std::vector<NodeProto>& func_nodes,
-    const std::vector<OperatorSetIdProto>& relied_opsets,
-    int opset_version) {
+    const std::vector<NodeProto>& func_nodes, const std::vector<OperatorSetIdProto>& relied_opsets, int opset_version
+) {
   if (opset_version == OpSchema::kUninitializedSinceVersion && since_version_ != OpSchema::kUninitializedSinceVersion) {
     opset_version = since_version_;
   }
@@ -857,7 +877,8 @@ bool OpSchema::ValidateReferencedOpsInFuncton(
     const FunctionProto* function,
     int requested_opset_version,
     int function_since_version,
-    std::set<std::string>* updated_ops) const {
+    std::set<std::string>* updated_ops
+) const {
   bool all_ops_are_invalid = true;
   if (requested_opset_version == function_since_version) {
     return all_ops_are_invalid;
@@ -1080,7 +1101,8 @@ OpName_Domain_Version_Schema_Map& OpSchemaRegistry::map() {
             "%u schema were exposed from operator sets and automatically placed into the static registry.  "
             "%u were expected based on calls to registration macros. Operator set functions may need to be updated.",
             dbg_registered_schema_count,
-            ONNX_DBG_GET_COUNT_IN_OPSETS());
+            ONNX_DBG_GET_COUNT_IN_OPSETS()
+        );
       }
 #endif
     }
@@ -1115,4 +1137,4 @@ size_t ReplaceAll(std::string& s, const char* from, const char* to) {
   return numReplaced;
 }
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -190,7 +190,8 @@ class OpSchema final {
         FormalParameterOption param_option = Single,
         bool is_homogeneous = true,
         int min_arity = 1,
-        DifferentiationCategory differentiation_category = Unknown)
+        DifferentiationCategory differentiation_category = Unknown
+    )
         : name_(std::move(name)),
           type_set_(std::move(allowed_type_set)),
           type_str_(std::move(type_str)),
@@ -213,7 +214,8 @@ class OpSchema final {
         FormalParameterOption param_option = Single,
         bool is_homogeneous = true,
         int min_arity = 1,
-        DifferentiationCategory differentiation_category = Unknown)
+        DifferentiationCategory differentiation_category = Unknown
+    )
         : name_(std::move(name)),
           type_str_(std::move(type_str)),
 #ifndef __ONNX_NO_DOC_STRINGS
@@ -289,9 +291,9 @@ class OpSchema final {
   };
 
   enum class SupportType : uint8_t {
-    COMMON, // Supported by all frameworks that support this IR.
-    EXPERIMENTAL, // This OP is experimental and can be changed or removed in
-                  // the future.
+    COMMON,  // Supported by all frameworks that support this IR.
+    EXPERIMENTAL,  // This OP is experimental and can be changed or removed in
+                   // the future.
   };
 
   OpSchema() : OpSchema("unknown", "unknown", 0) {}
@@ -351,7 +353,7 @@ class OpSchema final {
    * SinceVersion(3), and another, updated op schema entry for Foo
    * with SinceVersion(6).
    */
-  OpSchema& SinceVersion(OperatorSetVersion n); // aka int
+  OpSchema& SinceVersion(OperatorSetVersion n);  // aka int
 
   /**
    * Marks this op as deprecated as of it's since_version. This will cause the
@@ -450,17 +452,20 @@ class OpSchema final {
   OpSchema& Attr(Attribute attr);
 
 // Register "optional" attribute with default value.
-#define ATTR_SETTER_WITH_DEFAULT_VALUE(TypeName)                                                                    \
-  OpSchema& Attr(                                                                                                   \
-      std::string name, std::string description, AttributeProto::AttributeType type, const TypeName& defaultValue); \
-  /* non-STL wrapper to reduce binary size */                                                                       \
-  OpSchema& Attr(                                                                                                   \
-      const char* name, const char* description, AttributeProto::AttributeType type, const TypeName& defaultValue); \
-  OpSchema& Attr(                                                                                                   \
-      std::string name,                                                                                             \
-      std::string description,                                                                                      \
-      AttributeProto::AttributeType type,                                                                           \
-      const std::vector<TypeName>& defaultValue);
+#define ATTR_SETTER_WITH_DEFAULT_VALUE(TypeName)                                                                  \
+  OpSchema& Attr(                                                                                                 \
+      std::string name, std::string description, AttributeProto::AttributeType type, const TypeName& defaultValue \
+  );                                                                                                              \
+  /* non-STL wrapper to reduce binary size */                                                                     \
+  OpSchema& Attr(                                                                                                 \
+      const char* name, const char* description, AttributeProto::AttributeType type, const TypeName& defaultValue \
+  );                                                                                                              \
+  OpSchema& Attr(                                                                                                 \
+      std::string name,                                                                                           \
+      std::string description,                                                                                    \
+      AttributeProto::AttributeType type,                                                                         \
+      const std::vector<TypeName>& defaultValue                                                                   \
+  );
 
   ATTR_SETTER_WITH_DEFAULT_VALUE(int64_t)
   ATTR_SETTER_WITH_DEFAULT_VALUE(float)
@@ -473,7 +478,8 @@ class OpSchema final {
       std::string name,
       std::string description,
       std::string conditionExplanation,
-      AttributeProto::AttributeType attr_type);
+      AttributeProto::AttributeType attr_type
+  );
 
   // Register "required" attribute without default value.
   OpSchema& Attr(std::string name, std::string description, AttributeProto::AttributeType type, bool required = true);
@@ -486,9 +492,8 @@ class OpSchema final {
   // Type constraint.
   struct TypeConstraintParam final {
     TypeConstraintParam(
-        std::string type_param_str_,
-        std::vector<std::string> allowed_type_strs_,
-        std::string description_)
+        std::string type_param_str_, std::vector<std::string> allowed_type_strs_, std::string description_
+    )
         : type_param_str(std::move(type_param_str_)),
           allowed_type_strs(std::move(allowed_type_strs_)),
           description(std::move(description_)) {}
@@ -538,7 +543,8 @@ class OpSchema final {
       FormalParameterOption param_option = Single,
       bool is_homogeneous = true,
       int min_arity = 1,
-      DifferentiationCategory differentiation_category = Unknown);
+      DifferentiationCategory differentiation_category = Unknown
+  );
 
   // Non-STL wrapper to reduce binary size
   OpSchema& Input(
@@ -549,7 +555,8 @@ class OpSchema final {
       FormalParameterOption param_option = Single,
       bool is_homogeneous = true,
       int min_arity = 1,
-      DifferentiationCategory differentiation_category = Unknown);
+      DifferentiationCategory differentiation_category = Unknown
+  );
 
   OpSchema& Output(int n, FormalParameter formal_parameter);
 
@@ -561,7 +568,8 @@ class OpSchema final {
       FormalParameterOption param_option = Single,
       bool is_homogeneous = true,
       int min_arity = 1,
-      DifferentiationCategory differentiation_category = Unknown);
+      DifferentiationCategory differentiation_category = Unknown
+  );
 
   // Non-STL wrapper to reduce binary size
   OpSchema& Output(
@@ -572,13 +580,15 @@ class OpSchema final {
       FormalParameterOption param_option = Single,
       bool is_homogeneous = true,
       int min_arity = 1,
-      DifferentiationCategory differentiation_category = Unknown);
+      DifferentiationCategory differentiation_category = Unknown
+  );
 
   OpSchema& TypeConstraint(std::string type_str, std::vector<std::string> constraints, std::string description);
 
   // Non-STL wrapper to reduce binary size
-  OpSchema&
-  TypeConstraint(const char* type_str, std::initializer_list<const char*> constraints, const char* description);
+  OpSchema& TypeConstraint(
+      const char* type_str, std::initializer_list<const char*> constraints, const char* description
+  );
 
   // Convenience members for types
 
@@ -596,7 +606,8 @@ class OpSchema final {
         "tensor(float8e4m3fn)",
         "tensor(float8e4m3fnuz)",
         "tensor(float8e5m2)",
-        "tensor(float8e5m2fnuz)"};
+        "tensor(float8e5m2fnuz)"
+    };
     return numeric_types_for_math_reduction_ir9;
   }
 
@@ -609,7 +620,8 @@ class OpSchema final {
         "tensor(float16)",
         "tensor(float)",
         "tensor(double)",
-        "tensor(bfloat16)"};
+        "tensor(bfloat16)"
+    };
     return numeric_types_for_math_reduction_ir4;
   }
 
@@ -621,7 +633,8 @@ class OpSchema final {
         "tensor(int64)",
         "tensor(float16)",
         "tensor(float)",
-        "tensor(double)"};
+        "tensor(double)"
+    };
     return numeric_types_for_math_reduction;
   }
 
@@ -642,7 +655,8 @@ class OpSchema final {
         "tensor(float8e4m3fn)",
         "tensor(float8e4m3fnuz)",
         "tensor(float8e5m2)",
-        "tensor(float8e5m2fnuz)"};
+        "tensor(float8e5m2fnuz)"
+    };
     return all_numeric_types_ir9;
   }
 
@@ -659,7 +673,8 @@ class OpSchema final {
         "tensor(float16)",
         "tensor(float)",
         "tensor(double)",
-        "tensor(bfloat16)"};
+        "tensor(bfloat16)"
+    };
     return all_numeric_types_ir4;
   }
 
@@ -675,7 +690,8 @@ class OpSchema final {
         "tensor(int64)",
         "tensor(float16)",
         "tensor(float)",
-        "tensor(double)"};
+        "tensor(double)"
+    };
     return all_numeric_types;
   }
 
@@ -691,7 +707,8 @@ class OpSchema final {
         "seq(tensor(int64))",
         "seq(tensor(float16))",
         "seq(tensor(float))",
-        "seq(tensor(double))"};
+        "seq(tensor(double))"
+    };
     return all_numeric_sequence_types;
   }
 
@@ -711,7 +728,8 @@ class OpSchema final {
         "tensor(string)",
         "tensor(bool)",
         "tensor(complex64)",
-        "tensor(complex128)"};
+        "tensor(complex128)"
+    };
     return all_tensor_types;
   }
 
@@ -732,13 +750,15 @@ class OpSchema final {
         "tensor(string)",
         "tensor(bool)",
         "tensor(complex64)",
-        "tensor(complex128)"};
+        "tensor(complex128)"
+    };
     return all_tensor_types_ir4;
   }
 
   static const std::vector<std::string>& all_float_types_ir4() {
     static const std::vector<std::string> all_float_types_ir4 = {
-        "tensor(bfloat16)", "tensor(float16)", "tensor(float)", "tensor(double)"};
+        "tensor(bfloat16)", "tensor(float16)", "tensor(float)", "tensor(double)"
+    };
     return all_float_types_ir4;
   }
 
@@ -751,7 +771,8 @@ class OpSchema final {
         "tensor(float8e4m3fn)",
         "tensor(float8e4m3fnuz)",
         "tensor(float8e5m2)",
-        "tensor(float8e5m2fnuz)"};
+        "tensor(float8e5m2fnuz)"
+    };
     return all_float_types_ir9;
   }
 
@@ -761,7 +782,8 @@ class OpSchema final {
         "tensor(int8)",         "tensor(int16)",          "tensor(int32)",      "tensor(int64)",
         "tensor(bfloat16)",     "tensor(float16)",        "tensor(float)",      "tensor(double)",
         "tensor(string)",       "tensor(bool)",           "tensor(complex64)",  "tensor(complex128)",
-        "tensor(float8e4m3fn)", "tensor(float8e4m3fnuz)", "tensor(float8e5m2)", "tensor(float8e5m2fnuz)"};
+        "tensor(float8e4m3fn)", "tensor(float8e4m3fnuz)", "tensor(float8e5m2)", "tensor(float8e5m2fnuz)"
+    };
     return all_tensor_types_ir9;
   }
 
@@ -781,7 +803,8 @@ class OpSchema final {
         "seq(tensor(string))",
         "seq(tensor(bool))",
         "seq(tensor(complex64))",
-        "seq(tensor(complex128))"};
+        "seq(tensor(complex128))"
+    };
     return all_tensor_sequence_types;
   }
 
@@ -802,7 +825,8 @@ class OpSchema final {
         "seq(tensor(string))",
         "seq(tensor(bool))",
         "seq(tensor(complex64))",
-        "seq(tensor(complex128))"};
+        "seq(tensor(complex128))"
+    };
     return all_tensor_sequence_types_ir4;
   }
 
@@ -814,7 +838,8 @@ class OpSchema final {
         "seq(tensor(float16))",    "seq(tensor(float))",         "seq(tensor(double))",
         "seq(tensor(string))",     "seq(tensor(bool))",          "seq(tensor(complex64))",
         "seq(tensor(complex128))", "seq(tensor(float8e4m3fn))",  "seq(tensor(float8e4m3fnuz))",
-        "seq(tensor(float8e5m2))", "seq(tensor(float8e5m2fnuz))"};
+        "seq(tensor(float8e5m2))", "seq(tensor(float8e5m2fnuz))"
+    };
     return all_tensor_sequence_types_ir4;
   }
 
@@ -829,7 +854,8 @@ class OpSchema final {
         "optional(tensor(uint64))",      "optional(tensor(int8))",           "optional(tensor(int16))",
         "optional(tensor(int32))",       "optional(tensor(int64))",          "optional(tensor(float16))",
         "optional(tensor(float))",       "optional(tensor(double))",         "optional(tensor(string))",
-        "optional(tensor(bool))",        "optional(tensor(complex64))",      "optional(tensor(complex128))"};
+        "optional(tensor(bool))",        "optional(tensor(complex64))",      "optional(tensor(complex128))"
+    };
     return all_optional_types;
   }
 
@@ -845,7 +871,8 @@ class OpSchema final {
         "optional(tensor(int16))",           "optional(tensor(int32))",       "optional(tensor(int64))",
         "optional(tensor(bfloat16))",        "optional(tensor(float16))",     "optional(tensor(float))",
         "optional(tensor(double))",          "optional(tensor(string))",      "optional(tensor(bool))",
-        "optional(tensor(complex64))",       "optional(tensor(complex128))"};
+        "optional(tensor(complex64))",       "optional(tensor(complex128))"
+    };
     return all_optional_types;
   }
 
@@ -862,7 +889,8 @@ class OpSchema final {
         "optional(tensor(bfloat16))",        "optional(tensor(float16))",     "optional(tensor(float))",
         "optional(tensor(double))",          "optional(tensor(string))",      "optional(tensor(bool))",
         "optional(tensor(complex64))",       "optional(tensor(complex128))",  "optional(tensor(float8e4m3fn))",
-        "optional(tensor(float8e4m3fnuz))",  "optional(tensor(float8e5m2))",  "optional(tensor(float8e5m2fnuz))"};
+        "optional(tensor(float8e4m3fnuz))",  "optional(tensor(float8e5m2))",  "optional(tensor(float8e5m2fnuz))"
+    };
     return all_optional_types;
   }
 
@@ -953,7 +981,8 @@ class OpSchema final {
   OpSchema& FunctionBody(
       const std::vector<NodeProto>& func_nodes,
       const std::vector<OperatorSetIdProto>& opsets,
-      int opset_version = kUninitializedSinceVersion);
+      int opset_version = kUninitializedSinceVersion
+  );
 
   OpSchema& FunctionBody(const char* func_body, int opset_version = kUninitializedSinceVersion);
 
@@ -975,8 +1004,8 @@ class OpSchema final {
   // Inside GetFunction we ensure that ops being used to construct a function body do not endure such
   // issue.
   const FunctionProto* GetFunction(
-      int requested_opset_version = OpSchema::kUninitializedSinceVersion,
-      bool validate = false) const;
+      int requested_opset_version = OpSchema::kUninitializedSinceVersion, bool validate = false
+  ) const;
 
   std::vector<int> context_dependent_function_opset_versions() const {
     std::vector<int> opset_versions;
@@ -996,13 +1025,14 @@ class OpSchema final {
   }
 
   OpSchema& SetContextDependentFunctionBodyBuilder(
-      ContextDependentFunctionBodyBuilder,
-      int opset_version = kUninitializedSinceVersion);
+      ContextDependentFunctionBodyBuilder, int opset_version = kUninitializedSinceVersion
+  );
 
   bool BuildContextDependentFunction(
       const FunctionBodyBuildContext& ctx,
       FunctionProto& function_proto,
-      int requested_opset_version = OpSchema::kUninitializedSinceVersion) const;
+      int requested_opset_version = OpSchema::kUninitializedSinceVersion
+  ) const;
 
   // Verifies that the schema is valid and all specifications are compatible.
   // It will also parse all type strings specified for inputs/outputs into valid
@@ -1015,12 +1045,14 @@ class OpSchema final {
 
  private:
   void ParseAndSetTypes(
-      /*out*/ std::vector<OpSchema::FormalParameter>* formalParameters);
+      /*out*/ std::vector<OpSchema::FormalParameter>* formalParameters
+  );
   bool ValidateReferencedOpsInFuncton(
       const FunctionProto* function,
       int requested_opset_version,
       int function_since_version,
-      std::set<std::string>* updated_ops = nullptr) const;
+      std::set<std::string>* updated_ops = nullptr
+  ) const;
   void UpdateFunctionProtoOpsetImportVersion(FunctionProto& function_proto, int opset_version) const;
 
   std::string name_;
@@ -1061,8 +1093,9 @@ class ISchemaRegistry {
  public:
   virtual ~ISchemaRegistry() = default;
 
-  virtual const OpSchema*
-  GetSchema(const std::string& key, const int maxInclusiveVersion, const std::string& domain = ONNX_DOMAIN) const = 0;
+  virtual const OpSchema* GetSchema(
+      const std::string& key, const int maxInclusiveVersion, const std::string& domain = ONNX_DOMAIN
+  ) const = 0;
 };
 
 /**
@@ -1109,8 +1142,9 @@ class OpSchemaRegistry final : public ISchemaRegistry {
     // standard ONNX domains as above). Custom-domains are free to interpret
     // this as appropriate (that is, as relative to releases of custom-domain
     // as opposed to ONNX releases).
-    void
-    AddDomainToVersion(const std::string& domain, int min_version, int max_version, int last_release_version = -1) {
+    void AddDomainToVersion(
+        const std::string& domain, int min_version, int max_version, int last_release_version = -1
+    ) {
       std::lock_guard<std::mutex> lock(mutex_);
       assert(map_.end() == map_.find(domain));
       map_[domain] = std::make_pair(min_version, max_version);
@@ -1201,9 +1235,8 @@ class OpSchemaRegistry final : public ISchemaRegistry {
     }
 
     static void CheckDomainAndVersionToRegister(
-        const OpSchema& op_schema,
-        const std::string& op_name,
-        const std::string& op_domain) {
+        const OpSchema& op_schema, const std::string& op_name, const std::string& op_domain
+    ) {
       auto ver_range_map = DomainToVersionRange::Instance().Map();
       auto ver_range_it = ver_range_map.find(op_domain);
       auto ver = op_schema.SinceVersion();
@@ -1265,8 +1298,9 @@ class OpSchemaRegistry final : public ISchemaRegistry {
   // Return the schema with biggest version, which is not greater than specified
   // <maxInclusiveVersion> in specified domain. Domain with default value
   // ONNX_DOMAIN means ONNX.
-  static const OpSchema*
-  Schema(const std::string& key, const int maxInclusiveVersion, const std::string& domain = ONNX_DOMAIN) {
+  static const OpSchema* Schema(
+      const std::string& key, const int maxInclusiveVersion, const std::string& domain = ONNX_DOMAIN
+  ) {
     auto& m = map();
     if (m.count(key) && m[key].count(domain)) {
       const auto& schema_ver_map = m[key][domain];
@@ -1292,9 +1326,8 @@ class OpSchemaRegistry final : public ISchemaRegistry {
   static OpSchemaRegistry* Instance();
 
   const OpSchema* GetSchema(
-      const std::string& key,
-      const int maxInclusiveVersion,
-      const std::string& domain = ONNX_DOMAIN) const override {
+      const std::string& key, const int maxInclusiveVersion, const std::string& domain = ONNX_DOMAIN
+  ) const override {
     return Schema(key, maxInclusiveVersion, domain);
   }
   static void SetLoadedSchemaVersion(int target_version) {
@@ -1506,4 +1539,4 @@ support).
 #define POPULATE_OP_DOC_STR(DocPopulatorCode)
 #endif
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/sequence/defs.cc
+++ b/onnx/defs/sequence/defs.cc
@@ -24,7 +24,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "(Optional) The data type of the tensors in the output sequence. "
             "The default type is 'float'.",
             AttributeProto::INT,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Output(0, "output", "Empty sequence.", "S")
         .TypeConstraint("S", OpSchema::all_tensor_sequence_types(), "Constrain output types to any tensor type.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -38,8 +39,10 @@ ONNX_OPERATOR_SET_SCHEMA(
             elem_type = static_cast<TensorProto_DataType>(attr_value);
           }
           ctx.getOutputType(0)->mutable_sequence_type()->mutable_elem_type()->mutable_tensor_type()->set_elem_type(
-              elem_type);
-        }));
+              elem_type
+          );
+        })
+);
 
 static const char* SequenceConstruct_ver11_doc = R"DOC(
 Construct a tensor sequence containing 'inputs' tensors.
@@ -91,7 +94,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             const auto& input_shape = ctx.getInputType(i)->tensor_type().shape();
             UnionShapeInfo(input_shape, *output_tensor_type);
           }
-        }));
+        })
+);
 
 static const char* SequenceInsert_ver11_doc = R"DOC(
 Outputs a tensor sequence that inserts 'tensor' into 'input_sequence' at 'position'.
@@ -119,14 +123,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "It is an error if any of the index values are out of bounds. "
             "It must be a scalar(tensor of empty shape).",
             "I",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(0, "output_sequence", "Output sequence that contains the inserted tensor at given position.", "S")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain to any tensor type.")
         .TypeConstraint("S", OpSchema::all_tensor_sequence_types(), "Constrain to any tensor type.")
         .TypeConstraint(
             "I",
             {"tensor(int32)", "tensor(int64)"},
-            "Constrain position to integral tensor. It must be a scalar(tensor of empty shape).")
+            "Constrain position to integral tensor. It must be a scalar(tensor of empty shape)."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           const auto input0_type = ctx.getInputType(0);
           const auto input1_type = ctx.getInputType(1);
@@ -140,7 +146,8 @@ ONNX_OPERATOR_SET_SCHEMA(
                 "Input Sequence and Tensor are expected to have the same elem type. Sequence=",
                 seq_elem_type,
                 " Tensor=",
-                tensor_elem_type);
+                tensor_elem_type
+            );
           }
 
           auto* output_tensor_type =
@@ -154,7 +161,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           *(output_tensor_type->mutable_shape()) = input0_type->sequence_type().elem_type().tensor_type().shape();
 
           UnionShapeInfo(input1_type->tensor_type().shape(), *output_tensor_type);
-        }));
+        })
+);
 
 static const char* SequenceAt_ver11_doc = R"DOC(
 Outputs a tensor copy from the tensor at 'position' in 'input_sequence'.
@@ -177,21 +185,24 @@ ONNX_OPERATOR_SET_SCHEMA(
             "where `n` is the number of tensors in 'input_sequence'. "
             "It is an error if any of the index values are out of bounds. "
             "It must be a scalar(tensor of empty shape).",
-            "I")
+            "I"
+        )
         .Output(0, "tensor", "Output tensor at the specified position in the input sequence.", "T")
         .TypeConstraint("S", OpSchema::all_tensor_sequence_types(), "Constrain to any tensor type.")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain to any tensor type.")
         .TypeConstraint(
             "I",
             {"tensor(int32)", "tensor(int64)"},
-            "Constrain position to integral tensor. It must be a scalar(tensor of empty shape).")
+            "Constrain position to integral tensor. It must be a scalar(tensor of empty shape)."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           const auto input0_type = ctx.getInputType(0);
           if (nullptr == input0_type) {
             fail_type_inference("Input type for input at index 0 is null. Type info is expected.")
           }
           ctx.getOutputType(0)->CopyFrom(input0_type->sequence_type().elem_type());
-        }));
+        })
+);
 
 static const char* SequenceErase_ver11_doc = R"DOC(
 Outputs a tensor sequence that removes the tensor at 'position' from 'input_sequence'.
@@ -216,20 +227,23 @@ ONNX_OPERATOR_SET_SCHEMA(
             "It is an error if any of the index values are out of bounds. "
             "It must be a scalar(tensor of empty shape).",
             "I",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(0, "output_sequence", "Output sequence that has the tensor at the specified position removed.", "S")
         .TypeConstraint("S", OpSchema::all_tensor_sequence_types(), "Constrain to any tensor type.")
         .TypeConstraint(
             "I",
             {"tensor(int32)", "tensor(int64)"},
-            "Constrain position to integral tensor. It must be a scalar(tensor of empty shape).")
+            "Constrain position to integral tensor. It must be a scalar(tensor of empty shape)."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           const auto input0_type = ctx.getInputType(0);
           if (nullptr == input0_type) {
             fail_type_inference("Input type for input at index 0 is null. Type info is expected.")
           }
           ctx.getOutputType(0)->CopyFrom(*input0_type);
-        }));
+        })
+);
 
 static const char* SequenceLength_ver11_doc = R"DOC(
 Produces a scalar(tensor of empty shape) containing the number of tensors in 'input_sequence'.
@@ -244,14 +258,14 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Output(0, "length", "Length of input sequence. It must be a scalar(tensor of empty shape).", "I")
         .TypeConstraint("S", OpSchema::all_tensor_sequence_types(), "Constrain to any tensor type.")
         .TypeConstraint(
-            "I",
-            {"tensor(int64)"},
-            "Constrain output to integral tensor. It must be a scalar(tensor of empty shape).")
+            "I", {"tensor(int64)"}, "Constrain output to integral tensor. It must be a scalar(tensor of empty shape)."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           auto* output_tensor_type = ctx.getOutputType(0)->mutable_tensor_type();
           output_tensor_type->set_elem_type(TensorProto::INT64);
           output_tensor_type->mutable_shape()->Clear();
-        }));
+        })
+);
 
 // Updated operators that consume/produce sequence of tensors.
 
@@ -282,7 +296,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Length of each output. "
             "It can be either a scalar(tensor of empty shape), or a 1-D tensor. All values must be >= 0. ",
             "I",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(0, "output_sequence", "One or more outputs forming a sequence of tensors after splitting", "S")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input types to all tensor types.")
         .TypeConstraint("I", {"tensor(int32)", "tensor(int64)"}, "Constrain split size to integral tensor.")
@@ -292,13 +307,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Which axis to split on. "
             "A negative value means counting dimensions from the back. Accepted range is [-rank, rank-1].",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "keepdims",
             "Keep the split dimension or not. Default 1, which means we keep split dimension. "
             "If input 'split' is specified, this attribute is ignored.",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .SetDoc(SplitToSequence_ver11_doc)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           const auto input0_type = ctx.getInputType(0);
@@ -306,7 +323,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             fail_type_inference("Input type for input at index 0 is null. Type info is expected.")
           }
           ctx.getOutputType(0)->mutable_sequence_type()->mutable_elem_type()->mutable_tensor_type()->set_elem_type(
-              input0_type->tensor_type().elem_type());
+              input0_type->tensor_type().elem_type()
+          );
 
           if (!hasInputShape(ctx, 0)) {
             return;
@@ -382,7 +400,8 @@ ONNX_OPERATOR_SET_SCHEMA(
                       "Sum of split values not equal to 'input' dim size on 'axis'. 'axis' dim size=",
                       splitDimValue,
                       " sum of split values=",
-                      splitSizesSum);
+                      splitSizesSum
+                  );
                 }
                 if (std::adjacent_find(splitSizes.begin(), splitSizes.end(), std::not_equal_to<int64_t>()) ==
                     splitSizes.end()) {
@@ -423,7 +442,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               }
             }
           }
-        }));
+        })
+);
 
 static const char* ConcatFromSequence_ver11_doc = R"DOC(
 Concatenate a sequence of tensors into a single tensor.
@@ -441,13 +461,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Which axis to concat on. Accepted range in `[-r, r - 1]`, "
             "where `r` is the rank of input tensors. "
             "When `new_axis` is 1, accepted range is `[-r - 1, r]`. ",
-            AttributeProto::INT)
+            AttributeProto::INT
+        )
         .Attr(
             "new_axis",
             "Insert and concatenate on a new axis or not, "
             "default 0 means do not insert new axis.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .SetDoc(ConcatFromSequence_ver11_doc)
         .Input(0, "input_sequence", "Sequence of tensors for concatenation", "S")
         .Output(0, "concat_result", "Concatenated tensor", "T")
@@ -488,12 +510,8 @@ ONNX_OPERATOR_SET_SCHEMA(
 
           if (axis < lower_bound || axis > upper_bound) {
             fail_shape_inference(
-                "Invalid value of attribute 'axis'. Accepted range=[",
-                lower_bound,
-                ", ",
-                upper_bound,
-                "], Value=",
-                axis);
+                "Invalid value of attribute 'axis'. Accepted range=[", lower_bound, ", ", upper_bound, "], Value=", axis
+            );
           }
 
           if (axis < 0) {
@@ -508,7 +526,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               output_shape->mutable_dim(i)->CopyFrom(input_shape.dim((i > axis && new_axis) ? i - 1 : i));
             }
           }
-        }));
+        })
+);
 
 static const char* SequenceMap_ver17_doc = R"DOC(
 Applies a sub-graph to each sample in the input sequence(s).
@@ -566,7 +585,8 @@ void SequenceMapInferenceFunction(InferenceContext& ctx) {
           "Graph attribute inferencing returned type information for ",
           subgraph_output_types.size(),
           " outputs. Expected ",
-          num_outputs);
+          num_outputs
+      );
     }
 
     for (size_t outputIndex = 0; outputIndex < num_outputs; outputIndex++) {
@@ -577,9 +597,8 @@ void SequenceMapInferenceFunction(InferenceContext& ctx) {
 }
 
 bool BuildSequenceMapBodyFunc(
-    const FunctionBodyBuildContext& ctx,
-    const OpSchema& schema,
-    FunctionProto& functionProto) {
+    const FunctionBodyBuildContext& ctx, const OpSchema& schema, FunctionProto& functionProto
+) {
   schema.BuildFunction(functionProto);
 
   // variadic input/outputs will be expanded
@@ -611,7 +630,7 @@ bool BuildSequenceMapBodyFunc(
 
   auto schema_inputs = schema.inputs();
   auto input_0_name = schema_inputs[0].GetName();
-  auto input_1_name = schema_inputs[1].GetName(); // variadic input
+  auto input_1_name = schema_inputs[1].GetName();  // variadic input
 
   *functionProto.add_input() = input_0_name;
   for (int i = 1; i < ninputs; i++) {
@@ -768,7 +787,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The graph to be run for each sample in the sequence(s). "
             "It should have as many inputs and outputs as inputs and "
             "outputs to the SequenceMap function.",
-            AttributeProto::GRAPH)
+            AttributeProto::GRAPH
+        )
         .Input(0, "input_sequence", "Input sequence.", "S")
         .Input(1, "additional_inputs", "Additional inputs to the graph", "V", OpSchema::Variadic, false, 0)
         .Output(0, "out_sequence", "Output sequence(s)", "S", OpSchema::Variadic, false)
@@ -781,8 +801,10 @@ ONNX_OPERATOR_SET_SCHEMA(
               t.insert(t.end(), s.begin(), s.end());
               return t;
             }(),
-            "Constrain to any tensor or sequence type.")
+            "Constrain to any tensor or sequence type."
+        )
         .SetContextDependentFunctionBodyBuilder(BuildSequenceMapBodyFunc)
-        .TypeAndShapeInferenceFunction(SequenceMapInferenceFunction));
+        .TypeAndShapeInferenceFunction(SequenceMapInferenceFunction)
+);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/shape_inference.cc
+++ b/onnx/defs/shape_inference.cc
@@ -23,7 +23,8 @@ void propagateElemTypeFromTensorInputToOutput(InferenceContext& ctx, size_t inpu
   const auto input_value_case = input_type->value_case();
   if (input_value_case != TypeProto::kTensorType && input_value_case != TypeProto::kSparseTensorType) {
     fail_type_inference(
-        "Input ", inputIndex, " expected to have tensor or sparse tensor type. Got: ", input_value_case);
+        "Input ", inputIndex, " expected to have tensor or sparse tensor type. Got: ", input_value_case
+    );
   }
 
   const auto input_elem_type = getTensorElementType(*input_type);
@@ -40,7 +41,8 @@ void propagateElemTypeFromTensorInputToOutput(InferenceContext& ctx, size_t inpu
   } else {
     // This is not expected to happen
     fail_type_inference(
-        "Output ", outputIndex, " expected to have tensor or sparse tensor type. Got: ", output_value_case);
+        "Output ", outputIndex, " expected to have tensor or sparse tensor type. Got: ", output_value_case
+    );
   }
 }
 
@@ -123,7 +125,8 @@ void mergeInShapeInfo(const TensorShapeProto& source, TensorShapeProto& target) 
         "Mismatch between number of inferred and declared dimensions. inferred=",
         num_source_dims,
         " declared=",
-        num_target_dims);
+        num_target_dims
+    );
   }
 
   auto& source_dims = source.dim();
@@ -262,7 +265,8 @@ void UnionShapeInfo(const TensorShapeProto& source_shape, TypeProto_SparseTensor
 void UnionTypeInfo(const TypeProto& source_type, TypeProto& target_type) {
   if (source_type.value_case() != target_type.value_case()) {
     fail_type_inference(
-        "Mismatched type:", " inferred=", source_type.value_case(), " declared=", target_type.value_case());
+        "Mismatched type:", " inferred=", source_type.value_case(), " declared=", target_type.value_case()
+    );
   }
 
   const auto target_case = target_type.value_case();
@@ -272,7 +276,8 @@ void UnionTypeInfo(const TypeProto& source_type, TypeProto& target_type) {
 
     if (source_elem_type != target_elem_type) {
       fail_type_inference(
-          "Mismatched tensor element type:", " inferred=", source_elem_type, " declared=", target_elem_type);
+          "Mismatched tensor element type:", " inferred=", source_elem_type, " declared=", target_elem_type
+      );
     }
 
     UnionShapeInfo(source_type.tensor_type(), *target_type.mutable_tensor_type());
@@ -281,7 +286,8 @@ void UnionTypeInfo(const TypeProto& source_type, TypeProto& target_type) {
     auto target_elem_type = target_type.sparse_tensor_type().elem_type();
     if (source_elem_type != target_elem_type) {
       fail_type_inference(
-          "Mismatched sparse tensor element type:", " inferred=", source_elem_type, " declared=", target_elem_type);
+          "Mismatched sparse tensor element type:", " inferred=", source_elem_type, " declared=", target_elem_type
+      );
     }
     UnionShapeInfo(source_type.sparse_tensor_type(), *target_type.mutable_sparse_tensor_type());
   } else if (target_case == TypeProto::ValueCase::kSequenceType) {
@@ -315,7 +321,8 @@ void UnionTypeInfo(const TypeProto& source_type, TypeProto& target_type) {
           " inferred=",
           Utils::DataTypeUtils::ToDataTypeString(source_key_type),
           " declared=",
-          Utils::DataTypeUtils::ToDataTypeString(target_key_type));
+          Utils::DataTypeUtils::ToDataTypeString(target_key_type)
+      );
     }
 
     if (!source_type.map_type().has_value_type()) {
@@ -358,7 +365,8 @@ void propagateTensorElemTypeWithValidation(const TypeProto* input_type, TypeProt
     if (output_elem_type != TensorProto::UNDEFINED) {
       if (input_elem_type != output_elem_type) {
         fail_type_inference(
-            "Input element type of ", input_elem_type, " does not match existing output type of ", output_elem_type);
+            "Input element type of ", input_elem_type, " does not match existing output type of ", output_elem_type
+        );
       }
     } else {
       setTensorElementType(input_elem_type, output_value_case, *output_type);
@@ -382,7 +390,8 @@ void propagateSequenceElemTypeWithValidation(const TypeProto* input_type, TypePr
 
   if (input_seq_type.has_elem_type()) {
     propagateElemTypeWithValidation(
-        &input_seq_type.elem_type(), output_type->mutable_sequence_type()->mutable_elem_type());
+        &input_seq_type.elem_type(), output_type->mutable_sequence_type()->mutable_elem_type()
+    );
   } else {
     fail_type_inference("Element type of sequence input was unknown");
   }
@@ -401,7 +410,8 @@ void propagateOptionalElemTypeWithValidation(const TypeProto* input_type, TypePr
 
   if (input_opt_type.has_elem_type()) {
     propagateElemTypeWithValidation(
-        &input_opt_type.elem_type(), output_type->mutable_optional_type()->mutable_elem_type());
+        &input_opt_type.elem_type(), output_type->mutable_optional_type()->mutable_elem_type()
+    );
   } else {
     fail_type_inference("Element type of optional input was unknown");
   }
@@ -446,7 +456,8 @@ void propagateElemTypeWithValidation(const TypeProto* input_type, TypeProto* out
     propagateMapElemTypeWithValidation(input_type, output_type);
   } else {
     fail_type_inference(
-        "Input was expected to have either tensor, sequence, optional or map type. Got ", input_value_case);
+        "Input was expected to have either tensor, sequence, optional or map type. Got ", input_value_case
+    );
   }
 }
 
@@ -504,8 +515,8 @@ std::string stringify(const Container& elements) {
 }
 
 std::pair<int, int> getAttributeElementTypeAndLength(
-    const InferenceContext& ctx,
-    const std::initializer_list<std::string>& attribute_names) {
+    const InferenceContext& ctx, const std::initializer_list<std::string>& attribute_names
+) {
   // Get element type and lengths of 1D attribute lists
   int32_t elem_type = TensorProto::UNDEFINED;
   int32_t length = 0;
@@ -528,7 +539,8 @@ std::pair<int, int> getAttributeElementTypeAndLength(
       } else if (attr_proto->has_t()) {
         if (attr_proto->t().dims_size() != 1) {
           fail_type_inference(
-              "Attribute ", attribute, " expected to be a 1D tensor but was ", attr_proto->t().dims_size(), "D");
+              "Attribute ", attribute, " expected to be a 1D tensor but was ", attr_proto->t().dims_size(), "D"
+          );
         }
         elem_type = attr_proto->t().data_type();
         length = attr_proto->t().dims(0);
@@ -538,4 +550,4 @@ std::pair<int, int> getAttributeElementTypeAndLength(
   return {elem_type, length};
 }
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -50,8 +50,8 @@ class GraphInferencer {
   // Perform inferencing on the graph contained in GraphInferencer.
   // Returns the graph output types post-inferencing.
   virtual std::vector<const TypeProto*> doInferencing(
-      const std::vector<const TypeProto*>& inputTypes,
-      const std::vector<const TensorProto*>& inputData) = 0;
+      const std::vector<const TypeProto*>& inputTypes, const std::vector<const TensorProto*>& inputData
+  ) = 0;
   virtual ~GraphInferencer() = default;
 };
 
@@ -164,8 +164,9 @@ inline int64_t getAttribute(DataPropagationContext& ctx, const std::string& attr
   return defaultValue;
 }
 
-inline std::string
-getAttribute(InferenceContext& ctx, const std::string& attributeName, const std::string& defaultValue) {
+inline std::string getAttribute(
+    InferenceContext& ctx, const std::string& attributeName, const std::string& defaultValue
+) {
   auto attr_proto = ctx.getAttribute(attributeName);
   if ((nullptr != attr_proto) && attr_proto->has_s())
     return attr_proto->s();
@@ -188,8 +189,8 @@ template <typename Container>
 std::string stringify(const Container& elements);
 
 std::pair<int, int> getAttributeElementTypeAndLength(
-    const InferenceContext& ctx,
-    const std::initializer_list<std::string>& attribute_names);
+    const InferenceContext& ctx, const std::initializer_list<std::string>& attribute_names
+);
 
 inline TensorShapeProto::Dimension operator*(TensorShapeProto::Dimension dim1, int64_t dim2) {
   TensorShapeProto::Dimension result;
@@ -249,10 +250,8 @@ void propagateElemTypeFromInputToOutput(InferenceContext& ctx, size_t inputIndex
 void propagateElemTypeFromTensorInputToOutput(InferenceContext& ctx, size_t inputIndex, size_t outputIndex);
 
 inline void propagateElemTypeFromDtypeToOutput(
-    InferenceContext& ctx,
-    const int data_type,
-    size_t outputIndex,
-    TypeProto::ValueCase expected_value_case) {
+    InferenceContext& ctx, const int data_type, size_t outputIndex, TypeProto::ValueCase expected_value_case
+) {
   const auto attribute_tensor_datatype = data_type;
   auto output_type = ctx.getOutputType(outputIndex);
   const auto output_value_case = output_type->value_case();
@@ -261,7 +260,8 @@ inline void propagateElemTypeFromDtypeToOutput(
   } else {
     // This is not expected to happen
     fail_type_inference(
-        "Output ", outputIndex, " expected to have: ", expected_value_case, " or UNDEFINED. Got: ", output_value_case);
+        "Output ", outputIndex, " expected to have: ", expected_value_case, " or UNDEFINED. Got: ", output_value_case
+    );
   }
 }
 
@@ -353,10 +353,8 @@ inline const TensorShapeProto* getOptionalInputShape(InferenceContext& ctx, size
 
 // Caller must make sure fromDimIndex is strictly less than shape.dim_size()
 inline void appendSingleDimCopiedFromInputTypeToOutputType(
-    InferenceContext& ctx,
-    size_t inputIndex,
-    size_t outputIndex,
-    size_t fromDimIndex) {
+    InferenceContext& ctx, size_t inputIndex, size_t outputIndex, size_t fromDimIndex
+) {
   auto output_type = ctx.getOutputType(outputIndex);
   const auto output_value_case = output_type->value_case();
   auto input_type = ctx.getInputType(inputIndex);
@@ -370,7 +368,8 @@ inline void appendSingleDimCopiedFromInputTypeToOutputType(
         " does not match type of output: ",
         outputIndex,
         "type: ",
-        output_value_case);
+        output_value_case
+    );
   }
   if (TypeProto::kTensorType == input_value_case) {
     auto* dim = output_type->mutable_tensor_type()->mutable_shape()->add_dim();
@@ -380,7 +379,8 @@ inline void appendSingleDimCopiedFromInputTypeToOutputType(
     *dim = input_type->sparse_tensor_type().shape().dim(static_cast<int>(fromDimIndex));
   } else {
     fail_type_inference(
-        "Input ", inputIndex, " and Output ", outputIndex, " expected to have tensor or sparse tensor type");
+        "Input ", inputIndex, " and Output ", outputIndex, " expected to have tensor or sparse tensor type"
+    );
   }
 }
 
@@ -389,7 +389,8 @@ inline void propagateShape(const TypeProto* from_type, TypeProto* to_type) {
   const auto to_type_case = to_type->value_case();
   if (from_type_case != to_type_case) {
     fail_shape_inference(
-        "Mismatch between inferred and declared type. Inferred=", from_type_case, " Declared=", to_type_case);
+        "Mismatch between inferred and declared type. Inferred=", from_type_case, " Declared=", to_type_case
+    );
   }
 
   if (TypeProto::kTensorType == from_type_case || TypeProto::kSparseTensorType == from_type_case) {
@@ -428,8 +429,9 @@ inline void propagateShapeAndTypeFromFirstInput(InferenceContext& ctx) {
   propagateShapeFromInputToOutput(ctx, 0, 0);
 }
 
-inline void
-updateOutputElemType(InferenceContext& ctx, size_t outputIndex, int32_t elemType, TypeProto::ValueCase expected_type) {
+inline void updateOutputElemType(
+    InferenceContext& ctx, size_t outputIndex, int32_t elemType, TypeProto::ValueCase expected_type
+) {
   auto output_type = ctx.getOutputType(outputIndex);
   if (output_type == nullptr) {
     fail_type_inference("Output ", outputIndex, " is null");
@@ -453,9 +455,10 @@ inline void propagateElemTypeFromAttributeToOutput(
     const std::string& attributeName,
     size_t outputIndex,
     TypeProto::ValueCase expected_type,
-    TensorProto_DataType default_value = TensorProto::UNDEFINED) {
+    TensorProto_DataType default_value = TensorProto::UNDEFINED
+) {
   auto attr_proto = ctx.getAttribute(attributeName);
-  if (nullptr == attr_proto) { // attribute not present
+  if (nullptr == attr_proto) {  // attribute not present
     if (default_value != TensorProto::UNDEFINED) {
       updateOutputElemType(ctx, outputIndex, default_value, expected_type);
       return;
@@ -478,7 +481,8 @@ inline void propagateElemTypeFromAttributeToOutput(
     InferenceContext& ctx,
     const std::string& attributeName,
     size_t outputIndex,
-    TensorProto_DataType default_value = TensorProto::UNDEFINED) {
+    TensorProto_DataType default_value = TensorProto::UNDEFINED
+) {
   propagateElemTypeFromAttributeToOutput(ctx, attributeName, outputIndex, TypeProto::kTensorType, default_value);
 }
 
@@ -491,8 +495,9 @@ inline TensorShapeProto* getTensorMutableShape(TypeProto::ValueCase value_case, 
   return nullptr;
 }
 
-inline TensorShapeProto*
-getOutputShape(InferenceContext& ctx, size_t n, TypeProto::ValueCase default_type = TypeProto::kTensorType) {
+inline TensorShapeProto* getOutputShape(
+    InferenceContext& ctx, size_t n, TypeProto::ValueCase default_type = TypeProto::kTensorType
+) {
   auto output_type = ctx.getOutputType(n);
   if (output_type == nullptr) {
     fail_type_inference("Output ", n, " expected to have tensor or sparse type");
@@ -515,7 +520,8 @@ inline void updateOutputShape(
     InferenceContext& ctx,
     size_t outputIndex,
     const TensorShapeProto& shape,
-    TypeProto::ValueCase default_type = TypeProto::kTensorType) {
+    TypeProto::ValueCase default_type = TypeProto::kTensorType
+) {
   auto* output_shape = getOutputShape(ctx, outputIndex, default_type);
   *output_shape = shape;
 }
@@ -524,7 +530,8 @@ inline void updateOutputShape(
     InferenceContext& ctx,
     size_t outputIndex,
     const TensorProto& tensorProto,
-    TypeProto::ValueCase default_type = TypeProto::kTensorType) {
+    TypeProto::ValueCase default_type = TypeProto::kTensorType
+) {
   auto* output_shape = getOutputShape(ctx, outputIndex, default_type);
   for (auto d : tensorProto.dims()) {
     auto* dim = output_shape->add_dim();
@@ -536,7 +543,8 @@ inline void updateOutputShape(
     InferenceContext& ctx,
     size_t outputIndex,
     std::initializer_list<TensorShapeProto::Dimension> dims,
-    TypeProto::ValueCase default_type = TypeProto::kTensorType) {
+    TypeProto::ValueCase default_type = TypeProto::kTensorType
+) {
   auto* output_shape = getOutputShape(ctx, outputIndex, default_type);
   for (auto& d : dims) {
     auto* dim = output_shape->add_dim();
@@ -556,7 +564,8 @@ inline void propagateShapeFromAttributeToOutput(
     InferenceContext& ctx,
     const std::string& attributeName,
     size_t outputIndex,
-    TypeProto::ValueCase default_type = TypeProto::kTensorType) {
+    TypeProto::ValueCase default_type = TypeProto::kTensorType
+) {
   auto attr_proto = ctx.getAttribute(attributeName);
   if ((nullptr == attr_proto) || (!attr_proto->has_type()) ||
       (attr_proto->type() != AttributeProto_AttributeType_INTS)) {
@@ -575,8 +584,8 @@ inline void propagateShapeFromAttributeToOutput(
 }
 
 inline void multidirectionalBroadcastShapeInference(
-    const std::vector<const TensorShapeProto*>& shapes,
-    TensorShapeProto& resultShape) {
+    const std::vector<const TensorShapeProto*>& shapes, TensorShapeProto& resultShape
+) {
   int result_shape_size = 0;
   // Get the result shape size.
   for (size_t i = 0; i < shapes.size(); ++i) {
@@ -625,9 +634,8 @@ inline void multidirectionalBroadcastShapeInference(
 }
 
 inline void bidirectionalBroadcastShapeInference(
-    const TensorShapeProto& shapeL,
-    const TensorShapeProto& shapeR,
-    TensorShapeProto& resultShape) {
+    const TensorShapeProto& shapeL, const TensorShapeProto& shapeR, TensorShapeProto& resultShape
+) {
   std::vector<const TensorShapeProto*> shapes;
   shapes.push_back(&shapeL);
   shapes.push_back(&shapeR);
@@ -647,9 +655,8 @@ Currently, there is no way to refine/update dimension information for the
 source from information available in the target.
 */
 inline void mergeInDimensionInfo(
-    const TensorShapeProto_Dimension& source_dim,
-    TensorShapeProto_Dimension& target_dim,
-    int dim_index) {
+    const TensorShapeProto_Dimension& source_dim, TensorShapeProto_Dimension& target_dim, int dim_index
+) {
   // if source has value, merge into target
   // else if target has value, preserve it
   // else merge params
@@ -665,7 +672,8 @@ inline void mergeInDimensionInfo(
             " Declared=",
             target_value,
             " Dimension=",
-            dim_index);
+            dim_index
+        );
       }
     } else {
       target_dim.set_dim_value(source_value);
@@ -796,7 +804,8 @@ inline void unifyInputDim(InferenceContext& ctx, size_t input_index, int dim_ind
     // This shape is expected to have rank > dim_index:
     if (input_shape.dim_size() <= dim_index) {
       fail_shape_inference(
-          "Input ", input_index, " expected to have rank >", dim_index, " but has rank ", input_shape.dim_size());
+          "Input ", input_index, " expected to have rank >", dim_index, " but has rank ", input_shape.dim_size()
+      );
     }
     const Dim& input_dim = input_shape.dim(dim_index);
     // Now, unify dim and input_dim:
@@ -841,8 +850,9 @@ void UnionTypeInfo(const TypeProto& source_type, TypeProto& target_type);
 // adjustNegativeAxes: Negative axes values are translated to the right axis in the positive range
 template <typename Axes>
 void adjustNegativeAxes(Axes& axes, int rank) {
-  std::transform(
-      axes.begin(), axes.end(), axes.begin(), [&](int64_t axis) -> int64_t { return axis < 0 ? axis + rank : axis; });
+  std::transform(axes.begin(), axes.end(), axes.begin(), [&](int64_t axis) -> int64_t {
+    return axis < 0 ? axis + rank : axis;
+  });
 }
 
 // checkAxesRange: Checks that values are within the range [-rank, rank)
@@ -866,4 +876,4 @@ void checkDuplicateAxes(Axes& axes, int rank) {
   }
 }
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -89,7 +89,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "to",
             "The data type to which the elements of the input tensor are cast. "
             "Strictly must be one of the types from DataType enum in TensorProto",
-            AttributeProto::INT)
+            AttributeProto::INT
+        )
         .Attr(
             "saturate",
             "The parameter defines how the conversion behaves if an input value is out of "
@@ -97,7 +98,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "(float8e4m3fn, float8e4m3fnuz, float8e5m2, float8e5m2fnuz). It is true by default. "
             "All cases are fully described in two tables inserted in the operator description.",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .Input(0, "input", "Input tensor to be cast.", "T1", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Output(
             0,
@@ -108,7 +110,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T1",
             {"tensor(float16)",
@@ -129,7 +132,8 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(float8e4m3fnuz)",
              "tensor(float8e5m2)",
              "tensor(float8e5m2fnuz)"},
-            "Constrain input types. Casting from complex is not supported.")
+            "Constrain input types. Casting from complex is not supported."
+        )
         .TypeConstraint(
             "T2",
             {"tensor(float16)",
@@ -150,16 +154,17 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(float8e4m3fnuz)",
              "tensor(float8e5m2)",
              "tensor(float8e5m2fnuz)"},
-            "Constrain output types. Casting to complex is not supported.")
+            "Constrain output types. Casting to complex is not supported."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromAttributeToOutput(ctx, "to", 0);
           if (hasNInputShapes(ctx, 1)) {
             propagateShapeFromInputToOutput(ctx, 0, 0);
           }
         })
-        .PartialDataPropagationFunction([](DataPropagationContext& ctx) {
-          PropagateShapeDataFromInputToOutput(ctx, 0);
-        }));
+        .PartialDataPropagationFunction([](DataPropagationContext& ctx) { PropagateShapeDataFromInputToOutput(ctx, 0); }
+        )
+);
 
 static const char* CastLike_ver19_doc = R"DOC(
 The operator casts the elements of a given input tensor (the first input) to
@@ -179,7 +184,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "(float8e4m3fn, float8e4m3fnuz, float8e5m2, float8e5m2fnuz). It is true by default. "
             "Please refer to operator Cast description for further details.",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .Input(0, "input", "Input tensor to be cast.", "T1", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
             1,
@@ -189,7 +195,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "output",
@@ -198,7 +205,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T1",
             {"tensor(float16)",
@@ -219,7 +227,8 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(float8e4m3fnuz)",
              "tensor(float8e5m2)",
              "tensor(float8e5m2fnuz)"},
-            "Constrain input types. Casting from complex is not supported.")
+            "Constrain input types. Casting from complex is not supported."
+        )
         .TypeConstraint(
             "T2",
             {"tensor(float16)",
@@ -240,7 +249,8 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(float8e4m3fnuz)",
              "tensor(float8e5m2)",
              "tensor(float8e5m2fnuz)"},
-            "Constrain output types. Casting to complex is not supported.")
+            "Constrain output types. Casting to complex is not supported."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 1, 0);
           if (hasNInputShapes(ctx, 1)) {
@@ -258,10 +268,13 @@ ONNX_OPERATOR_SET_SCHEMA(
               FunctionBuilder builder(functionProto);
               builder.Add(
                   MakeString("output = Cast <to= ", (int64_t)(target_elt_type), ", saturate: int = @saturate> (input)")
-                      .c_str());
+                      .c_str()
+              );
               schema.BuildFunction(functionProto);
               return true;
-            }));
+            }
+        )
+);
 
 static const char* Reshape_ver19_doc = R"DOC(
 Reshape the input tensor similar to numpy.reshape.
@@ -291,7 +304,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "allowzero=1 indicates that if any value in the 'shape' input is set to zero, "
             "the zero value is honored, similar to NumPy.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(0, "data", "An input tensor.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
             1,
@@ -301,7 +315,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(0, "reshaped", "Reshaped data.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint("T", OpSchema::all_tensor_types_ir9(), "Constrain input and output types to all tensor types.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -425,7 +440,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               negativeOneDim->set_dim_value(inputProduct / outputProduct);
             }
           }
-        }));
+        })
+);
 
 static const char* Shape_ver15_doc = R"DOC(
 Takes a tensor as input and outputs an 1D int64 tensor containing the shape of the input tensor.
@@ -480,14 +496,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "(Optional) Starting axis for slicing the shape. Default value is 0."
             "Negative value means counting dimensions from the back.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "end",
             "(Optional) Ending axis for slicing the shape. "
             "Negative value means counting dimensions from the back. "
             "If omitted, sizes of all axes upto (including) the last one will be included.",
             AttributeProto::INT,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types_ir9(), "Input tensor can be of arbitrary type.")
         .TypeConstraint("T1", {"tensor(int64)"}, "Constrain output to int64 tensor.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -528,7 +546,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
             ctx.addOutputData(0, std::move(output_shape));
           }
-        }));
+        })
+);
 
 static const char* Size_ver13_doc = R"DOC(
 Takes a tensor as input and outputs a int64 scalar that equals to the total number of elements of the input tensor.
@@ -548,7 +567,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types_ir9(), "Input tensor can be of arbitrary type.")
         .TypeConstraint("T1", {"tensor(int64)"}, "Constrain output to int64 tensor, which should be a scalar though.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -562,7 +582,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             tsp.mutable_dim()->Add()->set_dim_value(input_data->dim_size());
             ctx.addOutputData(0, std::move(tsp));
           }
-        }));
+        })
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Concat,
@@ -572,19 +593,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "axis",
             "Which axis to concat on. A negative value means counting dimensions from the back. "
             "Accepted range is [-r, r-1] where r = rank(inputs)..",
-            AttributeProto::INT)
+            AttributeProto::INT
+        )
         .SetDoc(
             "Concatenate a list of tensors into a single tensor. "
-            "All input tensors must have the same shape, except for the dimension size of the axis to concatenate on.")
+            "All input tensors must have the same shape, except for the dimension size of the axis to concatenate on."
+        )
         .Input(
-            0,
-            "inputs",
-            "List of tensors for concatenation",
-            "T",
-            OpSchema::Variadic,
-            true,
-            1,
-            OpSchema::Differentiable)
+            0, "inputs", "List of tensors for concatenation", "T", OpSchema::Variadic, true, 1, OpSchema::Differentiable
+        )
         .Output(0, "concat_result", "Concatenated tensor", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain output types to any tensor type.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -626,7 +643,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             const auto& shape = ctx.getInputType(i)->tensor_type().shape();
             if (shape.dim_size() != rank) {
               fail_shape_inference(
-                  "All inputs to Concat must have same rank. Input ", i, " has rank ", shape.dim_size(), " != ", rank);
+                  "All inputs to Concat must have same rank. Input ", i, " has rank ", shape.dim_size(), " != ", rank
+              );
             }
             for (int j = 0; j < rank; j++) {
               if (j == axis) {
@@ -664,7 +682,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (tsp.dim_size() > 0) {
             ctx.addOutputData(0, std::move(tsp));
           }
-        }));
+        })
+);
 
 static const char* Split_ver18_doc =
     R"DOC(Split a tensor into a list of tensors, along the specified 'axis'.
@@ -688,7 +707,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "outputs",
@@ -697,7 +717,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Variadic,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to all tensor types.")
         .Attr(
             "axis",
@@ -705,13 +726,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "A negative value means counting dimensions from the back. Accepted range is [-rank, rank-1] "
             "where r = rank(input).",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "num_outputs",
             "Number of outputs to split parts of the tensor into. "
             "If the tensor is not evenly splittable the last chunk will be smaller.",
             AttributeProto::INT,
-            false)
+            false
+        )
         .SetDoc(Split_ver18_doc)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           for (int i = 0; i < static_cast<int>(ctx.getNumOutputs()); ++i) {
@@ -744,7 +767,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (ctx.hasInput(1) && num_outputs_attr) {
             fail_shape_inference("Both 'split' input and 'num_outputs' attribute were given");
           }
-          if (ctx.hasInput(1)) { //'split' is input
+          if (ctx.hasInput(1)) {  //'split' is input
             auto split_proto = ctx.getInputData(1);
             if (split_proto == nullptr) {
               // skip if split is not an initializer
@@ -753,7 +776,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             split = ParseData<int64_t>(split_proto);
             if (split.size() != ctx.getNumOutputs()) {
               fail_shape_inference(
-                  "Mismatch between number of splits (", split.size(), ") and outputs (", ctx.getNumOutputs(), ")");
+                  "Mismatch between number of splits (", split.size(), ") and outputs (", ctx.getNumOutputs(), ")"
+              );
             }
             int64_t total_dim = 0;
             for (int64_t d : split) {
@@ -765,18 +789,19 @@ ONNX_OPERATOR_SET_SCHEMA(
                   total_dim,
                   ") and the split dimension of the input (",
                   split_dim_value,
-                  ")");
+                  ")"
+              );
             }
-          } else { // no value available for 'split'
+          } else {  // no value available for 'split'
             if (num_outputs_attr) {
               const auto num_outputs = num_outputs_attr->i();
               if (num_outputs < 1) {
                 fail_shape_inference("Attribute `num_outputs` value cannot be lower than 1");
               }
-              if (split_dim_value % num_outputs == 0) { // tensor is evenly splittable
+              if (split_dim_value % num_outputs == 0) {  // tensor is evenly splittable
                 int chunk_size = split_dim_value / num_outputs;
                 split.resize(num_outputs, chunk_size);
-              } else { // tensor needs to be split unevenly
+              } else {  // tensor needs to be split unevenly
                 int chunk_size = (split_dim_value / num_outputs) + 1;
                 int last_chunk_size = split_dim_value - (chunk_size * (num_outputs - 1));
                 split.resize(num_outputs - 1, chunk_size);
@@ -790,7 +815,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             *ctx.getOutputType(i)->mutable_tensor_type()->mutable_shape() = shape;
             ctx.getOutputType(i)->mutable_tensor_type()->mutable_shape()->mutable_dim(axis)->set_dim_value(split[i]);
           }
-        }));
+        })
+);
 
 static const char* Slice_ver13_doc = R"DOC(
 Produces a slice of the input tensor along multiple axes. Similar to numpy:
@@ -894,7 +920,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             1,
             "starts",
@@ -903,7 +930,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "ends",
@@ -912,7 +940,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             3,
             "axes",
@@ -923,7 +952,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             4,
             "steps",
@@ -934,7 +964,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(0, "output", "Sliced data tensor.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to all tensor types.")
         .TypeConstraint("Tind", {"tensor(int32)", "tensor(int64)"}, "Constrain indices to integer types")
@@ -1090,14 +1121,15 @@ ONNX_OPERATOR_SET_SCHEMA(
                 starts->dim_size(),
                 ") vs (",
                 ends->dim_size(),
-                ").");
+                ")."
+            );
           }
           // Only supports axis = 0 since the data comes from Shape
           if ((!axes_specified || (axes->dim_size() == 1 && axes->dim(0).dim_value() == 0)) &&
               starts->dim_size() == 1 && ends->dim_size() == 1) {
             auto start = starts->dim(0).dim_value();
             auto end = ends->dim(0).dim_value();
-            int64_t step = 1; // Default step is 1
+            int64_t step = 1;  // Default step is 1
             if (steps_specified) {
               if (steps->dim_size() != 1) {
                 return;
@@ -1123,7 +1155,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               ctx.addOutputData(0, std::move(tsp));
             }
           }
-        }));
+        })
+);
 
 static const char* Transpose_ver13_doc = R"DOC(
 Transpose the input tensor similar to numpy.transpose. For example, when
@@ -1141,7 +1174,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "A list of integers. By default, reverse the dimensions, "
             "otherwise permute the axes according to the values given.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Input(0, "data", "An input tensor.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Output(0, "transposed", "Transposed output.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to all tensor types.")
@@ -1193,7 +1227,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           for (size_t i = 0; i < perm.size(); ++i) {
             appendSingleDimCopiedFromInputTypeToOutputType(ctx, 0, 0, static_cast<size_t>(perm[i]));
           }
-        }));
+        })
+);
 
 static const char* Scatter_ver11_doc = R"DOC(
 This operator is deprecated. Please use ScatterElements, which provides the same functionality.
@@ -1262,7 +1297,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Which axis to scatter on. Negative value means "
             "counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(data).",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(0, "data", "Tensor of rank r >= 1.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
             1,
@@ -1273,7 +1309,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "updates",
@@ -1282,7 +1319,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Output(
             0,
             "output",
@@ -1291,7 +1329,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Input and output types can be of any tensor type.")
         .TypeConstraint("Tind", {"tensor(int32)", "tensor(int64)"}, "Constrain indices to integer types")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -1299,7 +1338,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (hasNInputShapes(ctx, 1)) {
             propagateShapeFromInputToOutput(ctx, 0, 0);
           }
-        }));
+        })
+);
 
 static const char* ScatterND_ver18_doc = R"DOC(
 ScatterND takes three inputs `data` tensor of rank r >= 1, `indices` tensor of rank q >= 1,
@@ -1393,7 +1433,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "'max': reduction using the maximum operation."
             "'min': reduction using the minimum operation.",
             AttributeProto::STRING,
-            std::string("none"))
+            std::string("none")
+        )
         .Input(0, "data", "Tensor of rank r >= 1.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
             1,
@@ -1403,7 +1444,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "updates",
@@ -1412,7 +1454,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Output(0, "output", "Tensor of rank r >= 1.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to any tensor type.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -1420,7 +1463,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (hasNInputShapes(ctx, 1)) {
             propagateShapeFromInputToOutput(ctx, 0, 0);
           }
-        }));
+        })
+);
 
 static const char* ScatterElements_ver18_doc = R"DOC(
 ScatterElements takes three inputs `data`, `updates`, and `indices` of the same
@@ -1497,7 +1541,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Which axis to scatter on. Negative value means "
             "counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(data).",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "reduction",
             "Type of reduction to apply: none (default), add, mul, max, min. "
@@ -1507,7 +1552,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "'max': reduction using the maximum operation."
             "'min': reduction using the minimum operation.",
             AttributeProto::STRING,
-            std::string("none"))
+            std::string("none")
+        )
         .Input(0, "data", "Tensor of rank r >= 1.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
             1,
@@ -1518,7 +1564,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "updates",
@@ -1527,7 +1574,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Output(
             0,
             "output",
@@ -1536,7 +1584,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Input and output types can be of any tensor type.")
         .TypeConstraint("Tind", {"tensor(int32)", "tensor(int64)"}, "Constrain indices to integer types")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -1544,7 +1593,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (hasNInputShapes(ctx, 1)) {
             propagateShapeFromInputToOutput(ctx, 0, 0);
           }
-        }));
+        })
+);
 
 static const char* Gather_ver13_doc = R"DOC(
 Given `data` tensor of rank r >= 1, and `indices` tensor of rank q, gather
@@ -1607,7 +1657,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Which axis to gather on. Negative value means "
             "counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(data).",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(0, "data", "Tensor of rank r >= 1.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
             1,
@@ -1618,7 +1669,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(0, "output", "Tensor of rank q + (r - 1).", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to any tensor type.")
         .TypeConstraint("Tind", {"tensor(int32)", "tensor(int64)"}, "Constrain indices to integer types")
@@ -1647,13 +1699,14 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
           for (int i = 0; i < out_rank; ++i) {
             *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim() = (i < axis) ? data_shape.dim(i)
-                                                                                                  : // i < axis < r
+                                                                                                  :  // i < axis < r
                 (i >= axis && i < axis + q) ? indices_shape.dim(i - axis)
-                                            : // i - axis < q
-                data_shape.dim(i - q + 1); // i < out_rank < q + r - 1
+                                            :  // i - axis < q
+                data_shape.dim(i - q + 1);  // i < out_rank < q + r - 1
           }
         })
-        .PartialDataPropagationFunction([](DataPropagationContext& ctx) { GatherOp13DataPropagator(ctx); }));
+        .PartialDataPropagationFunction([](DataPropagationContext& ctx) { GatherOp13DataPropagator(ctx); })
+);
 
 static const char* GatherElements_ver13_doc = R"DOC(
 
@@ -1720,7 +1773,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Which axis to gather on. Negative value means "
             "counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(data).",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(0, "data", "Tensor of rank r >= 1.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
             1,
@@ -1731,7 +1785,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "output",
@@ -1740,7 +1795,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to any tensor type.")
         .TypeConstraint("Tind", {"tensor(int32)", "tensor(int64)"}, "Constrain indices to integer types")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -1749,7 +1805,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (hasInputShape(ctx, 1)) {
             propagateShapeFromInputToOutput(ctx, 1, 0);
           }
-        }));
+        })
+);
 
 static const char* Squeeze_ver13_doc = R"DOC(
 Remove single-dimensional entries from the shape of a tensor.
@@ -1771,7 +1828,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             1,
             "axes",
@@ -1781,7 +1839,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "squeezed",
@@ -1790,7 +1849,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to all tensor types.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
@@ -1802,7 +1862,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           size_t num_inputs = ctx.getNumInputs();
           bool axes_not_specified = false;
 
-          if ((num_inputs == 2) && ctx.getInputType(1)) { //'axes' is input
+          if ((num_inputs == 2) && ctx.getInputType(1)) {  //'axes' is input
             auto axes_proto = ctx.getInputData(1);
             if (axes_proto == nullptr) {
               // skip if axes is not an initializer
@@ -1840,16 +1900,17 @@ ONNX_OPERATOR_SET_SCHEMA(
               // actually 1 when the op is evaluated
               if (input_shape.dim(i).has_dim_value() && input_shape.dim(i).dim_value() != 1) {
                 fail_shape_inference(
-                    "Dimension of input ", i, " must be 1 instead of ", input_shape.dim(i).dim_value());
+                    "Dimension of input ", i, " must be 1 instead of ", input_shape.dim(i).dim_value()
+                );
               }
             } else {
               *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim() = input_shape.dim(i);
             }
           }
         })
-        .PartialDataPropagationFunction([](DataPropagationContext& ctx) {
-          PropagateShapeDataFromInputToOutput(ctx, 0);
-        }));
+        .PartialDataPropagationFunction([](DataPropagationContext& ctx) { PropagateShapeDataFromInputToOutput(ctx, 0); }
+        )
+);
 
 static const char* Unsqueeze_ver13_doc = R"DOC(
 Insert single-dimensional entries to the shape of an input tensor (`data`).
@@ -1879,7 +1940,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "expanded",
@@ -1888,7 +1950,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to all tensor types.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
@@ -1928,9 +1991,9 @@ ONNX_OPERATOR_SET_SCHEMA(
             ++j;
           }
         })
-        .PartialDataPropagationFunction([](DataPropagationContext& ctx) {
-          PropagateShapeDataFromInputToOutput(ctx, 0);
-        }));
+        .PartialDataPropagationFunction([](DataPropagationContext& ctx) { PropagateShapeDataFromInputToOutput(ctx, 0); }
+        )
+);
 
 static const char* SpaceToDepth_ver13_doc =
     R"DOC(SpaceToDepth rearranges blocks of spatial data into depth. More specifically,
@@ -1953,7 +2016,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Output(
             0,
             "output",
@@ -1962,7 +2026,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to all tensor types.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
@@ -1981,12 +2046,14 @@ ONNX_OPERATOR_SET_SCHEMA(
                   {input_shape.dim(0),
                    input_shape.dim(1) * (blocksize * blocksize),
                    input_shape.dim(2) / blocksize,
-                   input_shape.dim(3) / blocksize});
+                   input_shape.dim(3) / blocksize}
+              );
             } else {
               fail_shape_inference("Input tensor must be 4-dimensional");
             }
           }
-        }));
+        })
+);
 
 static const char* DepthToSpace_ver13_doc =
     R"DOC(DepthToSpace rearranges (permutes) data from depth into blocks of spatial data.
@@ -2023,7 +2090,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "mode",
             "DCR (default) for depth-column-row order re-arrangement. Use CRD for column-row-depth order.",
             AttributeProto::STRING,
-            std::string("DCR"))
+            std::string("DCR")
+        )
         .SetDoc(DepthToSpace_ver13_doc)
         .Input(
             0,
@@ -2034,7 +2102,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Output(
             0,
             "output",
@@ -2043,7 +2112,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to all tensor types.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
@@ -2062,12 +2132,14 @@ ONNX_OPERATOR_SET_SCHEMA(
                   {input_shape.dim(0),
                    input_shape.dim(1) / (blocksize * blocksize),
                    input_shape.dim(2) * blocksize,
-                   input_shape.dim(3) * blocksize});
+                   input_shape.dim(3) * blocksize}
+              );
             } else {
               fail_shape_inference("Input tensor must be 4-dimensional");
             }
           }
-        }));
+        })
+);
 
 static const char* Tile_ver13_doc =
     R"DOC(Constructs a tensor by tiling a given tensor.
@@ -2090,7 +2162,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "output",
@@ -2100,7 +2173,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to all tensor types.")
         .TypeConstraint("T1", {"tensor(int64)"}, "Constrain repeat's type to int64 tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -2133,7 +2207,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               fail_shape_inference(
                   "'Repeats' input has incorrect number of values. "
                   "The number of values in 'repeats' must be equal "
-                  "to the number of input dimensions.");
+                  "to the number of input dimensions."
+              );
             }
 
             for (size_t i = 0; (int64_t)i < input_rank; ++i) {
@@ -2152,7 +2227,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
           }
           return;
-        }));
+        })
+);
 
 static const char* Upsample_ver10_doc = R"DOC(
 Upsample the input tensor.
@@ -2169,7 +2245,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "mode",
             "Two interpolation modes: nearest (default), and linear (including bilinear, trilinear, etc)",
             AttributeProto::STRING,
-            std::string("nearest"))
+            std::string("nearest")
+        )
         .Input(0, "X", "N-D tensor", "T", OpSchema::Single)
         .Input(
             1,
@@ -2177,11 +2254,13 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The scale array along each dimension. It takes value greater than or equal to 1."
             " The number of elements of 'scales' should be the same as the rank of input 'X'.",
             "tensor(float)",
-            OpSchema::Single)
+            OpSchema::Single
+        )
         .Output(0, "Y", "N-D tensor after resizing", "T", OpSchema::Single)
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input 'X' and output 'Y' to all tensor types.")
         .SetDoc(Upsample_ver10_doc)
-        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { resizeShapeInference_opset7_to_10(ctx); }));
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { resizeShapeInference_opset7_to_10(ctx); })
+);
 
 static const char* Resize_ver19_doc = R"DOC(
 Resize the input tensor. In general, it calculates every value in the output tensor as a weighted average of neighborhood (a.k.a. sampling locations) in the input tensor.
@@ -2273,41 +2352,48 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The \"linear\" mode includes linear interpolation for 1D tensor and N-linear interpolation for N-D tensor (for example, bilinear interpolation for 2D tensor). "
             "The \"cubic\" mode includes cubic interpolation for 1D tensor and N-cubic interpolation for N-D tensor (for example, bicubic interpolation for 2D tensor).",
             AttributeProto::STRING,
-            std::string("nearest"))
+            std::string("nearest")
+        )
         .Attr(
             "cubic_coeff_a",
             "The coefficient 'a' used in cubic interpolation. Two common choice are -0.5 (in some cases of TensorFlow) and -0.75"
             " (in PyTorch). Check out Equation (4) in https://ieeexplore.ieee.org/document/1163711 for the details. "
             "This attribute is valid only if mode is \"cubic\".",
             AttributeProto::FLOAT,
-            static_cast<float>(-0.75))
+            static_cast<float>(-0.75)
+        )
         .Attr(
             "exclude_outside",
             "If set to 1, the weight of sampling locations outside the tensor will be set to 0"
             " and the weight will be renormalized so that their sum is 1.0. The default value is 0.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "coordinate_transformation_mode",
             Resize_ver19_attr_coordinate_transformation_mode_doc,
             AttributeProto::STRING,
-            std::string("half_pixel"))
+            std::string("half_pixel")
+        )
         .Attr(
             "nearest_mode",
             "Four modes: \"round_prefer_floor\" (default, as known as round half down), \"round_prefer_ceil\" (as known as round half up), \"floor\", \"ceil\". Only used by nearest interpolation. It indicates how to get \"nearest\" pixel in input tensor from x_original, so this attribute is valid only if \"mode\" is \"nearest\".",
             AttributeProto::STRING,
-            std::string("round_prefer_floor"))
+            std::string("round_prefer_floor")
+        )
         .Attr(
             "extrapolation_value",
             "When coordinate_transformation_mode is \"tf_crop_and_resize\" and x_original is outside the range [0, length_original - 1], this value is used as the corresponding output value. Default is 0.0f.",
             AttributeProto::FLOAT,
-            static_cast<float>(0))
+            static_cast<float>(0)
+        )
         .Attr(
             "antialias",
             "If set to 1, \"linear\" and \"cubic\" interpolation modes will use an antialiasing filter when downscaling. "
             "Antialiasing is achieved by stretching the resampling filter by a factor max(1, 1 / scale), which means that when downsampling, more input pixels contribute to an output pixel.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "axes",
             "If provided, it specifies a subset of axes that 'roi', 'scales' and 'sizes' refer to. "
@@ -2316,12 +2402,14 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Negative value means counting dimensions from the back. Accepted range is [-r, r-1], where r = rank(data). "
             "Behavior is undefined if an axis is repeated.",
             AttributeProto::INTS,
-            false)
+            false
+        )
         .Attr(
             "keep_aspect_ratio_policy",
             Resize_ver19_attr_keep_aspect_ratio_policy_doc,
             AttributeProto::STRING,
-            std::string("stretch"))
+            std::string("stretch")
+        )
         .Input(0, "X", "N-D tensor", "T1", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
             1,
@@ -2332,7 +2420,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "scales",
@@ -2344,7 +2433,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             3,
             "sizes",
@@ -2355,18 +2445,18 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(0, "Y", "N-D tensor after resizing", "T1", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint(
-            "T1",
-            OpSchema::all_tensor_types_ir4(),
-            "Constrain input 'X' and output 'Y' to all tensor types.")
+            "T1", OpSchema::all_tensor_types_ir4(), "Constrain input 'X' and output 'Y' to all tensor types."
+        )
         .TypeConstraint(
-            "T2",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain roi type to float or double.")
+            "T2", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain roi type to float or double."
+        )
         .SetDoc(Resize_ver19_doc)
-        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { resizeShapeInference_opset18_to_19(ctx); }));
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { resizeShapeInference_opset18_to_19(ctx); })
+);
 
 static const char* GridSample_ver20_doc = R"DOC(
 Given an input `X` and a flow-field `grid`, computes the output `Y` using `X` values and pixel locations from the `grid`.
@@ -2401,7 +2491,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The \"cubic\" mode also includes N-cubic interpolation modes following the same rules. The \"nearest\" mode rounds "
             "to the nearest even index when the sampling point falls halfway between two indices.",
             AttributeProto::STRING,
-            std::string("linear"))
+            std::string("linear")
+        )
         .Attr(
             "padding_mode",
             "Support padding modes for outside grid values: `zeros`(default), `border`, `reflection`. "
@@ -2412,14 +2503,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "For location far away from the border, it will keep being reflected until becoming in bound. "
             "If pixel location x = -3.5 reflects by border -1 and becomes x' = 1.5, then reflects by border 1 and becomes x'' = 0.5.",
             AttributeProto::STRING,
-            std::string("zeros"))
+            std::string("zeros")
+        )
         .Attr(
             "align_corners",
             "If align_corners=1, the extrema (-1 and 1) are considered as referring to the center points of the input's corner pixels (voxels, etc.). "
             "If align_corners=0, they are instead considered as referring to the corner points of the input's corner pixels (voxels, etc.), "
             "making the sampling more resolution agnostic.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(
             0,
             "X",
@@ -2429,7 +2522,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             1,
             "grid",
@@ -2444,7 +2538,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "Y",
@@ -2454,17 +2549,17 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
-            "T1",
-            OpSchema::all_tensor_types(),
-            "Constrain input `X` and output `Y` types to all tensor types.")
+            "T1", OpSchema::all_tensor_types(), "Constrain input `X` and output `Y` types to all tensor types."
+        )
         .TypeConstraint(
-            "T2",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain grid types to float tensors.")
+            "T2", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain grid types to float tensors."
+        )
         .SetDoc(GridSample_ver20_doc)
-        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { gridSampleShapeInference(ctx); }));
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { gridSampleShapeInference(ctx); })
+);
 
 static const char* AffineGrid_ver20_doc = R"DOC(
 Generates a 2D or 3D flow field (sampling grid), given a batch of affine matrices theta
@@ -2505,7 +2600,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "if align_corners=1, consider -1 and 1 to refer to the centers of the corner pixels. "
             "if align_corners=0, consider -1 and 1 to refer to the outer edge the corner pixels.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(
             0,
             "theta",
@@ -2514,7 +2610,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             1,
             "size",
@@ -2523,7 +2620,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "grid",
@@ -2532,7 +2630,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint("T1", OpSchema::all_float_types_ir4(), "Constrain grid types to float tensors.")
         .TypeConstraint("T2", {"tensor(int64)"}, "Constrain size's type to int64 tensors.")
         .SetDoc(AffineGrid_ver20_doc)
@@ -2746,7 +2845,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             *output_shape->add_dim() = W;
             output_shape->add_dim()->set_dim_value(3);
           }
-        }));
+        })
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Identity,
@@ -2765,8 +2865,10 @@ ONNX_OPERATOR_SET_SCHEMA(
               t.insert(t.end(), o.begin(), o.end());
               return t;
             }(),
-            "Constrain input and output types to all tensor, sequence, and optional types.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to all tensor, sequence, and optional types."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Compress_ver11_doc = R"DOC(
     Selects slices from an input tensor along a given axis where condition evaluates to True for each axis index.
@@ -2785,7 +2887,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "input is flattened before elements being selected. Negative value means counting dimensions "
             "from the back. Accepted range is [-r, r-1] where r = rank(input).",
             AttributeProto::INT,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Input(0, "input", "Tensor of rank r >= 1.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
             1,
@@ -2798,7 +2901,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "output",
@@ -2807,7 +2911,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to all tensor types.")
         .TypeConstraint("T1", {"tensor(bool)"}, "Constrain to boolean tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -2839,7 +2944,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (!axisAttr) {
             updateOutputShape(ctx, 0, {Dim()});
           }
-        }));
+        })
+);
 
 static const char* OneHot_ver11_doc = R"DOC(
     Produces a one-hot tensor based on inputs.
@@ -2875,7 +2981,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "innermost/last dimension in the output tensor. Negative value means counting dimensions "
             "from the back. Accepted range is [-r-1, r] where r = rank(indices).",
             AttributeProto::INT,
-            static_cast<int64_t>(-1))
+            static_cast<int64_t>(-1)
+        )
         .Input(
             0,
             "indices",
@@ -2887,7 +2994,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             1,
             "depth",
@@ -2900,7 +3008,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "values",
@@ -2912,7 +3021,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "output",
@@ -2923,7 +3033,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .TypeConstraint("T1", OpSchema::all_numeric_types(), "Constrain input to only numeric types.")
         .TypeConstraint("T2", OpSchema::all_numeric_types(), "Constrain input to only numeric types.")
         .TypeConstraint("T3", OpSchema::all_tensor_types(), "Constrain to any tensor type.")
@@ -2995,7 +3106,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               }
             }
           }
-        }));
+        })
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     IsNaN,
@@ -3011,7 +3123,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (hasInputShape(ctx, 0)) {
             propagateShapeFromInputToOutput(ctx, 0, 0);
           }
-        }));
+        })
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     IsInf,
@@ -3026,14 +3139,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "so that positive infinity induces true. Set this attribute to 0 "
             "if positive infinity should be mapped to false.",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .Attr(
             "detect_negative",
             "(Optional) Whether map negative infinity to true. Default to 1 "
             "so that negative infinity induces true. Set this attribute to 0 "
             "if negative infinity should be mapped to false.",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .TypeConstraint("T1", OpSchema::all_float_types_ir9(), "Constrain input types to float tensors.")
         .TypeConstraint("T2", {"tensor(bool)"}, "Constrain output types to boolean tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -3041,7 +3156,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (hasInputShape(ctx, 0)) {
             propagateShapeFromInputToOutput(ctx, 0, 0);
           }
-        }));
+        })
+);
 
 static const char* Where_ver16_doc = R"DOC(
 Return elements, either from X or Y, depending on condition.
@@ -3064,7 +3180,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             1,
             "X",
@@ -3073,7 +3190,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             2,
             "Y",
@@ -3082,7 +3200,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Output(
             0,
             "output",
@@ -3091,12 +3210,14 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint("B", {"tensor(bool)"}, "Constrain to boolean tensors.")
         .TypeConstraint(
             "T",
             OpSchema::all_tensor_types_ir4(),
-            "Constrain input and output types to all tensor types (including bfloat).")
+            "Constrain input and output types to all tensor types (including bfloat)."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 1, 0);
           if (hasNInputShapes(ctx, 3)) {
@@ -3105,9 +3226,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             shapes.push_back(&ctx.getInputType(1)->tensor_type().shape());
             shapes.push_back(&ctx.getInputType(2)->tensor_type().shape());
             multidirectionalBroadcastShapeInference(
-                shapes, *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
+                shapes, *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()
+            );
           }
-        }));
+        })
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     NonZero,
@@ -3127,7 +3250,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
           output_shape.add_dim();
           updateOutputShape(ctx, 0, output_shape);
-        }));
+        })
+);
 
 static const char* ReverseSequence_ver10_doc = R"DOC(
 Reverse batch of sequences having different lengths specified by `sequence_lens`.
@@ -3174,19 +3298,22 @@ ONNX_OPERATOR_SET_SCHEMA(
             "time_axis",
             "(Optional) Specify which axis is time axis. Must be one of 0 (default), or 1.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "batch_axis",
             "(Optional) Specify which axis is batch axis. Must be one of 1 (default), or 0.",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .Input(0, "input", "Tensor of rank r >= 2.", "T", OpSchema::Single)
         .Input(
             1,
             "sequence_lens",
             "Tensor specifying lengths of the sequences in a batch. It has shape `[batch_size]`.",
             "tensor(int64)",
-            OpSchema::Single)
+            OpSchema::Single
+        )
         .Output(0, "Y", "Tensor with same shape of input.", "T", OpSchema::Single)
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Input and output types can be of any tensor type.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -3205,7 +3332,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
 
           propagateShapeFromInputToOutput(ctx, 0, 0);
-        }));
+        })
+);
 
 static const char* Unique_ver11_doc = R"DOC(
 Find the unique elements of a tensor. When an optional attribute 'axis' is provided, unique subtensors sliced along the 'axis' are returned.
@@ -3317,14 +3445,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "(Optional) Whether to sort the unique elements in ascending order before returning as output. "
             "Must be one of 0, or 1 (default).",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .Attr(
             "axis",
             "(Optional) The dimension to apply unique. If not specified, the unique elements of the "
             "flattened input are returned. Negative value means counting dimensions "
             "from the back. Accepted range is [-r, r-1] where r = rank(input).",
             AttributeProto::INT,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Input(
             0,
             "X",
@@ -3333,7 +3463,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "Y",
@@ -3344,7 +3475,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             1,
             "indices",
@@ -3356,7 +3488,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             2,
             "inverse_indices",
@@ -3368,7 +3501,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             3,
             "counts",
@@ -3379,7 +3513,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Input can be of any tensor type.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           // Type inference
@@ -3440,7 +3575,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               }
             }
           }
-        }));
+        })
+);
 
 static const char* GatherND_ver13_doc = R"DOC(
 Given `data` tensor of rank `r` >= 1, `indices` tensor of rank `q` >= 1, and `batch_dims` integer `b`, this operator gathers
@@ -3538,7 +3674,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "batch_dims",
             "The number of batch dimensions. The gather of indexing starts from dimension of data[batch_dims:]",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(0, "data", "Tensor of rank r >= 1.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
             1,
@@ -3549,7 +3686,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "output",
@@ -3558,7 +3696,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to any tensor type.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           // Type inference
@@ -3580,7 +3719,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (data_rank < 1 || indices_rank < 1) {
             fail_shape_inference(
                 "Both `data` and `indices` input tensors in GatherND op "
-                "need to have rank larger than 0.");
+                "need to have rank larger than 0."
+            );
           }
 
           // cannot ascertain if the input shapes are valid if shape of
@@ -3594,7 +3734,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (last_index_dimension > data_rank) {
             fail_shape_inference(
                 "Last dimension of `indices` input tensor in GatherND op "
-                "must not be larger than the rank of `data` tensor");
+                "must not be larger than the rank of `data` tensor"
+            );
           }
 
           for (int i = 0; i < indices_rank - 1; ++i) {
@@ -3604,7 +3745,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           for (int i = static_cast<int>(last_index_dimension); i < data_rank; ++i) {
             *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim() = data_shape.dim(i);
           }
-        }));
+        })
+);
 
 static const char* Pad_ver19_doc = R"DOC(
 Given a tensor containing the data to be padded (`data`), a tensor containing the number of start and end pad values for axis (`pads`), (optionally) a `mode`, and (optionally) `constant_value`,
@@ -3712,8 +3854,9 @@ output = [
 ONNX_OPERATOR_SET_SCHEMA(
     Pad,
     19,
-    OpSchema().FillUsing(
-        PadDocGenerator(Pad_ver19_doc, "Supported modes: `constant`(default), `reflect`, `edge`, `wrap`")));
+    OpSchema()
+        .FillUsing(PadDocGenerator(Pad_ver19_doc, "Supported modes: `constant`(default), `reflect`, `edge`, `wrap`"))
+);
 
 static const char* Trilu_ver14_doc = R"DOC(
 Given a 2-D matrix or batches of 2-D matrices, returns the upper or lower triangular part of the tensor(s).
@@ -3739,16 +3882,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             "upper",
             "Boolean. Indicates whether upper or lower part of matrix is retained. Default is true.",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .Input(
-            0,
-            "input",
-            "Input tensor of rank 2 or higher.",
-            "T",
-            OpSchema::Single,
-            true,
-            1,
-            OpSchema::Differentiable)
+            0, "input", "Input tensor of rank 2 or higher.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable
+        )
         .Input(
             1,
             "k",
@@ -3758,7 +3896,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "output",
@@ -3767,7 +3906,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to all tensor types.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           // Type inference
@@ -3781,7 +3921,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
             propagateShapeFromInputToOutput(ctx, 0, 0);
           }
-        }));
+        })
+);
 
 static const char* CenterCropPad_ver18_doc = R"DOC(
 Center crop or pad an input to given dimensions.
@@ -3807,7 +3948,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             1,
             "shape",
@@ -3816,7 +3958,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(0, "output_data", "Output data.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Attr(
             "axes",
@@ -3825,7 +3968,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Negative value means counting dimensions from the back. Accepted range is [-r, r-1], where r = rank(data). "
             "Behavior is undefined if an axis is repeated.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to all tensor types.")
         .TypeConstraint("Tind", {"tensor(int32)", "tensor(int64)"}, "Constrain indices to integer types")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -3879,7 +4023,8 @@ ONNX_OPERATOR_SET_SCHEMA(
                 shape.size(),
                 ") does not match the number of axes (",
                 axes.size(),
-                ").");
+                ")."
+            );
           }
 
           // Populating default dims
@@ -3906,10 +4051,10 @@ ONNX_OPERATOR_SET_SCHEMA(
           builder.Const("k2", std::vector<int64_t>{2});
 
           auto axes_attr = ctx.getAttribute("axes");
-          if (axes_attr) { // axes provided, need to work on a subset of dimensions
+          if (axes_attr) {  // axes provided, need to work on a subset of dimensions
             builder.Add("axes_input = Constant <value_ints : ints = @axes>()");
             builder.Add("x_shape_alldims = Shape (input_data)").Add("x_shape = Gather (x_shape_alldims, axes_input)");
-          } else { // axes not provided, assuming all dims
+          } else {  // axes not provided, assuming all dims
             builder.Add("x_shape = Shape (input_data)");
           }
 
@@ -3942,6 +4087,7 @@ ONNX_OPERATOR_SET_SCHEMA(
 
           schema.BuildFunction(functionProto);
           return true;
-        }));
+        })
+);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/tensor/old.cc
+++ b/onnx/defs/tensor/old.cc
@@ -59,7 +59,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "to",
             "The data type to which the elements of the input tensor are cast. "
             "Strictly must be one of the types from DataType enum in TensorProto",
-            AttributeProto::INT)
+            AttributeProto::INT
+        )
         .Input(0, "input", "Input tensor to be cast.", "T1", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Output(
             0,
@@ -70,7 +71,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T1",
             {"tensor(float16)",
@@ -87,7 +89,8 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(bool)",
              "tensor(string)",
              "tensor(bfloat16)"},
-            "Constrain input types. Casting from complex is not supported.")
+            "Constrain input types. Casting from complex is not supported."
+        )
         .TypeConstraint(
             "T2",
             {"tensor(float16)",
@@ -104,16 +107,17 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(bool)",
              "tensor(string)",
              "tensor(bfloat16)"},
-            "Constrain output types. Casting to complex is not supported.")
+            "Constrain output types. Casting to complex is not supported."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromAttributeToOutput(ctx, "to", 0);
           if (hasNInputShapes(ctx, 1)) {
             propagateShapeFromInputToOutput(ctx, 0, 0);
           }
         })
-        .PartialDataPropagationFunction([](DataPropagationContext& ctx) {
-          PropagateShapeDataFromInputToOutput(ctx, 0);
-        }));
+        .PartialDataPropagationFunction([](DataPropagationContext& ctx) { PropagateShapeDataFromInputToOutput(ctx, 0); }
+        )
+);
 
 static const char* CastLike_ver15_doc = R"DOC(
 The operator casts the elements of a given input tensor (the first input) to
@@ -135,7 +139,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "output",
@@ -144,7 +149,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
             "T1",
             {"tensor(float16)",
@@ -161,7 +167,8 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(bool)",
              "tensor(string)",
              "tensor(bfloat16)"},
-            "Constrain input types. Casting from complex is not supported.")
+            "Constrain input types. Casting from complex is not supported."
+        )
         .TypeConstraint(
             "T2",
             {"tensor(float16)",
@@ -178,7 +185,8 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(bool)",
              "tensor(string)",
              "tensor(bfloat16)"},
-            "Constrain output types. Casting to complex is not supported.")
+            "Constrain output types. Casting to complex is not supported."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 1, 0);
           if (hasNInputShapes(ctx, 1)) {
@@ -197,7 +205,9 @@ ONNX_OPERATOR_SET_SCHEMA(
               builder.Add("output = Cast (input)", "to", (int64_t)(target_elt_type));
               schema.BuildFunction(functionProto);
               return true;
-            }));
+            }
+        )
+);
 
 static const char* Cast_ver9_doc = R"DOC(
 The operator casts the elements of a given input tensor to a data type
@@ -230,14 +240,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "to",
             "The data type to which the elements of the input tensor are cast. "
             "Strictly must be one of the types from DataType enum in TensorProto",
-            AttributeProto::INT)
+            AttributeProto::INT
+        )
         .Input(0, "input", "Input tensor to be cast.", "T1")
         .Output(
             0,
             "output",
             "Output tensor with the same shape as input with type "
             "specified by the 'to' argument",
-            "T2")
+            "T2"
+        )
         .TypeConstraint(
             "T1",
             {"tensor(float16)",
@@ -253,7 +265,8 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(uint64)",
              "tensor(bool)",
              "tensor(string)"},
-            "Constrain input types. Casting from complex is not supported.")
+            "Constrain input types. Casting from complex is not supported."
+        )
         .TypeConstraint(
             "T2",
             {"tensor(float16)",
@@ -269,13 +282,15 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(uint64)",
              "tensor(bool)",
              "tensor(string)"},
-            "Constrain output types. Casting to complex is not supported.")
+            "Constrain output types. Casting to complex is not supported."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromAttributeToOutput(ctx, "to", 0);
           if (hasNInputShapes(ctx, 1)) {
             propagateShapeFromInputToOutput(ctx, 0, 0);
           }
-        }));
+        })
+);
 
 static const char* GridSample_ver16_doc = R"DOC(
 Given an input `X` and a flow-field `grid`, computes the output `Y` using `X` values and pixel locations from `grid`.
@@ -301,7 +316,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "mode",
             "Three interpolation modes: bilinear (default), nearest and bicubic.",
             AttributeProto::STRING,
-            std::string("bilinear"))
+            std::string("bilinear")
+        )
         .Attr(
             "padding_mode",
             "Support padding modes for outside grid values: `zeros`(default), `border`, `reflection`. "
@@ -312,13 +328,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "For location far away from the border, it will keep being reflected until becoming in bound. "
             "If pixel location x = -3.5 reflects by border -1 and becomes x' = 1.5, then reflects by border 1 and becomes x'' = 0.5.",
             AttributeProto::STRING,
-            std::string("zeros"))
+            std::string("zeros")
+        )
         .Attr(
             "align_corners",
             "If align_corners=1, the extrema (-1 and 1) are considered as referring to the center points of the input's corner pixels. "
             "If align_corners=0, they are instead considered as referring to the corner points of the input's corner pixels, making the sampling more resolution agnostic.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(
             0,
             "X",
@@ -329,7 +347,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             1,
             "grid",
@@ -342,7 +361,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "Y",
@@ -352,17 +372,17 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint(
-            "T1",
-            OpSchema::all_tensor_types(),
-            "Constrain input `X` and output `Y` types to all tensor types.")
+            "T1", OpSchema::all_tensor_types(), "Constrain input `X` and output `Y` types to all tensor types."
+        )
         .TypeConstraint(
-            "T2",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain grid types to float tensors.")
+            "T2", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain grid types to float tensors."
+        )
         .SetDoc(GridSample_ver16_doc)
-        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { gridSampleShapeInference(ctx); }));
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { gridSampleShapeInference(ctx); })
+);
 
 static const char* Reshape_ver13_doc = R"DOC(
 Reshape the input tensor similar to numpy.reshape.
@@ -387,7 +407,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(0, "reshaped", "Reshaped data.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to all tensor types.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -488,7 +509,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               negativeOneDim->set_dim_value(inputProduct / outputProduct);
             }
           }
-        }));
+        })
+);
 
 static const char* Reshape_ver5_doc = R"DOC(
 Reshape the input tensor similar to numpy.reshape.
@@ -607,7 +629,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               negativeOneDim->set_dim_value(inputProduct / outputProduct);
             }
           }
-        }));
+        })
+);
 
 static const char* Shape_ver13_doc = R"DOC(
 Takes a tensor as input and outputs an 1D int64 tensor containing the shape of the input tensor.
@@ -649,7 +672,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             output_length->set_dim_value(ctx.getInputType(0)->tensor_type().shape().dim_size());
           }
         })
-        .PartialDataPropagationFunction([](DataPropagationContext& ctx) { ShapeOp13DataPropagator(ctx); }));
+        .PartialDataPropagationFunction([](DataPropagationContext& ctx) { ShapeOp13DataPropagator(ctx); })
+);
 
 static const char* Shape_ver1_doc = R"DOC(
 Takes a tensor as input and outputs an 1D int64 tensor containing the shape of the input tensor.
@@ -677,7 +701,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             output_length->set_dim_value(ctx.getInputType(0)->tensor_type().shape().dim_size());
           }
         })
-        .PartialDataPropagationFunction([](DataPropagationContext& ctx) { ShapeOp13DataPropagator(ctx); }));
+        .PartialDataPropagationFunction([](DataPropagationContext& ctx) { ShapeOp13DataPropagator(ctx); })
+);
 
 static const char* Size_ver1_doc = R"DOC(
 Takes a tensor as input and outputs a int64 scalar that equals to the total number of elements of the input tensor.
@@ -695,7 +720,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           ctx.getOutputType(0)->mutable_tensor_type()->set_elem_type(TensorProto::INT64);
           ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
-        }));
+        })
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Concat,
@@ -705,10 +731,12 @@ ONNX_OPERATOR_SET_SCHEMA(
             "axis",
             "Which axis to concat on. A negative value means counting dimensions from the back. "
             "Accepted range is [-r, r-1] where r = rank(inputs)..",
-            AttributeProto::INT)
+            AttributeProto::INT
+        )
         .SetDoc(
             "Concatenate a list of tensors into a single tensor. "
-            "All input tensors must have the same shape, except for the dimension size of the axis to concatenate on.")
+            "All input tensors must have the same shape, except for the dimension size of the axis to concatenate on."
+        )
         .Input(0, "inputs", "List of tensors for concatenation", "T", OpSchema::Variadic)
         .Output(0, "concat_result", "Concatenated tensor", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain output types to any tensor type.")
@@ -751,7 +779,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             const auto& shape = ctx.getInputType(i)->tensor_type().shape();
             if (shape.dim_size() != rank) {
               fail_shape_inference(
-                  "All inputs to Concat must have same rank. Input ", i, " has rank ", shape.dim_size(), " != ", rank);
+                  "All inputs to Concat must have same rank. Input ", i, " has rank ", shape.dim_size(), " != ", rank
+              );
             }
             for (int j = 0; j < rank; j++) {
               if (j == axis) {
@@ -771,7 +800,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (all_lengths_known) {
             output_shape->mutable_dim(axis)->set_dim_value(total_length);
           }
-        }));
+        })
+);
 
 static const char* Split_ver11_doc =
     R"DOC(Split a tensor into a list of tensors, along the specified
@@ -792,7 +822,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "A negative value means counting dimensions from the back. Accepted range is [-rank, rank-1] "
             "where r = rank(input).",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr("split", "length of each output. Values should be >= 0.", AttributeProto::INTS, OPTIONAL_VALUE)
         .SetDoc(Split_ver11_doc)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -826,7 +857,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (getRepeatedAttribute(ctx, "split", split)) {
             if (split.size() != ctx.getNumOutputs()) {
               fail_shape_inference(
-                  "Mismatch between number of splits (", split.size(), ") and outputs (", ctx.getNumOutputs(), ")");
+                  "Mismatch between number of splits (", split.size(), ") and outputs (", ctx.getNumOutputs(), ")"
+              );
             }
             int64_t total_dim = 0;
             for (int64_t d : split) {
@@ -838,7 +870,8 @@ ONNX_OPERATOR_SET_SCHEMA(
                   total_dim,
                   ") and the split dimension of the input (",
                   split_dim_value,
-                  ")");
+                  ")"
+              );
             }
           } else {
             int num_outputs = static_cast<int>(ctx.getNumOutputs());
@@ -854,7 +887,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             *ctx.getOutputType(i)->mutable_tensor_type()->mutable_shape() = shape;
             ctx.getOutputType(i)->mutable_tensor_type()->mutable_shape()->mutable_dim(axis)->set_dim_value(split[i]);
           }
-        }));
+        })
+);
 
 static const char* Split_ver13_doc =
     R"DOC(Split a tensor into a list of tensors, along the specified
@@ -876,7 +910,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             0,
             "outputs",
@@ -885,7 +920,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Variadic,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to all tensor types.")
         .Attr(
             "axis",
@@ -893,7 +929,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "A negative value means counting dimensions from the back. Accepted range is [-rank, rank-1] "
             "where r = rank(input).",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .SetDoc(Split_ver13_doc)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           for (int i = 0; i < static_cast<int>(ctx.getNumOutputs()); ++i) {
@@ -924,7 +961,7 @@ ONNX_OPERATOR_SET_SCHEMA(
 
           std::vector<int64_t> split;
           size_t num_inputs = ctx.getNumInputs();
-          if ((num_inputs == 2) && ctx.getInputType(1)) { //'split' is input
+          if ((num_inputs == 2) && ctx.getInputType(1)) {  //'split' is input
             auto split_proto = ctx.getInputData(1);
             if (split_proto == nullptr) {
               // skip if split is not an initializer
@@ -933,7 +970,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             split = ParseData<int64_t>(split_proto);
             if (split.size() != ctx.getNumOutputs()) {
               fail_shape_inference(
-                  "Mismatch between number of splits (", split.size(), ") and outputs (", ctx.getNumOutputs(), ")");
+                  "Mismatch between number of splits (", split.size(), ") and outputs (", ctx.getNumOutputs(), ")"
+              );
             }
             int64_t total_dim = 0;
             for (int64_t d : split) {
@@ -945,9 +983,10 @@ ONNX_OPERATOR_SET_SCHEMA(
                   total_dim,
                   ") and the split dimension of the input (",
                   split_dim_value,
-                  ")");
+                  ")"
+              );
             }
-          } else { // no value available for 'split'
+          } else {  // no value available for 'split'
             int num_outputs = static_cast<int>(ctx.getNumOutputs());
             if (split_dim_value % num_outputs != 0) {
               fail_shape_inference("The input is not evenly splittable");
@@ -962,7 +1001,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             *ctx.getOutputType(i)->mutable_tensor_type()->mutable_shape() = shape;
             ctx.getOutputType(i)->mutable_tensor_type()->mutable_shape()->mutable_dim(axis)->set_dim_value(split[i]);
           }
-        }));
+        })
+);
 
 static const char* Slice_ver11_doc = R"DOC(
 Produces a slice of the input tensor along multiple axes. Similar to numpy:
@@ -1017,7 +1057,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "1-D tensor of axes that `starts` and `ends` apply to. Negative value means counting dimensions "
             "from the back. Accepted range is [-r, r-1] where r = rank(data).",
             "Tind",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Input(
             4,
             "steps",
@@ -1025,7 +1066,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Negative value means slicing backward. 'steps' cannot be 0. "
             "Defaults to 1.",
             "Tind",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(0, "output", "Sliced data tensor.", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to all tensor types.")
         .TypeConstraint("Tind", {"tensor(int32)", "tensor(int64)"}, "Constrain indices to integer types")
@@ -1188,7 +1230,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             // assign output value
             ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->mutable_dim((int)axis)->set_dim_value(temp);
           }
-        }));
+        })
+);
 
 static const char* Transpose_ver1_doc = R"DOC(
 Transpose the input tensor similar to numpy.transpose. For example, when
@@ -1206,7 +1249,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "A list of integers. By default, reverse the dimensions, "
             "otherwise permute the axes according to the values given.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Input(0, "data", "An input tensor.", "T")
         .Output(0, "transposed", "Transposed output.", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to all tensor types.")
@@ -1255,7 +1299,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           for (size_t i = 0; i < perm.size(); ++i) {
             appendSingleDimCopiedFromInputTypeToOutputType(ctx, 0, 0, static_cast<size_t>(perm[i]));
           }
-        }));
+        })
+);
 
 static const char* ScatterND_ver16_doc = R"DOC(
 ScatterND takes three inputs `data` tensor of rank r >= 1, `indices` tensor of rank q >= 1,
@@ -1338,7 +1383,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "'add':  reduction using the addition operation. "
             "'mul': reduction using the multiplication operation.",
             AttributeProto::STRING,
-            std::string("none"))
+            std::string("none")
+        )
         .Input(0, "data", "Tensor of rank r >= 1.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
             1,
@@ -1348,7 +1394,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "updates",
@@ -1357,7 +1404,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Output(0, "output", "Tensor of rank r >= 1.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to any tensor type.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -1365,7 +1413,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (hasNInputShapes(ctx, 1)) {
             propagateShapeFromInputToOutput(ctx, 0, 0);
           }
-        }));
+        })
+);
 
 static const char* ScatterND_ver13_doc = R"DOC(
 ScatterND takes three inputs `data` tensor of rank r >= 1, `indices` tensor of rank q >= 1,
@@ -1441,7 +1490,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "updates",
@@ -1450,7 +1500,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Output(0, "output", "Tensor of rank r >= 1.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to any tensor type.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -1458,7 +1509,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (hasNInputShapes(ctx, 1)) {
             propagateShapeFromInputToOutput(ctx, 0, 0);
           }
-        }));
+        })
+);
 
 static const char* ScatterND_ver11_doc = R"DOC(
 ScatterND takes three inputs `data` tensor of rank r >= 1, `indices` tensor of rank q >= 1,
@@ -1535,7 +1587,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (hasNInputShapes(ctx, 1)) {
             propagateShapeFromInputToOutput(ctx, 0, 0);
           }
-        }));
+        })
+);
 
 static const char* ScatterElements_ver16_doc = R"DOC(
 ScatterElements takes three inputs `data`, `updates`, and `indices` of the same
@@ -1610,7 +1663,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Which axis to scatter on. Negative value means "
             "counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(data).",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "reduction",
             "Type of reduction to apply: none (default), add, mul. "
@@ -1618,7 +1672,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "'add':  reduction using the addition operation. "
             "'mul': reduction using the multiplication operation.",
             AttributeProto::STRING,
-            std::string("none"))
+            std::string("none")
+        )
         .Input(0, "data", "Tensor of rank r >= 1.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
             1,
@@ -1629,7 +1684,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "updates",
@@ -1638,7 +1694,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Output(
             0,
             "output",
@@ -1647,7 +1704,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Input and output types can be of any tensor type.")
         .TypeConstraint("Tind", {"tensor(int32)", "tensor(int64)"}, "Constrain indices to integer types")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -1655,7 +1713,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (hasNInputShapes(ctx, 1)) {
             propagateShapeFromInputToOutput(ctx, 0, 0);
           }
-        }));
+        })
+);
 
 static const char* ScatterElements_ver13_doc = R"DOC(
 ScatterElements takes three inputs `data`, `updates`, and `indices` of the same
@@ -1721,7 +1780,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Which axis to scatter on. Negative value means "
             "counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(data).",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(0, "data", "Tensor of rank r >= 1.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
             1,
@@ -1732,7 +1792,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "updates",
@@ -1741,7 +1802,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Output(
             0,
             "output",
@@ -1750,7 +1812,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Input and output types can be of any tensor type.")
         .TypeConstraint("Tind", {"tensor(int32)", "tensor(int64)"}, "Constrain indices to integer types")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -1758,7 +1821,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (hasNInputShapes(ctx, 1)) {
             propagateShapeFromInputToOutput(ctx, 0, 0);
           }
-        }));
+        })
+);
 
 static const char* ScatterElements_ver11_doc = R"DOC(
 ScatterElements takes three inputs `data`, `updates`, and `indices` of the same
@@ -1824,14 +1888,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Which axis to scatter on. Negative value means "
             "counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(data).",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(0, "data", "Tensor of rank r >= 1.", "T")
         .Input(
             1,
             "indices",
             "Tensor of int32/int64 indices, of r >= 1 (same rank as input). All index values are expected to be "
             "within bounds [-s, s-1] along axis of size s. It is an error if any of the index values are out of bounds.",
-            "Tind")
+            "Tind"
+        )
         .Input(2, "updates", "Tensor of rank r >=1 (same rank and shape as indices)", "T")
         .Output(0, "output", "Tensor of rank r >= 1 (same rank as input).", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Input and output types can be of any tensor type.")
@@ -1841,7 +1907,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (hasNInputShapes(ctx, 1)) {
             propagateShapeFromInputToOutput(ctx, 0, 0);
           }
-        }));
+        })
+);
 
 static const char* Gather_ver11_doc = R"DOC(
 Given `data` tensor of rank r >= 1, and `indices` tensor of rank q, gather
@@ -1911,14 +1978,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Which axis to gather on. Negative value means "
             "counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(data).",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(0, "data", "Tensor of rank r >= 1.", "T")
         .Input(
             1,
             "indices",
             "Tensor of int32/int64 indices, of any rank q. All index values are expected to be within bounds [-s, s-1] "
             "along axis of size s. It is an error if any of the index values are out of bounds.",
-            "Tind")
+            "Tind"
+        )
         .Output(0, "output", "Tensor of rank q + (r - 1).", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to any tensor type.")
         .TypeConstraint("Tind", {"tensor(int32)", "tensor(int64)"}, "Constrain indices to integer types")
@@ -1947,13 +2016,14 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
           for (int i = 0; i < out_rank; ++i) {
             *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim() = (i < axis) ? data_shape.dim(i)
-                                                                                                  : // i < axis < r
+                                                                                                  :  // i < axis < r
                 (i >= axis && i < axis + q) ? indices_shape.dim(i - axis)
-                                            : // i - axis < q
-                data_shape.dim(i - q + 1); // i < out_rank < q + r - 1
+                                            :  // i - axis < q
+                data_shape.dim(i - q + 1);  // i < out_rank < q + r - 1
           }
         })
-        .PartialDataPropagationFunction([](DataPropagationContext& ctx) { GatherOp13DataPropagator(ctx); }));
+        .PartialDataPropagationFunction([](DataPropagationContext& ctx) { GatherOp13DataPropagator(ctx); })
+);
 
 static const char* GatherElements_ver11_doc = R"DOC(
 
@@ -2024,14 +2094,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Which axis to gather on. Negative value means "
             "counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(data).",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(0, "data", "Tensor of rank r >= 1.", "T")
         .Input(
             1,
             "indices",
             "Tensor of int32/int64 indices, with the same rank r as the input. All index values are expected to be "
             "within bounds [-s, s-1] along axis of size s. It is an error if any of the index values are out of bounds.",
-            "Tind")
+            "Tind"
+        )
         .Output(0, "output", "Tensor of the same shape as indices.", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to any tensor type.")
         .TypeConstraint("Tind", {"tensor(int32)", "tensor(int64)"}, "Constrain indices to integer types")
@@ -2041,7 +2113,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (hasInputShape(ctx, 1)) {
             propagateShapeFromInputToOutput(ctx, 1, 0);
           }
-        }));
+        })
+);
 
 static const char* Squeeze_ver11_doc = R"DOC(
 Remove single-dimensional entries from the shape of a tensor.
@@ -2059,7 +2132,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "List of integers indicating the dimensions to squeeze. Negative value means counting dimensions "
             "from the back. Accepted range is [-r, r-1] where r = rank(data).",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .SetDoc(Squeeze_ver11_doc)
         .Input(0, "data", "Tensors with at least max(dims) dimensions.", "T")
         .Output(0, "squeezed", "Reshaped tensor with same data as input.", "T")
@@ -2090,13 +2164,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             if (std::find(axes.begin(), axes.end(), i) != axes.end()) {
               if (input_shape.dim(i).has_dim_value() && input_shape.dim(i).dim_value() != 1) {
                 fail_shape_inference(
-                    "Dimension of input ", i, " must be 1 instead of ", input_shape.dim(i).dim_value());
+                    "Dimension of input ", i, " must be 1 instead of ", input_shape.dim(i).dim_value()
+                );
               }
             } else {
               *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim() = input_shape.dim(i);
             }
           }
-        }));
+        })
+);
 
 static const char* Unsqueeze_ver11_doc = R"DOC(
 Insert single-dimensional entries to the shape of an input tensor (`data`).
@@ -2121,7 +2197,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "axes",
             "List of integers indicating the dimensions to be inserted. Negative value means counting dimensions "
             "from the back. Accepted range is [-r, r-1] where r = rank(expanded).",
-            AttributeProto::INTS)
+            AttributeProto::INTS
+        )
         .SetDoc(Unsqueeze_ver11_doc)
         .Input(0, "data", "Original tensor", "T")
         .Output(0, "expanded", "Reshaped tensor with same data as input.", "T")
@@ -2182,7 +2259,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
             ++j;
           }
-        }));
+        })
+);
 
 static const char* SpaceToDepth_ver1_doc =
     R"DOC(SpaceToDepth rearranges blocks of spatial data into depth. More specifically,
@@ -2201,7 +2279,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "input",
             "Input tensor of [N,C,H,W], where N is the batch axis, C is the channel or depth"
             ", H is the height and W is the width.",
-            "T")
+            "T"
+        )
         .Output(0, "output", "Output tensor of [N, C * blocksize * blocksize, H/blocksize, W/blocksize].", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to all tensor types.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -2221,12 +2300,14 @@ ONNX_OPERATOR_SET_SCHEMA(
                   {input_shape.dim(0),
                    input_shape.dim(1) * (blocksize * blocksize),
                    input_shape.dim(2) / blocksize,
-                   input_shape.dim(3) / blocksize});
+                   input_shape.dim(3) / blocksize}
+              );
             } else {
               fail_shape_inference("Input tensor must be 4-dimensional");
             }
           }
-        }));
+        })
+);
 
 static const char* DepthToSpace_ver11_doc =
     R"DOC(DepthToSpace rearranges (permutes) data from depth into blocks of spatial data.
@@ -2267,14 +2348,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "mode",
             "DCR (default) for depth-column-row order re-arrangement. Use CRD for column-row-depth order.",
             AttributeProto::STRING,
-            std::string("DCR"))
+            std::string("DCR")
+        )
         .SetDoc(DepthToSpace_ver11_doc)
         .Input(
             0,
             "input",
             "Input tensor of [N,C,H,W], where N is the batch axis, C is the channel or depth"
             ", H is the height and W is the width.",
-            "T")
+            "T"
+        )
         .Output(0, "output", "Output tensor of [N, C/(blocksize * blocksize), H * blocksize, W * blocksize].", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to all tensor types.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -2294,12 +2377,14 @@ ONNX_OPERATOR_SET_SCHEMA(
                   {input_shape.dim(0),
                    input_shape.dim(1) / (blocksize * blocksize),
                    input_shape.dim(2) * blocksize,
-                   input_shape.dim(3) * blocksize});
+                   input_shape.dim(3) * blocksize}
+              );
             } else {
               fail_shape_inference("Input tensor must be 4-dimensional");
             }
           }
-        }));
+        })
+);
 
 static const char* Tile_ver6_doc =
     R"DOC(Constructs a tensor by tiling a given tensor.
@@ -2318,13 +2403,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "repeats",
             "1D int64 tensor of the same length as input's dimension number, "
             "includes numbers of repeated copies along input's dimensions.",
-            "T1")
+            "T1"
+        )
         .Output(
             0,
             "output",
             "Output tensor of the same dimensions and type as tensor input. "
             "output_dim[i] = input_dim[i] * repeats[i]",
-            "T")
+            "T"
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to all tensor types.")
         .TypeConstraint("T1", {"tensor(int64)"}, "Constrain repeat's type to int64 tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -2357,7 +2444,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               fail_shape_inference(
                   "'Repeats' input has incorrect number of values. "
                   "The number of values in 'repeats' must be equal "
-                  "to the number of input dimensions.");
+                  "to the number of input dimensions."
+              );
             }
 
             for (size_t i = 0; (int64_t)i < input_rank; ++i) {
@@ -2376,7 +2464,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
           }
           return;
-        }));
+        })
+);
 
 static const char* Resize_ver18_doc = R"DOC(
 Resize the input tensor. In general, it calculates every value in the output tensor as a weighted average of neighborhood (a.k.a. sampling locations) in the input tensor.
@@ -2438,41 +2527,48 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The \"linear\" mode includes linear interpolation for 1D tensor and N-linear interpolation for N-D tensor (for example, bilinear interpolation for 2D tensor). "
             "The \"cubic\" mode includes cubic interpolation for 1D tensor and N-cubic interpolation for N-D tensor (for example, bicubic interpolation for 2D tensor).",
             AttributeProto::STRING,
-            std::string("nearest"))
+            std::string("nearest")
+        )
         .Attr(
             "cubic_coeff_a",
             "The coefficient 'a' used in cubic interpolation. Two common choice are -0.5 (in some cases of TensorFlow) and -0.75"
             " (in PyTorch). Check out Equation (4) in https://ieeexplore.ieee.org/document/1163711 for the details. "
             "This attribute is valid only if mode is \"cubic\".",
             AttributeProto::FLOAT,
-            static_cast<float>(-0.75))
+            static_cast<float>(-0.75)
+        )
         .Attr(
             "exclude_outside",
             "If set to 1, the weight of sampling locations outside the tensor will be set to 0"
             " and the weight will be renormalized so that their sum is 1.0. The default value is 0.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "coordinate_transformation_mode",
             Resize_ver18_attr_coordinate_transformation_mode_doc,
             AttributeProto::STRING,
-            std::string("half_pixel"))
+            std::string("half_pixel")
+        )
         .Attr(
             "nearest_mode",
             "Four modes: \"round_prefer_floor\" (default, as known as round half down), \"round_prefer_ceil\" (as known as round half up), \"floor\", \"ceil\". Only used by nearest interpolation. It indicates how to get \"nearest\" pixel in input tensor from x_original, so this attribute is valid only if \"mode\" is \"nearest\".",
             AttributeProto::STRING,
-            std::string("round_prefer_floor"))
+            std::string("round_prefer_floor")
+        )
         .Attr(
             "extrapolation_value",
             "When coordinate_transformation_mode is \"tf_crop_and_resize\" and x_original is outside the range [0, length_original - 1], this value is used as the corresponding output value. Default is 0.0f.",
             AttributeProto::FLOAT,
-            static_cast<float>(0))
+            static_cast<float>(0)
+        )
         .Attr(
             "antialias",
             "If set to 1, \"linear\" and \"cubic\" interpolation modes will use an antialiasing filter when downscaling. "
             "Antialiasing is achieved by stretching the resampling filter by a factor max(1, 1 / scale), which means that when downsampling, more input pixels contribute to an output pixel.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "axes",
             "If provided, it specifies a subset of axes that 'roi', 'scales' and 'sizes' refer to. "
@@ -2481,12 +2577,14 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Negative value means counting dimensions from the back. Accepted range is [-r, r-1], where r = rank(data). "
             "Behavior is undefined if an axis is repeated.",
             AttributeProto::INTS,
-            false)
+            false
+        )
         .Attr(
             "keep_aspect_ratio_policy",
             Resize_ver18_attr_keep_aspect_ratio_policy_doc,
             AttributeProto::STRING,
-            std::string("stretch"))
+            std::string("stretch")
+        )
         .Input(0, "X", "N-D tensor", "T1", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
             1,
@@ -2497,7 +2595,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "scales",
@@ -2509,7 +2608,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             3,
             "sizes",
@@ -2520,18 +2620,18 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(0, "Y", "N-D tensor after resizing", "T1", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint(
-            "T1",
-            OpSchema::all_tensor_types_ir4(),
-            "Constrain input 'X' and output 'Y' to all tensor types.")
+            "T1", OpSchema::all_tensor_types_ir4(), "Constrain input 'X' and output 'Y' to all tensor types."
+        )
         .TypeConstraint(
-            "T2",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain roi type to float or double.")
+            "T2", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain roi type to float or double."
+        )
         .SetDoc(Resize_ver18_doc)
-        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { resizeShapeInference_opset13_to_18(ctx); }));
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { resizeShapeInference_opset13_to_18(ctx); })
+);
 
 static const char* Resize_ver13_doc = R"DOC(
 Resize the input tensor. In general, it calculates every value in the output tensor as a weighted average of neighborhood (a.k.a. sampling locations) in the input tensor.
@@ -2570,35 +2670,41 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The \"linear\" mode includes linear interpolation for 1D tensor and N-linear interpolation for N-D tensor (for example, bilinear interpolation for 2D tensor). "
             "The \"cubic\" mode includes cubic interpolation for 1D tensor and N-cubic interpolation for N-D tensor (for example, bicubic interpolation for 2D tensor).",
             AttributeProto::STRING,
-            std::string("nearest"))
+            std::string("nearest")
+        )
         .Attr(
             "cubic_coeff_a",
             "The coefficient 'a' used in cubic interpolation. Two common choice are -0.5 (in some cases of TensorFlow) and -0.75"
             " (in PyTorch). Check out Equation (4) in https://ieeexplore.ieee.org/document/1163711 for the details. "
             "This attribute is valid only if \"mode\" is \"cubic\".",
             AttributeProto::FLOAT,
-            static_cast<float>(-0.75))
+            static_cast<float>(-0.75)
+        )
         .Attr(
             "exclude_outside",
             "If set to 1, the weight of sampling locations outside the tensor will be set to 0"
             " and the weight will be renormalized so that their sum is 1.0. The default value is 0.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "coordinate_transformation_mode",
             Resize_ver13_attr_coordinate_transformation_mode_doc,
             AttributeProto::STRING,
-            std::string("half_pixel"))
+            std::string("half_pixel")
+        )
         .Attr(
             "nearest_mode",
             "Four modes: round_prefer_floor (default, as known as round half down), round_prefer_ceil (as known as round half up), floor, ceil. Only used by nearest interpolation. It indicates how to get \"nearest\" pixel in input tensor from x_original, so this attribute is valid only if \"mode\" is \"nearest\".",
             AttributeProto::STRING,
-            std::string("round_prefer_floor"))
+            std::string("round_prefer_floor")
+        )
         .Attr(
             "extrapolation_value",
             "When coordinate_transformation_mode is \"tf_crop_and_resize\" and x_original is outside the range [0, length_original - 1], this value is used as the corresponding output value. Default is 0.0f.",
             AttributeProto::FLOAT,
-            static_cast<float>(0))
+            static_cast<float>(0)
+        )
         .Input(0, "X", "N-D tensor", "T1", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
             1,
@@ -2608,7 +2714,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "scales",
@@ -2619,7 +2726,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             3,
             "sizes",
@@ -2629,18 +2737,18 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(0, "Y", "N-D tensor after resizing", "T1", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint(
-            "T1",
-            OpSchema::all_tensor_types_ir4(),
-            "Constrain input 'X' and output 'Y' to all tensor types.")
+            "T1", OpSchema::all_tensor_types_ir4(), "Constrain input 'X' and output 'Y' to all tensor types."
+        )
         .TypeConstraint(
-            "T2",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain roi type to float or double.")
+            "T2", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain roi type to float or double."
+        )
         .SetDoc(Resize_ver13_doc)
-        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { resizeShapeInference_opset13_to_18(ctx); }));
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { resizeShapeInference_opset13_to_18(ctx); })
+);
 
 static const char* Resize_ver11_doc = R"DOC(
 Resize the input tensor. In general, it calculates every value in the output tensor as a weighted average of neighborhood (a.k.a. sampling locations) in the input tensor.
@@ -2682,63 +2790,72 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The \"linear\" mode includes linear interpolation for 1D tensor and N-linear interpolation for N-D tensor (for example, bilinear interpolation for 2D tensor). "
             "The \"cubic\" mode includes cubic interpolation for 1D tensor and N-cubic interpolation for N-D tensor (for example, bicubic interpolation for 2D tensor).",
             AttributeProto::STRING,
-            std::string("nearest"))
+            std::string("nearest")
+        )
         .Attr(
             "cubic_coeff_a",
             "The coefficient 'a' used in cubic interpolation. Two common choice are -0.5 (in some cases of TensorFlow) and -0.75"
             " (in PyTorch). Check out Equation (4) in https://ieeexplore.ieee.org/document/1163711 for the details. "
             "This attribute is valid only if \"mode\" is \"cubic\".",
             AttributeProto::FLOAT,
-            static_cast<float>(-0.75))
+            static_cast<float>(-0.75)
+        )
         .Attr(
             "exclude_outside",
             "If set to 1, the weight of sampling locations outside the tensor will be set to 0"
             " and the weight will be renormalized so that their sum is 1.0. The default value is 0.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "coordinate_transformation_mode",
             Resize_attr_coordinate_transformation_mode_doc,
             AttributeProto::STRING,
-            std::string("half_pixel"))
+            std::string("half_pixel")
+        )
         .Attr(
             "nearest_mode",
             "Four modes: round_prefer_floor (default, as known as round half down), round_prefer_ceil (as known as round half up), floor, ceil. Only used by nearest interpolation. It indicates how to get \"nearest\" pixel in input tensor from x_original, so this attribute is valid only if \"mode\" is \"nearest\".",
             AttributeProto::STRING,
-            std::string("round_prefer_floor"))
+            std::string("round_prefer_floor")
+        )
         .Attr(
             "extrapolation_value",
             "When coordinate_transformation_mode is \"tf_crop_and_resize\" and x_original is outside the range [0, length_original - 1], this value is used as the corresponding output value. Default is 0.0f.",
             AttributeProto::FLOAT,
-            static_cast<float>(0))
+            static_cast<float>(0)
+        )
         .Input(0, "X", "N-D tensor", "T1")
         .Input(
             1,
             "roi",
             "1-D tensor given as [start1, ..., startN, end1, ..., endN], where N is the rank of X. The RoIs' coordinates are normalized in the coordinate system of the input image. It only takes effect when coordinate_transformation_mode is \"tf_crop_and_resize\"",
-            "T2")
+            "T2"
+        )
         .Input(
             2,
             "scales",
             "The scale array along each dimension. It takes value greater than 0. If it's less than 1,"
             " it's sampling down, otherwise, it's upsampling. The number of elements of 'scales' should"
             " be the same as the rank of input 'X'. If 'size' is needed, the user must set 'scales' to an empty tensor.",
-            "tensor(float)")
+            "tensor(float)"
+        )
         .Input(
             3,
             "sizes",
             "The size of the output tensor. The number of elements of 'sizes' should be the same as the"
             " rank of input 'X'. May only be set if 'scales' is set to an empty tensor.",
             "tensor(int64)",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(0, "Y", "N-D tensor after resizing", "T1")
         .TypeConstraint("T1", OpSchema::all_tensor_types(), "Constrain input 'X' and output 'Y' to all tensor types.")
         .TypeConstraint(
-            "T2",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain roi type to float or double.")
+            "T2", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain roi type to float or double."
+        )
         .SetDoc(Resize_ver11_doc)
-        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { resizeShapeInference_opset11_to_12(ctx); }));
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { resizeShapeInference_opset11_to_12(ctx); })
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Identity,
@@ -2748,7 +2865,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Input(0, "input", "Input tensor", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Output(0, "output", "Tensor to copy input into.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to all tensor types.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Identity,
@@ -2758,7 +2876,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Input(0, "input", "Input tensor", "T")
         .Output(0, "output", "Tensor to copy input into.", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to all tensor types.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     IsNaN,
@@ -2768,16 +2887,16 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Input(0, "X", "input", "T1")
         .Output(0, "Y", "output", "T2")
         .TypeConstraint(
-            "T1",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input types to float tensors.")
+            "T1", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain input types to float tensors."
+        )
         .TypeConstraint("T2", {"tensor(bool)"}, "Constrain output types to boolean tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           updateOutputElemType(ctx, 0, TensorProto::BOOL);
           if (hasInputShape(ctx, 0)) {
             propagateShapeFromInputToOutput(ctx, 0, 0);
           }
-        }));
+        })
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     IsNaN,
@@ -2789,14 +2908,16 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T1",
             {"tensor(float16)", "tensor(float)", "tensor(double)", "tensor(bfloat16)"},
-            "Constrain input types to float tensors.")
+            "Constrain input types to float tensors."
+        )
         .TypeConstraint("T2", {"tensor(bool)"}, "Constrain output types to boolean tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           updateOutputElemType(ctx, 0, TensorProto::BOOL);
           if (hasInputShape(ctx, 0)) {
             propagateShapeFromInputToOutput(ctx, 0, 0);
           }
-        }));
+        })
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     IsInf,
@@ -2811,14 +2932,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "so that positive infinity induces true. Set this attribute to 0 "
             "if positive infinity should be mapped to false.",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .Attr(
             "detect_negative",
             "(Optional) Whether map negative infinity to true. Default to 1 "
             "so that negative infinity induces true. Set this attribute to 0 "
             "if negative infinity should be mapped to false.",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .TypeConstraint("T1", {"tensor(float)", "tensor(double)"}, "Constrain input types to float tensors.")
         .TypeConstraint("T2", {"tensor(bool)"}, "Constrain output types to boolean tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -2826,7 +2949,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (hasInputShape(ctx, 0)) {
             propagateShapeFromInputToOutput(ctx, 0, 0);
           }
-        }));
+        })
+);
 
 const char* NonZero_ver9_doc = R"DOC(
     Returns the indices of the elements that are non-zero
@@ -2854,7 +2978,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
           output_shape.add_dim();
           updateOutputShape(ctx, 0, output_shape);
-        }));
+        })
+);
 
 static const char* GatherND_ver12_doc = R"DOC(
 Given `data` tensor of rank `r` >= 1, `indices` tensor of rank `q` >= 1, and `batch_dims` integer `b`, this operator gathers
@@ -2959,14 +3084,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "batch_dims",
             "The number of batch dimensions. The gather of indexing starts from dimension of data[batch_dims:]",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(0, "data", "Tensor of rank r >= 1.", "T")
         .Input(
             1,
             "indices",
             "Tensor of rank q >= 1. All index values are expected to be within bounds [-s, s-1] "
             "along axis of size s. It is an error if any of the index values are out of bounds.",
-            "tensor(int64)")
+            "tensor(int64)"
+        )
         .Output(0, "output", "Tensor of rank q + r - indices_shape[-1] - 1.", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to any tensor type.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -2989,7 +3116,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (data_rank < 1 || indices_rank < 1) {
             fail_shape_inference(
                 "Both `data` and `indices` input tensors in GatherND op "
-                "need to have rank larger than 0.");
+                "need to have rank larger than 0."
+            );
           }
 
           // cannot ascertain if the input shapes are valid if shape of
@@ -3003,7 +3131,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (last_index_dimension > data_rank) {
             fail_shape_inference(
                 "Last dimension of `indices` input tensor in GatherND op "
-                "must not be larger than the rank of `data` tensor");
+                "must not be larger than the rank of `data` tensor"
+            );
           }
 
           for (int i = 0; i < indices_rank - 1; ++i) {
@@ -3013,7 +3142,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           for (int i = static_cast<int>(last_index_dimension); i < data_rank; ++i) {
             *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim() = data_shape.dim(i);
           }
-        }));
+        })
+);
 
 static const char* Pad_ver11_doc = R"DOC(
 Given a tensor containing the data to be padded (`data`), a tensor containing the number of start and end pad values for axis (`pads`), (optionally) a `mode`, and (optionally) `constant_value`,
@@ -3101,7 +3231,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "mode",
             "Supported modes: `constant`(default), `reflect`, `edge`",
             AttributeProto::STRING,
-            std::string("constant"))
+            std::string("constant")
+        )
         .SetDoc(Pad_ver11_doc)
         .Input(0, "data", "Input tensor.", "T")
         .Input(
@@ -3113,13 +3244,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "`pads` format should be: [x1_begin, x2_begin,...,x1_end, x2_end,...], "
             "where xi_begin is the number of pad values added at the beginning of axis `i` and "
             "xi_end, the number of pad values added at the end of axis `i`.",
-            "tensor(int64)")
+            "tensor(int64)"
+        )
         .Input(
             2,
             "constant_value",
             "(Optional) A scalar value to be used if the mode chosen is `constant` (by default it is 0).",
             "T",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(0, "output", "Tensor after padding.", "T")
         .TypeConstraint("T", OpSchema::all_numeric_types(), "Constrain input and output to only numeric types.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -3162,7 +3295,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
           }
           return;
-        }));
+        })
+);
 
 static const char* Cast_ver1_doc = R"DOC(
 The operator casts the elements of a given input tensor to a data type
@@ -3181,14 +3315,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "to",
             "The data type to which the elements of the input tensor are cast. "
             "Strictly must be one of the types from DataType enum in TensorProto",
-            AttributeProto::STRING)
+            AttributeProto::STRING
+        )
         .Input(0, "input", "Input tensor to be cast.", "T1")
         .Output(
             0,
             "output",
             "Output tensor with the same shape as input with type "
             "specified by the 'to' argument",
-            "T2")
+            "T2"
+        )
         .TypeConstraint(
             "T1",
             {"tensor(float16)",
@@ -3203,7 +3339,8 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(uint32)",
              "tensor(uint64)",
              "tensor(bool)"},
-            "Constrain input types. Casting from strings and complex are not supported.")
+            "Constrain input types. Casting from strings and complex are not supported."
+        )
         .TypeConstraint(
             "T2",
             {"tensor(float16)",
@@ -3218,7 +3355,9 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(uint32)",
              "tensor(uint64)",
              "tensor(bool)"},
-            "Constrain output types. Casting to strings and complex are not supported."));
+            "Constrain output types. Casting to strings and complex are not supported."
+        )
+);
 
 static const char* Cast_ver6_doc = R"DOC(
 The operator casts the elements of a given input tensor to a data type
@@ -3237,14 +3376,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "to",
             "The data type to which the elements of the input tensor are cast. "
             "Strictly must be one of the types from DataType enum in TensorProto",
-            AttributeProto::INT)
+            AttributeProto::INT
+        )
         .Input(0, "input", "Input tensor to be cast.", "T1")
         .Output(
             0,
             "output",
             "Output tensor with the same shape as input with type "
             "specified by the 'to' argument",
-            "T2")
+            "T2"
+        )
         .TypeConstraint(
             "T1",
             {"tensor(float16)",
@@ -3259,7 +3400,8 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(uint32)",
              "tensor(uint64)",
              "tensor(bool)"},
-            "Constrain input types. Casting from strings and complex are not supported.")
+            "Constrain input types. Casting from strings and complex are not supported."
+        )
         .TypeConstraint(
             "T2",
             {"tensor(float16)",
@@ -3274,13 +3416,15 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(uint32)",
              "tensor(uint64)",
              "tensor(bool)"},
-            "Constrain output types. Casting to strings and complex are not supported.")
+            "Constrain output types. Casting to strings and complex are not supported."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromAttributeToOutput(ctx, "to", 0);
           if (hasNInputShapes(ctx, 1)) {
             propagateShapeFromInputToOutput(ctx, 0, 0);
           }
-        }));
+        })
+);
 
 static const char* Concat_ver1_doc = R"DOC(Concatenate a list of tensors into a single tensor)DOC";
 
@@ -3293,9 +3437,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Input(0, "inputs", "List of tensors for concatenation", "T", OpSchema::Variadic)
         .Output(0, "concat_result", "Concatenated tensor", "T")
         .TypeConstraint(
-            "T",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain output types to float tensors."));
+            "T", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain output types to float tensors."
+        )
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Concat,
@@ -3324,7 +3468,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             fail_shape_inference("rank must be greater than axis");
           }
           if (axis < 0) {
-            return; // TODO: check if negative axis must be supported
+            return;  // TODO: check if negative axis must be supported
           }
 
           bool all_lengths_known = true;
@@ -3359,7 +3503,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (all_lengths_known) {
             output_shape->mutable_dim(axis)->set_dim_value(total_length);
           }
-        }));
+        })
+);
 
 static const char* Split_ver1_doc =
     R"DOC(Split a tensor into a list of tensors, along the specified
@@ -3376,12 +3521,12 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Input(1, "split", "Optional list of output lengths (see also arg 'split')", "T", OpSchema::Optional)
         .Output(0, "outputs...", "One or more outputs forming list of tensors after splitting", "T", OpSchema::Variadic)
         .TypeConstraint(
-            "T",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input types to float tensors.")
+            "T", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain input types to float tensors."
+        )
         .Attr("axis", "Which axis to split on", AttributeProto::INT, OPTIONAL_VALUE)
         .Attr("split", "length of each output", AttributeProto::INTS, OPTIONAL_VALUE)
-        .SetDoc(Split_ver1_doc));
+        .SetDoc(Split_ver1_doc)
+);
 
 static const char* Pad_ver1_doc = R"DOC(
 Given `data` tensor, paddings, mode, and value.
@@ -3414,7 +3559,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "[x1_begin, x2_begin...x1_end, x2_end,...], where xi_begin the number of pixels "
             "added at the beginning of axis `i` and xi_end, the number of pixels added at "
             "the end of axis `i`.",
-            AttributeProto::INTS)
+            AttributeProto::INTS
+        )
         .Attr("mode", "Three modes: constant(default), reflect, edge", AttributeProto::STRING, std::string("constant"))
         .Attr("value", "One float, indicates the value to be filled, default is 0", AttributeProto::FLOAT, 0.0f)
         .SetDoc(Pad_ver1_doc)
@@ -3423,7 +3569,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* Reshape_ver1_doc = R"DOC(
 Reshape the input tensor similar to numpy.reshape.
@@ -3449,7 +3597,9 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors."));
+            "Constrain input and output types to float tensors."
+        )
+);
 
 static const char* Upsample_ver1_doc = R"DOC(
 Upsample the input tensor.
@@ -3484,16 +3634,16 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Input(2, "axis", "Axis along which to repeat.", "T")
         .Output(0, "output", "Output tensor of same shape and type as input.", "T")
         .TypeConstraint(
-            "T",
-            {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input types to float tensors.")
+            "T", {"tensor(float16)", "tensor(float)", "tensor(double)"}, "Constrain input types to float tensors."
+        )
         .TypeConstraint("T1", {"tensor(int64)"}, "Constrain tiles and axis's type to int64 tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
           // Only rank of output can be inferred. We can do better if second
           // input is a constant, but this requires extending InferenceContext
           // interface to get values of constant inputs.
-        }));
+        })
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Upsample,
@@ -3503,23 +3653,28 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Attr(
             "width_scale",
             "The scale along width dimension. It takes value greater than or equal to 1.",
-            AttributeProto::FLOAT)
+            AttributeProto::FLOAT
+        )
         .Attr(
             "height_scale",
             "The scale along height dimension. It takes value greater than or equal to 1.",
-            AttributeProto::FLOAT)
+            AttributeProto::FLOAT
+        )
         .Attr(
             "mode",
             "Two interpolation modes: nearest(default), bilinear",
             AttributeProto::STRING,
-            std::string("nearest"))
+            std::string("nearest")
+        )
         .Input(0, "X", "4-D tensor, [N,C,H,W]", "T")
         .Output(0, "Y", "4-D tensor after resizing, [N,C,H,W]", "T")
         .TypeConstraint(
             "T",
             {"tensor(bool)", "tensor(int32)", "tensor(int64)", "tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain output types to bool, int32, int64, float16, float, double tensors.")
-        .SetDoc(Upsample_ver1_doc));
+            "Constrain output types to bool, int32, int64, float16, float, double tensors."
+        )
+        .SetDoc(Upsample_ver1_doc)
+);
 
 static const char* Upsample_ver7_doc = R"DOC(
 Upsample the input tensor.
@@ -3535,12 +3690,14 @@ ONNX_OPERATOR_SET_SCHEMA(
             "scales",
             "The scale array along each dimension. It takes value greater than or equal to 1."
             " The number of elements of 'scales' should be the same as the rank of input 'X'.",
-            AttributeProto::FLOATS)
+            AttributeProto::FLOATS
+        )
         .Attr(
             "mode",
             "Two interpolation modes: nearest (default), and linear (including bilinear, trilinear, etc)",
             AttributeProto::STRING,
-            std::string("nearest"))
+            std::string("nearest")
+        )
         .Input(0, "X", "N-D tensor", "T")
         .Output(0, "Y", "N-D tensor after resizing", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to all tensor types.")
@@ -3561,9 +3718,10 @@ ONNX_OPERATOR_SET_SCHEMA(
                   input_shape.dim_size(),
                   ") is not equal to the existing rank value (",
                   output_shape->dim_size(),
-                  ").");
+                  ")."
+              );
             }
-          } else { // Infer the rank of output anyway
+          } else {  // Infer the rank of output anyway
             for (int i = 0; i < input_shape.dim_size(); ++i) {
               output_shape->add_dim();
             }
@@ -3579,11 +3737,12 @@ ONNX_OPERATOR_SET_SCHEMA(
               resizeShapeInferenceHelper_opset7_to_10(input_shape, scales_data, output_shape);
             } else {
               fail_shape_inference("Attribute 'scales' must have floats type.");
-            } // scales->type() == float
+            }  // scales->type() == float
           } else {
             fail_shape_inference("Attribute 'scales' is required.");
-          } // nullptr != scales
-        }));
+          }  // nullptr != scales
+        })
+);
 
 static const char* Upsample_ver9_doc = R"DOC(
 Upsample the input tensor.
@@ -3599,18 +3758,21 @@ ONNX_OPERATOR_SET_SCHEMA(
             "mode",
             "Two interpolation modes: nearest (default), and linear (including bilinear, trilinear, etc)",
             AttributeProto::STRING,
-            std::string("nearest"))
+            std::string("nearest")
+        )
         .Input(0, "X", "N-D tensor", "T")
         .Input(
             1,
             "scales",
             "The scale array along each dimension. It takes value greater than or equal to 1."
             " The number of elements of 'scales' should be the same as the rank of input 'X'.",
-            "tensor(float)")
+            "tensor(float)"
+        )
         .Output(0, "Y", "N-D tensor after resizing", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input 'X' and output 'Y' to all tensor types.")
         .SetDoc(Upsample_ver9_doc)
-        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { resizeShapeInference_opset7_to_10(ctx); }));
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { resizeShapeInference_opset7_to_10(ctx); })
+);
 
 static const char* Resize_ver10_doc = R"DOC(
 Resize the input tensor.
@@ -3626,7 +3788,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "mode",
             "Two interpolation modes: nearest (default), and linear (including bilinear, trilinear, etc)",
             AttributeProto::STRING,
-            std::string("nearest"))
+            std::string("nearest")
+        )
         .Input(0, "X", "N-D tensor", "T")
         .Input(
             1,
@@ -3634,11 +3797,13 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The scale array along each dimension. It takes value greater than 0. If it's less than 1,"
             " it's sampling down, otherwise, it's upsampling. The number of elements of 'scales' should"
             " be the same as the rank of input 'X'.",
-            "tensor(float)")
+            "tensor(float)"
+        )
         .Output(0, "Y", "N-D tensor after resizing", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input 'X' and output 'Y' to all tensor types.")
         .SetDoc(Resize_ver10_doc)
-        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { resizeShapeInference_opset7_to_10(ctx); }));
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { resizeShapeInference_opset7_to_10(ctx); })
+);
 
 static const char* Slice_ver1_doc = R"DOC(
 Produces a slice of the input tensor along multiple axes. Similar to numpy:
@@ -3686,7 +3851,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "It's optional. If not present, will be treated as "
             "[0, 1, ..., len(`starts`) - 1].",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr("starts", "Starting indices of corresponding axis in `axes`", AttributeProto::INTS)
         .Attr("ends", "Ending indices (exclusive) of corresponding axis in axes`", AttributeProto::INTS)
         .Output(0, "output", "Sliced data tensor.", "T")
@@ -3749,7 +3915,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               *newdim = ctx.getInputType(0)->tensor_type().shape().dim((int)i);
             }
           }
-        }));
+        })
+);
 
 static const char* Slice_ver10_doc = R"DOC(
 Produces a slice of the input tensor along multiple axes. Similar to numpy:
@@ -3802,7 +3969,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "steps",
             "1-D tensor of slice step of corresponding axis in `axes`. Default to 1. ",
             "Tind",
-            OpSchema::Optional)
+            OpSchema::Optional
+        )
         .Output(0, "output", "Sliced data tensor.", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to all tensor types.")
         .TypeConstraint("Tind", {"tensor(int32)", "tensor(int64)"}, "Constrain indices to integer types")
@@ -3956,7 +4124,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             // assign output value
             ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->mutable_dim((int)axis)->set_dim_value(temp);
           }
-        }));
+        })
+);
 
 static const char* Scatter_ver9_doc = R"DOC(
 Given `data`, `updates` and `indices` input tensors of rank r >= 1, write the values provided by `updates`
@@ -4002,7 +4171,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Which axis to scatter on. Negative value means "
             "counting dimensions from the back. Accepted range is [-r, r-1]",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(0, "data", "Tensor of rank r >= 1.", "T")
         .Input(1, "indices", "Tensor of int32/int64 indices, of r >= 1 (same rank as input).", "Tind")
         .Input(2, "updates", "Tensor of rank r >=1 (same rank and shape as indices)", "T")
@@ -4014,7 +4184,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (hasNInputShapes(ctx, 1)) {
             propagateShapeFromInputToOutput(ctx, 0, 0);
           }
-        }));
+        })
+);
 
 static const char* DepthToSpace_ver1_doc =
     R"DOC(DepthToSpace rearranges (permutes) data from depth into blocks of spatial data.
@@ -4034,7 +4205,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "input",
             "Input tensor of [N,C,H,W], where N is the batch axis, C is the channel or depth"
             ", H is the height and W is the width.",
-            "T")
+            "T"
+        )
         .Output(0, "output", "Output tensor of [N, C/(blocksize * blocksize), H * blocksize, W * blocksize].", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to all tensor types.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -4054,12 +4226,14 @@ ONNX_OPERATOR_SET_SCHEMA(
                   {input_shape.dim(0),
                    input_shape.dim(1) / (blocksize * blocksize),
                    input_shape.dim(2) * blocksize,
-                   input_shape.dim(3) * blocksize});
+                   input_shape.dim(3) * blocksize}
+              );
             } else {
               fail_shape_inference("Input tensor must be 4-dimensional");
             }
           }
-        }));
+        })
+);
 
 static const char* Gather_ver1_doc = R"DOC(
 Given `data` tensor of rank r >= 1, and `indices` tensor of rank q, gather
@@ -4116,14 +4290,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Which axis to gather on. Negative value means "
             "counting dimensions from the back. Accepted range is [-r, r-1]",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(0, "data", "Tensor of rank r >= 1.", "T")
         .Input(
             1,
             "indices",
             "Tensor of int32/int64 indices, of any rank q. All index values are expected to be within bounds. "
             "It is an error if any of the index values are out of bounds.",
-            "Tind")
+            "Tind"
+        )
         .Output(0, "output", "Tensor of rank q + (r - 1).", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to any tensor type.")
         .TypeConstraint("Tind", {"tensor(int32)", "tensor(int64)"}, "Constrain indices to integer types")
@@ -4153,13 +4329,14 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
           for (int i = 0; i < out_rank; ++i) {
             *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim() = (i < axis) ? data_shape.dim(i)
-                                                                                                  : // i < axis < r
+                                                                                                  :  // i < axis < r
                 (i >= axis && i < axis + q) ? indices_shape.dim(i - axis)
-                                            : // i - axis < q
-                data_shape.dim(i - q + 1); // i < out_rank < q + r - 1
+                                            :  // i - axis < q
+                data_shape.dim(i - q + 1);  // i < out_rank < q + r - 1
           }
         })
-        .PartialDataPropagationFunction([](DataPropagationContext& ctx) { GatherOp13DataPropagator(ctx); }));
+        .PartialDataPropagationFunction([](DataPropagationContext& ctx) { GatherOp13DataPropagator(ctx); })
+);
 
 static const char* Squeeze_ver1_doc = R"DOC(
 Remove single-dimensional entries from the shape of a tensor.
@@ -4176,7 +4353,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "axes",
             "List of non-negative integers, indicate the dimensions to squeeze.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .SetDoc(Squeeze_ver1_doc)
         .Input(0, "data", "Tensors with at least max(dims) dimensions.", "T")
         .Output(0, "squeezed", "Reshaped tensor with same data as input.", "T")
@@ -4203,14 +4381,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             if (static_cast<size_t>(j) < axes.size() && axes[j] == i) {
               if (input_shape.dim(i).has_dim_value() && input_shape.dim(i).dim_value() != 1) {
                 fail_shape_inference(
-                    "Dimension of input ", i, " must be 1 instead of ", input_shape.dim(i).dim_value());
+                    "Dimension of input ", i, " must be 1 instead of ", input_shape.dim(i).dim_value()
+                );
               }
               ++j;
             } else {
               *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim() = input_shape.dim(i);
             }
           }
-        }));
+        })
+);
 
 static const char* Unsqueeze_ver1_doc = R"DOC(
 Insert single-dimensional entries to the shape of a tensor.
@@ -4262,7 +4442,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
             ++j;
           }
-        }));
+        })
+);
 
 static const char* OneHot_ver9_doc = R"DOC(
     Produces a one-hot tensor based on inputs.
@@ -4290,7 +4471,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "axis=-1 means that the additional dimension will be inserted as the "
             "innermost/last dimension in the output tensor.",
             AttributeProto::INT,
-            static_cast<int64_t>(-1))
+            static_cast<int64_t>(-1)
+        )
         .Input(
             0,
             "indices",
@@ -4298,7 +4480,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Any entries in the 'indices' input tensor with values outside the range [0, depth) "
             "will result in one-hot representation with all 'off_value' values in the output tensor."
             "In case 'indices' is of non-integer type, the values will be casted to int64 before use.",
-            "T1")
+            "T1"
+        )
         .Input(
             1,
             "depth",
@@ -4307,7 +4490,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "added on in the output tensor. The values in the 'indices' input tensor are expected to be "
             "in the range [0, depth). "
             "In case 'depth' is of non-integer type, it will be casted to int64 before use.",
-            "T2")
+            "T2"
+        )
         .Input(
             2,
             "values",
@@ -4315,14 +4499,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "where 'on_value' is the value used for filling locations specified in 'indices' input "
             "tensor, and 'off_value' is the value used for filling locations other than those specified "
             "in 'indices' input tensor. ",
-            "T3")
+            "T3"
+        )
         .Output(
             0,
             "output",
             "Tensor of rank one greater than input tensor 'indices', i.e. rank(output) = rank(indices) + 1. "
             "The data type for the elements of the output tensor is the same as the type of input 'values' "
             "is used.",
-            "T3")
+            "T3"
+        )
         .TypeConstraint("T1", OpSchema::all_numeric_types(), "Constrain input to only numeric types.")
         .TypeConstraint("T2", OpSchema::all_numeric_types(), "Constrain input to only numeric types.")
         .TypeConstraint("T3", OpSchema::all_tensor_types(), "Constrain to any tensor type.")
@@ -4394,7 +4580,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               }
             }
           }
-        }));
+        })
+);
 
 static const char* Compress_ver9_doc = R"DOC(
     Selects slices from an input tensor along a given axis where condition evaluates to True for each axis index.
@@ -4412,7 +4599,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "(Optional) Axis along which to take slices. If not specified, "
             "input is flattened before elements being selected.",
             AttributeProto::INT,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Input(0, "input", "Tensor of rank r >= 1.", "T")
         .Input(
             1,
@@ -4421,10 +4609,12 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Its length can be less than the input length alone the axis "
             "or the flattened input size if axis is not specified. "
             "In such cases data slices or elements exceeding the condition length are discarded.",
-            "T1")
+            "T1"
+        )
         .Output(0, "output", "Tensor of rank r if axis is specified. Otherwise output is a Tensor of rank 1.", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to all tensor types.")
-        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain to boolean tensors."));
+        .TypeConstraint("T1", {"tensor(bool)"}, "Constrain to boolean tensors.")
+);
 
 static const char* Split_ver2_doc =
     R"DOC(Split a tensor into a list of tensors, along the specified
@@ -4477,7 +4667,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (getRepeatedAttribute(ctx, "split", split)) {
             if (split.size() != ctx.getNumOutputs()) {
               fail_shape_inference(
-                  "Mismatch between number of splits (", split.size(), ") and outputs (", ctx.getNumOutputs(), ")");
+                  "Mismatch between number of splits (", split.size(), ") and outputs (", ctx.getNumOutputs(), ")"
+              );
             }
             int64_t total_dim = 0;
             for (int64_t d : split) {
@@ -4489,7 +4680,8 @@ ONNX_OPERATOR_SET_SCHEMA(
                   total_dim,
                   ") and the split dimension of the input (",
                   split_dim_value,
-                  ")");
+                  ")"
+              );
             }
           } else {
             int num_outputs = static_cast<int>(ctx.getNumOutputs());
@@ -4505,7 +4697,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             *ctx.getOutputType(i)->mutable_tensor_type()->mutable_shape() = shape;
             ctx.getOutputType(i)->mutable_tensor_type()->mutable_shape()->mutable_dim(axis)->set_dim_value(split[i]);
           }
-        }));
+        })
+);
 
 static const char* Pad_ver2_doc = R"DOC(
 Given `data` tensor, pads, mode, and value.
@@ -4538,7 +4731,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "[x1_begin, x2_begin...x1_end, x2_end,...], where xi_begin the number of pixels "
             "added at the beginning of axis `i` and xi_end, the number of pixels added at "
             "the end of axis `i`.",
-            AttributeProto::INTS)
+            AttributeProto::INTS
+        )
         .Attr("mode", "Three modes: constant(default), reflect, edge", AttributeProto::STRING, std::string("constant"))
         .Attr("value", "One float, indicates the value to be filled.", AttributeProto::FLOAT, 0.0f)
         .SetDoc(Pad_ver2_doc)
@@ -4547,7 +4741,8 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Constrain input and output types to float tensors.")
+            "Constrain input and output types to float tensors."
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
           if (!hasNInputShapes(ctx, 1)) {
@@ -4572,12 +4767,14 @@ ONNX_OPERATOR_SET_SCHEMA(
             if (ctx.getInputType(0)->tensor_type().shape().dim((int)i).has_dim_value()) {
               newdim->set_dim_value(
                   ctx.getInputType(0)->tensor_type().shape().dim((int)i).dim_value() + pads[i] +
-                  pads[input_shape.dim_size() + i]);
+                  pads[input_shape.dim_size() + i]
+              );
             } else if (pads[i] + pads[input_shape.dim_size() + i] == 0) {
               *newdim = input_shape.dim((int)i);
             }
           }
-        }));
+        })
+);
 
 static const char* GatherND_ver11_doc = R"DOC(
 Given `data` tensor of rank `r` >= 1, and `indices` tensor of rank `q` >= 1, this operator gathers
@@ -4658,7 +4855,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "indices",
             "Tensor of rank q >= 1. All index values are expected to be within bounds [-s, s-1] "
             "along axis of size s. It is an error if any of the index values are out of bounds.",
-            "tensor(int64)")
+            "tensor(int64)"
+        )
         .Output(0, "output", "Tensor of rank q + r - indices_shape[-1] - 1.", "T")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to any tensor type.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -4680,7 +4878,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (data_rank < 1 || indices_rank < 1) {
             fail_shape_inference(
                 "Both `data` and `indices` input tensors in GatherND op "
-                "need to have rank larger than 0.");
+                "need to have rank larger than 0."
+            );
           }
 
           // cannot ascertain if the input shapes are valid if shape of
@@ -4694,7 +4893,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (last_index_dimension > data_rank) {
             fail_shape_inference(
                 "Last dimension of `indices` input tensor in GatherND op "
-                "must not be larger than the rank of `data` tensor");
+                "must not be larger than the rank of `data` tensor"
+            );
           }
 
           for (int i = 0; i < indices_rank - 1; ++i) {
@@ -4704,7 +4904,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           for (int i = static_cast<int>(last_index_dimension); i < data_rank; ++i) {
             *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim() = data_shape.dim(i);
           }
-        }));
+        })
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Identity,
@@ -4721,8 +4922,10 @@ ONNX_OPERATOR_SET_SCHEMA(
               t.insert(t.end(), s.begin(), s.end());
               return t;
             }(),
-            "Constrain input and output types to all tensor and sequence types.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to all tensor and sequence types."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Where_ver9_doc = R"DOC(
 Return elements, either from X or Y, depending on condition.
@@ -4745,7 +4948,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             1,
             "X",
@@ -4754,7 +4958,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Input(
             2,
             "Y",
@@ -4763,7 +4968,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .Output(
             0,
             "output",
@@ -4772,7 +4978,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::Differentiable)
+            OpSchema::Differentiable
+        )
         .TypeConstraint("B", {"tensor(bool)"}, "Constrain to boolean tensors.")
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to all tensor types.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -4783,9 +4990,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             shapes.push_back(&ctx.getInputType(1)->tensor_type().shape());
             shapes.push_back(&ctx.getInputType(2)->tensor_type().shape());
             multidirectionalBroadcastShapeInference(
-                shapes, *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
+                shapes, *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()
+            );
           }
-        }));
+        })
+);
 
 static const char* Pad_ver13_doc = R"DOC(
 Given a tensor containing the data to be padded (`data`), a tensor containing the number of start and end pad values for axis (`pads`), (optionally) a `mode`, and (optionally) `constant_value`,
@@ -4873,7 +5082,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "mode",
             "Supported modes: `constant`(default), `reflect`, `edge`",
             AttributeProto::STRING,
-            std::string("constant"))
+            std::string("constant")
+        )
         .SetDoc(Pad_ver13_doc)
         .Input(0, "data", "Input tensor.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
@@ -4889,7 +5099,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Input(
             2,
             "constant_value",
@@ -4899,7 +5110,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(0, "output", "Tensor after padding.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to all tensor types.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -4942,7 +5154,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
           }
           return;
-        }));
+        })
+);
 
 static const char* Pad_ver18_doc = R"DOC(
 Given a tensor containing the data to be padded (`data`), a tensor containing the number of start and end pad values for axis (`pads`), (optionally) a `mode`, and (optionally) `constant_value`,
@@ -5025,7 +5238,8 @@ output = [
 ONNX_OPERATOR_SET_SCHEMA(
     Pad,
     18,
-    OpSchema().FillUsing(PadDocGenerator(Pad_ver18_doc, "Supported modes: `constant`(default), `reflect`, `edge`")));
+    OpSchema().FillUsing(PadDocGenerator(Pad_ver18_doc, "Supported modes: `constant`(default), `reflect`, `edge`"))
+);
 
 ONNX_OPERATOR_SET_SCHEMA(
     Identity,
@@ -5044,8 +5258,10 @@ ONNX_OPERATOR_SET_SCHEMA(
               t.insert(t.end(), o.begin(), o.end());
               return t;
             }(),
-            "Constrain input and output types to all tensor, sequence, and optional types.")
-        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput));
+            "Constrain input and output types to all tensor, sequence, and optional types."
+        )
+        .TypeAndShapeInferenceFunction(propagateShapeAndTypeFromFirstInput)
+);
 
 static const char* Reshape_ver14_doc = R"DOC(
 Reshape the input tensor similar to numpy.reshape.
@@ -5075,7 +5291,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "allowzero=1 indicates that if any value in the 'shape' input is set to zero, "
             "the zero value is honored, similar to NumPy.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Input(0, "data", "An input tensor.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
             1,
@@ -5085,7 +5302,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(0, "reshaped", "Reshaped data.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to all tensor types.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -5209,7 +5427,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               negativeOneDim->set_dim_value(inputProduct / outputProduct);
             }
           }
-        }));
+        })
+);
 
 static const char* Shape_ver15_doc = R"DOC(
 Takes a tensor as input and outputs an 1D int64 tensor containing the shape of the input tensor.
@@ -5264,14 +5483,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "(Optional) Starting axis for slicing the shape. Default value is 0."
             "Negative value means counting dimensions from the back.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "end",
             "(Optional) Ending axis for slicing the shape. "
             "Negative value means counting dimensions from the back. "
             "If omitted, sizes of all axes upto (including) the last one will be included.",
             AttributeProto::INT,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Input tensor can be of arbitrary type.")
         .TypeConstraint("T1", {"tensor(int64)"}, "Constrain output to int64 tensor.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -5312,7 +5533,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
             ctx.addOutputData(0, std::move(output_shape));
           }
-        }));
+        })
+);
 
 static const char* Size_ver13_doc = R"DOC(
 Takes a tensor as input and outputs a int64 scalar that equals to the total number of elements of the input tensor.
@@ -5332,7 +5554,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Input tensor can be of arbitrary type.")
         .TypeConstraint("T1", {"tensor(int64)"}, "Constrain output to int64 tensor, which should be a scalar though.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
@@ -5346,6 +5569,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             tsp.mutable_dim()->Add()->set_dim_value(input_data->dim_size());
             ctx.addOutputData(0, std::move(tsp));
           }
-        }));
+        })
+);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/tensor/utils.cc
+++ b/onnx/defs/tensor/utils.cc
@@ -13,9 +13,8 @@
 
 namespace ONNX_NAMESPACE {
 void resizeShapeInferenceHelper(
-    const TensorShapeProto& input_shape,
-    const std::vector<int64_t>& sizes_data,
-    TensorShapeProto* output_shape) {
+    const TensorShapeProto& input_shape, const std::vector<int64_t>& sizes_data, TensorShapeProto* output_shape
+) {
   if (!sizes_data.empty()) {
     for (int i = 0; i < input_shape.dim_size(); ++i) {
       auto* dim = output_shape->mutable_dim(i);
@@ -31,7 +30,8 @@ void KeepAspectRatioHelper(
     KeepAspectRatioPolicy policy,
     const TensorShapeProto& input_shape,
     const std::vector<int64_t>& axes,
-    std::vector<int64_t>& sizes_data) {
+    std::vector<int64_t>& sizes_data
+) {
   if (policy != KeepAspectRatioPolicy::NOT_LARGER && policy != KeepAspectRatioPolicy::NOT_SMALLER) {
     return;
   }
@@ -84,7 +84,8 @@ void gridSampleShapeInference(InferenceContext& ctx) {
         ". ",
         "Got grid tensor rank: ",
         grid_shape.dim_size(),
-        ". ");
+        ". "
+    );
   }
 
   int const num_dims = input_shape.dim_size();
@@ -94,7 +95,8 @@ void gridSampleShapeInference(InferenceContext& ctx) {
         "The input tensor and grid tensor ranks must be >= 3. ",
         "Got input tensor and grid tensor ranks: ",
         num_dims,
-        ". ");
+        ". "
+    );
   }
   auto const& last_dim = grid_shape.dim(num_dims - 1);
   if (last_dim.has_dim_value() && (last_dim.dim_value() != num_dims - 2)) {
@@ -104,7 +106,8 @@ void gridSampleShapeInference(InferenceContext& ctx) {
         num_dims,
         "Got the last dimension of the grid tensor: ",
         last_dim.dim_value(),
-        ". ");
+        ". "
+    );
   }
 
   auto* output_shape = getOutputShape(ctx, 0);
@@ -125,9 +128,8 @@ void gridSampleShapeInference(InferenceContext& ctx) {
 }
 
 void resizeShapeInferenceHelper(
-    const TensorShapeProto& input_shape,
-    const std::vector<float>& scales_data,
-    TensorShapeProto* output_shape) {
+    const TensorShapeProto& input_shape, const std::vector<float>& scales_data, TensorShapeProto* output_shape
+) {
   for (int i = 0; i < input_shape.dim_size(); ++i) {
     auto* dim = output_shape->mutable_dim(i);
     // If input_shape has dim_value, we calculate the scaled result
@@ -144,12 +146,13 @@ void resizeShapeInferenceHelper(
               dim_value,
               ") is not equal to the existing dim value (",
               dim->dim_value(),
-              ").");
+              ")."
+          );
         }
       } else {
         dim->set_dim_value(static_cast<int64_t>(dim_value));
-      } // dim->has_dim_value()
-    } // input_shape.dim(i).has_dim_value()
+      }  // dim->has_dim_value()
+    }  // input_shape.dim(i).has_dim_value()
   }
 }
 
@@ -209,8 +212,8 @@ void resizeShapeInferenceVersioned(InferenceContext& ctx, int opset_version) {
   }
 
   if (hasScalesInput && keep_aspect_ratio_policy != KeepAspectRatioPolicy::STRETCH) {
-    fail_shape_inference(
-        "Providing `scales` is incompatible with a `keep_aspect_ratio_policy` other than \"stretch\".");
+    fail_shape_inference("Providing `scales` is incompatible with a `keep_aspect_ratio_policy` other than \"stretch\"."
+    );
   }
 
   if (output_shape->dim_size() > 0) {
@@ -220,9 +223,10 @@ void resizeShapeInferenceVersioned(InferenceContext& ctx, int opset_version) {
           input_shape.dim_size(),
           ") is not equal to the existing rank value (",
           output_shape->dim_size(),
-          ").");
+          ")."
+      );
     }
-  } else { // Infer the rank of output anyway
+  } else {  // Infer the rank of output anyway
     for (int i = 0; i < input_shape.dim_size(); ++i) {
       output_shape->add_dim();
     }
@@ -245,7 +249,8 @@ void resizeShapeInferenceVersioned(InferenceContext& ctx, int opset_version) {
             sizes_data.size(),
             ") does not match the number of axes (",
             axes.size(),
-            ").");
+            ")."
+        );
       }
     } else {
       // sizes_data contains scales for all axes
@@ -255,7 +260,8 @@ void resizeShapeInferenceVersioned(InferenceContext& ctx, int opset_version) {
             sizes_data.size(),
             ") must be same as rank of input 'X' (",
             rank_x,
-            ").");
+            ")."
+        );
       }
     }
 
@@ -289,7 +295,8 @@ void resizeShapeInferenceVersioned(InferenceContext& ctx, int opset_version) {
               scales_data.size(),
               ") does not match the number of axes (",
               axes.size(),
-              ").");
+              ")."
+          );
         }
 
         std::vector<float> tmp(rank_x, 1.0f);
@@ -308,7 +315,7 @@ void resizeShapeInferenceVersioned(InferenceContext& ctx, int opset_version) {
     } else {
       fail_shape_inference("Input 'scales' must have float element type.");
     }
-  } // nullptr != scales
+  }  // nullptr != scales
 }
 
 void resizeShapeInference_opset18_to_19(InferenceContext& ctx) {
@@ -324,9 +331,8 @@ void resizeShapeInference_opset11_to_12(InferenceContext& ctx) {
 }
 
 void resizeShapeInferenceHelper_opset7_to_10(
-    const TensorShapeProto& input_shape,
-    const std::vector<float>& scales_data,
-    TensorShapeProto* output_shape) {
+    const TensorShapeProto& input_shape, const std::vector<float>& scales_data, TensorShapeProto* output_shape
+) {
   for (int i = 0; i < input_shape.dim_size(); ++i) {
     auto* dim = output_shape->mutable_dim(i);
     // If input_shape has dim_value, we calculate the scaled result
@@ -343,12 +349,13 @@ void resizeShapeInferenceHelper_opset7_to_10(
               dim_value,
               ") is not equal to the existing dim value (",
               dim->dim_value(),
-              ").");
+              ")."
+          );
         }
       } else {
         dim->set_dim_value(static_cast<int64_t>(dim_value));
-      } // dim->has_dim_value()
-    } // input_shape.dim(i).has_dim_value()
+      }  // dim->has_dim_value()
+    }  // input_shape.dim(i).has_dim_value()
   }
 }
 
@@ -368,9 +375,10 @@ void resizeShapeInference_opset7_to_10(InferenceContext& ctx) {
           input_shape.dim_size(),
           ") is not equal to the existing rank value (",
           output_shape->dim_size(),
-          ").");
+          ")."
+      );
     }
-  } else { // Infer the rank of output anyway
+  } else {  // Infer the rank of output anyway
     for (int i = 0; i < input_shape.dim_size(); ++i) {
       output_shape->add_dim();
     }
@@ -386,7 +394,7 @@ void resizeShapeInference_opset7_to_10(InferenceContext& ctx) {
       resizeShapeInferenceHelper_opset7_to_10(input_shape, scales_data, output_shape);
     } else {
       fail_shape_inference("Input 'scales' must have float element type.");
-    } // nullptr != scales
+    }  // nullptr != scales
   }
 }
 
@@ -409,7 +417,8 @@ std::function<void(OpSchema&)> PadDocGenerator(const char* description, const ch
         OpSchema::Single,
         true,
         1,
-        OpSchema::NonDifferentiable);
+        OpSchema::NonDifferentiable
+    );
     schema.Input(
         2,
         "constant_value",
@@ -419,7 +428,8 @@ std::function<void(OpSchema&)> PadDocGenerator(const char* description, const ch
         OpSchema::Optional,
         true,
         1,
-        OpSchema::NonDifferentiable);
+        OpSchema::NonDifferentiable
+    );
     schema.Input(
         3,
         "axes",
@@ -430,11 +440,13 @@ std::function<void(OpSchema&)> PadDocGenerator(const char* description, const ch
         OpSchema::Optional,
         true,
         1,
-        OpSchema::NonDifferentiable);
+        OpSchema::NonDifferentiable
+    );
 
     schema.Output(0, "output", "Tensor after padding.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable);
     schema.TypeConstraint(
-        "T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to all tensor types.");
+        "T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to all tensor types."
+    );
     schema.TypeConstraint("Tind", {"tensor(int32)", "tensor(int64)"}, "Constrain indices to integer types");
     schema.TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
       // Type inference
@@ -447,10 +459,10 @@ std::function<void(OpSchema&)> PadDocGenerator(const char* description, const ch
       const auto input_rank = input_shape.dim_size();
 
       std::vector<int64_t> axes;
-      if (hasInputShape(ctx, 3)) { //'axes' input
+      if (hasInputShape(ctx, 3)) {  //'axes' input
         auto axes_initializer = ctx.getInputData(3);
         if (axes_initializer == nullptr)
-          return; // can't do shape inference then
+          return;  // can't do shape inference then
 
         axes = ParseData<int64_t>(axes_initializer);
         checkAxesRange(axes, input_rank);
@@ -486,7 +498,8 @@ std::function<void(OpSchema&)> PadDocGenerator(const char* description, const ch
               num_axes,
               " values. Got ",
               pads_data.size(),
-              " values.");
+              " values."
+          );
         }
 
         // Set default dim values
@@ -512,4 +525,4 @@ std::function<void(OpSchema&)> PadDocGenerator(const char* description, const ch
     });
   };
 };
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/tensor/utils.h
+++ b/onnx/defs/tensor/utils.h
@@ -17,14 +17,12 @@ void resizeShapeInference(InferenceContext& ctx);
 void gridSampleShapeInference(InferenceContext& ctx);
 
 void resizeShapeInferenceHelper(
-    const TensorShapeProto& input_shape,
-    const std::vector<float>& scales_data,
-    TensorShapeProto* output_shape);
+    const TensorShapeProto& input_shape, const std::vector<float>& scales_data, TensorShapeProto* output_shape
+);
 
 void resizeShapeInferenceHelper(
-    const TensorShapeProto& input_shape,
-    const std::vector<int64_t>& sizes_data,
-    TensorShapeProto* output_shape);
+    const TensorShapeProto& input_shape, const std::vector<int64_t>& sizes_data, TensorShapeProto* output_shape
+);
 
 // Belows are called by ops between opset versions in the name inclusively.
 void resizeShapeInference_opset7_to_10(InferenceContext& ctx);
@@ -33,9 +31,8 @@ void resizeShapeInference_opset13_to_18(InferenceContext& ctx);
 void resizeShapeInference_opset18_to_19(InferenceContext& ctx);
 
 void resizeShapeInferenceHelper_opset7_to_10(
-    const TensorShapeProto& input_shape,
-    const std::vector<float>& scales_data,
-    TensorShapeProto* output_shape);
+    const TensorShapeProto& input_shape, const std::vector<float>& scales_data, TensorShapeProto* output_shape
+);
 
 enum class KeepAspectRatioPolicy {
   STRETCH,
@@ -47,9 +44,10 @@ void KeepAspectRatioHelper(
     KeepAspectRatioPolicy policy,
     const TensorShapeProto& input_shape,
     const std::vector<int64_t>& axes,
-    std::vector<int64_t>& sizes_data);
+    std::vector<int64_t>& sizes_data
+);
 
 extern const char* NonZero_ver9_doc;
 
 std::function<void(OpSchema&)> PadDocGenerator(const char* description, const char* mode_description);
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/tensor_proto_util.cc
+++ b/onnx/defs/tensor_proto_util.cc
@@ -46,14 +46,16 @@ namespace ONNX_NAMESPACE {
           ". Expected:",                                                                                           \
           Utils::DataTypeUtils::ToDataTypeString(tensorproto_datatype),                                            \
           " Actual:",                                                                                              \
-          Utils::DataTypeUtils::ToDataTypeString(tensor_proto->data_type()));                                      \
+          Utils::DataTypeUtils::ToDataTypeString(tensor_proto->data_type())                                        \
+      );                                                                                                           \
     }                                                                                                              \
     std::vector<type> res;                                                                                         \
     if (tensor_proto->has_data_location() && tensor_proto->data_location() == TensorProto_DataLocation_EXTERNAL) { \
       fail_shape_inference(                                                                                        \
           "Cannot parse data from external tensors. Please ",                                                      \
           "load external data into raw data for tensor: ",                                                         \
-          tensor_proto->name());                                                                                   \
+          tensor_proto->name()                                                                                     \
+      );                                                                                                           \
     } else if (!tensor_proto->has_raw_data()) {                                                                    \
       const auto& data = tensor_proto->typed_data_fetch();                                                         \
       int expected_size = 1;                                                                                       \
@@ -67,7 +69,8 @@ namespace ONNX_NAMESPACE {
             " expected size ",                                                                                     \
             expected_size,                                                                                         \
             " does not match the actual size",                                                                     \
-            data.size());                                                                                          \
+            data.size()                                                                                            \
+        );                                                                                                         \
       }                                                                                                            \
       res.insert(res.end(), data.begin(), data.end());                                                             \
       return res;                                                                                                  \
@@ -77,7 +80,8 @@ namespace ONNX_NAMESPACE {
           tensor_proto->name(),                                                                                    \
           " data type is string. string",                                                                          \
           " content is required to be stored in repeated bytes string_data field.",                                \
-          " raw_data type cannot be string.");                                                                     \
+          " raw_data type cannot be string."                                                                       \
+      );                                                                                                           \
     }                                                                                                              \
     /* The given tensor does have raw_data itself so parse it by given type */                                     \
     /* make copy as we may have to reverse bytes */                                                                \
@@ -136,4 +140,4 @@ DEFINE_PARSE_DATA(int64_t, int64_data, TensorProto_DataType_INT64)
 DEFINE_PARSE_DATA(float, float_data, TensorProto_DataType_FLOAT)
 DEFINE_PARSE_DATA(double, double_data, TensorProto_DataType_DOUBLE)
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/tensor_proto_util.h
+++ b/onnx/defs/tensor_proto_util.h
@@ -19,4 +19,4 @@ TensorProto ToTensor(const std::vector<T>& values);
 template <typename T>
 const std::vector<T> ParseData(const TensorProto* tensor_proto);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/tensor_util.cc
+++ b/onnx/defs/tensor_util.cc
@@ -58,4 +58,4 @@ DEFINE_PARSE_DATA(float, floats)
 DEFINE_PARSE_DATA(double, doubles)
 DEFINE_PARSE_DATA(uint64_t, uint64s)
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/tensor_util.h
+++ b/onnx/defs/tensor_util.h
@@ -13,4 +13,4 @@ namespace ONNX_NAMESPACE {
 template <typename T>
 const std::vector<T> ParseData(const Tensor* tensor);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/text/defs.cc
+++ b/onnx/defs/text/defs.cc
@@ -12,14 +12,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     20,
     OpSchema()
         .Input(
-            0,
-            "X",
-            "Tensor to prepend in concatenation",
-            "T",
-            OpSchema::Single,
-            true,
-            1,
-            OpSchema::NonDifferentiable)
+            0, "X", "Tensor to prepend in concatenation", "T", OpSchema::Single, true, 1, OpSchema::NonDifferentiable
+        )
         .Input(1, "Y", "Tensor to append in concatenation", "T", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
         .Output(0, "Z", "Concatenated string tensor", "T", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
         .TypeConstraint("T", {"tensor(string)"}, "Inputs and outputs must be UTF-8 strings")
@@ -30,8 +24,10 @@ ONNX_OPERATOR_SET_SCHEMA(
             bidirectionalBroadcastShapeInference(
                 ctx.getInputType(0)->tensor_type().shape(),
                 ctx.getInputType(1)->tensor_type().shape(),
-                *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape());
-        }));
+                *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()
+            );
+        })
+);
 
 static const char* RegexFullMatch_doc =
     R"DOC(RegexFullMatch performs a full regex match on each element of the input tensor. If an element fully matches the regex pattern specified as an attribute, the corresponding element in the output is True and it is False otherwise. [RE2](https://github.com/google/re2/wiki/Syntax) regex syntax is used.)DOC";
@@ -49,17 +45,20 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .TypeConstraint("T1", {"tensor(string)"}, "Inputs must be UTF-8 strings")
         .TypeConstraint(
             "T2",
             {"tensor(bool)"},
-            "Outputs are bools and are True where there is a full regex match and False otherwise.")
+            "Outputs are bools and are True where there is a full regex match and False otherwise."
+        )
         .SetDoc(RegexFullMatch_doc)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           updateOutputElemType(ctx, 0, TensorProto::BOOL);
           propagateShapeFromInputToOutput(ctx, 0, 0);
-        }));
+        })
+);
 
 static const char* StringSplit_doc =
     R"DOC(StringSplit splits a string tensor's elements into substrings based on a delimiter attribute and a maxsplit attribute.
@@ -77,12 +76,14 @@ ONNX_OPERATOR_SET_SCHEMA(
             "delimiter",
             "Delimiter to split on. If left unset or set to the empty string (\"\"), the input is split on consecutive whitespace.",
             AttributeProto::STRING,
-            false)
+            false
+        )
         .Attr(
             "maxsplit",
             "Maximum number of splits (from left to right). If left unset (or if the number of possible splits are less than maxsplit), it will make as many splits as possible. Note that the maximum possible number of substrings returned with `maxsplit` specified is `maxsplit+1` since the remaining suffix after the `maxsplit`th split is included in the output.",
             AttributeProto::INT,
-            false)
+            false
+        )
         .Output(
             0,
             "Y",
@@ -91,7 +92,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .Output(
             1,
             "Z",
@@ -100,7 +102,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::Single,
             true,
             1,
-            OpSchema::NonDifferentiable)
+            OpSchema::NonDifferentiable
+        )
         .TypeConstraint("T1", {"tensor(string)"}, "The input must be a UTF-8 string tensor")
         .TypeConstraint("T2", {"tensor(string)"}, "Tensor of substrings.")
         .TypeConstraint("T3", {"tensor(int64)"}, "The number of substrings generated.")
@@ -126,7 +129,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           // results.
           ctx.getOutputType(1)->mutable_tensor_type()->set_elem_type(TensorProto::INT64);
           propagateShapeFromInputToOutput(ctx, 0, 1);
-        }));
+        })
+);
 
 static const char* StringNormalizer_ver10_doc = R"DOC(
 StringNormalization performs string operations for basic cleaning.
@@ -151,23 +155,27 @@ ONNX_OPERATOR_SET_SCHEMA(
             std::string("string enum that cases output to be lowercased/uppercases/unchanged."
                         " Valid values are \"LOWER\", \"UPPER\", \"NONE\". Default is \"NONE\""),
             AttributeProto::STRING,
-            std::string("NONE"))
+            std::string("NONE")
+        )
         .Attr(
             std::string("is_case_sensitive"),
             std::string("Boolean. Whether the identification of stop words in X is case-sensitive. Default is false"),
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "stopwords",
             "List of stop words. If not set, no word would be removed from X.",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "locale",
             "Environment dependent string that denotes the locale according to which output strings needs to be upper/lowercased."
             "Default en_US or platform specific equivalent as decided by the implementation.",
             AttributeProto::STRING,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .SetDoc(StringNormalizer_ver10_doc)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           auto output_elem_type = ctx.getOutputType(0)->mutable_tensor_type();
@@ -195,5 +203,6 @@ ONNX_OPERATOR_SET_SCHEMA(
             fail_shape_inference("Input shape must have either [C] or [1,C] dimensions where C > 0");
           }
           updateOutputShape(ctx, 0, output_shape);
-        }));
-} // namespace ONNX_NAMESPACE
+        })
+);
+}  // namespace ONNX_NAMESPACE

--- a/onnx/defs/traditionalml/defs.cc
+++ b/onnx/defs/traditionalml/defs.cc
@@ -68,7 +68,9 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)", "tensor(string)"},
-            "The input must be a tensor of a numeric type or string. The output will be of the same tensor type."));
+            "The input must be a tensor of a numeric type or string. The output will be of the same tensor type."
+        )
+);
 
 static const char* Binarizer_ver1_doc = R"DOC(
     Maps the values of the input tensor to either 0 or 1, element-wise, based on the outcome of a comparison against a threshold value.
@@ -84,9 +86,11 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)"},
-            "The input must be a tensor of a numeric type. The output will be of the same tensor type.")
+            "The input must be a tensor of a numeric type. The output will be of the same tensor type."
+        )
         .Attr("threshold", "Values greater than this are mapped to 1, others to 0.", AttributeProto::FLOAT, 0.f)
-        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { propagateShapeAndTypeFromFirstInput(ctx); }));
+        .TypeAndShapeInferenceFunction([](InferenceContext& ctx) { propagateShapeAndTypeFromFirstInput(ctx); })
+);
 
 static const char* CastMap_ver1_doc = R"DOC(
     Converts a map to a tensor.<br>The map key must be an int64 and the values will be ordered
@@ -104,26 +108,31 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T1",
             {"map(int64, string)", "map(int64, float)"},
-            "The input must be an integer map to either string or float.")
+            "The input must be an integer map to either string or float."
+        )
         .TypeConstraint(
             "T2",
             {"tensor(string)", "tensor(float)", "tensor(int64)"},
-            "The output is a 1-D tensor of string, float, or integer.")
+            "The output is a 1-D tensor of string, float, or integer."
+        )
         .Attr(
             "cast_to",
             "A string indicating the desired element type of the output tensor, one of 'TO_FLOAT', 'TO_STRING', 'TO_INT64'.",
             AttributeProto::STRING,
-            std::string("TO_FLOAT"))
+            std::string("TO_FLOAT")
+        )
         .Attr(
             "map_form",
             "Indicates whether to only output as many values as are in the input (dense), or position the input based on using the key of the map as the index of the output (sparse).<br>One of 'DENSE', 'SPARSE'.",
             AttributeProto::STRING,
-            std::string("DENSE"))
+            std::string("DENSE")
+        )
         .Attr(
             "max_map",
             "If the value of map_form is 'SPARSE,' this attribute indicates the total length of the output tensor.",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           auto cast_to_attr = ctx.getAttribute("cast_to");
           auto output_type = ctx.getOutputType(0)->mutable_tensor_type();
@@ -139,7 +148,8 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
           } else if (0 == cast_to.compare("TO_STRING")) {
             output_type->set_elem_type(TensorProto::STRING);
           }
-        }));
+        })
+);
 
 static const char* CategoryMapper_ver1_doc = R"DOC(
     Converts strings to integers and vice versa.<br>
@@ -162,31 +172,37 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T1",
             {"tensor(string)", "tensor(int64)"},
-            "The input must be a tensor of strings or integers, either [N,C] or [C].")
+            "The input must be a tensor of strings or integers, either [N,C] or [C]."
+        )
         .TypeConstraint(
             "T2",
             {"tensor(string)", "tensor(int64)"},
-            "The output is a tensor of strings or integers. Its shape will be the same as the input shape.")
+            "The output is a tensor of strings or integers. Its shape will be the same as the input shape."
+        )
         .Attr(
             "cats_strings",
             "The strings of the map. This sequence must be the same length as the 'cats_int64s' sequence",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "cats_int64s",
             "The integers of the map. This sequence must be the same length as the 'cats_strings' sequence.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "default_string",
             "A string to use when an input integer value is not found in the map.<br>One and only one of the 'default_*' attributes must be defined.",
             AttributeProto::STRING,
-            std::string("_Unused"))
+            std::string("_Unused")
+        )
         .Attr(
             "default_int64",
             "An integer to use when an input string value is not found in the map.<br>One and only one of the 'default_*' attributes must be defined.",
             AttributeProto::INT,
-            static_cast<int64_t>(-1))
+            static_cast<int64_t>(-1)
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           if (nullptr == ctx.getInputType(0))
             return;
@@ -199,7 +215,8 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
           if (hasInputShape(ctx, 0)) {
             propagateShapeFromInputToOutput(ctx, 0, 0);
           }
-        }));
+        })
+);
 
 static const char* DictVectorizer_ver1_doc = R"DOC(
     Uses an index mapping to convert a dictionary to an array.<br>
@@ -230,26 +247,31 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
              "map(int64, double)",
              "map(string, float)",
              "map(string, double)"},
-            "The input must be a map from strings or integers to either strings or a numeric type. The key and value types cannot be the same.")
+            "The input must be a map from strings or integers to either strings or a numeric type. The key and value types cannot be the same."
+        )
         .TypeConstraint(
             "T2",
             {"tensor(int64)", "tensor(float)", "tensor(double)", "tensor(string)"},
-            "The output will be a tensor of the value type of the input map. It's shape will be [1,C], where C is the length of the input dictionary.")
+            "The output will be a tensor of the value type of the input map. It's shape will be [1,C], where C is the length of the input dictionary."
+        )
         .Attr(
             "string_vocabulary",
             "A string vocabulary array.<br>One and only one of the vocabularies must be defined.",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "int64_vocabulary",
             "An integer vocabulary array.<br>One and only one of the vocabularies must be defined.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           auto input_elem_type = ctx.getInputType(0)->map_type().value_type().tensor_type().elem_type();
           auto output_elem_type = ctx.getOutputType(0)->mutable_tensor_type();
           output_elem_type->set_elem_type(input_elem_type);
-        }));
+        })
+);
 
 static const char* FeatureVectorizer_ver1_doc = R"DOC(
     Concatenates input tensors into one continuous output.<br>
@@ -268,8 +290,10 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T1",
             {"tensor(int32)", "tensor(int64)", "tensor(float)", "tensor(double)"},
-            "The input type must be a tensor of a numeric type.")
-        .Attr("inputdimensions", "The size of each input in the input list", AttributeProto::INTS, OPTIONAL_VALUE));
+            "The input type must be a tensor of a numeric type."
+        )
+        .Attr("inputdimensions", "The size of each input in the input list", AttributeProto::INTS, OPTIONAL_VALUE)
+);
 
 static const char* Imputer_ver1_doc = R"DOC(
     Replaces inputs that equal one value with another, leaving all other elements alone.<br>
@@ -292,11 +316,13 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)"},
-            "The input type must be a tensor of a numeric type, either [N,C] or [C]. The output type will be of the same tensor type and shape.")
+            "The input type must be a tensor of a numeric type, either [N,C] or [C]. The output type will be of the same tensor type and shape."
+        )
         .Attr("imputed_value_floats", "Value(s) to change to", AttributeProto::FLOATS, OPTIONAL_VALUE)
         .Attr("replaced_value_float", "A value that needs replacing.", AttributeProto::FLOAT, 0.f)
         .Attr("imputed_value_int64s", "Value(s) to change to.", AttributeProto::INTS, OPTIONAL_VALUE)
-        .Attr("replaced_value_int64", "A value that needs replacing.", AttributeProto::INT, static_cast<int64_t>(0)));
+        .Attr("replaced_value_int64", "A value that needs replacing.", AttributeProto::INT, static_cast<int64_t>(0))
+);
 
 static const char* LabelEncoder_ver4_doc = R"DOC(
     Maps each element in the input tensor to another value.<br>
@@ -330,16 +356,19 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T1",
             {"tensor(string)", "tensor(int64)", "tensor(float)", "tensor(int32)", "tensor(int16)", "tensor(double)"},
-            "The input type is a tensor of any shape.")
+            "The input type is a tensor of any shape."
+        )
         .TypeConstraint(
             "T2",
             {"tensor(string)", "tensor(int64)", "tensor(float)", "tensor(int32)", "tensor(int16)", "tensor(double)"},
-            "Output type is determined by the specified 'values_*' attribute.")
+            "Output type is determined by the specified 'values_*' attribute."
+        )
         .Attr(
             "keys_tensor",
             "Keys encoded as a 1D tensor. One and only one of 'keys_*'s should be set.",
             AttributeProto::TENSOR,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr("keys_strings", "A list of strings.", AttributeProto::STRINGS, OPTIONAL_VALUE)
         .Attr("keys_int64s", "A list of ints.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr("keys_floats", "A list of floats.", AttributeProto::FLOATS, OPTIONAL_VALUE)
@@ -347,7 +376,8 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
             "values_tensor",
             "Values encoded as a 1D tensor. One and only one of 'values_*'s should be set.",
             AttributeProto::TENSOR,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr("values_strings", "A list of strings.", AttributeProto::STRINGS, OPTIONAL_VALUE)
         .Attr("values_int64s", "A list of ints.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr("values_floats", "A list of floats.", AttributeProto::FLOATS, OPTIONAL_VALUE)
@@ -358,7 +388,8 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
             "default_tensor",
             "A default tensor.",
             "{\"_Unused\"} if values_* has string type, {-1} if values_* has integral type, and {-0.f} if values_* has float type.",
-            AttributeProto::TENSOR)
+            AttributeProto::TENSOR
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           int key_length, key_type;
           std::tie(key_type, key_length) =
@@ -372,20 +403,24 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
                 ctx.getInputType(0)->tensor_type().elem_type(),
                 " and the key type ",
                 key_type,
-                " are different, which is not permitted for LabelEncoders.");
+                " are different, which is not permitted for LabelEncoders."
+            );
           }
 
           int value_length, value_type;
           std::tie(value_type, value_length) = getAttributeElementTypeAndLength(
-              ctx, {"values_tensor", "values_strings", "values_int64s", "values_floats"});
+              ctx, {"values_tensor", "values_strings", "values_int64s", "values_floats"}
+          );
           if (value_type == TensorProto::UNDEFINED) {
             fail_shape_inference(
-                "At least one of values_tensor, values_strings, values_int64s, values_floats must be set.");
+                "At least one of values_tensor, values_strings, values_int64s, values_floats must be set."
+            );
           }
 
           int default_length, default_type;
           std::tie(default_type, default_length) = getAttributeElementTypeAndLength(
-              ctx, {"default_tensor", "default_string", "default_int64", "default_float"});
+              ctx, {"default_tensor", "default_string", "default_int64", "default_float"}
+          );
           if (default_type != TensorProto::UNDEFINED) {
             if (value_type != default_type) {
               fail_shape_inference(
@@ -393,7 +428,8 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
                   value_type,
                   " and the default type ",
                   default_type,
-                  " are different, which is not permitted for LabelEncoders.");
+                  " are different, which is not permitted for LabelEncoders."
+              );
             }
 
             // Ensure default_tensor is a singleton if set
@@ -410,13 +446,15 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
                 key_length,
                 " and the number of values ",
                 value_length,
-                " must be the same in the LabelEncoder.");
+                " must be the same in the LabelEncoder."
+            );
           }
 
           // Propagate shape from input type and assign output type based on value type
           ctx.getOutputType(0)->mutable_tensor_type()->set_elem_type(value_type);
           propagateShapeFromInputToOutput(ctx, 0, 0);
-        }));
+        })
+);
 
 static const char* LinearClassifier_ver1_doc = R"DOC(
     Linear classifier
@@ -433,33 +471,37 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T1",
             {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)"},
-            "The input must be a tensor of a numeric type, and of shape [N,C] or [C]. In the latter case, it will be treated as [1,C]")
+            "The input must be a tensor of a numeric type, and of shape [N,C] or [C]. In the latter case, it will be treated as [1,C]"
+        )
         .TypeConstraint(
-            "T2",
-            {"tensor(string)", "tensor(int64)"},
-            "The output will be a tensor of strings or integers.")
+            "T2", {"tensor(string)", "tensor(int64)"}, "The output will be a tensor of strings or integers."
+        )
         .Attr("coefficients", "A collection of weights of the model(s).", AttributeProto::FLOATS)
         .Attr("intercepts", "A collection of intercepts.", AttributeProto::FLOATS, OPTIONAL_VALUE)
         .Attr(
             "multi_class",
             "Indicates whether to do OvR or multinomial (0=OvR is the default).",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr(
             "classlabels_strings",
             "Class labels when using string labels. One and only one 'classlabels' attribute must be defined.",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "classlabels_ints",
             "Class labels when using integer labels. One and only one 'classlabels' attribute must be defined.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "post_transform",
             "Indicates the transform to apply to the scores vector.<br>One of 'NONE,' 'SOFTMAX,' 'LOGISTIC,' 'SOFTMAX_ZERO,' or 'PROBIT'",
             AttributeProto::STRING,
-            std::string("NONE"))
+            std::string("NONE")
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           std::vector<std::string> label_strs;
           std::vector<int64_t> label_ints;
@@ -511,7 +553,8 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
 
           updateOutputShape(ctx, 0, {batch_size_dim});
           updateOutputShape(ctx, 1, {batch_size_dim, class_count_dim});
-        }));
+        })
+);
 
 static const char* LinearRegressor_ver1_doc = R"DOC(
     Generalized linear regression evaluation.<br>
@@ -532,19 +575,23 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)"},
-            "The input must be a tensor of a numeric type.")
+            "The input must be a tensor of a numeric type."
+        )
         .Attr(
             "post_transform",
             "Indicates the transform to apply to the regression output vector.<br>One of 'NONE,' 'SOFTMAX,' 'LOGISTIC,' 'SOFTMAX_ZERO,' or 'PROBIT'",
             AttributeProto::STRING,
-            std::string("NONE"))
+            std::string("NONE")
+        )
         .Attr("coefficients", "Weights of the model(s).", AttributeProto::FLOATS, OPTIONAL_VALUE)
         .Attr("intercepts", "Weights of the intercepts, if used.", AttributeProto::FLOATS, OPTIONAL_VALUE)
         .Attr(
             "targets",
             "The total number of regression targets, 1 if not defined.",
             AttributeProto::INT,
-            static_cast<int64_t>(1)));
+            static_cast<int64_t>(1)
+        )
+);
 
 static const char* Normalizer_ver1_doc = R"DOC(
     Normalize the input.  There are three normalization modes, which have the corresponding formulas,
@@ -569,8 +616,10 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)"},
-            "The input must be a tensor of a numeric type.")
-        .Attr("norm", "One of 'MAX,' 'L1,' 'L2'", AttributeProto::STRING, std::string("MAX")));
+            "The input must be a tensor of a numeric type."
+        )
+        .Attr("norm", "One of 'MAX,' 'L1,' 'L2'", AttributeProto::STRING, std::string("MAX"))
+);
 
 static const char* OneHotEncoder_ver1_doc = R"DOC(
     Replace each input element with an array of ones and zeros, where a single
@@ -593,22 +642,26 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(string)", "tensor(int64)", "tensor(int32)", "tensor(float)", "tensor(double)"},
-            "The input must be a tensor of a numeric type.")
+            "The input must be a tensor of a numeric type."
+        )
         .Attr(
             "cats_int64s",
             "List of categories, ints.<br>One and only one of the 'cats_*' attributes must be defined.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "cats_strings",
             "List of categories, strings.<br>One and only one of the 'cats_*' attributes must be defined.",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "zeros",
             "If true and category is not present, will return all zeros; if false and a category if not found, the operator will fail.",
             AttributeProto::INT,
-            static_cast<int64_t>(1))
+            static_cast<int64_t>(1)
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           std::vector<int64_t> cats_int64s;
           bool has_int64s = getRepeatedAttribute(ctx, "cats_int64s", cats_int64s);
@@ -624,7 +677,8 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
           }
           shape->add_dim()->set_dim_value(std::max(cats_int64s.size(), cats_strings.size()));
           updateOutputElemType(ctx, 0, TensorProto::FLOAT);
-        }));
+        })
+);
 
 static const char* Scaler_ver1_doc = R"DOC(
     Rescale input data, for example to standardize features by removing the mean and scaling to unit variance.
@@ -640,17 +694,21 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)"},
-            "The input must be a tensor of a numeric type.")
+            "The input must be a tensor of a numeric type."
+        )
         .Attr(
             "offset",
             "First, offset by this.<br>Can be length of features in an [N,F] tensor or length 1, in which case it applies to all features, regardless of dimension count.",
             AttributeProto::FLOATS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "scale",
             "Second, multiply by this.<br>Can be length of features in an [N,F] tensor or length 1, in which case it applies to all features, regardless of dimension count.<br>Must be same length as 'offset'",
             AttributeProto::FLOATS,
-            OPTIONAL_VALUE));
+            OPTIONAL_VALUE
+        )
+);
 
 static const char* SVMClassifier_ver1_doc = R"DOC(
     Support Vector Machine classifier
@@ -667,25 +725,30 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
             1,
             "Z",
             "Class scores (one per class per example), if prob_a and prob_b are provided they are probabilities for each class, otherwise they are raw scores.",
-            "tensor(float)")
+            "tensor(float)"
+        )
         .TypeConstraint(
             "T1",
             {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)"},
-            "The input must be a tensor of a numeric type, either [C] or [N,C].")
+            "The input must be a tensor of a numeric type, either [C] or [N,C]."
+        )
         .TypeConstraint(
             "T2",
             {"tensor(string)", "tensor(int64)"},
-            "The output type will be a tensor of strings or integers, depending on which of the classlabels_* attributes is used. Its size will match the bactch size of the input.")
+            "The output type will be a tensor of strings or integers, depending on which of the classlabels_* attributes is used. Its size will match the bactch size of the input."
+        )
         .Attr(
             "kernel_type",
             "The kernel type, one of 'LINEAR,' 'POLY,' 'RBF,' 'SIGMOID'.",
             AttributeProto::STRING,
-            std::string("LINEAR"))
+            std::string("LINEAR")
+        )
         .Attr(
             "kernel_params",
             "List of 3 elements containing gamma, coef0, and degree, in that order. Zero if unused for the kernel.",
             AttributeProto::FLOATS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr("vectors_per_class", "", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr("support_vectors", "", AttributeProto::FLOATS, OPTIONAL_VALUE)
         .Attr("coefficients", "", AttributeProto::FLOATS, OPTIONAL_VALUE)
@@ -694,23 +757,27 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
             "prob_b",
             "Second set of probability coefficients. This array must be same size as prob_a.<br>If these are provided then output Z are probability estimates, otherwise they are raw scores.",
             AttributeProto::FLOATS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr("rho", "", AttributeProto::FLOATS, OPTIONAL_VALUE)
         .Attr(
             "post_transform",
             "Indicates the transform to apply to the score. <br>One of 'NONE,' 'SOFTMAX,' 'LOGISTIC,' 'SOFTMAX_ZERO,' or 'PROBIT'",
             AttributeProto::STRING,
-            std::string("NONE"))
+            std::string("NONE")
+        )
         .Attr(
             "classlabels_strings",
             "Class labels if using string labels.<br>One and only one of the 'classlabels_*' attributes must be defined.",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "classlabels_ints",
             "Class labels if using integer labels.<br>One and only one of the 'classlabels_*' attributes must be defined.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           std::vector<std::string> label_strs;
           auto result = getRepeatedAttribute(ctx, "classlabels_strings", label_strs);
@@ -721,7 +788,8 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
           } else {
             output_elem_type->set_elem_type(TensorProto::INT64);
           }
-        }));
+        })
+);
 
 static const char* SVMRegressor_ver1_doc = R"DOC(
     Support Vector Machine regression prediction and one-class SVM anomaly detection.
@@ -737,31 +805,37 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)"},
-            "The input type must be a tensor of a numeric type, either [C] or [N,C].")
+            "The input type must be a tensor of a numeric type, either [C] or [N,C]."
+        )
         .Attr(
             "kernel_type",
             "The kernel type, one of 'LINEAR,' 'POLY,' 'RBF,' 'SIGMOID'.",
             AttributeProto::STRING,
-            std::string("LINEAR"))
+            std::string("LINEAR")
+        )
         .Attr(
             "kernel_params",
             "List of 3 elements containing gamma, coef0, and degree, in that order. Zero if unused for the kernel.",
             AttributeProto::FLOATS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr("support_vectors", "Chosen support vectors", AttributeProto::FLOATS, OPTIONAL_VALUE)
         .Attr(
             "one_class",
             "Flag indicating whether the regression is a one-class SVM or not.",
             AttributeProto::INT,
-            static_cast<int64_t>(0))
+            static_cast<int64_t>(0)
+        )
         .Attr("coefficients", "Support vector coefficients.", AttributeProto::FLOATS, OPTIONAL_VALUE)
         .Attr("n_supports", "The number of support vectors.", AttributeProto::INT, static_cast<int64_t>(0))
         .Attr(
             "post_transform",
             "Indicates the transform to apply to the score. <br>One of 'NONE,' 'SOFTMAX,' 'LOGISTIC,' 'SOFTMAX_ZERO,' or 'PROBIT.'",
             AttributeProto::STRING,
-            std::string("NONE"))
-        .Attr("rho", "", AttributeProto::FLOATS, OPTIONAL_VALUE));
+            std::string("NONE")
+        )
+        .Attr("rho", "", AttributeProto::FLOATS, OPTIONAL_VALUE)
+);
 
 static const char* TreeEnsembleClassifier_ver3_doc = R"DOC(
     Tree Ensemble classifier. Returns the top class for each of N inputs.<br>
@@ -788,84 +862,93 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T1",
             {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)"},
-            "The input type must be a tensor of a numeric type.")
+            "The input type must be a tensor of a numeric type."
+        )
         .TypeConstraint(
             "T2",
             {"tensor(string)", "tensor(int64)"},
-            "The output type will be a tensor of strings or integers, depending on which of the classlabels_* attributes is used.")
+            "The output type will be a tensor of strings or integers, depending on which of the classlabels_* attributes is used."
+        )
         .Attr("nodes_treeids", "Tree id for each node.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr(
             "nodes_nodeids",
             "Node id for each node. Ids may restart at zero for each tree, but it not required to.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr("nodes_featureids", "Feature id for each node.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr(
-            "nodes_values",
-            "Thresholds to do the splitting on for each node.",
-            AttributeProto::FLOATS,
-            OPTIONAL_VALUE)
+            "nodes_values", "Thresholds to do the splitting on for each node.", AttributeProto::FLOATS, OPTIONAL_VALUE
+        )
         .Attr(
             "nodes_values_as_tensor",
             "Thresholds to do the splitting on for each node.",
             AttributeProto::TENSOR,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "nodes_hitrates",
             "Popularity of each node, used for performance and may be omitted.",
             AttributeProto::FLOATS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "nodes_hitrates_as_tensor",
             "Popularity of each node, used for performance and may be omitted.",
             AttributeProto::TENSOR,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "nodes_modes",
             "The node kind, that is, the comparison to make at the node. There is no comparison to make at a leaf node.<br>One of 'BRANCH_LEQ', 'BRANCH_LT', 'BRANCH_GTE', 'BRANCH_GT', 'BRANCH_EQ', 'BRANCH_NEQ', 'LEAF'",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr("nodes_truenodeids", "Child node if expression is true.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr("nodes_falsenodeids", "Child node if expression is false.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr(
             "nodes_missing_value_tracks_true",
             "For each node, define what to do in the presence of a missing value: if a value is missing (NaN), use the 'true' or 'false' branch based on the value in this array.<br>This attribute may be left undefined, and the default value is false (0) for all nodes.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr("class_treeids", "The id of the tree that this node is in.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr("class_nodeids", "node id that this weight is for.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr("class_ids", "The index of the class list that each weight is for.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr("class_weights", "The weight for the class in class_id.", AttributeProto::FLOATS, OPTIONAL_VALUE)
         .Attr(
-            "class_weights_as_tensor",
-            "The weight for the class in class_id.",
-            AttributeProto::TENSOR,
-            OPTIONAL_VALUE)
+            "class_weights_as_tensor", "The weight for the class in class_id.", AttributeProto::TENSOR, OPTIONAL_VALUE
+        )
         .Attr(
             "classlabels_strings",
             "Class labels if using string labels.<br>One and only one of the 'classlabels_*' attributes must be defined.",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "classlabels_int64s",
             "Class labels if using integer labels.<br>One and only one of the 'classlabels_*' attributes must be defined.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "post_transform",
             "Indicates the transform to apply to the score. <br> One of 'NONE,' 'SOFTMAX,' 'LOGISTIC,' 'SOFTMAX_ZERO,' or 'PROBIT.'",
             AttributeProto::STRING,
-            std::string("NONE"))
+            std::string("NONE")
+        )
         .Attr(
             "base_values",
             "Base values for classification, added to final class score; the size must be the same as the classes or can be left unassigned (assumed 0)",
             AttributeProto::FLOATS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "base_values_as_tensor",
             "Base values for classification, added to final class score; the size must be the same as the classes or can be left unassigned (assumed 0)",
             AttributeProto::TENSOR,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           auto* nodes_values = ctx.getAttribute("nodes_values");
           auto* nodes_values_as_tensor = ctx.getAttribute("nodes_values_as_tensor");
@@ -878,19 +961,23 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
 
           if (nullptr != nodes_values && nullptr != nodes_values_as_tensor) {
             fail_shape_inference(
-                "Only one of the attributes 'nodes_values', 'nodes_values_as_tensor' should be specified.");
+                "Only one of the attributes 'nodes_values', 'nodes_values_as_tensor' should be specified."
+            );
           }
           if (nullptr != nodes_hitrates && nullptr != nodes_hitrates_as_tensor) {
             fail_shape_inference(
-                "Only one of the attributes 'nodes_hitrates', 'nodes_hitrates_as_tensor' should be specified.");
+                "Only one of the attributes 'nodes_hitrates', 'nodes_hitrates_as_tensor' should be specified."
+            );
           }
           if (nullptr != class_weights && nullptr != class_weights_as_tensor) {
             fail_shape_inference(
-                "Only one of the attributes 'class_weights', 'class_weights_as_tensor' should be specified.");
+                "Only one of the attributes 'class_weights', 'class_weights_as_tensor' should be specified."
+            );
           }
           if (nullptr != base_values && nullptr != base_values_as_tensor) {
             fail_shape_inference(
-                "Only one of the attributes 'base_values', 'base_values_as_tensor' should be specified.");
+                "Only one of the attributes 'base_values', 'base_values_as_tensor' should be specified."
+            );
           }
 
           std::vector<std::string> classlabels_strings;
@@ -919,7 +1006,8 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
           }
           updateOutputShape(ctx, 0, {N});
           updateOutputShape(ctx, 1, {N, E});
-        }));
+        })
+);
 
 static const char* TreeEnsembleRegressor_ver3_doc = R"DOC(
     Tree Ensemble regressor.  Returns the regressed values for each input in N.<br>
@@ -946,46 +1034,51 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)"},
-            "The input type must be a tensor of a numeric type.")
+            "The input type must be a tensor of a numeric type."
+        )
         .Attr("nodes_treeids", "Tree id for each node.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr(
             "nodes_nodeids",
             "Node id for each node. Node ids must restart at zero for each tree and increase sequentially.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr("nodes_featureids", "Feature id for each node.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr(
-            "nodes_values",
-            "Thresholds to do the splitting on for each node.",
-            AttributeProto::FLOATS,
-            OPTIONAL_VALUE)
+            "nodes_values", "Thresholds to do the splitting on for each node.", AttributeProto::FLOATS, OPTIONAL_VALUE
+        )
         .Attr(
             "nodes_values_as_tensor",
             "Thresholds to do the splitting on for each node.",
             AttributeProto::TENSOR,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "nodes_hitrates",
             "Popularity of each node, used for performance and may be omitted.",
             AttributeProto::FLOATS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "nodes_hitrates_as_tensor",
             "Popularity of each node, used for performance and may be omitted.",
             AttributeProto::TENSOR,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "nodes_modes",
             "The node kind, that is, the comparison to make at the node. There is no comparison to make at a leaf node.<br>One of 'BRANCH_LEQ', 'BRANCH_LT', 'BRANCH_GTE', 'BRANCH_GT', 'BRANCH_EQ', 'BRANCH_NEQ', 'LEAF'",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr("nodes_truenodeids", "Child node if expression is true", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr("nodes_falsenodeids", "Child node if expression is false", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr(
             "nodes_missing_value_tracks_true",
             "For each node, define what to do in the presence of a NaN: use the 'true' (if the attribute value is 1) or 'false' (if the attribute value is 0) branch based on the value in this array.<br>This attribute may be left undefined and the default value is false (0) for all nodes.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr("target_treeids", "The id of the tree that each node is in.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr("target_nodeids", "The node id of each weight", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr("target_ids", "The index of the target that each weight is for", AttributeProto::INTS, OPTIONAL_VALUE)
@@ -996,22 +1089,26 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
             "post_transform",
             "Indicates the transform to apply to the score. <br>One of 'NONE,' 'SOFTMAX,' 'LOGISTIC,' 'SOFTMAX_ZERO,' or 'PROBIT'",
             AttributeProto::STRING,
-            std::string("NONE"))
+            std::string("NONE")
+        )
         .Attr(
             "aggregate_function",
             "Defines how to aggregate leaf values within a target. <br>One of 'AVERAGE,' 'SUM,' 'MIN,' 'MAX.'",
             AttributeProto::STRING,
-            std::string("SUM"))
+            std::string("SUM")
+        )
         .Attr(
             "base_values",
             "Base values for classification, added to final class score; the size must be the same as the classes or can be left unassigned (assumed 0)",
             AttributeProto::FLOATS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "base_values_as_tensor",
             "Base values for classification, added to final class score; the size must be the same as the classes or can be left unassigned (assumed 0)",
             AttributeProto::TENSOR,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           auto* nodes_values = ctx.getAttribute("nodes_values");
           auto* nodes_values_as_tensor = ctx.getAttribute("nodes_values_as_tensor");
@@ -1024,19 +1121,23 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
 
           if (nullptr != nodes_values && nullptr != nodes_values_as_tensor) {
             fail_shape_inference(
-                "Only one of the attributes 'nodes_values', 'nodes_values_as_tensor' should be specified.");
+                "Only one of the attributes 'nodes_values', 'nodes_values_as_tensor' should be specified."
+            );
           }
           if (nullptr != nodes_hitrates && nullptr != nodes_hitrates_as_tensor) {
             fail_shape_inference(
-                "Only one of the attributes 'nodes_hitrates', 'nodes_hitrates_as_tensor' should be specified.");
+                "Only one of the attributes 'nodes_hitrates', 'nodes_hitrates_as_tensor' should be specified."
+            );
           }
           if (nullptr != target_weights && nullptr != target_weights_as_tensor) {
             fail_shape_inference(
-                "Only one of the attributes 'target_weights', 'target_weights_as_tensor' should be specified.");
+                "Only one of the attributes 'target_weights', 'target_weights_as_tensor' should be specified."
+            );
           }
           if (nullptr != base_values && nullptr != base_values_as_tensor) {
             fail_shape_inference(
-                "Only one of the attributes 'base_values', 'base_values_as_tensor' should be specified.");
+                "Only one of the attributes 'base_values', 'base_values_as_tensor' should be specified."
+            );
           }
 
           checkInputRank(ctx, 0, 2);
@@ -1047,7 +1148,8 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
           }
           updateOutputElemType(ctx, 0, TensorProto::FLOAT);
           updateOutputShape(ctx, 0, {N, E});
-        }));
+        })
+);
 
 static const char* ZipMap_ver1_doc = R"DOC(
     Creates a map from the input and the attributes.<br>
@@ -1066,24 +1168,27 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"seq(map(string, float))", "seq(map(int64, float))"},
-            "The output will be a sequence of string or integer maps to float.")
+            "The output will be a sequence of string or integer maps to float."
+        )
         .Attr(
             "classlabels_strings",
             "The keys when using string keys.<br>One and only one of the 'classlabels_*' attributes must be defined.",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "classlabels_int64s",
             "The keys when using int keys.<br>One and only one of the 'classlabels_*' attributes must be defined.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           std::vector<std::string> classlabels_strings;
           bool result = getRepeatedAttribute(ctx, "classlabels_strings", classlabels_strings);
           auto output_map_type = ctx.getOutputType(0)->mutable_sequence_type()->mutable_elem_type()->mutable_map_type();
           auto output_value_tensor_type = output_map_type->mutable_value_type()->mutable_tensor_type();
           output_value_tensor_type->set_elem_type(TensorProto::FLOAT);
-          output_value_tensor_type->mutable_shape(); // Initialize to scalar
+          output_value_tensor_type->mutable_shape();  // Initialize to scalar
           if (hasInputShape(ctx, 0) && getInputShape(ctx, 0).dim_size() != 1 && getInputShape(ctx, 0).dim_size() != 2) {
             fail_shape_inference("ZipMap input shape should be 1D or 2D.")
           }
@@ -1095,7 +1200,8 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
           if (result && !classlabels_int64s.empty()) {
             output_map_type->set_key_type(TensorProto::INT64);
           }
-        }));
+        })
+);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE
 #endif

--- a/onnx/defs/traditionalml/old.cc
+++ b/onnx/defs/traditionalml/old.cc
@@ -29,22 +29,26 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T1",
             {"tensor(string)", "tensor(int64)"},
-            "The input type must be a tensor of integers or strings, of any shape.")
+            "The input type must be a tensor of integers or strings, of any shape."
+        )
         .TypeConstraint(
             "T2",
             {"tensor(string)", "tensor(int64)"},
-            "The output type will be a tensor of strings or integers, and will have the same shape as the input.")
+            "The output type will be a tensor of strings or integers, and will have the same shape as the input."
+        )
         .Attr("classes_strings", "A list of labels.", AttributeProto::STRINGS, OPTIONAL_VALUE)
         .Attr(
             "default_int64",
             "An integer to use when an input string value is not found in the map.<br>One and only one of the 'default_*' attributes must be defined.",
             AttributeProto::INT,
-            static_cast<int64_t>(-1))
+            static_cast<int64_t>(-1)
+        )
         .Attr(
             "default_string",
             "A string to use when an input integer value is not found in the map.<br>One and only one of the 'default_*' attributes must be defined.",
             AttributeProto::STRING,
-            std::string("_Unused"))
+            std::string("_Unused")
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           auto input_elem_type = ctx.getInputType(0)->tensor_type().elem_type();
           auto output_elem_type = ctx.getOutputType(0)->mutable_tensor_type();
@@ -53,7 +57,8 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
           } else if (TensorProto::INT64 == input_elem_type) {
             output_elem_type->set_elem_type(TensorProto::STRING);
           }
-        }));
+        })
+);
 
 static const char* TreeEnsembleClassifier_ver1_doc = R"DOC(
     Tree Ensemble classifier.  Returns the top class for each of N inputs.<br>
@@ -78,40 +83,44 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T1",
             {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)"},
-            "The input type must be a tensor of a numeric type.")
+            "The input type must be a tensor of a numeric type."
+        )
         .TypeConstraint(
             "T2",
             {"tensor(string)", "tensor(int64)"},
-            "The output type will be a tensor of strings or integers, depending on which of the classlabels_* attributes is used.")
+            "The output type will be a tensor of strings or integers, depending on which of the classlabels_* attributes is used."
+        )
         .Attr("nodes_treeids", "Tree id for each node.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr(
             "nodes_nodeids",
             "Node id for each node. Ids may restart at zero for each tree, but it not required to.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr("nodes_featureids", "Feature id for each node.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr(
-            "nodes_values",
-            "Thresholds to do the splitting on for each node.",
-            AttributeProto::FLOATS,
-            OPTIONAL_VALUE)
+            "nodes_values", "Thresholds to do the splitting on for each node.", AttributeProto::FLOATS, OPTIONAL_VALUE
+        )
         .Attr(
             "nodes_hitrates",
             "Popularity of each node, used for performance and may be omitted.",
             AttributeProto::FLOATS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "nodes_modes",
             "The node kind, that is, the comparison to make at the node. There is no comparison to make at a leaf node.<br>One of 'BRANCH_LEQ', 'BRANCH_LT', 'BRANCH_GTE', 'BRANCH_GT', 'BRANCH_EQ', 'BRANCH_NEQ', 'LEAF'",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr("nodes_truenodeids", "Child node if expression is true.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr("nodes_falsenodeids", "Child node if expression is false.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr(
             "nodes_missing_value_tracks_true",
             "For each node, define what to do in the presence of a missing value: if a value is missing (NaN), use the 'true' or 'false' branch based on the value in this array.<br>This attribute may be left undefined, and the default value is false (0) for all nodes.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr("class_treeids", "The id of the tree that this node is in.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr("class_nodeids", "node id that this weight is for.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr("class_ids", "The index of the class list that each weight is for.", AttributeProto::INTS, OPTIONAL_VALUE)
@@ -120,22 +129,26 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
             "classlabels_strings",
             "Class labels if using string labels.<br>One and only one of the 'classlabels_*' attributes must be defined.",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "classlabels_int64s",
             "Class labels if using integer labels.<br>One and only one of the 'classlabels_*' attributes must be defined.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "post_transform",
             "Indicates the transform to apply to the score. <br> One of 'NONE,' 'SOFTMAX,' 'LOGISTIC,' 'SOFTMAX_ZERO,' or 'PROBIT.'",
             AttributeProto::STRING,
-            std::string("NONE"))
+            std::string("NONE")
+        )
         .Attr(
             "base_values",
             "Base values for classification, added to final class score; the size must be the same as the classes or can be left unassigned (assumed 0)",
             AttributeProto::FLOATS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           std::vector<std::string> label_strs;
           auto result = getRepeatedAttribute(ctx, "classlabels_strings", label_strs);
@@ -146,7 +159,8 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
           } else {
             output_elem_type->set_elem_type(TensorProto::INT64);
           }
-        }));
+        })
+);
 
 static const char* TreeEnsembleRegressor_ver1_doc = R"DOC(
     Tree Ensemble regressor.  Returns the regressed values for each input in N.<br>
@@ -171,36 +185,39 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T",
             {"tensor(float)", "tensor(double)", "tensor(int64)", "tensor(int32)"},
-            "The input type must be a tensor of a numeric type.")
+            "The input type must be a tensor of a numeric type."
+        )
         .Attr("nodes_treeids", "Tree id for each node.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr(
             "nodes_nodeids",
             "Node id for each node. Node ids must restart at zero for each tree and increase sequentially.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr("nodes_featureids", "Feature id for each node.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr(
-            "nodes_values",
-            "Thresholds to do the splitting on for each node.",
-            AttributeProto::FLOATS,
-            OPTIONAL_VALUE)
+            "nodes_values", "Thresholds to do the splitting on for each node.", AttributeProto::FLOATS, OPTIONAL_VALUE
+        )
         .Attr(
             "nodes_hitrates",
             "Popularity of each node, used for performance and may be omitted.",
             AttributeProto::FLOATS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "nodes_modes",
             "The node kind, that is, the comparison to make at the node. There is no comparison to make at a leaf node.<br>One of 'BRANCH_LEQ', 'BRANCH_LT', 'BRANCH_GTE', 'BRANCH_GT', 'BRANCH_EQ', 'BRANCH_NEQ', 'LEAF'",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr("nodes_truenodeids", "Child node if expression is true", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr("nodes_falsenodeids", "Child node if expression is false", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr(
             "nodes_missing_value_tracks_true",
             "For each node, define what to do in the presence of a NaN: use the 'true' (if the attribute value is 1) or 'false' (if the attribute value is 0) branch based on the value in this array.<br>This attribute may be left undefined and the default value is false (0) for all nodes.",
             AttributeProto::INTS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr("target_treeids", "The id of the tree that each node is in.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr("target_nodeids", "The node id of each weight", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr("target_ids", "The index of the target that each weight is for", AttributeProto::INTS, OPTIONAL_VALUE)
@@ -210,17 +227,21 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
             "post_transform",
             "Indicates the transform to apply to the score. <br>One of 'NONE,' 'SOFTMAX,' 'LOGISTIC,' 'SOFTMAX_ZERO,' or 'PROBIT'",
             AttributeProto::STRING,
-            std::string("NONE"))
+            std::string("NONE")
+        )
         .Attr(
             "aggregate_function",
             "Defines how to aggregate leaf values within a target. <br>One of 'AVERAGE,' 'SUM,' 'MIN,' 'MAX.'",
             AttributeProto::STRING,
-            std::string("SUM"))
+            std::string("SUM")
+        )
         .Attr(
             "base_values",
             "Base values for classification, added to final class score; the size must be the same as the classes or can be left unassigned (assumed 0)",
             AttributeProto::FLOATS,
-            OPTIONAL_VALUE));
+            OPTIONAL_VALUE
+        )
+);
 
 static const char* LabelEncoder_ver2_doc = R"DOC(
     Maps each element in the input tensor to another value.<br>
@@ -250,25 +271,27 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
         .Input(0, "X", "Input data. It can be either tensor or scalar.", "T1")
         .Output(0, "Y", "Output data.", "T2")
         .TypeConstraint(
-            "T1",
-            {"tensor(string)", "tensor(int64)", "tensor(float)"},
-            "The input type is a tensor of any shape.")
+            "T1", {"tensor(string)", "tensor(int64)", "tensor(float)"}, "The input type is a tensor of any shape."
+        )
         .TypeConstraint(
             "T2",
             {"tensor(string)", "tensor(int64)", "tensor(float)"},
-            "Output type is determined by the specified 'values_*' attribute.")
+            "Output type is determined by the specified 'values_*' attribute."
+        )
         .Attr(
             "keys_strings",
             "A list of strings. One and only one of 'keys_*'s should be set.",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr("keys_int64s", "A list of ints.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr("keys_floats", "A list of floats.", AttributeProto::FLOATS, OPTIONAL_VALUE)
         .Attr(
             "values_strings",
             "A list of strings. One and only one of 'value_*'s should be set.",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr("values_int64s", "A list of ints.", AttributeProto::INTS, OPTIONAL_VALUE)
         .Attr("values_floats", "A list of floats.", AttributeProto::FLOATS, OPTIONAL_VALUE)
         .Attr("default_string", "A string.", AttributeProto::STRING, std::string("_Unused"))
@@ -336,7 +359,8 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
 
           // Input and output shapes are the same.
           propagateShapeFromInputToOutput(ctx, 0, 0);
-        }));
+        })
+);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE
 #endif

--- a/onnx/defs/training/defs.cc
+++ b/onnx/defs/training/defs.cc
@@ -152,7 +152,8 @@ ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA(
             "input is substituted for all the occurrences of \"C\".",
             "T1",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Output(
             0,
             "Outputs",
@@ -162,7 +163,8 @@ ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA(
             "respect to the i-th tensor specified in the attribute \"xs\".",
             "T2",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Attr(
             "xs",
             "Input tensor names of the differentiated sub-graph. It "
@@ -170,7 +172,8 @@ ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA(
             "inputs of a (sub-)graph. Variables (usually called "
             "intermediate variables) that can be generated from inputs "
             "cannot be included in this attribute.",
-            AttributeProto::STRINGS)
+            AttributeProto::STRINGS
+        )
         .Attr(
             "zs",
             "Input tensor names of the differentiated sub-graph. It "
@@ -179,19 +182,23 @@ ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA(
             "intermediate variables) that can be generated from inputs "
             "cannot be included in this attribute.",
             AttributeProto::STRINGS,
-            OPTIONAL_VALUE)
+            OPTIONAL_VALUE
+        )
         .Attr(
             "y",
             "The targeted tensor. It can be viewed as the output of the "
             "differentiated function. The attribute \"xs\" and attribute "
             "\"zs\" are the minimal independent variable set that determines "
             "the value of \"y\".",
-            AttributeProto::STRING)
+            AttributeProto::STRING
+        )
         .TypeConstraint("T1", OpSchema::all_tensor_types(), "Allow outputs to be any kind of tensor.")
         .TypeConstraint(
             "T2",
             {"tensor(float16)", "tensor(float)", "tensor(double)"},
-            "Allow inputs to be any kind of floating-point tensor."));
+            "Allow inputs to be any kind of floating-point tensor."
+        )
+);
 
 static const char* Adagrad_ver1_doc = R"DOC(
     Compute one iteration of ADAGRAD, a stochastic gradient based optimization
@@ -268,7 +275,8 @@ ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA(
             "accumulated squared gradient of \"X_2\"].",
             "T3",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Output(
             0,
             "outputs",
@@ -279,7 +287,8 @@ ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA(
             "new accumulated squared gradient of \"X_1\", new accumulated squared gradient of \"X_2\"].",
             "T3",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Attr("epsilon", "Small scalar to avoid dividing by zero.", AttributeProto::FLOAT, 1e-6f)
         .Attr(
             "decay_factor",
@@ -287,13 +296,15 @@ ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA(
             "The effective learning rate is computed by r = R / (1 + T * decay_factor). "
             "Default to 0 so that increasing update counts doesn't reduce the learning rate.",
             AttributeProto::FLOAT,
-            0.0f)
+            0.0f
+        )
         .Attr(
             "norm_coefficient",
             "Regularization coefficient in 0.5 * norm_coefficient * ||X||_2^2. Default to 0, "
             "which means no regularization.",
             AttributeProto::FLOAT,
-            0.0f)
+            0.0f
+        )
         .TypeConstraint("T1", {"tensor(float)", "tensor(double)"}, "Constrain input types to float scalars.")
         .TypeConstraint("T2", {"tensor(int64)"}, "Constrain input types to 64-bit integer scalars.")
         .TypeConstraint("T3", {"tensor(float)", "tensor(double)"}, "Constrain input and output types to float tensors.")
@@ -317,7 +328,8 @@ ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA(
             propagateElemTypeFromInputToOutput(ctx, i_in, i_out);
             propagateShapeFromInputToOutput(ctx, i_in, i_out);
           }
-        }));
+        })
+);
 
 static const char* Momentum_ver1_doc = R"DOC(
     Compute one iteration of stochastic gradient update with momentum.
@@ -398,7 +410,8 @@ ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA(
             "[\"X_1\", \"X_2\", gradient of \"X_1\", gradient of \"X_2\", momentum of \"X_1\", momentum of \"X_2\"].",
             "T3",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Output(
             0,
             "outputs",
@@ -408,19 +421,22 @@ ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA(
             "new momentum of \"X_1\", new momentum of \"X_2\"].",
             "T3",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Attr("alpha", "The decay factor of momentum. It should be a scalar.", AttributeProto::FLOAT)
         .Attr(
             "beta",
             "The coefficient of gradient in computing new momentum. It should be a scalar.",
-            AttributeProto::FLOAT)
+            AttributeProto::FLOAT
+        )
         .Attr("norm_coefficient", "Coefficient of 0.5 * norm_coefficient * ||X||^2.", AttributeProto::FLOAT)
         .Attr(
             "mode",
             "Its value should be either \"nesterov\" or \"standard\". The value \"nesterov\" leads "
             "to the use of Nesterov's momentum while \"standard\" invokes stochastic gradient method "
             "using standard momentum",
-            AttributeProto::STRING)
+            AttributeProto::STRING
+        )
         .TypeConstraint("T1", {"tensor(float)", "tensor(double)"}, "Constrain input types to float scalars.")
         .TypeConstraint("T2", {"tensor(int64)"}, "Constrain input types to 64-bit integer scalars.")
         .TypeConstraint("T3", {"tensor(float)", "tensor(double)"}, "Constrain input types to float tensors.")
@@ -436,7 +452,8 @@ ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA(
           if (num_adjustable_tensors % 3 != 0) {
             fail_shape_inference(
                 "The sum of optimized tensor count and momentum tensor count ",
-                "should be a multiple of 2 in the input list of Momentum operator");
+                "should be a multiple of 2 in the input list of Momentum operator"
+            );
           }
 
           // The count of "X1" and "X2".
@@ -453,7 +470,8 @@ ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA(
             propagateElemTypeFromInputToOutput(ctx, i_in, i_out);
             propagateShapeFromInputToOutput(ctx, i_in, i_out);
           }
-        }));
+        })
+);
 
 static const char* Adam_ver1_doc = R"DOC(
     Compute one iteration of Adam, a stochastic gradient based optimization
@@ -539,7 +557,8 @@ ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA(
             "accumulated squared gradient of \"X_1\", accumulated squared gradient of \"X_2\"].",
             "T3",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Output(
             0,
             "outputs",
@@ -555,29 +574,34 @@ ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA(
             "new accumulated squared gradient of \"X_2\"].",
             "T3",
             OpSchema::Variadic,
-            false)
+            false
+        )
         .Attr(
             "alpha",
             "Coefficient of previously accumulated gradient in running average. Default to 0.9.",
             AttributeProto::FLOAT,
-            0.9f)
+            0.9f
+        )
         .Attr(
             "beta",
             "Coefficient of previously accumulated squared-gradient in running average. Default to 0.999.",
             AttributeProto::FLOAT,
-            0.999f)
+            0.999f
+        )
         .Attr(
             "norm_coefficient",
             "Regularization coefficient of 0.5 * norm_coefficient * ||X||_2^2. Default to 0, "
             "which means no regularization.",
             AttributeProto::FLOAT,
-            0.0f)
+            0.0f
+        )
         .Attr(
             "norm_coefficient_post",
             "Regularization coefficient of 0.5 * norm_coefficient * ||X||_2^2. Default to 0, "
             "which means no regularization.",
             AttributeProto::FLOAT,
-            0.0f)
+            0.0f
+        )
         .Attr("epsilon", "Small scalar to avoid dividing by zero.", AttributeProto::FLOAT, 1e-6f)
         .TypeConstraint("T1", {"tensor(float)", "tensor(double)"}, "Constrain input types to float scalars.")
         .TypeConstraint("T2", {"tensor(int64)"}, "Constrain input types to 64-bit integer scalars.")
@@ -595,7 +619,8 @@ ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA(
             fail_shape_inference(
                 "The sum of optimized tensor count, gradient tensor count, momentum tensor count, ",
                 "accumulated squared-gradient tensor count should be a multiple of 4 in the ",
-                "\"inputs\" of Adam operator.");
+                "\"inputs\" of Adam operator."
+            );
           }
 
           // The count of "X1" and "X2".
@@ -619,6 +644,7 @@ ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA(
             propagateElemTypeFromInputToOutput(ctx, i_in, i_out);
             propagateShapeFromInputToOutput(ctx, i_in, i_out);
           }
-        }));
+        })
+);
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/inliner/inliner.cc
+++ b/onnx/inliner/inliner.cc
@@ -24,7 +24,7 @@
 namespace ONNX_NAMESPACE {
 namespace inliner {
 
-namespace { // internal/private API
+namespace {  // internal/private API
 
 using namespace internal;
 
@@ -217,13 +217,15 @@ class InliningRenamer : private MutableVisitor {
   template <bool isOutput>
   void Bind(
       google::protobuf::RepeatedPtrField<std::string>& formals,
-      const google::protobuf::RepeatedPtrField<std::string>& actuals) {
+      const google::protobuf::RepeatedPtrField<std::string>& actuals
+  ) {
     // Every formal parameter name FP should be replace by the corresponding actual parameter name AP.
     // However, if AP is empty, it is a missing optional parameter. This does not make any difference
     // for inputs. However, for outputs we use a unique dummy name to handle the case that it
     // is used in an output-context where it is not optional.
     ONNX_ASSERTM(
-        actuals.size() <= formals.size(), "Number of actual parameters cannot exceed number of formal parameters");
+        actuals.size() <= formals.size(), "Number of actual parameters cannot exceed number of formal parameters"
+    );
     auto& current_scope = rename_scopes.back();
     int i = 0;
     for (; i < actuals.size(); ++i) {
@@ -256,7 +258,7 @@ class InliningRenamer : private MutableVisitor {
     for (auto& y : *node->mutable_output()) {
       LookupOrRename(y, true);
     }
-    return true; // Process attribute subgraphs in traversal
+    return true;  // Process attribute subgraphs in traversal
   }
 
   // Process a sub-graph, contained as an attribute in a control-flow op node.
@@ -279,8 +281,9 @@ class InliningRenamer : private MutableVisitor {
   // Renames variables in a FunctionProto for inlining a particular call-site. This does the following:
   // (i)  Rename all intermediate variables in the function to ensure that they are unique (wrt the main graph).
   // (ii) Rename inputs and outputs using names of actual parameters.
-  static void
-  Rename(const NodeProto& callnode, FunctionProto& callee, std::string unique_suffix, NameGenerator& generator) {
+  static void Rename(
+      const NodeProto& callnode, FunctionProto& callee, std::string unique_suffix, NameGenerator& generator
+  ) {
     InliningRenamer renamer(std::move(unique_suffix), generator);
 
     renamer.Bind<false>(*callee.mutable_input(), callnode.input());
@@ -341,7 +344,7 @@ class ComputeInputs : private Visitor {
         }
       }
     }
-    return true; // process sub-graphs
+    return true;  // process sub-graphs
   }
 
  public:
@@ -469,7 +472,8 @@ void InlineFunctions(NodeList& nodes, const FunctionMap& map, NameGenerator& nam
             "Internal Error: Inlining function %s::%s requires version conversion, "
             "but version conversion is supported only for models, not functions.",
             callee.domain().c_str(),
-            callee.name().c_str());
+            callee.name().c_str()
+        );
         ConvertVersion(*model, node, callee, target_version);
       }
       // Append nodes of called function
@@ -515,13 +519,13 @@ class VectorSet : public FunctionIdSet {
   bool invert_;
 };
 
-} // namespace
+}  // namespace
 
 // Public API implementation:
 
 std::unique_ptr<FunctionIdSet> ONNX_NAMESPACE::inliner::FunctionIdSet::Create(
-    FunctionIdVector&& function_ids,
-    bool invert) {
+    FunctionIdVector&& function_ids, bool invert
+) {
   auto* p = new VectorSet(std::move(function_ids), invert);
   return std::unique_ptr<FunctionIdSet>(p);
 }
@@ -598,5 +602,5 @@ void InlineSelectedFunctions(ModelProto& model, const FunctionIdSet& to_inline) 
   }
 }
 
-} // namespace inliner
-} // namespace ONNX_NAMESPACE
+}  // namespace inliner
+}  // namespace ONNX_NAMESPACE

--- a/onnx/inliner/inliner.h
+++ b/onnx/inliner/inliner.h
@@ -45,5 +45,5 @@ void InlineSelectedFunctions(ModelProto& model, const FunctionIdSet& to_inline);
 // functions that use opset versions that are compatible with the model.
 void InlineLocalFunctions(ModelProto& model, bool convert_version = false);
 
-} // namespace inliner
-} // namespace ONNX_NAMESPACE
+}  // namespace inliner
+}  // namespace ONNX_NAMESPACE

--- a/onnx/onnx_pb.h
+++ b/onnx/onnx_pb.h
@@ -53,4 +53,4 @@
 #include "onnx/onnx.pb.h"
 #endif
 
-#endif // ! ONNX_ONNX_PB_H
+#endif  // ! ONNX_ONNX_PB_H

--- a/onnx/proto_utils.h
+++ b/onnx/proto_utils.h
@@ -14,9 +14,9 @@
 
 #ifdef ONNX_USE_LITE_PROTO
 #include <google/protobuf/message_lite.h>
-#else // ONNX_USE_LITE_PROTO
+#else  // ONNX_USE_LITE_PROTO
 #include <google/protobuf/message.h>
-#endif // !ONNX_USE_LITE_PROTO
+#endif  // !ONNX_USE_LITE_PROTO
 
 namespace ONNX_NAMESPACE {
 
@@ -68,4 +68,4 @@ inline std::vector<float> RetrieveValues(const AttributeProto& attr) {
   return {attr.floats().begin(), attr.floats().end()};
 }
 
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/py_utils.h
+++ b/onnx/py_utils.h
@@ -20,4 +20,4 @@ bool ParseProtoFromPyBytes(Proto* proto, const py::bytes& bytes) {
 
   return ParseProtoFromBytes(proto, buffer, length);
 }
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/shape_inference/attribute_binder.h
+++ b/onnx/shape_inference/attribute_binder.h
@@ -8,7 +8,7 @@
 #include "onnx/common/visitor.h"
 
 namespace ONNX_NAMESPACE {
-namespace internal { // internal/private API
+namespace internal {  // internal/private API
 
 using AttributeMap = std::unordered_map<std::string, const AttributeProto*>;
 
@@ -63,5 +63,5 @@ class AttributeBinder : public MutableVisitor {
   const AttributeMap& attr_map_;
 };
 
-} // namespace internal
-} // namespace ONNX_NAMESPACE
+}  // namespace internal
+}  // namespace ONNX_NAMESPACE

--- a/onnx/shape_inference/implementation.cc
+++ b/onnx/shape_inference/implementation.cc
@@ -70,7 +70,7 @@ inline bool IsOnnxDomainOp(const NodeProto& node, const std::string& op_type) {
   return (IsOnnxDomain(node.domain()) && (node.op_type() == op_type));
 }
 
-} // namespace
+}  // namespace
 
 template <class T>
 void CheckTensorShapesAndTypes(const T& inferred_type, const T& existing_type) {
@@ -119,26 +119,26 @@ void checkShapesAndTypes(const TypeProto& inferred_type, const TypeProto& existi
         "type case mismatch. existing=",
         GetValueCaseString(existing_type),
         " inferred=",
-        GetValueCaseString(inferred_type));
+        GetValueCaseString(inferred_type)
+    );
   }
 
   if (inferred_value_case == TypeProto::kTensorType && existing_value_case == TypeProto::kTensorType) {
     CheckTensorShapesAndTypes(inferred_type.tensor_type(), existing_type.tensor_type());
-  } else if (
-      inferred_value_case == TypeProto::kSparseTensorType && existing_value_case == TypeProto::kSparseTensorType) {
+  } else if (inferred_value_case == TypeProto::kSparseTensorType && existing_value_case == TypeProto::kSparseTensorType) {
     CheckTensorShapesAndTypes(inferred_type.sparse_tensor_type(), existing_type.sparse_tensor_type());
   } else if (inferred_value_case == TypeProto::kSequenceType && existing_value_case == TypeProto::kSequenceType) {
     checkShapesAndTypes(inferred_type.sequence_type().elem_type(), existing_type.sequence_type().elem_type());
   } else if (inferred_value_case == TypeProto::kOptionalType && existing_value_case == TypeProto::kOptionalType) {
     checkShapesAndTypes(inferred_type.optional_type().elem_type(), existing_type.optional_type().elem_type());
-  } else if (
-      inferred_value_case == TypeProto::TypeProto::kMapType && existing_value_case == TypeProto::TypeProto::kMapType) {
+  } else if (inferred_value_case == TypeProto::TypeProto::kMapType && existing_value_case == TypeProto::TypeProto::kMapType) {
     if (inferred_type.map_type().key_type() != existing_type.map_type().key_type()) {
       fail_type_inference(
           "key type mismatch from MapProto. existing=",
           Utils::DataTypeUtils::ToDataTypeString(existing_type.map_type().key_type()),
           " inferred=",
-          Utils::DataTypeUtils::ToDataTypeString(inferred_type.map_type().key_type()));
+          Utils::DataTypeUtils::ToDataTypeString(inferred_type.map_type().key_type())
+      );
     }
     checkShapesAndTypes(inferred_type.map_type().value_type(), existing_type.map_type().value_type());
   } else {
@@ -202,10 +202,12 @@ void mergeShapesAndTypes(const TypeProto& inferred_type, TypeProto* existing_typ
     mergeShapesAndTypes(inferred_type.sparse_tensor_type(), existing_type->mutable_sparse_tensor_type());
   } else if (inferred_val_case == TypeProto::kSequenceType) {
     mergeShapesAndTypes(
-        inferred_type.sequence_type().elem_type(), existing_type->mutable_sequence_type()->mutable_elem_type());
+        inferred_type.sequence_type().elem_type(), existing_type->mutable_sequence_type()->mutable_elem_type()
+    );
   } else if (inferred_val_case == TypeProto::kOptionalType) {
     mergeShapesAndTypes(
-        inferred_type.optional_type().elem_type(), existing_type->mutable_optional_type()->mutable_elem_type());
+        inferred_type.optional_type().elem_type(), existing_type->mutable_optional_type()->mutable_elem_type()
+    );
   } else if (inferred_val_case == TypeProto::kMapType) {
     if (existing_type->map_type().key_type() == TensorProto::UNDEFINED) {
       existing_type->mutable_map_type()->set_key_type(inferred_type.map_type().key_type());
@@ -289,10 +291,8 @@ class InferredTypes {
 
 // Initialize a DataValueMap for a called function from the DataValueMap of the caller
 void BindValuesOnCall(
-    const DataValueMap& caller_map,
-    const NodeProto& caller,
-    DataValueMap& callee_map,
-    const FunctionProto& callee) {
+    const DataValueMap& caller_map, const NodeProto& caller, DataValueMap& callee_map, const FunctionProto& callee
+) {
   auto num_inputs = (std::min)(caller.input_size(), callee.input_size());
   for (int i = 0; i < num_inputs; ++i) {
     const std::string& actual = caller.input(i);
@@ -308,10 +308,8 @@ void BindValuesOnCall(
 
 // Update a DataValueMap for a calling function from the DataValueMap of the callee
 void BindValuesOnReturn(
-    const DataValueMap& callee_map,
-    const FunctionProto& callee,
-    DataValueMap& caller_map,
-    const NodeProto& caller) {
+    const DataValueMap& callee_map, const FunctionProto& callee, DataValueMap& caller_map, const NodeProto& caller
+) {
   auto num_outputs = (std::min)(caller.output_size(), callee.output_size());
   for (int i = 0; i < num_outputs; ++i) {
     const std::string& actual = caller.output(i);
@@ -420,7 +418,8 @@ class ShapeInferenceImplBase {
       BindValuesOnCall(*generated_shape_data_by_name, caller, callee_value_map, callee);
     }
     InferShapeForFunctionNode(
-        callee, schema_registry, ctx, options, model_local_functions_map, symbol_table, &callee_value_map);
+        callee, schema_registry, ctx, options, model_local_functions_map, symbol_table, &callee_value_map
+    );
     if (generated_shape_data_by_name != nullptr) {
       BindValuesOnReturn(callee_value_map, callee, *generated_shape_data_by_name, caller);
     }
@@ -441,7 +440,8 @@ class ShapeInferenceImplBase {
             ". No opset import for domain ",
             n.domain(),
             " optype ",
-            n.op_type());
+            n.op_type()
+        );
       }
     }
     auto domain_version = dit->second;
@@ -453,7 +453,8 @@ class ShapeInferenceImplBase {
         input_sparse_data_by_name,
         options,
         generated_shape_data_by_name,
-        &graph_inference_context);
+        &graph_inference_context
+    );
 
     ONNX_TRY {
       if (schema) {
@@ -461,7 +462,7 @@ class ShapeInferenceImplBase {
           schema->GetTypeAndShapeInferenceFunction()(ctx);
         } else if (schema->HasFunction()) {
           ProcessCall(n, *(schema->GetFunction()), ctx);
-        } // else: rely on schema->CheckInputOutputType() down below.
+        }  // else: rely on schema->CheckInputOutputType() down below.
         // check type-constraints specified via type variables
         if (options.check_type) {
           schema->CheckInputOutputType(ctx);
@@ -489,10 +490,12 @@ class ShapeInferenceImplBase {
         if (options.enable_data_propagation && schema && schema->has_data_propagation_function()) {
           if (generated_shape_data_by_name == nullptr) {
             fail_shape_inference(
-                "Container for generated shape data cannot be nullptr when enable_data_propagation option is set.");
+                "Container for generated shape data cannot be nullptr when enable_data_propagation option is set."
+            );
           }
           DataPropagationContextImpl data_propagation_ctx(
-              n, value_types_by_name, input_data_by_name, *generated_shape_data_by_name);
+              n, value_types_by_name, input_data_by_name, *generated_shape_data_by_name
+          );
           schema->GetDataPropagationFunction()(data_propagation_ctx);
         }
       }
@@ -526,7 +529,8 @@ class ShapeInferenceImplBase {
       const std::string& name,
       const T& tensorValue,
       TypeProto& initializer_type,
-      std::unordered_map<std::string, const T*>& map) {
+      std::unordered_map<std::string, const T*>& map
+  ) {
     map[name] = &tensorValue;
     auto iter = value_types_by_name.find(name);
     // If it already exists in input, check input and initializer is sync
@@ -659,7 +663,7 @@ class ShapeInferenceImplBase {
 
  public:
   ShapeInferenceImplBase(
-      GraphProto* graph, // nullptr for FunctionProto inference
+      GraphProto* graph,  // nullptr for FunctionProto inference
       const std::unordered_map<std::string, TypeProto*>& outer_scope_value_types_by_name_in,
       const std::unordered_map<std::string, int>& opset_imports_in,
       const ShapeInferenceOptions& options_in,
@@ -667,8 +671,8 @@ class ShapeInferenceImplBase {
       const ModelLocalFunctionsMap& model_local_functions_map_in,
       const ISchemaRegistry* schema_registry_in = OpSchemaRegistry::Instance(),
       DataValueMap* generated_shape_data_by_name_in = nullptr,
-      const int ir_version_in = IR_VERSION // default the latest one
-      )
+      const int ir_version_in = IR_VERSION  // default the latest one
+  )
       : inferred_types(graph),
         value_types_by_name(outer_scope_value_types_by_name_in),
         opset_imports(opset_imports_in),
@@ -685,10 +689,12 @@ class ShapeInferenceImplBase {
             model_local_functions_map,
             schema_registry,
             generated_shape_data_by_name,
-            ir_version} {
+            ir_version
+        } {
     if (options.enable_data_propagation && generated_shape_data_by_name == nullptr) {
       fail_shape_inference(
-          "Container for generated shape data cannot be nullptr when enable_data_propagation option is set.");
+          "Container for generated shape data cannot be nullptr when enable_data_propagation option is set."
+      );
     }
   }
 
@@ -749,7 +755,7 @@ static void InferShapesImpl(
     const ModelLocalFunctionsMap& model_local_functions_map,
     const ISchemaRegistry* schema_registry = OpSchemaRegistry::Instance(),
     DataValueMap* generated_shape_data_by_name = nullptr,
-    const int ir_version = IR_VERSION // default the latest one
+    const int ir_version = IR_VERSION  // default the latest one
 ) {
   DataValueMap empty;
   if (generated_shape_data_by_name == nullptr) {
@@ -764,7 +770,8 @@ static void InferShapesImpl(
       model_local_functions_map,
       schema_registry,
       generated_shape_data_by_name,
-      ir_version);
+      ir_version
+  );
   base.Process(*g);
   base.FinalizeShapeInference();
 }
@@ -784,7 +791,8 @@ void InferShapes(
     const std::unordered_map<std::string, int>& opset_imports,
     const ISchemaRegistry* schema_registry,
     const ShapeInferenceOptions& options,
-    const std::unordered_map<std::string, const FunctionProto*>& model_local_functions) {
+    const std::unordered_map<std::string, const FunctionProto*>& model_local_functions
+) {
   SymbolTableImpl symbol_table;
   InferShapesImpl(
       g,
@@ -793,20 +801,23 @@ void InferShapes(
       options,
       &symbol_table,
       model_local_functions,
-      schema_registry);
+      schema_registry
+  );
 }
 
 void InferShapes(
     ModelProto& m,
     const ISchemaRegistry* schema_registry,
     const ShapeInferenceOptions& options,
-    DataValueMap* generated_shape_data_by_name) {
+    DataValueMap* generated_shape_data_by_name
+) {
   auto opset_imports = GetOpsetImportsFromProto(m);
   SymbolTableImpl symbol_table;
   ModelLocalFunctionsMap model_local_functions_by_id;
   for (const auto& function_proto : m.functions()) {
     model_local_functions_by_id.insert(
-        {GetModelLocalFunctionsMapIdentifier(function_proto.domain(), function_proto.name()), &function_proto});
+        {GetModelLocalFunctionsMapIdentifier(function_proto.domain(), function_proto.name()), &function_proto}
+    );
   }
   InferShapesImpl(
       m.mutable_graph(),
@@ -817,7 +828,8 @@ void InferShapes(
       model_local_functions_by_id,
       schema_registry,
       generated_shape_data_by_name,
-      m.ir_version());
+      m.ir_version()
+  );
 }
 
 void InferShapes(
@@ -825,7 +837,8 @@ void InferShapes(
     const std::string& save_path,
     const ISchemaRegistry* schema_registry,
     const ShapeInferenceOptions& options,
-    DataValueMap* generated_shape_data_by_name) {
+    DataValueMap* generated_shape_data_by_name
+) {
   ModelProto model;
   LoadProtoFromPath(model_path, model);
   InferShapes(model, schema_registry, options, generated_shape_data_by_name);
@@ -851,16 +864,18 @@ void InferShapeForFunctionNode(
     const ShapeInferenceOptions& options,
     const std::unordered_map<std::string, const FunctionProto*>& model_local_functions_map,
     SymbolTable* symbol_table,
-    DataValueMap* generated_shape_data_by_name) {
+    DataValueMap* generated_shape_data_by_name
+) {
   ShapeInferenceImplBase base(
-      nullptr, // no graph
-      {}, // outer_scope_value_types_by_name
+      nullptr,  // no graph
+      {},  // outer_scope_value_types_by_name
       func_opset_imports,
       options,
       symbol_table,
       model_local_functions_map,
       schema_registry,
-      generated_shape_data_by_name);
+      generated_shape_data_by_name
+  );
   base.Process(func_proto, ctx);
   base.FinalizeShapeInference();
 }
@@ -872,7 +887,8 @@ void InferShapeForFunctionNode(
     const ShapeInferenceOptions& options,
     const std::unordered_map<std::string, const FunctionProto*>& model_local_functions_map,
     SymbolTable* symbol_table,
-    DataValueMap* generated_shape_data_by_name) {
+    DataValueMap* generated_shape_data_by_name
+) {
   auto opset_imports = GetOpsetImportsFromProto(function_proto);
   InferShapeForFunctionNode(
       function_proto,
@@ -882,7 +898,8 @@ void InferShapeForFunctionNode(
       options,
       model_local_functions_map,
       symbol_table,
-      generated_shape_data_by_name);
+      generated_shape_data_by_name
+  );
 }
 
 struct FunctionInferenceContext : public InferenceContext {
@@ -890,7 +907,8 @@ struct FunctionInferenceContext : public InferenceContext {
       const FunctionProto& func_proto,
       const std::vector<TypeProto>& input_types,
       const std::vector<AttributeProto>& attributes,
-      const ShapeInferenceOptions& options)
+      const ShapeInferenceOptions& options
+  )
       : input_types_(input_types), options_(options) {
     for (const auto& attr : attributes) {
       attributesByName_[attr.name()] = &attr;
@@ -933,22 +951,22 @@ struct FunctionInferenceContext : public InferenceContext {
   }
 
   GraphInferencer* getGraphAttributeInferencer(const std::string& attribute_name) override {
-    ONNX_UNUSED_PARAMETER(attribute_name); // This method is unused for function-type-inference.
+    ONNX_UNUSED_PARAMETER(attribute_name);  // This method is unused for function-type-inference.
     return nullptr;
   }
 
   const TensorProto* getInputData(size_t index) const override {
-    ONNX_UNUSED_PARAMETER(index); // This inference doesn't take advantage of statically known input values.
+    ONNX_UNUSED_PARAMETER(index);  // This inference doesn't take advantage of statically known input values.
     return nullptr;
   }
 
   const SparseTensorProto* getInputSparseData(size_t index) const override {
-    ONNX_UNUSED_PARAMETER(index); // This inference doesn't take advantage of statically known input values.
+    ONNX_UNUSED_PARAMETER(index);  // This inference doesn't take advantage of statically known input values.
     return nullptr;
   }
 
   const TensorShapeProto* getSymbolicInput(size_t index) const override {
-    ONNX_UNUSED_PARAMETER(index); // This inference doesn't take advantage of data-propagation.
+    ONNX_UNUSED_PARAMETER(index);  // This inference doesn't take advantage of data-propagation.
     return nullptr;
   }
 
@@ -966,29 +984,31 @@ struct FunctionInferenceContext : public InferenceContext {
 std::vector<TypeProto> InferFunctionOutputTypes(
     const FunctionProto& function_proto,
     const std::vector<TypeProto>& input_types,
-    const std::vector<AttributeProto>& attributes) {
+    const std::vector<AttributeProto>& attributes
+) {
   // TODO: if it is desirable for infer_function_output_types to provide check_type, strict_mode, data_prop,
   // we can add them to the Python API. For now we just assume the default options.
   ShapeInferenceOptions options{true, 1, false};
   FunctionInferenceContext ctx(function_proto, input_types, attributes, options);
   auto opset_imports = GetOpsetImportsFromProto(function_proto);
   ShapeInferenceImplBase base(
-      nullptr, // no graph
-      {}, // outer_scope_value_types_by_name
+      nullptr,  // no graph
+      {},  // outer_scope_value_types_by_name
       opset_imports,
       options,
       /*symbol_table*/ nullptr,
       /*model_local_functions_map*/ {},
       /*schema_registry*/ OpSchemaRegistry::Instance(),
-      /*generated_shape_data_by_name*/ nullptr);
+      /*generated_shape_data_by_name*/ nullptr
+  );
   base.Process(function_proto, ctx);
   base.FinalizeShapeInference();
   return ctx.popOutputTypes();
 }
 
 std::vector<const TypeProto*> GraphInferencerImpl::doInferencing(
-    const std::vector<const TypeProto*>& input_types,
-    const std::vector<const TensorProto*>& input_data) {
+    const std::vector<const TypeProto*>& input_types, const std::vector<const TensorProto*>& input_data
+) {
   SymbolTable* symbol_table = context_->symbol_table;
   int num_inputs = int(input_types.size());
   std::unordered_set<std::string> initializer_name_set;
@@ -1003,7 +1023,8 @@ std::vector<const TypeProto*> GraphInferencerImpl::doInferencing(
     for (int i = 0; i < g_->input_size(); ++i) {
       if (initializer_name_set.count(g_->input(i).name()) > 0) {
         fail_shape_inference(
-            "Cannot use the same name as both a subgraph initializer and subgraph input: ", g_->input(i).name());
+            "Cannot use the same name as both a subgraph initializer and subgraph input: ", g_->input(i).name()
+        );
       }
     }
   } else {
@@ -1016,7 +1037,8 @@ std::vector<const TypeProto*> GraphInferencerImpl::doInferencing(
           " inputs but ",
           num_inputs,
           " were provided.",
-          "The number of graph input cannot be smaller than the number of node input");
+          "The number of graph input cannot be smaller than the number of node input"
+      );
     } else if (num_inputs < g_->input_size()) {
       for (int i = 0; i < g_->input_size(); ++i) {
         if (i < num_inputs && initializer_name_set.count(g_->input(i).name()) > 0) {
@@ -1049,13 +1071,14 @@ std::vector<const TypeProto*> GraphInferencerImpl::doInferencing(
   (void)input_data;
   InferShapesImpl(
       g_,
-      *context_->outer_scope_value_types_by_name, // never null
+      *context_->outer_scope_value_types_by_name,  // never null
       context_->opset_imports,
       options_,
       symbol_table,
       context_->model_local_functions,
       context_->schema_registry,
-      context_->generated_shape_data_by_name);
+      context_->generated_shape_data_by_name
+  );
 
   std::vector<const TypeProto*> graph_output_types;
   graph_output_types.reserve(g_->output().size());
@@ -1082,5 +1105,5 @@ void TraverseGraphsToAddExistingSymbols(const GraphProto& g, SymbolTable& symbol
   }
 }
 
-} // namespace shape_inference
-} // namespace ONNX_NAMESPACE
+}  // namespace shape_inference
+}  // namespace ONNX_NAMESPACE

--- a/onnx/shape_inference/implementation.h
+++ b/onnx/shape_inference/implementation.h
@@ -103,7 +103,8 @@ struct GraphInferenceContext {
       const ModelLocalFunctionsMap& model_local_functions_in = {},
       const ISchemaRegistry* schema_registry_in = OpSchemaRegistry::Instance(),
       DataValueMap* generated_shape_data_by_name_in = nullptr,
-      const int ir_version_in = IR_VERSION)
+      const int ir_version_in = IR_VERSION
+  )
       : outer_scope_value_types_by_name{&outer_scope_value_types_by_name_in},
         opset_imports{opset_imports_in},
         symbol_table{symbol_table_in},
@@ -128,8 +129,8 @@ class GraphInferencerImpl : public GraphInferencer {
       : g_{&g}, context_{&context}, options_(options) {}
 
   std::vector<const TypeProto*> doInferencing(
-      const std::vector<const TypeProto*>& inputTypes,
-      const std::vector<const TensorProto*>& inputData) override;
+      const std::vector<const TypeProto*>& inputTypes, const std::vector<const TensorProto*>& inputData
+  ) override;
 
  private:
   GraphProto* g_;
@@ -145,7 +146,8 @@ struct InferenceContextImpl : public InferenceContext {
       const std::unordered_map<std::string, const SparseTensorProto*>& inputSparseDataByName,
       const ShapeInferenceOptions& options,
       DataValueMap* generatedShapeData = nullptr,
-      GraphInferenceContext* graphInferenceContext = nullptr)
+      GraphInferenceContext* graphInferenceContext = nullptr
+  )
       : graphInferenceContext_{graphInferenceContext}, options_(options) {
     for (auto& attr : *n.mutable_attribute()) {
       attributesByName_[attr.name()] = &attr;
@@ -266,7 +268,8 @@ struct InferenceContextImpl : public InferenceContext {
       }
 
       std::unique_ptr<GraphInferencer> new_inferencer{
-          new GraphInferencerImpl(*attrNameToGraphProto->second, *graphInferenceContext_, options_)};
+          new GraphInferencerImpl(*attrNameToGraphProto->second, *graphInferenceContext_, options_)
+      };
 
       inferencer = new_inferencer.get();
       graphAttributeInferencers_.emplace(attr_name, std::move(new_inferencer));
@@ -296,7 +299,8 @@ struct DataPropagationContextImpl : public DataPropagationContext {
       NodeProto& n,
       const std::unordered_map<std::string, TypeProto*>& valueTypesByName,
       const std::unordered_map<std::string, const TensorProto*>& inputDataByName,
-      DataValueMap& generatedShapeData)
+      DataValueMap& generatedShapeData
+  )
       : generatedShapeData_(generatedShapeData) {
     size_t input_idx = 0;
 
@@ -450,20 +454,23 @@ void InferShapes(
     const std::unordered_map<std::string, int>& opset_imports,
     const ISchemaRegistry* schema_registry = OpSchemaRegistry::Instance(),
     const ShapeInferenceOptions& options = {},
-    const ModelLocalFunctionsMap& in_model_functions = {});
+    const ModelLocalFunctionsMap& in_model_functions = {}
+);
 
 void InferShapes(
     ModelProto& m,
     const ISchemaRegistry* schema_registry = OpSchemaRegistry::Instance(),
     const ShapeInferenceOptions& options = {},
-    DataValueMap* generated_shape_data_by_name = nullptr);
+    DataValueMap* generated_shape_data_by_name = nullptr
+);
 
 void InferShapes(
     const std::string& model_path,
     const std::string& save_path = "",
     const ISchemaRegistry* schema_registry = OpSchemaRegistry::Instance(),
     const ShapeInferenceOptions& options = {},
-    DataValueMap* generated_shape_data_by_name = nullptr);
+    DataValueMap* generated_shape_data_by_name = nullptr
+);
 
 ///
 /// ModelLocalFunctionsMap is a map of function id -> model local function proto
@@ -476,7 +483,8 @@ void InferShapeForFunctionNode(
     const ShapeInferenceOptions& options = {},
     const ModelLocalFunctionsMap& model_local_functions_map = {},
     SymbolTable* symbolTable = nullptr,
-    DataValueMap* generated_shape_data_by_name = nullptr);
+    DataValueMap* generated_shape_data_by_name = nullptr
+);
 
 ///
 /// ModelLocalFunctionsMap is a map of function id -> model local function proto
@@ -490,7 +498,8 @@ void InferShapeForFunctionNode(
     const ShapeInferenceOptions& options = {},
     const ModelLocalFunctionsMap& model_local_functions_map = {},
     SymbolTable* symbolTable = nullptr,
-    DataValueMap* generated_shape_data_by_name = nullptr);
+    DataValueMap* generated_shape_data_by_name = nullptr
+);
 
 ///
 /// Apply type-and-shape-inference based checks to a Function body.
@@ -503,11 +512,12 @@ void InferShapeForFunctionNode(
 std::vector<TypeProto> InferFunctionOutputTypes(
     const FunctionProto& func_proto,
     const std::vector<TypeProto>& input_types,
-    const std::vector<AttributeProto>& attributes);
+    const std::vector<AttributeProto>& attributes
+);
 
 std::string GetErrorWithNodeInfo(const NodeProto& n, const std::runtime_error& err);
 
 void TraverseGraphsToAddExistingSymbols(const GraphProto& g, SymbolTable& symbolTable);
 
-} // namespace shape_inference
-} // namespace ONNX_NAMESPACE
+}  // namespace shape_inference
+}  // namespace ONNX_NAMESPACE

--- a/onnx/string_utils.h
+++ b/onnx/string_utils.h
@@ -28,7 +28,7 @@ inline int stoi(const std::string& str) {
 #else
 using std::stoi;
 using std::to_string;
-#endif // defined(__ANDROID__)
+#endif  // defined(__ANDROID__)
 
 inline void MakeStringInternal(std::stringstream& /*ss*/) {}
 
@@ -58,4 +58,4 @@ inline std::string MakeString(const std::string& str) {
 inline std::string MakeString(const char* c_str) {
   return std::string(c_str);
 }
-} // namespace ONNX_NAMESPACE
+}  // namespace ONNX_NAMESPACE

--- a/onnx/test/cpp/common_path_test.cc
+++ b/onnx/test/cpp/common_path_test.cc
@@ -55,6 +55,6 @@ TEST(PathTest, CleanRelativePathTest) {
   EXPECT_EQ(clean_relative_path("abc//./../def"), "def");
   EXPECT_EQ(clean_relative_path("abc/../../././../def"), "../../def");
 }
-} // namespace Test
-} // namespace ONNX_NAMESPACE
+}  // namespace Test
+}  // namespace ONNX_NAMESPACE
 #endif

--- a/onnx/test/cpp/data_propagation_test.cc
+++ b/onnx/test/cpp/data_propagation_test.cc
@@ -21,23 +21,22 @@ namespace ONNX_NAMESPACE {
 namespace Test {
 
 inline bool CompareShape(
-    const TensorShapeProto& inferredShape,
-    const TensorShapeProto& expectedShape,
-    bool checkSameParam = false) {
+    const TensorShapeProto& inferredShape, const TensorShapeProto& expectedShape, bool checkSameParam = false
+) {
   EXPECT_TRUE(inferredShape.dim_size() == expectedShape.dim_size())
       << "Dim size for inferred and expected shape is different.";
 
   for (int i = 0; i < inferredShape.dim_size(); i++) {
     EXPECT_TRUE(
         (inferredShape.dim(i).has_dim_value() == expectedShape.dim(i).has_dim_value()) &&
-        (inferredShape.dim(i).has_dim_param() == expectedShape.dim(i).has_dim_param()))
-        << "Inferred and expected dim values are different.";
+        (inferredShape.dim(i).has_dim_param() == expectedShape.dim(i).has_dim_param())
+    ) << "Inferred and expected dim values are different.";
 
     EXPECT_TRUE(
         inferredShape.dim(i).has_dim_value() ? inferredShape.dim(i).dim_value() == expectedShape.dim(i).dim_value()
             : checkSameParam                 ? inferredShape.dim(i).dim_param() == expectedShape.dim(i).dim_param()
-                                             : true)
-        << "Inferred and expected dims are different.";
+                                             : true
+    ) << "Inferred and expected dims are different.";
   }
 
   return true;
@@ -397,5 +396,5 @@ agraph (int32[1,2,3,4,5,6,7,8] x) => (int32[3] w)
   EXPECT_TRUE(CompareShape(propagated_tsp, expected_tsp));
 }
 
-} // namespace Test
-} // namespace ONNX_NAMESPACE
+}  // namespace Test
+}  // namespace ONNX_NAMESPACE

--- a/onnx/test/cpp/function_context_test.cc
+++ b/onnx/test/cpp/function_context_test.cc
@@ -61,23 +61,24 @@ void BuildNodes(FunctionProto& functionProto, const std::vector<FunctionBodyHelp
 }
 
 bool BuildFunctionProto(
-    FunctionProto& functionProto,
-    const OpSchema& schema,
-    const std::vector<FunctionBodyHelper::NodeDef>& node_defs) {
+    FunctionProto& functionProto, const OpSchema& schema, const std::vector<FunctionBodyHelper::NodeDef>& node_defs
+) {
   BuildNodes(functionProto, node_defs);
   schema.BuildFunction(functionProto);
   return true;
 }
 
 // A monomorphic context-dependent function test-case.
-static bool
-BuildFloatFunctionBody(const FunctionBodyBuildContext& ctx, const OpSchema& schema, FunctionProto& functionProto) {
+static bool BuildFloatFunctionBody(
+    const FunctionBodyBuildContext& ctx, const OpSchema& schema, FunctionProto& functionProto
+) {
   // Create a scalar-tensor constant 2.0 of float type:
   auto two_as_tensor = ToTensor(2.0, TensorProto_DataType::TensorProto_DataType_FLOAT);
 
   std::vector<FunctionBodyHelper::NodeDef> body{// nodes: {outputs, op, inputs, attributes}
                                                 {{"Two"}, "Constant", {}, {{"value", two_as_tensor}}},
-                                                {{"Y"}, "Mul", {"X", "Two"}}};
+                                                {{"Y"}, "Mul", {"X", "Two"}}
+  };
 
   return BuildFunctionProto(functionProto, schema, body);
 }
@@ -125,8 +126,9 @@ TEST(FunctionAPITest, ContextDependentFunctionTest) {
 
 // A polymorphic context-dependent function test-case.
 
-static bool
-BuildFunctionBody(const FunctionBodyBuildContext& ctx, const OpSchema& schema, FunctionProto& functionProto) {
+static bool BuildFunctionBody(
+    const FunctionBodyBuildContext& ctx, const OpSchema& schema, FunctionProto& functionProto
+) {
   // Create a scalar-tensor constant 2.0 of input-type:
   auto* tp = ctx.getInputType(0);
   if ((tp == nullptr) || (!tp->has_tensor_type()))
@@ -136,7 +138,8 @@ BuildFunctionBody(const FunctionBodyBuildContext& ctx, const OpSchema& schema, F
 
   std::vector<FunctionBodyHelper::NodeDef> body{// nodes: {outputs, op, inputs, attributes}
                                                 {{"Two"}, "Constant", {}, {{"value", two_as_tensor}}},
-                                                {{"Y"}, "Mul", {"X", "Two"}}};
+                                                {{"Y"}, "Mul", {"X", "Two"}}
+  };
 
   return BuildFunctionProto(functionProto, schema, body);
 }
@@ -186,7 +189,8 @@ TEST(FunctionAPITest, VersionedFunctionBodyTest) {
           Z = Sub (X, Y)
         }
         )ONNX",
-          2);
+          2
+      );
 
   ONNX_NAMESPACE::OpSchema schema_ver9;
   schema_ver9.SetName("MySub")
@@ -203,14 +207,16 @@ TEST(FunctionAPITest, VersionedFunctionBodyTest) {
           Z = Sub (X, Y)
         }
         )ONNX",
-          9)
+          9
+      )
       .FunctionBody(
           R"ONNX(
         {
           Z = Sub (X, Y)
         }
         )ONNX",
-          16);
+          16
+      );
 
   ONNX_NAMESPACE::OpSchemaRegistry::OpSchemaRegisterOnce unused2(schema_ver2);
   (void)unused2;
@@ -223,7 +229,7 @@ TEST(FunctionAPITest, VersionedFunctionBodyTest) {
     try {
       bool validate = true;
       const FunctionProto* function = schema2->GetFunction(model_opset_import, validate);
-      if (model_opset_import >= 6) { // function body should be updated at opset 6 where Sub is updated
+      if (model_opset_import >= 6) {  // function body should be updated at opset 6 where Sub is updated
         ASSERT_TRUE(function == nullptr);
       } else {
         ASSERT_TRUE(function);
@@ -274,6 +280,6 @@ TEST(FunctionAPITest, TypeContextTest) {
   check_function(fnProto, checkerCtx, lexicalScope);
 }
 
-} // namespace Test
-} // namespace ONNX_NAMESPACE
+}  // namespace Test
+}  // namespace ONNX_NAMESPACE
 #pragma warning(pop)

--- a/onnx/test/cpp/function_get_test.cc
+++ b/onnx/test/cpp/function_get_test.cc
@@ -45,5 +45,5 @@ TEST(FunctionAPITest, GetMeanVarianceNormalizationFunctionWithVersion) {
   }
 }
 
-} // namespace Test
-} // namespace ONNX_NAMESPACE
+}  // namespace Test
+}  // namespace ONNX_NAMESPACE

--- a/onnx/test/cpp/function_verify_test.cc
+++ b/onnx/test/cpp/function_verify_test.cc
@@ -23,9 +23,8 @@ using namespace checker;
 using TENSOR_TYPES_MAP = std::unordered_map<std::string, std::vector<std::string>>;
 
 void GetFunctionProtoOpsetImport(
-    const OpSchema& op,
-    const FunctionProto* function_proto,
-    std::unordered_map<std::string, int>& op_set) {
+    const OpSchema& op, const FunctionProto* function_proto, std::unordered_map<std::string, int>& op_set
+) {
   if (function_proto->opset_import_size() > 0) {
     for (const auto& opset_import : function_proto->opset_import()) {
       op_set.insert({opset_import.domain(), opset_import.version()});
@@ -65,7 +64,8 @@ void VerifyTypeConstraint(const OpSchema& function_op, const FunctionProto* func
     if (it == op_set.end()) {
       fail_check(
           "Op " + op_type + " of domain " + node.domain() + " used in " + function_op.Name() +
-          " function body does not has a opset import.");
+          " function body does not has a opset import."
+      );
     }
 
     int opset_version = it->second;
@@ -92,7 +92,8 @@ void VerifyTypeConstraint(const OpSchema& function_op, const FunctionProto* func
           if (allowed_types.find(actual_type) == allowed_types.end()) {
             fail_check(
                 "Input type " + actual_type + " of parameter " + actual_param_name + " of function " +
-                function_op.Name() + " is not allowed by operator " + op_type);
+                function_op.Name() + " is not allowed by operator " + op_type
+            );
           }
         }
       }
@@ -139,7 +140,7 @@ struct FunctionOpAttributeMap {
     addTestCase("LeakyRelu", 16, {"alpha = 0.1"});
     addTestCase("HardSigmoid", 6, {"alpha = 0.2", "beta=0.5"});
     addTestCase("Selu", 6, {"alpha = 1.6", "gamma=1.05"});
-    addTestCase("ReduceL1", 18, {}); // Use default-value for attributes
+    addTestCase("ReduceL1", 18, {});  // Use default-value for attributes
     addTestCase("ReduceL1", 18, {"keepdims = 0"});
     addTestCase("ReduceL1", 18, {"noop_with_empty_axes = 1"});
     addTestCase("ReduceL2", 18, {});
@@ -375,7 +376,8 @@ void RegisterFunctionSchema() {
       .Input(0, "x", "Input tensor", "T1")
       .Output(0, "y", "Quantized output tensor", "T2")
       .Output(
-          1, "y_scale", "Output scale. It's a scalar, which means a per-tensor/layer quantization.", "tensor(float)")
+          1, "y_scale", "Output scale. It's a scalar, which means a per-tensor/layer quantization.", "tensor(float)"
+      )
       .Output(2, "y_zero_point", "Output zero point. It's a scalar, which means a per-tensor/layer quantization.", "T2")
       .TypeConstraint("T1", {"tensor(float)"}, "Constrain 'x' to float tensor.")
       .TypeConstraint("T2", {"tensor(uint8)"}, "Constrain 'y_zero_point' and 'y' to 8-bit unsigned integer tensor.")
@@ -397,7 +399,9 @@ void RegisterFunctionSchema() {
                {{"Zeropoint"}, "Cast", {"Rounded_ZeroPoint_FP"}, {MakeAttribute("to", int64_t(2))}},
                {{"y_scale"}, "Identity", {"Scale"}},
                {{"y_zero_point"}, "Identity", {"Zeropoint"}},
-               {{"y"}, "QuantizeLinear", {"x", "Scale", "Zeropoint"}}}),
+               {{"y"}, "QuantizeLinear", {"x", "Scale", "Zeropoint"}}
+              }
+          ),
           []() {
             std::vector<OperatorSetIdProto> operator_sets(2);
             auto& onnx_opset = operator_sets[0];
@@ -409,7 +413,8 @@ void RegisterFunctionSchema() {
             test_opset.set_version(2);
 
             return operator_sets;
-          }());
+          }()
+      );
   ONNX_NAMESPACE::OpSchemaRegistry::OpSchemaRegisterOnce unused(function_schema);
   (void)unused;
 }
@@ -554,5 +559,5 @@ foo (x) => (y) {
   ONNX_NAMESPACE::shape_inference::InferShapes(model, OpSchemaRegistry::Instance(), options);
 }
 
-} // namespace Test
-} // namespace ONNX_NAMESPACE
+}  // namespace Test
+}  // namespace ONNX_NAMESPACE

--- a/onnx/test/cpp/inliner_test.cc
+++ b/onnx/test/cpp/inliner_test.cc
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "onnx/inliner/inliner.h"
+
 #include <iostream>
 
 #include "gtest/gtest.h"
@@ -12,7 +14,6 @@
 #include "onnx/defs/parser.h"
 #include "onnx/defs/printer.h"
 #include "onnx/defs/schema.h"
-#include "onnx/inliner/inliner.h"
 #include "onnx/shape_inference/implementation.h"
 
 namespace ONNX_NAMESPACE {
@@ -297,5 +298,5 @@ bar (x) => (y) {
   ASSERT_EQ(node2.attribute_size(), 0);
 }
 
-} // namespace Test
-} // namespace ONNX_NAMESPACE
+}  // namespace Test
+}  // namespace ONNX_NAMESPACE

--- a/onnx/test/cpp/ir_test.cc
+++ b/onnx/test/cpp/ir_test.cc
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "onnx/common/ir.h"
+
 #include <iostream>
 
 #include "gtest/gtest.h"
-#include "onnx/common/ir.h"
 #include "onnx/common/ir_pb_converter.h"
 #include "onnx/defs/printer.h"
 
@@ -56,5 +57,5 @@ TEST(IR, ValidIdentifierTest) {
   }
 }
 
-} // namespace Test
-} // namespace ONNX_NAMESPACE
+}  // namespace Test
+}  // namespace ONNX_NAMESPACE

--- a/onnx/test/cpp/op_reg_test.cc
+++ b/onnx/test/cpp/op_reg_test.cc
@@ -24,5 +24,5 @@ TEST(OpRegistrationTest, GemmOp) {
   EXPECT_NE(opSchema->attributes().count("beta"), 0);
   EXPECT_EQ(opSchema->attributes().at("beta").type, AttributeProto_AttributeType_FLOAT);
 }
-} // namespace Test
-} // namespace ONNX_NAMESPACE
+}  // namespace Test
+}  // namespace ONNX_NAMESPACE

--- a/onnx/test/cpp/parser_test.cc
+++ b/onnx/test/cpp/parser_test.cc
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "onnx/defs/parser.h"
+
 #include "gtest/gtest.h"
 #include "onnx/checker.h"
-#include "onnx/defs/parser.h"
 #include "onnx/defs/printer.h"
 
 using namespace ONNX_NAMESPACE;
@@ -378,8 +379,8 @@ agraph (float y = {1.0}, float[N] z) => (float[N] w)
 
   EXPECT_EQ(graph.input_size(), 2);
   EXPECT_EQ(graph.output_size(), 1);
-  EXPECT_EQ(graph.initializer_size(), 3); // y, w1, w2
-  EXPECT_EQ(graph.value_info_size(), 1); // x
+  EXPECT_EQ(graph.initializer_size(), 3);  // y, w1, w2
+  EXPECT_EQ(graph.value_info_size(), 1);  // x
 }
 
 TEST(ParserTest, IfNodeTest) {
@@ -557,5 +558,5 @@ TEST(ParserTest, TypesModelTest2) {
   CheckModel(code);
 }
 
-} // namespace Test
-} // namespace ONNX_NAMESPACE
+}  // namespace Test
+}  // namespace ONNX_NAMESPACE

--- a/onnx/test/cpp/schema_registration_test.cc
+++ b/onnx/test/cpp/schema_registration_test.cc
@@ -271,5 +271,5 @@ TEST(SchemaRegistrationTest, RegisterAllThenSpecificVersion) {
 #endif
 }
 
-} // namespace Test
-} // namespace ONNX_NAMESPACE
+}  // namespace Test
+}  // namespace ONNX_NAMESPACE

--- a/onnx/test/cpp/shape_inference_test.cc
+++ b/onnx/test/cpp/shape_inference_test.cc
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "onnx/defs/shape_inference.h"
+
 #include <iostream>
 
 #include "gtest/gtest.h"
 #include "onnx/defs/parser.h"
 #include "onnx/defs/schema.h"
-#include "onnx/defs/shape_inference.h"
 #include "onnx/onnx_pb.h"
 #include "onnx/shape_inference/implementation.h"
 
@@ -399,7 +400,7 @@ static void doInferencingTest(bool use_scan_opset8) {
   }
 
   std::unordered_map<std::string, int> opset_imports;
-  opset_imports[ONNX_DOMAIN] = 8; // Scan is v8
+  opset_imports[ONNX_DOMAIN] = 8;  // Scan is v8
 
   const std::unordered_map<std::string, TypeProto*> outer_scope_value_types;
   SymbolTableImpl symbolTable;
@@ -458,7 +459,7 @@ static void doInferencingTest(bool use_scan_opset8) {
     scan.set_doc_string("Scan node");
     scan.set_op_type("Scan");
     if (use_scan_opset8)
-      scan.add_input(""); // optional sequence lens
+      scan.add_input("");  // optional sequence lens
     scan.add_input("loop_state_start");
     scan.add_input("scan_op_in");
     scan.add_output("loop_state_final");
@@ -468,19 +469,19 @@ static void doInferencingTest(bool use_scan_opset8) {
   TypeProto loop_state_in_tensor = simple_tensor_no_shape;
   auto* shape = loop_state_in_tensor.mutable_tensor_type()->mutable_shape();
   if (use_scan_opset8)
-    shape->add_dim()->set_dim_value(1); // batch size
-  shape->add_dim()->set_dim_value(2); // input size. must match subgraph
+    shape->add_dim()->set_dim_value(1);  // batch size
+  shape->add_dim()->set_dim_value(2);  // input size. must match subgraph
 
-  TypeProto loop_state_out_tensor = loop_state_in_tensor; // should be unchanged
+  TypeProto loop_state_out_tensor = loop_state_in_tensor;  // should be unchanged
 
   TypeProto scan_in_tensor = simple_tensor_no_shape;
   shape = scan_in_tensor.mutable_tensor_type()->mutable_shape();
   if (use_scan_opset8)
-    shape->add_dim()->set_dim_value(1); // batch size
-  shape->add_dim()->set_dim_value(1); // sequence length
-  shape->add_dim()->set_dim_value(2); // input size. must match subgraph
+    shape->add_dim()->set_dim_value(1);  // batch size
+  shape->add_dim()->set_dim_value(1);  // sequence length
+  shape->add_dim()->set_dim_value(2);  // input size. must match subgraph
 
-  TypeProto scan_out_tensor = scan_in_tensor; // should be unchanged
+  TypeProto scan_out_tensor = scan_in_tensor;  // should be unchanged
 
   std::unordered_map<std::string, TypeProto*> valueTypesByName;
   valueTypesByName["loop_state_start"] = &loop_state_in_tensor;
@@ -523,11 +524,13 @@ void RunReshapeShapeInfTest(const char* modelStr, TensorShapeProto& expectedShap
   for (int i = 0; i < inferredShape.dim_size(); i++) {
     EXPECT_TRUE(
         (inferredShape.dim(i).has_dim_value() && expectedShape.dim(i).has_dim_value()) ||
-        (inferredShape.dim(i).has_dim_param() && expectedShape.dim(i).has_dim_param()));
+        (inferredShape.dim(i).has_dim_param() && expectedShape.dim(i).has_dim_param())
+    );
 
     EXPECT_TRUE(
         inferredShape.dim(i).has_dim_value() ? inferredShape.dim(i).dim_value() == expectedShape.dim(i).dim_value()
-                                             : inferredShape.dim(i).dim_param() == expectedShape.dim(i).dim_param());
+                                             : inferredShape.dim(i).dim_param() == expectedShape.dim(i).dim_param()
+    );
   }
 }
 TEST(ShapeInferenceTest, ReshapeTestWithShapeAsSymInput) {
@@ -620,5 +623,5 @@ TEST(ShapeInferenceTest, CheckShapesAndTypesTest) {
 #endif
 }
 
-} // namespace Test
-} // namespace ONNX_NAMESPACE
+}  // namespace Test
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/BaseConverter.h
+++ b/onnx/version_converter/BaseConverter.h
@@ -78,8 +78,9 @@ class BaseVersionConverter {
     }
   }
 
-  virtual ModelProto
-  convert_version(const ModelProto& mp_in, const OpSetID& initial_version, const OpSetID& target_version) const = 0;
+  virtual ModelProto convert_version(
+      const ModelProto& mp_in, const OpSetID& initial_version, const OpSetID& target_version
+  ) const = 0;
 
   void registerAdapter(std::unique_ptr<Adapter> a_ptr) {
     const OpSetID& iv = a_ptr->initial_version();
@@ -92,5 +93,5 @@ class BaseVersionConverter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/adapter.h
+++ b/onnx/version_converter/adapters/adapter.h
@@ -64,5 +64,5 @@ class GenericAdapter final : public Adapter {
   NodeTransformerFunction transformer_;
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/axes_attribute_to_input.h
+++ b/onnx/version_converter/adapters/axes_attribute_to_input.h
@@ -46,5 +46,5 @@ class AxesAttributeToInput : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/axes_input_to_attribute.h
+++ b/onnx/version_converter/adapters/axes_input_to_attribute.h
@@ -38,7 +38,8 @@ class AxesInputToAttribute : public Adapter {
         std::string raw_data = node_ptr->t(kvalue).raw();
         ONNX_ASSERTM(
             raw_data.size() != 0 && raw_data.size() % 8 == 0,
-            "Raw Data must be non-empty and size must be a multiple of 8");
+            "Raw Data must be non-empty and size must be a multiple of 8"
+        );
         int64_t* raw = (int64_t*)const_cast<char*>(raw_data.c_str());
         node->is_(kaxes, std::vector<int64_t>(raw, raw + node_ptr->t(kvalue).size_from_dim(0)));
       } else {
@@ -67,5 +68,5 @@ class AxesInputToAttribute : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/axis_attribute_to_input.h
+++ b/onnx/version_converter/adapters/axis_attribute_to_input.h
@@ -18,11 +18,8 @@ namespace version_conversion {
 class AxisAttributeToInput : public Adapter {
  public:
   AxisAttributeToInput(
-      const std::string& op_name,
-      const OpSetID& initial,
-      const OpSetID& target,
-      size_t axis_index,
-      int64_t default_axis)
+      const std::string& op_name, const OpSetID& initial, const OpSetID& target, size_t axis_index, int64_t default_axis
+  )
       : Adapter(op_name, initial, target), axis_index(axis_index), default_axis(default_axis) {}
 
   Node* adapt(std::shared_ptr<Graph> graph, Node* node) const override {
@@ -70,5 +67,5 @@ class AxisAttributeToInput : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/axis_input_to_attribute.h
+++ b/onnx/version_converter/adapters/axis_input_to_attribute.h
@@ -18,11 +18,8 @@ namespace version_conversion {
 class AxisInputToAttribute : public Adapter {
  public:
   explicit AxisInputToAttribute(
-      const std::string& op_name,
-      const OpSetID& initial,
-      const OpSetID& target,
-      size_t axis_index,
-      int64_t default_axis)
+      const std::string& op_name, const OpSetID& initial, const OpSetID& target, size_t axis_index, int64_t default_axis
+  )
       : Adapter(op_name, initial, target), axis_index(axis_index), default_axis(default_axis) {}
 
   Node* adapt(std::shared_ptr<Graph> graph, Node* node) const override {
@@ -63,7 +60,8 @@ class AxisInputToAttribute : public Adapter {
       std::string raw_data = axis_node->t(kvalue).raw();
       ONNX_ASSERTM(
           raw_data.size() != 0 && raw_data.size() % 8 == 0,
-          "Raw Data must be non-empty and size must be a multiple of 8");
+          "Raw Data must be non-empty and size must be a multiple of 8"
+      );
       const int64_t* raw = reinterpret_cast<const int64_t*>(raw_data.c_str());
       node->i_(kaxis, raw[0]);
     } else {
@@ -95,5 +93,5 @@ class AxisInputToAttribute : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/batch_normalization_13_14.h
+++ b/onnx/version_converter/adapters/batch_normalization_13_14.h
@@ -21,7 +21,8 @@ class BatchNormalization_13_14 final : public Adapter {
     ONNX_ASSERTM(
         node->outputs().size() < 4,
         "BatchNormalization outputs 4 and 5 are not "
-        "supported in Opset 14.");
+        "supported in Opset 14."
+    );
   }
 
   Node* adapt(std::shared_ptr<Graph>, Node* node) const override {
@@ -30,5 +31,5 @@ class BatchNormalization_13_14 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/broadcast_backward_compatibility.h
+++ b/onnx/version_converter/adapters/broadcast_backward_compatibility.h
@@ -42,7 +42,8 @@ class BroadcastBackwardCompatibility final : public Adapter {
         "not have broadcastable inputs.",
         name().c_str(),
         initial_version().version(),
-        target_version().version());
+        target_version().version()
+    );
     if (req_broadcast == 1) {
       // If conditional is not fulfilled, we have a default broadcast
       // Add broadcast attribute
@@ -56,5 +57,5 @@ class BroadcastBackwardCompatibility final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/broadcast_forward_compatibility.h
+++ b/onnx/version_converter/adapters/broadcast_forward_compatibility.h
@@ -46,7 +46,7 @@ class BroadcastForwardCompatibility final : public Adapter {
             axes.emplace_back(B_sizes.size() + i);
             new_sizes.emplace_back(Dimension(1));
           }
-          if (target_version().version() >= 13) { // Unsqueeze takes 'axes' input
+          if (target_version().version() >= 13) {  // Unsqueeze takes 'axes' input
             Tensor t;
             t.elem_type() = TensorProto_DataType_INT64;
             t.sizes() = std::vector<int64_t>{static_cast<int64_t>(axes.size())};
@@ -58,7 +58,7 @@ class BroadcastForwardCompatibility final : public Adapter {
             constant->insertBefore(node);
             constant->t_(kvalue, t);
             node->addInput(constant->output());
-          } else { // Unsqueeze takes 'axes' attribute
+          } else {  // Unsqueeze takes 'axes' attribute
             n->is_(kaxes, std::forward<const std::vector<int64_t>>(axes));
           }
           // Move n before node
@@ -83,5 +83,5 @@ class BroadcastForwardCompatibility final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/cast_9_8.h
+++ b/onnx/version_converter/adapters/cast_9_8.h
@@ -30,5 +30,5 @@ class Cast_9_8 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/clip_10_11.h
+++ b/onnx/version_converter/adapters/clip_10_11.h
@@ -52,5 +52,5 @@ class Clip_10_11 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/compatible.h
+++ b/onnx/version_converter/adapters/compatible.h
@@ -26,5 +26,5 @@ struct CompatibleAdapter final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/dropout_11_12.h
+++ b/onnx/version_converter/adapters/dropout_11_12.h
@@ -42,5 +42,5 @@ class Dropout_11_12 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/extend_supported_types.h
+++ b/onnx/version_converter/adapters/extend_supported_types.h
@@ -28,7 +28,8 @@ struct ExtendSupportedTypes final : public Adapter {
       ArrayRef<Value*> inputs,
       const int to_type,
       const std::vector<Dimension>& output_shape,
-      const std::string& name) const {
+      const std::string& name
+  ) const {
     Node* node = graph->create(kCast, inputs);
     node->i_(kto, to_type);
     node->output()->setUniqueName(name);
@@ -58,9 +59,11 @@ struct ExtendSupportedTypes final : public Adapter {
     };
 
     ONNX_ASSERTM(
-        unsupported_version9_types.find(input_type) == unsupported_version9_types.end(), "Unsupported Input Type");
+        unsupported_version9_types.find(input_type) == unsupported_version9_types.end(), "Unsupported Input Type"
+    );
     ONNX_ASSERTM(
-        unsupported_version9_types.find(output_type) == unsupported_version9_types.end(), "Unsupported Output Type");
+        unsupported_version9_types.find(output_type) == unsupported_version9_types.end(), "Unsupported Output Type"
+    );
 
     bool castInput = (node->kind() != kConstant);
     bool castOutput = (node->kind() != kGreater && node->kind() != kLess);
@@ -71,7 +74,8 @@ struct ExtendSupportedTypes final : public Adapter {
             inputs[i],
             TensorProto_DataType::TensorProto_DataType_FLOAT,
             inputs[i]->sizes(),
-            "pre_cast_" + ONNX_NAMESPACE::to_string(i));
+            "pre_cast_" + ONNX_NAMESPACE::to_string(i)
+        );
         pre_cast->insertBefore(node);
         node->replaceInput(i, pre_cast->output());
       }
@@ -102,5 +106,5 @@ struct ExtendSupportedTypes final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/gemm_6_7.h
+++ b/onnx/version_converter/adapters/gemm_6_7.h
@@ -42,7 +42,8 @@ class Gemm_6_7 final : public Adapter {
     ONNX_ASSERTM(
         check_numpy_unibroadcastable_and_require_broadcast(MN, C_shape) != -1,
         "Gemm being converted from 6 to 7 does not have "
-        "broadcastable inputs.");
+        "broadcastable inputs."
+    );
     if (node->hasAttribute(kbroadcast))
       node->removeAttribute(kbroadcast);
   }
@@ -53,5 +54,5 @@ class Gemm_6_7 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/gemm_7_6.h
+++ b/onnx/version_converter/adapters/gemm_7_6.h
@@ -47,7 +47,8 @@ class Gemm_7_6 final : public Adapter {
         "not have broadcastable inputs.",
         name().c_str(),
         initial_version().version(),
-        target_version().version());
+        target_version().version()
+    );
     if (req_broadcast == 1) {
       node->i_(kbroadcast, 1);
     }
@@ -59,5 +60,5 @@ class Gemm_7_6 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/gridsample_19_20.h
+++ b/onnx/version_converter/adapters/gridsample_19_20.h
@@ -32,5 +32,5 @@ class GridSample_19_20 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/maxpool_8_7.h
+++ b/onnx/version_converter/adapters/maxpool_8_7.h
@@ -32,5 +32,5 @@ class MaxPool_8_7 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/no_previous_version.h
+++ b/onnx/version_converter/adapters/no_previous_version.h
@@ -28,5 +28,5 @@ class NoPreviousVersionAdapter final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/pad_10_11.h
+++ b/onnx/version_converter/adapters/pad_10_11.h
@@ -52,5 +52,5 @@ class Pad_10_11 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/remove_consumed_inputs.h
+++ b/onnx/version_converter/adapters/remove_consumed_inputs.h
@@ -28,5 +28,5 @@ class RemoveConsumedInputs : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/reshape_4_5.h
+++ b/onnx/version_converter/adapters/reshape_4_5.h
@@ -45,5 +45,5 @@ class Reshape_4_5 final : public RemoveConsumedInputs {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/reshape_5_4.h
+++ b/onnx/version_converter/adapters/reshape_5_4.h
@@ -36,7 +36,8 @@ class Reshape_5_4 final : public Adapter {
         std::string raw_data = node_ptr->t(kvalue).raw();
         ONNX_ASSERTM(
             raw_data.size() != 0 && raw_data.size() % 8 == 0,
-            "Raw Data must be non-empty and size must be a multiple of 8");
+            "Raw Data must be non-empty and size must be a multiple of 8"
+        );
         int64_t* raw = (int64_t*)const_cast<char*>(raw_data.c_str());
         node->is_(kshape, std::vector<int64_t>(raw, raw + node_ptr->t(kvalue).size_from_dim(0)));
       } else {
@@ -69,5 +70,5 @@ class Reshape_5_4 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/resize_10_11.h
+++ b/onnx/version_converter/adapters/resize_10_11.h
@@ -46,5 +46,5 @@ class Resize_10_11 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/scan_8_9.h
+++ b/onnx/version_converter/adapters/scan_8_9.h
@@ -60,5 +60,5 @@ struct Scan_8_9 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/scan_9_8.h
+++ b/onnx/version_converter/adapters/scan_9_8.h
@@ -89,5 +89,5 @@ struct Scan_9_8 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/scatter_10_11.h
+++ b/onnx/version_converter/adapters/scatter_10_11.h
@@ -39,5 +39,5 @@ class Scatter_10_11 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/slice_9_10.h
+++ b/onnx/version_converter/adapters/slice_9_10.h
@@ -50,5 +50,5 @@ class Slice_9_10 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/softmax_12_13.h
+++ b/onnx/version_converter/adapters/softmax_12_13.h
@@ -83,5 +83,5 @@ class Softmax_12_13 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/split_12_13.h
+++ b/onnx/version_converter/adapters/split_12_13.h
@@ -43,5 +43,5 @@ class Split_12_13 : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/split_13_12.h
+++ b/onnx/version_converter/adapters/split_13_12.h
@@ -37,7 +37,8 @@ class Split_13_12 : public Adapter {
         std::string raw_data = node_ptr->t(kvalue).raw();
         ONNX_ASSERTM(
             raw_data.size() != 0 && raw_data.size() % 8 == 0,
-            "Raw Data must be non-empty and size must be a multiple of 8");
+            "Raw Data must be non-empty and size must be a multiple of 8"
+        );
         int64_t* raw = (int64_t*)const_cast<char*>(raw_data.c_str());
         node->is_(ksplit, std::vector<int64_t>(raw, raw + node_ptr->t(kvalue).size_from_dim(0)));
       } else {
@@ -66,5 +67,5 @@ class Split_13_12 : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/split_17_18.h
+++ b/onnx/version_converter/adapters/split_17_18.h
@@ -34,5 +34,5 @@ class Split_17_18 : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/sum_8_7.h
+++ b/onnx/version_converter/adapters/sum_8_7.h
@@ -37,5 +37,5 @@ class Sum_8_7 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/topk_9_10.h
+++ b/onnx/version_converter/adapters/topk_9_10.h
@@ -39,5 +39,5 @@ class TopK_9_10 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/transformers.h
+++ b/onnx/version_converter/adapters/transformers.h
@@ -80,5 +80,5 @@ inline NodeTransformerFunction SetAttributeIfAbsent(Symbol attr, int64_t value) 
   };
 }
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/type_restriction.h
+++ b/onnx/version_converter/adapters/type_restriction.h
@@ -23,7 +23,8 @@ class TypeRestriction : public Adapter {
       const std::string& op_name,
       const OpSetID& initial,
       const OpSetID& target,
-      const std::vector<TensorProto_DataType>& unallowed_types)
+      const std::vector<TensorProto_DataType>& unallowed_types
+  )
       : Adapter(op_name, initial, target), unallowed_types_(unallowed_types) {}
 
   void adapt_type_restriction(std::shared_ptr<Graph>, Node* node) const {
@@ -53,9 +54,10 @@ class TypeRestriction : public Adapter {
         " of operator '%s' is unallowed for Opset Version %d.",
         val->elemType(),
         name().c_str(),
-        target_version().version());
+        target_version().version()
+    );
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/upsample_6_7.h
+++ b/onnx/version_converter/adapters/upsample_6_7.h
@@ -25,7 +25,8 @@ struct Upsample_6_7 final : public Adapter {
     Symbol height_scale_symbol = Symbol("height_scale");
     ONNX_ASSERTM(
         node->hasAttribute(width_scale_symbol) && node->hasAttribute(height_scale_symbol),
-        "Upsample in opset 1 needs to have width_scale and height_scale attributes");
+        "Upsample in opset 1 needs to have width_scale and height_scale attributes"
+    );
 
     auto width_scale = node->f(width_scale_symbol);
     auto height_scale = node->f(height_scale_symbol);
@@ -45,5 +46,5 @@ struct Upsample_6_7 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/upsample_8_9.h
+++ b/onnx/version_converter/adapters/upsample_8_9.h
@@ -46,5 +46,5 @@ struct Upsample_8_9 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/upsample_9_10.h
+++ b/onnx/version_converter/adapters/upsample_9_10.h
@@ -38,5 +38,5 @@ class Upsample_9_10 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/adapters/upsample_9_8.h
+++ b/onnx/version_converter/adapters/upsample_9_8.h
@@ -75,5 +75,5 @@ struct Upsample_9_8 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/convert.cc
+++ b/onnx/version_converter/convert.cc
@@ -27,9 +27,8 @@ ModelProto ConvertVersion(const ModelProto& mp_in, int target_version) {
 }
 
 void DefaultVersionConverter::convert_graph(
-    std::shared_ptr<Graph> g,
-    const OpSetID& initial_version,
-    const OpSetID& target_version) const {
+    std::shared_ptr<Graph> g, const OpSetID& initial_version, const OpSetID& target_version
+) const {
   assertNonNull(g);
 
   // TODO: Move to Inter-Domain Converter
@@ -65,7 +64,8 @@ void DefaultVersionConverter::convert_graph(
   while (curr_version != target_version.version()) {
     debug(
         "curr_version: " + ONNX_NAMESPACE::to_string(curr_version) +
-        ", next_version: " + ONNX_NAMESPACE::to_string(curr_version + step));
+        ", next_version: " + ONNX_NAMESPACE::to_string(curr_version + step)
+    );
     Node* cur_op;
     graph_node_list_iterator it = g->begin();
     // Iterate through and call adapter returned by adapter_lookup for ops from
@@ -119,9 +119,8 @@ void DefaultVersionConverter::convert_graph(
 }
 
 ModelProto DefaultVersionConverter::convert_version(
-    const ModelProto& mp_in,
-    const OpSetID& initial_version,
-    const OpSetID& target_version) const {
+    const ModelProto& mp_in, const OpSetID& initial_version, const OpSetID& target_version
+) const {
   const std::string& initial_domain = initial_version.domain();
   const std::string& target_domain = target_version.domain();
   assertDefaultDomain(initial_domain, target_domain);
@@ -129,7 +128,8 @@ ModelProto DefaultVersionConverter::convert_version(
   for (auto it = mp_in.opset_import().begin(); it != mp_in.opset_import().end(); ++it) {
     if (it->domain() == initial_version.domain()) {
       ONNX_ASSERTM(
-          initial_version.version() == it->version(), "initial_version does not reflect current state of model");
+          initial_version.version() == it->version(), "initial_version does not reflect current state of model"
+      );
     }
   }
 
@@ -144,5 +144,5 @@ ModelProto DefaultVersionConverter::convert_version(
   return mp_out;
 }
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/convert.h
+++ b/onnx/version_converter/convert.h
@@ -67,7 +67,8 @@ class DefaultVersionConverter : public BaseVersionConverter {
   bool searchOpDomainMap(
       const std::unordered_map<std::string, std::map<int64_t, const OpSchema*>>& op_domain_map,
       int64_t curr_version,
-      int64_t step) const {
+      int64_t step
+  ) const {
     bool up = step == 1;
     const auto version_it = op_domain_map.find("");
     return version_it != op_domain_map.end() &&
@@ -85,14 +86,16 @@ class DefaultVersionConverter : public BaseVersionConverter {
         version >= version_range.first && version <= version_range.second,
         "Warning: invalid version (must be between %d and %d)",
         version_range.first,
-        version_range.second);
+        version_range.second
+    );
   }
 
   void assertDefaultDomain(const std::string& initial_domain, const std::string& target_domain) const {
     ONNX_ASSERTM(
         (initial_domain == "" || initial_domain == "ai.onnx") && (target_domain == "" || target_domain == "ai.onnx"),
         "Warning: default onnx version converter can only convert "
-        " between default domain opset versions ('' or 'ai.onnx')\n");
+        " between default domain opset versions ('' or 'ai.onnx')\n"
+    );
     ONNX_ASSERTM(initial_domain == target_domain, "initial_version and target_version must have the same domains");
   }
 
@@ -121,8 +124,9 @@ class DefaultVersionConverter : public BaseVersionConverter {
           }
         }
         if (min_version > 1) {
-          registerAdapter(std::make_unique<NoPreviousVersionAdapter>(
-              op_pair.first, OpSetID(min_version), OpSetID(min_version - 1)));
+          registerAdapter(
+              std::make_unique<NoPreviousVersionAdapter>(op_pair.first, OpSetID(min_version), OpSetID(min_version - 1))
+          );
         }
       }
     }
@@ -147,7 +151,8 @@ class DefaultVersionConverter : public BaseVersionConverter {
         TensorProto_DataType_INT8,
         TensorProto_DataType_INT16,
         TensorProto_DataType_STRING,
-        TensorProto_DataType_BOOL};
+        TensorProto_DataType_BOOL
+    };
     registerAdapter(std::make_unique<TypeRestriction>("Concat", OpSetID(4), OpSetID(3), concat_unallowed_types));
 
     /******** 4 -> 5 ********/
@@ -191,10 +196,8 @@ class DefaultVersionConverter : public BaseVersionConverter {
 
     /******** 6 -> 5 ********/
     std::vector<TensorProto_DataType> broadcast_unallowed_types = {
-        TensorProto_DataType_INT32,
-        TensorProto_DataType_INT64,
-        TensorProto_DataType_UINT32,
-        TensorProto_DataType_UINT64};
+        TensorProto_DataType_INT32, TensorProto_DataType_INT64, TensorProto_DataType_UINT32, TensorProto_DataType_UINT64
+    };
     std::vector<TensorProto_DataType> int_unallowed_types = {
         TensorProto_DataType_UINT8,
         TensorProto_DataType_UINT16,
@@ -203,9 +206,11 @@ class DefaultVersionConverter : public BaseVersionConverter {
         TensorProto_DataType_INT8,
         TensorProto_DataType_INT16,
         TensorProto_DataType_INT32,
-        TensorProto_DataType_INT64};
+        TensorProto_DataType_INT64
+    };
     std::vector<TensorProto_DataType> neg_unallowed_types = {
-        TensorProto_DataType_INT32, TensorProto_DataType_INT8, TensorProto_DataType_UINT16, TensorProto_DataType_INT64};
+        TensorProto_DataType_INT32, TensorProto_DataType_INT8, TensorProto_DataType_UINT16, TensorProto_DataType_INT64
+    };
     registerAdapter(std::make_unique<TypeRestriction>("Add", OpSetID(6), OpSetID(5), broadcast_unallowed_types));
     registerAdapter(std::make_unique<TypeRestriction>("Mul", OpSetID(6), OpSetID(5), broadcast_unallowed_types));
     registerAdapter(std::make_unique<TypeRestriction>("Sub", OpSetID(6), OpSetID(5), broadcast_unallowed_types));
@@ -350,7 +355,8 @@ class DefaultVersionConverter : public BaseVersionConverter {
         TensorProto_DataType_INT16,
         TensorProto_DataType_FLOAT16,
         TensorProto_DataType_FLOAT,
-        TensorProto_DataType_DOUBLE};
+        TensorProto_DataType_DOUBLE
+    };
     registerAdapter(std::make_unique<CompatibleAdapter>("ArgMax", OpSetID(11), OpSetID(10)));
     registerAdapter(std::make_unique<CompatibleAdapter>("ArgMin", OpSetID(11), OpSetID(10)));
     registerAdapter(std::make_unique<CompatibleAdapter>("AveragePool", OpSetID(11), OpSetID(10)));
@@ -590,7 +596,8 @@ class DefaultVersionConverter : public BaseVersionConverter {
         TensorProto_DataType_FLOAT8E4M3FN,
         TensorProto_DataType_FLOAT8E4M3FNUZ,
         TensorProto_DataType_FLOAT8E5M2,
-        TensorProto_DataType_FLOAT8E5M2FNUZ};
+        TensorProto_DataType_FLOAT8E5M2FNUZ
+    };
     registerAdapter(std::make_unique<TypeRestriction>("IsNaN", OpSetID(19), OpSetID(20), is_nan_13_unallowed_types));
     const std::vector<TensorProto_DataType> is_inf_10_unallowed_types = {
         TensorProto_DataType_FLOAT16,
@@ -598,14 +605,17 @@ class DefaultVersionConverter : public BaseVersionConverter {
         TensorProto_DataType_FLOAT8E4M3FN,
         TensorProto_DataType_FLOAT8E4M3FNUZ,
         TensorProto_DataType_FLOAT8E5M2,
-        TensorProto_DataType_FLOAT8E5M2FNUZ};
+        TensorProto_DataType_FLOAT8E5M2FNUZ
+    };
     registerAdapter(std::make_unique<TypeRestriction>("IsInf", OpSetID(19), OpSetID(20), is_inf_10_unallowed_types));
     registerAdapter(std::make_unique<AxisInputToAttribute>("DFT", OpSetID(20), OpSetID(19), 2, -2));
     const std::vector<TensorProto_DataType> reduce_min_max_18_unallowed_types = {TensorProto_DataType_BOOL};
     registerAdapter(
-        std::make_unique<TypeRestriction>("ReduceMax", OpSetID(20), OpSetID(19), reduce_min_max_18_unallowed_types));
+        std::make_unique<TypeRestriction>("ReduceMax", OpSetID(20), OpSetID(19), reduce_min_max_18_unallowed_types)
+    );
     registerAdapter(
-        std::make_unique<TypeRestriction>("ReduceMin", OpSetID(20), OpSetID(19), reduce_min_max_18_unallowed_types));
+        std::make_unique<TypeRestriction>("ReduceMin", OpSetID(20), OpSetID(19), reduce_min_max_18_unallowed_types)
+    );
   }
 
   ModelProto convert_version(const ModelProto& mp_in, const OpSetID& initial_version, const OpSetID& target_version)
@@ -613,5 +623,5 @@ class DefaultVersionConverter : public BaseVersionConverter {
 };
 
 ModelProto ConvertVersion(const ModelProto& mp_in, int target_version);
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/helper.cc
+++ b/onnx/version_converter/helper.cc
@@ -11,8 +11,8 @@
 namespace ONNX_NAMESPACE {
 namespace version_conversion {
 int check_numpy_unibroadcastable_and_require_broadcast(
-    const std::vector<Dimension>& input1_sizes,
-    const std::vector<Dimension>& input2_sizes) {
+    const std::vector<Dimension>& input1_sizes, const std::vector<Dimension>& input2_sizes
+) {
   // Check that input1 is larger
   if (input1_sizes.size() < input2_sizes.size())
     return -1;
@@ -33,8 +33,8 @@ int check_numpy_unibroadcastable_and_require_broadcast(
 }
 
 void assert_numpy_multibroadcastable(
-    const std::vector<Dimension>& input1_sizes,
-    const std::vector<Dimension>& input2_sizes) {
+    const std::vector<Dimension>& input1_sizes, const std::vector<Dimension>& input2_sizes
+) {
   // Generalize above for multibroadcastable case
   const std::vector<Dimension>* A_ptr;
   const std::vector<Dimension>* B_ptr;
@@ -62,7 +62,8 @@ void assert_numpy_multibroadcastable(
         i,
         B,
         axis + i,
-        A);
+        A
+    );
   }
 }
 
@@ -78,11 +79,12 @@ void assertInputsAvailable(const ArrayRef<Value*>& inputs, const char* name, uin
       "%s in opset version 6 can only broadcast"
       " between %d inputs",
       name,
-      num_inputs);
+      num_inputs
+  );
   for (int i = 0; i < (int)num_inputs; i++) {
     ONNX_ASSERTM(inputs[i]->has_sizes(), "Shape of input %d is not available.", num_inputs);
     assertNotParams(inputs[i]->sizes());
   }
 }
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE

--- a/onnx/version_converter/helper.h
+++ b/onnx/version_converter/helper.h
@@ -13,15 +13,15 @@
 namespace ONNX_NAMESPACE {
 namespace version_conversion {
 int check_numpy_unibroadcastable_and_require_broadcast(
-    const std::vector<Dimension>& input1_sizes,
-    const std::vector<Dimension>& input2_sizes);
+    const std::vector<Dimension>& input1_sizes, const std::vector<Dimension>& input2_sizes
+);
 
 void assert_numpy_multibroadcastable(
-    const std::vector<Dimension>& input1_sizes,
-    const std::vector<Dimension>& input2_sizes);
+    const std::vector<Dimension>& input1_sizes, const std::vector<Dimension>& input2_sizes
+);
 
 void assertNotParams(const std::vector<Dimension>& sizes);
 
 void assertInputsAvailable(const ArrayRef<Value*>& inputs, const char* name, uint64_t num_inputs);
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+}  // namespace version_conversion
+}  // namespace ONNX_NAMESPACE


### PR DESCRIPTION
Update the config to use clang-format 17 entries, and update the style to use a more black-like style (block indent instead of hanging indent etc.) adapted from https://github.com/justinchuby/clang-format-black/tree/main

This should wait until 1.15 is released