### PR TITLE
Skip some int4 test with old numpy version

### DIFF
--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -12,6 +12,7 @@ from typing import Any, List, Tuple
 import numpy as np
 import parameterized
 import pytest
+import version_utils
 
 from onnx import (
     AttributeProto,
@@ -27,7 +28,6 @@ from onnx import (
     numpy_helper,
 )
 from onnx.reference.op_run import to_array_extended
-import version_utils
 
 
 class TestHelperAttributeFunctions(unittest.TestCase):
@@ -635,7 +635,10 @@ class TestHelperTensorFunctions(unittest.TestCase):
         ynp = numpy_helper.to_array(y)
         np.testing.assert_equal(expected, ynp)
 
-    @unittest.skipIf(version_utils.numpy_older_than("1.22.0"), "The test requires numpy 1.22.0 or later",)
+    @unittest.skipIf(
+        version_utils.numpy_older_than("1.22.0"),
+        "The test requires numpy 1.22.0 or later",
+    )
     @parameterized.parameterized.expand(
         itertools.product(
             (TensorProto.UINT4, TensorProto.INT4),

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -27,6 +27,7 @@ from onnx import (
     numpy_helper,
 )
 from onnx.reference.op_run import to_array_extended
+import version_utils
 
 
 class TestHelperAttributeFunctions(unittest.TestCase):
@@ -634,6 +635,7 @@ class TestHelperTensorFunctions(unittest.TestCase):
         ynp = numpy_helper.to_array(y)
         np.testing.assert_equal(expected, ynp)
 
+    @unittest.skipIf(version_utils.numpy_older_than("1.22.0"), "The test requires numpy 1.22.0 or later",)
     @parameterized.parameterized.expand(
         itertools.product(
             (TensorProto.UINT4, TensorProto.INT4),

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -635,15 +635,15 @@ class TestHelperTensorFunctions(unittest.TestCase):
         ynp = numpy_helper.to_array(y)
         np.testing.assert_equal(expected, ynp)
 
-    @unittest.skipIf(
-        version_utils.numpy_older_than("1.22.0"),
-        "The test requires numpy 1.22.0 or later",
-    )
     @parameterized.parameterized.expand(
         itertools.product(
             (TensorProto.UINT4, TensorProto.INT4),
             ((5, 4, 6), (4, 6, 5), (3, 3), (1,), (2**10,)),
         )
+    )
+    @unittest.skipIf(
+        version_utils.numpy_older_than("1.22.0"),
+        "The test requires numpy 1.22.0 or later",
     )
     def test_make_4bit_tensor(self, dtype, dims) -> None:
         type_range = {

--- a/onnx/test/reference_evaluator_test.py
+++ b/onnx/test/reference_evaluator_test.py
@@ -5349,10 +5349,6 @@ class TestReferenceEvaluator(unittest.TestCase):
         with self.assertRaises(ValueError):
             ref.run(None, {"X": np.array(["x"])})
 
-    @unittest.skipIf(
-        version_utils.numpy_older_than("1.22.0"),
-        "The test requires numpy 1.22.0 or later",
-    )
     @parameterized.parameterized.expand(
         [
             (
@@ -5374,6 +5370,10 @@ class TestReferenceEvaluator(unittest.TestCase):
             ),
             (TensorProto.INT4, [0], [0]),
         ]
+    )
+    @unittest.skipIf(
+        version_utils.numpy_older_than("1.22.0"),
+        "The test requires numpy 1.22.0 or later",
     )
     def test_quantize_linear_int4(self, qtype, data, expected):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None])

--- a/onnx/test/reference_evaluator_test.py
+++ b/onnx/test/reference_evaluator_test.py
@@ -5349,8 +5349,10 @@ class TestReferenceEvaluator(unittest.TestCase):
         with self.assertRaises(ValueError):
             ref.run(None, {"X": np.array(["x"])})
 
-
-    @unittest.skipIf(version_utils.numpy_older_than("1.22.0"), "The test requires numpy 1.22.0 or later",)
+    @unittest.skipIf(
+        version_utils.numpy_older_than("1.22.0"),
+        "The test requires numpy 1.22.0 or later",
+    )
     @parameterized.parameterized.expand(
         [
             (

--- a/onnx/test/reference_evaluator_test.py
+++ b/onnx/test/reference_evaluator_test.py
@@ -5349,6 +5349,8 @@ class TestReferenceEvaluator(unittest.TestCase):
         with self.assertRaises(ValueError):
             ref.run(None, {"X": np.array(["x"])})
 
+
+    @unittest.skipIf(version_utils.numpy_older_than("1.22.0"), "The test requires numpy 1.22.0 or later",)
     @parameterized.parameterized.expand(
         [
             (


### PR DESCRIPTION
### Description
some int4 tests requires numpy version higher than 1.22.0 for support of elementwise operations on numpy arrays of custom dtypes. release CIs have test of old numpy versions and thus failed.

### Motivation and Context
make release CI to pass.
