### PR TITLE
Improve attribute docs formatting on the docs site

### DIFF
--- a/docs/docsgen/source/onnx_sphinx.py
+++ b/docs/docsgen/source/onnx_sphinx.py
@@ -115,6 +115,8 @@ Other versions of this operator:
 
 #### Function Body
 
+The function definition for this operator.
+
 ```
 {{get_function_body(sch)}}
 ```
@@ -450,9 +452,7 @@ def get_markdown_doc(
         return textwrap.indent(text, s)
 
     def get_function_body(schema: OpSchema) -> str:
-        if schema.has_function:
-            return onnx.printer.to_text(schema.function_body)
-        return ""
+        return onnx.printer.to_text(schema.function_body)
 
     examples = get_onnx_example(op_name, domain) if example else {}
     docs = _template_operator.render(

--- a/docs/docsgen/source/onnx_sphinx.py
+++ b/docs/docsgen/source/onnx_sphinx.py
@@ -76,98 +76,98 @@ def _get_diff_template():
 
 def _get_ops_template():
     return jinja2.Template(
-        textwrap.dedent(
-            """
-        {% for sch in schemas %}
+        """\
+{% for sch in schemas %}
 
-        .. tag-diff-insert.
+.. tag-diff-insert.
 
-        (l-onnx-op{{sch.domain.lower().replace(".", "-")}}-{{sch.name.lower()}}-{{str(sch.since_version)}})=
+(l-onnx-op{{sch.domain.lower().replace(".", "-")}}-{{sch.name.lower()}}-{{str(sch.since_version)}})=
 
-        ## {{format_name_with_domain(sch)}}
+## {{format_name_with_domain(sch)}}
 
-        ### Version
+### Version
 
-        - **name**: [{{sch.name}} (GitHub)]({{build_doc_url(sch)}}{{sch.name}})
-        - **domain**: `{% if sch.domain == '' %}main{% else %}{{sch.domain}}{% endif %}`
-        - **since_version**: `{{sch.since_version}}`
-        - **function**: `{{sch.has_function or sch.has_context_dependent_function}}`
-        - **support_level**: `{{sch.support_level}}`
-        - **shape inference**: `{{sch.has_type_and_shape_inference_function}}`
+- **name**: [{{sch.name}} (GitHub)]({{build_doc_url(sch)}}{{sch.name}})
+- **domain**: `{% if sch.domain == '' %}main{% else %}{{sch.domain}}{% endif %}`
+- **since_version**: `{{sch.since_version}}`
+- **function**: `{{sch.has_function or sch.has_context_dependent_function}}`
+- **support_level**: `{{sch.support_level}}`
+- **shape inference**: `{{sch.has_type_and_shape_inference_function}}`
 
-        {% if sch.support_level == OpSchema.SupportType.EXPERIMENTAL %}
-        No versioning maintained for experimental ops.
-        {% else %}
-        This version of the operator has been {% if
-        sch.deprecated %}deprecated{% else %}available{% endif %}
-        **since version {{sch.since_version}}{% if
-        sch.domain %} of domain {{sch.domain}}{% endif %}**.
-        {% if len(sch.versions) > 1 %}
-        Other versions of this operator:
-        {% for v in sch.version[:-1] %} {{v}} {% endfor %}
-        {% endif %}
-        {% endif %}
+{% if sch.support_level == OpSchema.SupportType.EXPERIMENTAL %}
+No versioning maintained for experimental ops.
+{% else %}
+This version of the operator has been {% if
+sch.deprecated %}deprecated{% else %}available{% endif %}
+**since version {{sch.since_version}}{% if
+sch.domain %} of domain {{sch.domain}}{% endif %}**.
+{% if len(sch.versions) > 1 %}
+Other versions of this operator:
+{% for v in sch.version[:-1] %} {{v}} {% endfor %}
+{% endif %}
+{% endif %}
 
-        ### Summary
+### Summary
 
-        {{process_documentation(sch.doc)}}
-        {% if sch.attributes %}
+{{process_documentation(sch.doc)}}
+{% if sch.attributes %}
 
-        ### Attributes
+### Attributes
 
-        {% for _, attr in sorted(sch.attributes.items())
-        %}* **{{attr.name}} - {{str(attr.type).split('.')[-1]}}**{%
-          if attr.required %} (required){% endif %} {%
-          if attr.default_value %}{{clean_default_value(attr)}}{%
-          endif %}: {{text_wrap(attr.description, 2)}}
-        {% endfor %}
-        {% endif %}
-        {% if sch.inputs %}
+{% for _, attr in sorted(sch.attributes.items())
+%}* **{{attr.name}} - {{str(attr.type).split('.')[-1]}}**{%
+  if attr.required %} (required){% endif %} {%
+  if attr.default_value %}{{clean_default_value(attr)}}{%
+  endif %}:
+  {{text_wrap(process_documentation(attr.description), 2)}}
+{% endfor %}
+{% endif %}
+{% if sch.inputs %}
 
-        ### Inputs
+### Inputs
 
-        {% if sch.min_input != sch.max_input %}Between {{sch.min_input
-        }} and {{sch.max_input}} inputs.
-        {% endif %}
-        {% for ii, inp in enumerate(sch.inputs) %}
-        - **{{getname(inp, ii)}}**{{format_option(inp)}} - **{{inp.type_str}}**:
-        {{text_wrap(inp.description, 2)}}{% endfor %}
-        {% endif %}
-        {% if sch.outputs %}
+{% if sch.min_input != sch.max_input %}Between {{sch.min_input
+}} and {{sch.max_input}} inputs.
+{% endif %}
+{% for ii, inp in enumerate(sch.inputs) %}
+- **{{getname(inp, ii)}}**{{format_option(inp)}} - **{{inp.type_str}}**:
+{{text_wrap(inp.description, 2)}}{% endfor %}
+{% endif %}
+{% if sch.outputs %}
 
-        ### Outputs
+### Outputs
 
-        {% if sch.min_output != sch.max_output %}Between {{sch.min_output
-        }} and {{sch.max_output}} outputs.
-        {% endif %}
-        {% for ii, out in enumerate(sch.outputs) %}
-        - **{{getname(out, ii)}}**{{format_option(out)}} - **{{out.type_str}}**:
-        {{text_wrap(out.description, 2)}}{% endfor %}
-        {% endif %}
-        {% if sch.type_constraints %}
+{% if sch.min_output != sch.max_output %}Between {{sch.min_output
+}} and {{sch.max_output}} outputs.
+{% endif %}
+{% for ii, out in enumerate(sch.outputs) %}
+- **{{getname(out, ii)}}**{{format_option(out)}} - **{{out.type_str}}**:
+{{text_wrap(out.description, 2)}}{% endfor %}
+{% endif %}
+{% if sch.type_constraints %}
 
-        ### Type Constraints
+### Type Constraints
 
-        {% for ii, type_constraint in enumerate(sch.type_constraints)
-        %}* {{get_constraint(type_constraint, ii)}}:
-        {{text_wrap(type_constraint.description, 2)}}
-        {% endfor %}
-        {% endif %}
-        {% if examples and is_last_schema(sch): %}
+{% for ii, type_constraint in enumerate(sch.type_constraints)
+%}* {{get_constraint(type_constraint, ii)}}:
+{{text_wrap(type_constraint.description, 2)}}
+{% endfor %}
+{% endif %}
+{% if examples and is_last_schema(sch): %}
 
-        ### Examples
+### Examples
 
-        {% for example, code in examples.items(): %}
+{% for example, code in examples.items(): %}
 
-        #### {{ example }}
+#### {{ example }}
 
-        ```python
-        {{ format_example(code) }}
-        ```
-        {% endfor %}
-        {% endif %}
-        {% endfor %}
-        """
+```python
+{{ format_example(code) }}
+```
+{% endfor %}
+{% endif %}
+{% endfor %}
+"""
         ),
         autoescape=False,
     )


### PR DESCRIPTION
### Description

- Render function bodies when an operator has a function definition.

<img width="1091" alt="image" src="https://github.com/onnx/onnx/assets/11205048/4a21c0e7-b535-443b-942f-158928c5ce7a">


- Fix attribute documentation formatting

<img width="858" alt="image" src="https://github.com/onnx/onnx/assets/11205048/33ba9800-5888-4ebe-9a4f-c394bfc0ac53">


### Motivation and Context

Fixes https://github.com/onnx/onnx/issues/5872
