### PR TITLE
Fix label encoder definition in schema

### DIFF
--- a/docs/Changelog-ml.md
+++ b/docs/Changelog-ml.md
@@ -1183,8 +1183,8 @@ This version of the operator has been available since version 4 of the 'ai.onnx.
 <dd>An integer.</dd>
 <dt><tt>default_string</tt> : string (default is _Unused)</dt>
 <dd>A string.</dd>
-<dt><tt>default_tensor</tt> : tensor (default is {"_Unused"} if values_* has string type, {-1} if values_* has integral type, and {-0.f} if values_* has float type.)</dt>
-<dd>A default tensor.</dd>
+<dt><tt>default_tensor</tt> : tensor</dt>
+<dd>A default tensor. {"_Unused"} if values_* has string type, {-1} if values_* has integral type, and {-0.f} if values_* has float type.</dd>
 <dt><tt>keys_floats</tt> : list of floats</dt>
 <dd>A list of floats.</dd>
 <dt><tt>keys_int64s</tt> : list of ints</dt>

--- a/docs/Operators-ml.md
+++ b/docs/Operators-ml.md
@@ -428,8 +428,8 @@ Other versions of this operator: <a href="Changelog-ml.md#ai.onnx.ml.LabelEncode
 <dd>An integer.</dd>
 <dt><tt>default_string</tt> : string (default is _Unused)</dt>
 <dd>A string.</dd>
-<dt><tt>default_tensor</tt> : tensor (default is {"_Unused"} if values_* has string type, {-1} if values_* has integral type, and {-0.f} if values_* has float type.)</dt>
-<dd>A default tensor.</dd>
+<dt><tt>default_tensor</tt> : tensor</dt>
+<dd>A default tensor. {"_Unused"} if values_* has string type, {-1} if values_* has integral type, and {-0.f} if values_* has float type.</dd>
 <dt><tt>keys_floats</tt> : list of floats</dt>
 <dd>A list of floats.</dd>
 <dt><tt>keys_int64s</tt> : list of ints</dt>

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -445,21 +445,6 @@ OpSchema& OpSchema::Attr(std::string name, std::string description, AttributePro
   return *this;
 }
 
-OpSchema& OpSchema::Attr(
-    std::string name,
-    std::string description,
-    std::string conditionExplanation,
-    AttributeProto::AttributeType attr_type) {
-  AttributeProto a;
-  a.set_name(name);
-  a.set_type(attr_type);
-  if (attr_type == AttributeProto_AttributeType_UNDEFINED) {
-    a.mutable_t()->set_data_type(TensorProto_DataType_UNDEFINED);
-  }
-  a.mutable_doc_string()->assign(std::move(conditionExplanation));
-  return Attr(Attribute{std::move(name), std::move(description), std::move(a)});
-}
-
 OpSchema& OpSchema::Attr(const char* name, const char* description, AttributeProto::AttributeType type, bool required) {
   return Attr(std::string(name), std::string(description), type, required);
 }

--- a/onnx/defs/traditionalml/defs.cc
+++ b/onnx/defs/traditionalml/defs.cc
@@ -356,9 +356,9 @@ ONNX_ML_OPERATOR_SET_SCHEMA(
         .Attr("default_float", "A float.", AttributeProto::FLOAT, -0.f)
         .Attr(
             "default_tensor",
-            "A default tensor.",
-            "{\"_Unused\"} if values_* has string type, {-1} if values_* has integral type, and {-0.f} if values_* has float type.",
-            AttributeProto::TENSOR)
+            "A default tensor. {\"_Unused\"} if values_* has string type, {-1} if values_* has integral type, and {-0.f} if values_* has float type.",
+            AttributeProto::TENSOR,
+            OPTIONAL_VALUE)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           int key_length, key_type;
           std::tie(key_type, key_length) =


### PR DESCRIPTION
### Description
The use of the `OpSchema::Attr` with conditionExplanation ends up having a default AttributeProto without a TensorProto field. The `default_tensor` attribute is optional and so should not be setting a default value.

cc @gramalingam 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
