### PR TITLE
Print the actual and expected attribute types in checker

### DIFF
--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -266,9 +266,9 @@ void OpSchema::Verify(const NodeProto& node) const {
           "Mismatched attribute type in '",
           node.name() + " : " + name,
           "'. Expected: '",
-          expected_type,
+          AttributeProto_AttributeType_Name(expected_type),
           "', actual: '",
-          attr_proto.type(),
+          AttributeProto_AttributeType_Name(attr_proto.type()),
           "'");
     }
 

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -262,7 +262,14 @@ void OpSchema::Verify(const NodeProto& node) const {
 
     // Type would be UNDEFINED if not set
     if (attr_proto.type() != expected_type) {
-      fail_check("Mismatched attribute type in '", node.name() + " : " + name, "'");
+      fail_check(
+          "Mismatched attribute type in '",
+          node.name() + " : " + name,
+          "'. Expected: '",
+          expected_type,
+          "', actual: '",
+          attr_proto.type(),
+          "'");
     }
 
     // ref_attr_name is only valid when non-empty


### PR DESCRIPTION
### Description

Print the actual and expected attribute types in checker when there is a mismatched attribute type to help debugging.


### Motivation and Context

https://github.com/pytorch/pytorch/issues/112831