### PR TITLE
Add missing ReduceMax's empty set test

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -21868,6 +21868,38 @@ expect(
 
 
 <details>
+<summary>empty_set</summary>
+
+```python
+shape = [2, 0, 4]
+keepdims = 1
+reduced_shape = [2, 1, 4]
+
+node = onnx.helper.make_node(
+    "ReduceMax",
+    inputs=["data", "axes"],
+    outputs=["reduced"],
+    keepdims=keepdims,
+)
+
+data = np.array([], dtype=np.float32).reshape(shape)
+axes = np.array([1], dtype=np.int64)
+one = np.array(np.ones(reduced_shape, dtype=np.float32))
+zero = np.array(np.zeros(reduced_shape, dtype=np.float32))
+reduced = -(one / zero)  # -inf
+
+expect(
+    node,
+    inputs=[data, axes],
+    outputs=[reduced],
+    name="test_reduce_min_empty_set",
+)
+```
+
+</details>
+
+
+<details>
 <summary>keepdims</summary>
 
 ```python

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -14574,7 +14574,7 @@ expect(
 
 
 ### ReduceMax
-There are 5 test cases, listed as following:
+There are 6 test cases, listed as following:
 <details>
 <summary>bool_inputs</summary>
 
@@ -14690,6 +14690,36 @@ expect(
     outputs=[reduced],
     name="test_reduce_max_do_not_keepdims_random",
     opset_imports=[onnx.helper.make_opsetid("", 18)],
+)
+```
+
+</details>
+<details>
+<summary>empty_set</summary>
+
+```python
+shape = [2, 0, 4]
+keepdims = 1
+reduced_shape = [2, 1, 4]
+
+node = onnx.helper.make_node(
+    "ReduceMax",
+    inputs=["data", "axes"],
+    outputs=["reduced"],
+    keepdims=keepdims,
+)
+
+data = np.array([], dtype=np.float32).reshape(shape)
+axes = np.array([1], dtype=np.int64)
+one = np.array(np.ones(reduced_shape, dtype=np.float32))
+zero = np.array(np.zeros(reduced_shape, dtype=np.float32))
+reduced = -(one / zero)  # -inf
+
+expect(
+    node,
+    inputs=[data, axes],
+    outputs=[reduced],
+    name="test_reduce_min_empty_set",
 )
 ```
 

--- a/onnx/backend/test/case/node/reducemax.py
+++ b/onnx/backend/test/case/node/reducemax.py
@@ -202,3 +202,29 @@ class ReduceMax(Base):
             outputs=[reduced],
             name="test_reduce_max_bool_inputs",
         )
+
+    @staticmethod
+    def export_empty_set() -> None:
+        shape = [2, 0, 4]
+        keepdims = 1
+        reduced_shape = [2, 1, 4]
+
+        node = onnx.helper.make_node(
+            "ReduceMax",
+            inputs=["data", "axes"],
+            outputs=["reduced"],
+            keepdims=keepdims,
+        )
+
+        data = np.array([], dtype=np.float32).reshape(shape)
+        axes = np.array([1], dtype=np.int64)
+        one = np.array(np.ones(reduced_shape, dtype=np.float32))
+        zero = np.array(np.zeros(reduced_shape, dtype=np.float32))
+        reduced = -(one / zero)  # -inf
+
+        expect(
+            node,
+            inputs=[data, axes],
+            outputs=[reduced],
+            name="test_reduce_min_empty_set",
+        )


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Adds missing ReduceMax test with empty set

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
There is test for ReduceMin but for ReduceMax seems to be missing in https://github.com/onnx/onnx/pull/5568
