### PR TITLE
Fix shape inference for DequantizeLinear

### DIFF
--- a/onnx/defs/quantization/defs.cc
+++ b/onnx/defs/quantization/defs.cc
@@ -129,13 +129,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "'x_scale' determines the output type.")
         .SetDoc(DequantizeLinear_ver19_doc)
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-          auto y_type = ctx.getOutputType(0);
-          // only float is supported
-          y_type->mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto::FLOAT);
-
-          if (!hasInputShape(ctx, 0))
-            return;
-
+          propagateElemTypeFromInputToOutput(ctx, 1, 0);
           auto& input_shape = getInputShape(ctx, 0);
           updateOutputShape(ctx, 0, input_shape);
         }));

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -5250,11 +5250,12 @@ class TestShapeInference(TestShapeInferenceHelper):
         self._make_matmulinteger_test((5, 1, 4, 2), (1, 3, 2, 3))
         self._make_matmulinteger_test((4, 2), (3, 2, 3))
 
-    def test_quantizelinear(self) -> None:
+    @parameterized.expand([onnx.TensorProto.FLOAT, onnx.TensorProto.FLOAT16, onnx.TensorProto.BFLOAT16])
+    def test_quantizelinear(self, elem_type) -> None:
         graph = self._make_graph(
             [
-                ("x", TensorProto.FLOAT, (30, 4, 5)),
-                ("y_scale", TensorProto.FLOAT, ()),
+                ("x", elem_type, (30, 4, 5)),
+                ("y_scale", elem_type, ()),
                 ("y_zero_point", TensorProto.UINT8, ()),
             ],
             [make_node("QuantizeLinear", ["x", "y_scale", "y_zero_point"], ["y"])],
@@ -5284,18 +5285,19 @@ class TestShapeInference(TestShapeInferenceHelper):
             graph, [make_tensor_value_info("y", TensorProto.UINT8, (30, 4, 5))]
         )
 
-    def test_dequantizelinear(self) -> None:
+    @parameterized.expand([onnx.TensorProto.FLOAT, onnx.TensorProto.FLOAT16, onnx.TensorProto.BFLOAT16])
+    def test_dequantizelinear(self, elem_type) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.UINT8, (30, 4, 5)),
-                ("x_scale", TensorProto.FLOAT, ()),
+                ("x_scale", elem_type, ()),
                 ("x_zero_point", TensorProto.UINT8, ()),
             ],
             [make_node("DequantizeLinear", ["x", "x_scale", "x_zero_point"], ["y"])],
             [],
         )
         self._assert_inferred(
-            graph, [make_tensor_value_info("y", TensorProto.FLOAT, (30, 4, 5))]
+            graph, [make_tensor_value_info("y", elem_type, (30, 4, 5))]
         )
 
     def test_dynamicquantizelinear(self) -> None:

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -5250,7 +5250,9 @@ class TestShapeInference(TestShapeInferenceHelper):
         self._make_matmulinteger_test((5, 1, 4, 2), (1, 3, 2, 3))
         self._make_matmulinteger_test((4, 2), (3, 2, 3))
 
-    @parameterized.expand([onnx.TensorProto.FLOAT, onnx.TensorProto.FLOAT16, onnx.TensorProto.BFLOAT16])
+    @parameterized.expand(
+        [onnx.TensorProto.FLOAT, onnx.TensorProto.FLOAT16, onnx.TensorProto.BFLOAT16]
+    )
     def test_quantizelinear(self, elem_type) -> None:
         graph = self._make_graph(
             [
@@ -5285,7 +5287,9 @@ class TestShapeInference(TestShapeInferenceHelper):
             graph, [make_tensor_value_info("y", TensorProto.UINT8, (30, 4, 5))]
         )
 
-    @parameterized.expand([onnx.TensorProto.FLOAT, onnx.TensorProto.FLOAT16, onnx.TensorProto.BFLOAT16])
+    @parameterized.expand(
+        [onnx.TensorProto.FLOAT, onnx.TensorProto.FLOAT16, onnx.TensorProto.BFLOAT16]
+    )
     def test_dequantizelinear(self, elem_type) -> None:
         graph = self._make_graph(
             [


### PR DESCRIPTION
### Description
Fix shape inference for types float16 and bfloat16 for operator DequantizeLinear.

### Motivation and Context
Shape inference is wrong for DequanzeLinear-19 as reported in issue #5704.
