### PR TITLE
Print tensor dtypes as strings in shape inference

### DIFF
--- a/onnx/defs/shape_inference.cc
+++ b/onnx/defs/shape_inference.cc
@@ -272,7 +272,11 @@ void UnionTypeInfo(const TypeProto& source_type, TypeProto& target_type) {
 
     if (source_elem_type != target_elem_type) {
       fail_type_inference(
-          "Mismatched tensor element type:", " inferred=", source_elem_type, " declared=", target_elem_type);
+          "Mismatched tensor element type:",
+          " inferred=",
+          Utils::DataTypeUtils::ToDataTypeString(source_elem_type),
+          " declared=",
+          Utils::DataTypeUtils::ToDataTypeString(target_elem_type));
     }
 
     UnionShapeInfo(source_type.tensor_type(), *target_type.mutable_tensor_type());
@@ -281,7 +285,11 @@ void UnionTypeInfo(const TypeProto& source_type, TypeProto& target_type) {
     auto target_elem_type = target_type.sparse_tensor_type().elem_type();
     if (source_elem_type != target_elem_type) {
       fail_type_inference(
-          "Mismatched sparse tensor element type:", " inferred=", source_elem_type, " declared=", target_elem_type);
+          "Mismatched sparse tensor element type:",
+          " inferred=",
+          Utils::DataTypeUtils::ToDataTypeString(source_elem_type),
+          " declared=",
+          Utils::DataTypeUtils::ToDataTypeString(target_elem_type));
     }
     UnionShapeInfo(source_type.sparse_tensor_type(), *target_type.mutable_sparse_tensor_type());
   } else if (target_case == TypeProto::ValueCase::kSequenceType) {


### PR DESCRIPTION
Fix #5782 
