### PR TITLE
Add License/Copyright headers to azure yml files

### DIFF
--- a/.azure-pipelines/Linux-CI.yml
+++ b/.azure-pipelines/Linux-CI.yml
@@ -1,3 +1,7 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 schedules:
 - cron: '0 0 * * *'
   displayName: Nightly Linux CI in main branch

--- a/.azure-pipelines/MacOS-CI.yml
+++ b/.azure-pipelines/MacOS-CI.yml
@@ -1,3 +1,7 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 schedules:
 - cron: '0 0 * * *'
   displayName: Nightly MacOS CI in main branch

--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -1,3 +1,7 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 schedules:
 - cron: '0 0 * * *'
   displayName: Nightly Windows CI in main branch

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -9,9 +9,6 @@ Source: onnx.ai
 # Copyright: $YEAR $NAME <$CONTACT>
 # License: ...
 
-Files: .azure-pipelines/*.yml
-COPYRIGHT: Copyright (c) ONNX Project Contributors
-License: Apache-2.0
 
 Files: codecov.yml
 COPYRIGHT: Copyright (c) ONNX Project Contributors
@@ -29,7 +26,6 @@ Files: onnx/backend/test/data/simple/**/test_data_set_0/*pb
 COPYRIGHT: Copyright (c) ONNX Project Contributors
 License: Apache-2.0
 
-
 Files: onnx/backend/test/data/node/**/test_data_set_0/*.pb
 COPYRIGHT: Copyright (c) ONNX Project Contributors
 License: Apache-2.0
@@ -46,7 +42,6 @@ Files: onnx/backend/test/data/pytorch-operator/**/*.onnx
 COPYRIGHT: Copyright (c) ONNX Project Contributors
 License: Apache-2.0
 
-
 Files: onnx/backend/test/data/pytorch-operator/**/*.pb
 COPYRIGHT: Copyright (c) ONNX Project Contributors
 License: Apache-2.0
@@ -54,7 +49,6 @@ License: Apache-2.0
 Files: onnx/backend/test/data/node/**/*.onnx
 COPYRIGHT: Copyright (c) ONNX Project Contributors
 License: Apache-2.0
-
 
 Files: onnx/backend/test/data/pytorch-converted/**/test_data_set_0/*.pb
 COPYRIGHT: Copyright (c) ONNX Project Contributors
@@ -79,7 +73,6 @@ License: Apache-2.0
 Files: onnx/backend/test/data/light/light/*.onnx
 COPYRIGHT: Copyright (c) ONNX Project Contributors
 License: Apache-2.0
-
 
 Files: onnx/onnx-operators* onnx/onnx-ml* onnx/onnx-data* onnx/onnx*
 COPYRIGHT: Copyright (c) ONNX Project Contributors


### PR DESCRIPTION
### Description
Add License/Copyright headers to azure yml files

### Motivation and Context
Some cleanup (reduce number of files/exceptions within dep5 file)