### PR TITLE
Do not use LFS64 on non-glibc linux (#5668)

### DIFF
--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -190,11 +190,11 @@ void check_tensor(const TensorProto& tensor, const CheckerContext& ctx) {
         }
         std::string data_path = path_join(ctx.get_model_dir(), relative_path);
         // use stat64 to check whether the file exists
-#if defined(__APPLE__) || defined(__wasm__)
-        struct stat buffer; // APPLE does not have stat64
+#if defined(__APPLE__) || defined(__wasm__) || !defined(__GLIBC__)
+        struct stat buffer; // APPLE, wasm and non-glic stdlibs do not have stat64
         if (stat((data_path).c_str(), &buffer) != 0) {
 #else
-        struct stat64 buffer; // All POSIX except APPLE have stat64
+        struct stat64 buffer; // All POSIX under glibc except APPLE and wasm have stat64
         if (stat64((data_path).c_str(), &buffer) != 0) {
 #endif
           fail_check(


### PR DESCRIPTION
### Description
This PR closes #5668 and fixes building onnx on non-glibc linux systems (e.g. Alpine Linux / musl).

### Motivation and Context
The latest version of onnx (1.14.1) currently fails to compile on non-glibc systems (e.g. musl) due to an unsupported call to `stat64()` in checker.cc. See the latest [pipeline log](https://gitlab.alpinelinux.org/leso-kn/aports/-/jobs/1143766#L1155) of [aports!52138](https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/52138) for an example case.