### PR TITLE
Removed unused string_view include

### DIFF
--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -11,7 +11,6 @@
 #include <iostream>
 #include <stdexcept>
 #include <string>
-#include <string_view>
 #include <unordered_map>
 #include <vector>
 


### PR DESCRIPTION
### Description

Without C++17 current codebase cannot be compiled. 
But it seems that `string_view` include is not used and we can drop it.