### PR TITLE
Revert "Bump actions/upload-artifact from 3.1.3 to 4.0.0"

### DIFF
--- a/.github/workflows/release_linux_aarch64.yml
+++ b/.github/workflows/release_linux_aarch64.yml
@@ -75,7 +75,7 @@ jobs:
           pytest && \
           deactivate'
 
-    - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: wheels
         path: dist

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -57,7 +57,7 @@ jobs:
         python -m pip install dist/*manylinux2014_x86_64.whl
         pytest
 
-    - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392
+    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
       with:
         name: wheels
         path: dist

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -75,7 +75,7 @@ jobs:
       run: |
         pytest
 
-    - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: wheels
         path: dist

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -82,7 +82,7 @@ jobs:
         cd onnx
         pytest
 
-    - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: wheels
         path: ./onnx/dist

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v3.1.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.0
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
Reverts onnx/onnx#5830. It is breaking the release pipeline.

https://github.com/actions/upload-artifact/issues/478