### PR TITLE
Use mac-release 10.15

### DIFF
--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -10,9 +10,9 @@ on:
     branches: [main, rel-*]
   workflow_dispatch:
 
-# Use MACOSX_DEPLOYMENT_TARGET=10.12 to produce compatible wheel
+# Use MACOSX_DEPLOYMENT_TARGET=10.15 to produce compatible wheel
 env:
-  MACOSX_DEPLOYMENT_TARGET: 10.12
+  MACOSX_DEPLOYMENT_TARGET: 10.15
 
 permissions:
   contents: read
@@ -55,8 +55,8 @@ jobs:
         # Currently GitHub Action agent is using macos-11, we rename the wheels
         # to use the MACOSX_DEPLOYMENT_TARGET
         # Rename e.g. onnx-1.15.0-cp38-cp38-macosx_11_0_x86_64.whl
-        # to onnx-1.15.0-cp38-cp38-macosx_10_12_universal2.whl
-        ONNX_WHEEL_PLATFORM_NAME: macosx_10_12_${{ matrix.target-architecture }}
+        # to onnx-1.15.0-cp38-cp38-macosx_10_15_universal2.whl
+        ONNX_WHEEL_PLATFORM_NAME: macosx_10_15_${{ matrix.target-architecture }}
         CMAKE_ARGS: "-DONNX_USE_LITE_PROTO=ON"
       run: |
         # Install Protobuf from source

--- a/onnx/test/test_backend_reference.py
+++ b/onnx/test/test_backend_reference.py
@@ -182,7 +182,7 @@ if sys.platform == "win32":
     backend_test.exclude("test_image_decoder_decode_")
 
 if sys.platform == "darwin":
-    # https://github.com/onnx/onnx/issues/5792
+    # FIXME: https://github.com/onnx/onnx/issues/5792
     backend_test.exclude("test_qlinearmatmul_3D_int8_float16_cpu")
     backend_test.exclude("test_qlinearmatmul_3D_int8_float32_cpu")
 

--- a/onnx/test/test_backend_reference.py
+++ b/onnx/test/test_backend_reference.py
@@ -181,6 +181,11 @@ if sys.platform == "win32":
     backend_test.exclude("test_regex_full_match_empty_cpu")
     backend_test.exclude("test_image_decoder_decode_")
 
+print(f"sys.platform is: {sys.platform}")
+if sys.platform == "darwin":
+    backend_test.exclude("test_qlinearmatmul_3D_int8_float16_cpu")
+    backend_test.exclude("test_qlinearmatmul_3D_int8_float32_cpu")
+
 # op_dft and op_stft requires numpy >= 1.21.5
 if version_utils.numpy_older_than("1.21.5"):
     backend_test.exclude("test_stft")

--- a/onnx/test/test_backend_reference.py
+++ b/onnx/test/test_backend_reference.py
@@ -181,8 +181,8 @@ if sys.platform == "win32":
     backend_test.exclude("test_regex_full_match_empty_cpu")
     backend_test.exclude("test_image_decoder_decode_")
 
-print(f"sys.platform is: {sys.platform}")
 if sys.platform == "darwin":
+    # https://github.com/onnx/onnx/issues/5792
     backend_test.exclude("test_qlinearmatmul_3D_int8_float16_cpu")
     backend_test.exclude("test_qlinearmatmul_3D_int8_float32_cpu")
 


### PR DESCRIPTION
### Description
release build breaks due to https://github.com/onnx/onnx/pull/5806
filesystem not available on Mac 10.12.
also need to skip 2 reference implement tests (test_qlinearmatmul_3D_int8_float16_cpu, test_qlinearmatmul_3D_int8_float32_cpu) which are failing on MacOS (https://github.com/onnx/onnx/issues/5792)

### Motivation and Context
fix mac release CI