### PR TITLE
Unblock ci by skipping known ort 1.17 test failures

### DIFF
--- a/onnx/test/test_backend_onnxruntime.py
+++ b/onnx/test/test_backend_onnxruntime.py
@@ -304,18 +304,18 @@ if ort is not None:
         # onnxruntime release with ONNX 1.16.0 integrated. The work is covered in ONNX integration procedure.
         backend_test.exclude(
             "("
-            "deform_conv"   # deform_conv is not supported in onnxruntime
+            "deform_conv"  # deform_conv is not supported in onnxruntime
             "|dft"  # Max absolute difference > atol=1e-07. shall be able to set atol (https://github.com/onnx/onnx/issues/5897)
             "|group_normalization"  # new/updated test cases with opset and/or IR version not supported by onnxruntime 1.17
-            "|identity_opt" # fixed in ort 1.18 (https://github.com/microsoft/onnxruntime/pull/19273)
-            "|image_decoder"    # image_decoder is not supported in onnxruntime
-            "|optional_get_element_optional_sequence"   # fixed in ort 1.18 (https://github.com/microsoft/onnxruntime/pull/19273)
-            "|qlinearmatmul_2D_int8"    # new/updated test cases with opset and/or IR version not supported by onnxruntime 1.17
-            "|qlinearmatmul_2D_uint8_float16"   # new/updated test cases with opset and/or IR version not supported by onnxruntime 1.17
-            "|qlinearmatmul_3D_int8"    # new/updated test cases with opset and/or IR version not supported by onnxruntime 1.17
-            "|qlinearmatmul_3D_uint8_float16"   # new/updated test cases with opset and/or IR version not supported by onnxruntime 1.17
-            "|qlinearmatmul_2D_uint8_float32"   # new/updated test cases with opset and/or IR version not supported by onnxruntime 1.17
-            "|qlinearmatmul_3D_uint8_float32"   # new/updated test cases with opset and/or IR version not supported by onnxruntime 1.17
+            "|identity_opt"  # fixed in ort 1.18 (https://github.com/microsoft/onnxruntime/pull/19273)
+            "|image_decoder"  # image_decoder is not supported in onnxruntime
+            "|optional_get_element_optional_sequence"  # fixed in ort 1.18 (https://github.com/microsoft/onnxruntime/pull/19273)
+            "|qlinearmatmul_2D_int8"  # new/updated test cases with opset and/or IR version not supported by onnxruntime 1.17
+            "|qlinearmatmul_2D_uint8_float16"  # new/updated test cases with opset and/or IR version not supported by onnxruntime 1.17
+            "|qlinearmatmul_3D_int8"  # new/updated test cases with opset and/or IR version not supported by onnxruntime 1.17
+            "|qlinearmatmul_3D_uint8_float16"  # new/updated test cases with opset and/or IR version not supported by onnxruntime 1.17
+            "|qlinearmatmul_2D_uint8_float32"  # new/updated test cases with opset and/or IR version not supported by onnxruntime 1.17
+            "|qlinearmatmul_3D_uint8_float32"  # new/updated test cases with opset and/or IR version not supported by onnxruntime 1.17
             ")"
         )
 

--- a/onnx/test/test_backend_onnxruntime.py
+++ b/onnx/test/test_backend_onnxruntime.py
@@ -300,7 +300,7 @@ if ort is not None:
         )
     if ort_version is not None and ort_version < Version("1.18"):
         # when adding new tests to the list, please add a comment with the reason for exclusion
-        # for tests that "not supported by onnxruntime 1.17", it will be solved in the next 
+        # for tests that "not supported by onnxruntime 1.17", it will be solved in the next
         # onnxruntime release with ONNX 1.16.0 integrated. The work is covered in ONNX integration procedure.
         backend_test.exclude(
             "("

--- a/onnx/test/test_backend_onnxruntime.py
+++ b/onnx/test/test_backend_onnxruntime.py
@@ -299,20 +299,23 @@ if ort is not None:
             ")"
         )
     if ort_version is not None and ort_version < Version("1.18"):
+        # when adding new tests to the list, please add a comment with the reason for exclusion
+        # for tests that "not supported by onnxruntime 1.17", it will be solved in the next 
+        # onnxruntime release with ONNX 1.16.0 integrated. The work is covered in ONNX integration procedure.
         backend_test.exclude(
             "("
-            "deform_conv"
-            "|dft"  # Max absolute difference > atol=1e-07. shall be able to set atol
-            "|group_normalization"
-            "|identity_opt"
-            "|image_decoder"
-            "|optional_get_element_optional_sequence"
-            "|qlinearmatmul_2D_int8"
-            "|qlinearmatmul_2D_uint8_float16"
-            "|qlinearmatmul_3D_int8"
-            "|qlinearmatmul_3D_uint8_float16"
-            "|qlinearmatmul_2D_uint8_float32"
-            "|qlinearmatmul_3D_uint8_float32"
+            "deform_conv"   # deform_conv is not supported in onnxruntime
+            "|dft"  # Max absolute difference > atol=1e-07. shall be able to set atol (https://github.com/onnx/onnx/issues/5897)
+            "|group_normalization"  # new/updated test cases with opset and/or IR version not supported by onnxruntime 1.17
+            "|identity_opt" # fixed in ort 1.18 (https://github.com/microsoft/onnxruntime/pull/19273)
+            "|image_decoder"    # image_decoder is not supported in onnxruntime
+            "|optional_get_element_optional_sequence"   # fixed in ort 1.18 (https://github.com/microsoft/onnxruntime/pull/19273)
+            "|qlinearmatmul_2D_int8"    # new/updated test cases with opset and/or IR version not supported by onnxruntime 1.17
+            "|qlinearmatmul_2D_uint8_float16"   # new/updated test cases with opset and/or IR version not supported by onnxruntime 1.17
+            "|qlinearmatmul_3D_int8"    # new/updated test cases with opset and/or IR version not supported by onnxruntime 1.17
+            "|qlinearmatmul_3D_uint8_float16"   # new/updated test cases with opset and/or IR version not supported by onnxruntime 1.17
+            "|qlinearmatmul_2D_uint8_float32"   # new/updated test cases with opset and/or IR version not supported by onnxruntime 1.17
+            "|qlinearmatmul_3D_uint8_float32"   # new/updated test cases with opset and/or IR version not supported by onnxruntime 1.17
             ")"
         )
 

--- a/onnx/test/test_backend_onnxruntime.py
+++ b/onnx/test/test_backend_onnxruntime.py
@@ -298,6 +298,23 @@ if ort is not None:
             "|qlinearmatmul_3D_uint8_float32"
             ")"
         )
+    if ort_version is not None and ort_version < Version("1.18"):
+        backend_test.exclude(
+            "("
+            "deform_conv"
+            "|dft"  # Max absolute difference > atol=1e-07. shall be able to set atol
+            "|group_normalization"
+            "|identity_opt"
+            "|image_decoder"
+            "|optional_get_element_optional_sequence"
+            "|qlinearmatmul_2D_int8"
+            "|qlinearmatmul_2D_uint8_float16"
+            "|qlinearmatmul_3D_int8"
+            "|qlinearmatmul_3D_uint8_float16"
+            "|qlinearmatmul_2D_uint8_float32"
+            "|qlinearmatmul_3D_uint8_float32"
+            ")"
+        )
 
     # Import all test cases at global scope to make them visible to python.unittest
     globals().update(backend_test.test_cases)


### PR DESCRIPTION
### Description

Fix https://github.com/onnx/onnx/issues/5894

### Motivation and Context
unblock ci by skipping known ort test failures