### PR TITLE
Bump Numpy minimal version to 1.20

### DIFF
--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,7 +1,7 @@
 # Minimum package versions that ONNX supports
 protobuf==3.20.2; python_version<"3.12"
 protobuf==4.25.1; python_version>="3.12"
-numpy==1.20.0; python_version<"3.10"
+numpy==1.20.3; python_version<"3.10"
 numpy==1.23.2; python_version=="3.10"
 numpy==1.23.2; python_version=="3.11"
 numpy==1.26.0; python_version>="3.12"

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,7 +1,7 @@
 # Minimum package versions that ONNX supports
 protobuf==3.20.2; python_version<"3.12"
 protobuf==4.25.1; python_version>="3.12"
-numpy==1.16.6; python_version<"3.10"
+numpy==1.20.0; python_version<"3.10"
 numpy==1.23.2; python_version=="3.10"
 numpy==1.23.2; python_version=="3.11"
 numpy==1.26.0; python_version>="3.12"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-numpy
+numpy>=1.20
 protobuf>=3.20.2


### PR DESCRIPTION
### Description
Fix Linux release pipeline due to usage of np.broadcast_shapes which was introduced in numpy==1.20.0

### Motivation and Context

Fix https://github.com/onnx/onnx/issues/5900