### PR TITLE
Resurrect check function context logic

### DIFF
--- a/onnx/checker.py
+++ b/onnx/checker.py
@@ -101,10 +101,19 @@ def check_node(
 
 def check_function(
     function: FunctionProto,
-    ctx: C.CheckerContext = DEFAULT_CONTEXT,
+    ctx: C.CheckerContext | None = None,
     lexical_scope_ctx: C.LexicalScopeContext = LEXICAL_SCOPE_CONTEXT,
 ) -> None:
     _ensure_proto_type(function, FunctionProto)
+    if ctx is None:
+        ctx = C.CheckerContext()
+        ctx.ir_version = onnx.helper.find_min_ir_version_for(
+            function.opset_import, ignore_unknown=True
+        )
+        ctx.opset_imports = {
+            domain_version.domain: domain_version.version
+            for domain_version in function.opset_import
+        }
     C.check_function(function.SerializeToString(), ctx, lexical_scope_ctx)
 
 

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -100,13 +100,14 @@ OP_SET_ID_VERSION_MAP = create_op_set_id_version_map(VERSION_TABLE)
 
 
 def find_min_ir_version_for(
-    opsetidlist: List[OperatorSetIdProto], ignore_unknown: bool = False
+    opsetidlist: Sequence[OperatorSetIdProto], ignore_unknown: bool = False
 ) -> int:
     """Given list of opset ids, determine minimum IR version required.
 
     Args:
-        opsetidlist (List[OperatorSetIdProto]): The list of OperatorSetIdProto
-        ignore_unknown (bool): If True, ignore unknown domain and return default min version for that domain.
+        opsetidlist: A sequence of OperatorSetIdProto.
+        ignore_unknown: If True, ignore unknown domain and return default minimum
+            version for that domain.
 
     Returns:
         The minimum IR version required (integer)

--- a/onnx/test/checker_test.py
+++ b/onnx/test/checker_test.py
@@ -9,7 +9,6 @@ import numpy as np
 import onnx.defs
 import onnx.parser
 from onnx import (
-    IR_VERSION,
     GraphProto,
     SparseTensorProto,
     TensorProto,
@@ -92,13 +91,7 @@ class TestChecker(unittest.TestCase):
             func_nested_identity_add_nodes,
             func_nested_opset_imports,
         )
-        ctx = checker.C.CheckerContext()
-        ctx.ir_version = IR_VERSION
-        ctx.opset_imports = {"": 14}
-
-        lex_ctx = checker.C.LexicalScopeContext()
-
-        checker.check_function(func_nested_identity_add, ctx, lex_ctx)
+        checker.check_function(func_nested_identity_add)
 
     def test_check_graph_ir_version_3(self) -> None:
         ctx = checker.C.CheckerContext()


### PR DESCRIPTION
### Description

Resurrect check function context logic to handle when context is not provided to `check_function`. We need to support None because otherwise `check_function` breaks backward compatibility when only the first argument is provided.

### Motivation and Context

Fix https://github.com/onnx/onnx/issues/5774