### PR TITLE
fix: need setuptools>=64 for editable_mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
-requires = ["setuptools>=61", "protobuf>=3.20.2"]
+requires = ["setuptools>=64", "protobuf>=3.20.2"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
### Description
The attribute `editable_mode` in setuptools `build_py` was only introduced in v64, https://github.com/pypa/setuptools/commit/207da8caa9e2673ab8470f78dc10901e0d60a96f.

Since `editable_mode` is used in `setup.py` without try-except for AttributeErrors, `pyproject.toml` should require `setuptools>=64`.

### Motivation and Context
This is the cause of the original error in #5716.

### Alternatives Considered 
If compatibility with older `setuptools` versions is desired, then another fix could be to introduce try-except blocks in two places in `setup.py`. This would add to the complexity of `setup.py`.