### PR TITLE
Skip ssd_mobilenet_v1 due to subgraph shape inference enhancement

### DIFF
--- a/workflow_scripts/config.py
+++ b/workflow_scripts/config.py
@@ -10,10 +10,10 @@ SKIP_VERSION_CONVERTER_MODELS = {
     "vision/classification/vgg/model/vgg16-bn-7.onnx",  # version_converter/adapters/transformers.h:30: operator(): Assertion `node->i(attr) == value` failed: Attribute spatial must have value 1
     "vision/classification/vgg/model/vgg19-bn-7.onnx",  # version_converter/adapters/transformers.h:30: operator(): Assertion `node->i(attr) == value` failed: Attribute spatial must have value 1
     "vision/object_detection_segmentation/mask-rcnn/model/MaskRCNN-12-int8.onnx",  # unordered_map::at: key not found
-    "vision/object_detection_segmentation/ssd-mobilenetv1/model/ssd_mobilenet_v1_10.onnx", # starts failing after ONNX 1.15.0 due to subgraph shape inference enhancement:
+    "vision/object_detection_segmentation/ssd-mobilenetv1/model/ssd_mobilenet_v1_10.onnx",  # starts failing after ONNX 1.15.0 due to subgraph shape inference enhancement:
     # [ShapeInferenceError] Inference error(s): (op_type:Loop, node name: generic_loop_Loop__48):
     # [ShapeInferenceError] Inference error(s): (op_type:If, node name: Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond_If__115): 
     # [ShapeInferenceError] Inference error(s): (op_type:Concat, node name: Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond/concat): 
     # [ShapeInferenceError] All inputs to Concat must have same rank. Input 1 has rank 1 != 2
-    # TODO: tracking by https://github.com/onnx/models/issues/628
+    # TODO: remove this skip. Tracking by https://github.com/onnx/models/issues/628
 }

--- a/workflow_scripts/config.py
+++ b/workflow_scripts/config.py
@@ -10,4 +10,10 @@ SKIP_VERSION_CONVERTER_MODELS = {
     "vision/classification/vgg/model/vgg16-bn-7.onnx",  # version_converter/adapters/transformers.h:30: operator(): Assertion `node->i(attr) == value` failed: Attribute spatial must have value 1
     "vision/classification/vgg/model/vgg19-bn-7.onnx",  # version_converter/adapters/transformers.h:30: operator(): Assertion `node->i(attr) == value` failed: Attribute spatial must have value 1
     "vision/object_detection_segmentation/mask-rcnn/model/MaskRCNN-12-int8.onnx",  # unordered_map::at: key not found
+    "vision/object_detection_segmentation/ssd-mobilenetv1/model/ssd_mobilenet_v1_10.onnx", # starts failing after ONNX 1.15.0 due to subgraph shape inference enhancement:
+    # [ShapeInferenceError] Inference error(s): (op_type:Loop, node name: generic_loop_Loop__48):
+    # [ShapeInferenceError] Inference error(s): (op_type:If, node name: Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond_If__115): 
+    # [ShapeInferenceError] Inference error(s): (op_type:Concat, node name: Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond/concat): 
+    # [ShapeInferenceError] All inputs to Concat must have same rank. Input 1 has rank 1 != 2
+    # TODO: tracking by https://github.com/onnx/models/issues/628
 }

--- a/workflow_scripts/config.py
+++ b/workflow_scripts/config.py
@@ -12,8 +12,8 @@ SKIP_VERSION_CONVERTER_MODELS = {
     "vision/object_detection_segmentation/mask-rcnn/model/MaskRCNN-12-int8.onnx",  # unordered_map::at: key not found
     "vision/object_detection_segmentation/ssd-mobilenetv1/model/ssd_mobilenet_v1_10.onnx",  # starts failing after ONNX 1.15.0 due to subgraph shape inference enhancement:
     # [ShapeInferenceError] Inference error(s): (op_type:Loop, node name: generic_loop_Loop__48):
-    # [ShapeInferenceError] Inference error(s): (op_type:If, node name: Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond_If__115): 
-    # [ShapeInferenceError] Inference error(s): (op_type:Concat, node name: Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond/concat): 
+    # [ShapeInferenceError] Inference error(s): (op_type:If, node name: Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond_If__115):
+    # [ShapeInferenceError] Inference error(s): (op_type:Concat, node name: Postprocessor/BatchMultiClassNonMaxSuppression/map/while/PadOrClipBoxList/cond/concat):
     # [ShapeInferenceError] All inputs to Concat must have same rank. Input 1 has rank 1 != 2
     # TODO: remove this skip. Tracking by https://github.com/onnx/models/issues/628
 }


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Skip ssd_mobilenet_v1 due to recent subgraph shape inference enhancement.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
The CI of `Weekly CI with the latest ONNX and ONNX Model Zoo` started failing after Aug 27 (passed on Aug 20) probably due to this sugraph shape inference enhancement: https://github.com/onnx/onnx/pull/5488 (merged on Aug 21).

The root cause is track in Model Zoo repo: https://github.com/onnx/models/issues/628 and will be fixed there. For now we can just skip this test in ONNX repo.

cc @gramalingam since we have discussed it yesterday.
