### PR TITLE
Include pyi files in build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,7 +371,6 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP NAME SRCS HDRS ROOT_DIR DEPEND)
       list(APPEND PROTOC_ARGS --python_out
                   ${CMAKE_CURRENT_BINARY_DIR})
       if(ONNX_GEN_PB_TYPE_STUBS)
-        # Haven't figured out how to generate mypy stubs on Windows yet
         if(NOT WIN32)
           # use PYTHON_EXECUTABLE to python protoc-gen-mypy.py
           configure_file(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools>=61", "protobuf>=3.20.2"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -99,12 +99,6 @@ def cd(path):
 
 
 def get_ext_suffix():
-    if sys.version_info < (3, 8) and sys.platform == "win32":
-        # Workaround for https://bugs.python.org/issue39825
-        # Reference: https://github.com/pytorch/pytorch/commit/4b96fc060b0cb810965b5c8c08bc862a69965667
-        import distutils
-
-        return distutils.sysconfig.get_config_var("EXT_SUFFIX")
     return sysconfig.get_config_var("EXT_SUFFIX")
 
 
@@ -295,12 +289,12 @@ class BuildExt(setuptools.command.build_ext.build_ext):
             dst_dir = TOP_DIR
         else:
             dst_dir = build_lib
-        generated_python_files = (
-            *glob.glob(os.path.join(CMAKE_BUILD_DIR, "onnx", "*.py")),
-            *glob.glob(os.path.join(CMAKE_BUILD_DIR, "onnx", "*.pyi")),
-        )
-        assert generated_python_files, "Bug: No generated python files found"
-        for src in generated_python_files:
+
+        generated_py_files = glob.glob(os.path.join(CMAKE_BUILD_DIR, "onnx", "*.py"))
+        generated_pyi_files = glob.glob(os.path.join(CMAKE_BUILD_DIR, "onnx", "*.pyi"))
+        assert generated_py_files, "Bug: No generated python files found"
+        assert generated_pyi_files, "Bug: No generated python stubs found"
+        for src in (*generated_py_files, *generated_pyi_files):
             dst = os.path.join(dst_dir, os.path.relpath(src, CMAKE_BUILD_DIR))
             os.makedirs(os.path.dirname(dst), exist_ok=True)
             self.copy_file(src, dst)

--- a/tools/protoc-gen-mypy.py
+++ b/tools/protoc-gen-mypy.py
@@ -28,8 +28,7 @@ try:
     import google.protobuf.descriptor_pb2 as d_typed
     from google.protobuf.compiler import plugin_pb2 as plugin
 except ImportError as e:
-    sys.stderr.write(f"Failed to generate mypy stubs: {e}\n")
-    sys.exit(0)
+    raise RuntimeError("Failed to generate mypy stubs") from e
 
 
 # Hax to get around fact that google protobuf libraries aren't in typeshed yet


### PR DESCRIPTION
https://github.com/onnx/onnx/pull/5697 should include pyi files but doesn't. This is because we do not have a required build dependency `protobuf` when the `build` module creates the isolated build environment. I added it as a required dependency and updated outdated configs.

- Include protobuf in build dependencies
- Raise an error instead of silently skip when `tools/protoc-gen-mypy.py` gets import error.