### PR TITLE
Fix ReferenceEvaluator when run from a subclass

### DIFF
--- a/onnx/reference/op_run.py
+++ b/onnx/reference/op_run.py
@@ -213,10 +213,7 @@ class OpRun(abc.ABC):
     }
 
     def __init__(
-        self,
-        onnx_node: NodeProto,
-        run_params: dict[str, Any],
-        schema: Any = None,
+        self, onnx_node: NodeProto, run_params: dict[str, Any], schema: Any = None
     ):
         if not isinstance(run_params, dict):
             raise TypeError(f"run_params must be a dictionary not {type(run_params)}.")
@@ -248,9 +245,7 @@ class OpRun(abc.ABC):
         self.run_params["log"](pattern, *args)
 
     def _extract_attribute_value(
-        self,
-        att: AttributeProto,
-        ref_att: AttributeProto | None = None,
+        self, att: AttributeProto, ref_att: AttributeProto | None = None
     ) -> Any:
         """Converts an attribute value into a python value."""
         if att.type == AttributeProto.GRAPH:
@@ -657,10 +652,7 @@ class OpRunExpand(OpRun):
     """Class any operator to avoid must inherit from."""
 
     def __init__(
-        self,
-        onnx_node: NodeProto,
-        run_params: dict[str, Any],
-        impl: Any = None,
+        self, onnx_node: NodeProto, run_params: dict[str, Any], impl: Any = None
     ):
         raise RuntimeError(
             f"The reference implementation must not use this node ({type(self)})."

--- a/onnx/reference/ops/_op.py
+++ b/onnx/reference/ops/_op.py
@@ -16,9 +16,6 @@ class OpRunUnary(OpRun):
     Checks that input and output types are the same.
     """
 
-    def __init__(self, onnx_node: NodeProto, run_params: Dict[str, Any]):
-        OpRun.__init__(self, onnx_node, run_params)
-
     def run(self, x):  # type: ignore
         """Calls method ``_run``, catches exceptions, displays a longer error message.
 
@@ -42,9 +39,6 @@ class OpRunUnaryNum(OpRunUnary):
     Checks that input and output types are the same.
     """
 
-    def __init__(self, onnx_node: NodeProto, run_params: Dict[str, Any]):
-        OpRunUnary.__init__(self, onnx_node, run_params)
-
     def run(self, x):  # type: ignore
         """Calls method ``OpRunUnary.run``.
 
@@ -67,9 +61,6 @@ class OpRunBinary(OpRun):
 
     Checks that input and output types are the same.
     """
-
-    def __init__(self, onnx_node: NodeProto, run_params: Dict[str, Any]):
-        OpRun.__init__(self, onnx_node, run_params)
 
     def run(self, x, y):  # type: ignore
         """Calls method ``_run``, catches exceptions, displays a longer error message.
@@ -101,8 +92,7 @@ class OpRunBinary(OpRun):
 class OpRunBinaryComparison(OpRunBinary):
     """Ancestor to all binary operators in this subfolder comparing tensors."""
 
-    def __init__(self, onnx_node: NodeProto, run_params: Dict[str, Any]):
-        OpRunBinary.__init__(self, onnx_node, run_params)
+    pass
 
 
 class OpRunBinaryNum(OpRunBinary):
@@ -110,9 +100,6 @@ class OpRunBinaryNum(OpRunBinary):
 
     Checks that input oud output types are the same.
     """
-
-    def __init__(self, onnx_node: NodeProto, run_params: Dict[str, Any]):
-        OpRunBinary.__init__(self, onnx_node, run_params)
 
     def run(self, x, y):  # type: ignore
         """Calls method ``OpRunBinary.run``, catches exceptions, displays a longer error message."""

--- a/onnx/reference/ops/aionnx_preview_training/_op_list.py
+++ b/onnx/reference/ops/aionnx_preview_training/_op_list.py
@@ -21,7 +21,11 @@ def _build_registered_operators() -> Dict[str, Dict[Union[int, None], OpRunTrain
 
 
 def load_op(
-    domain: str, op_type: str, version: Union[None, int], custom: Any = None
+    domain: str,
+    op_type: str,
+    version: Union[None, int],
+    custom: Any = None,
+    evaluator_cls: TOptional[type] = None,
 ) -> Any:
     """Loads the implemented for a specified operator.
 
@@ -30,6 +34,7 @@ def load_op(
         op_type: oprator type
         version: requested version
         custom: custom implementation (like a function)
+        evaluator_cls: unused
 
     Returns:
         class
@@ -79,6 +84,6 @@ def load_op(
     return cl
 
 
-_registered_operators: TOptional[
-    Dict[str, Dict[Union[int, None], OpRunTraining]]
-] = None
+_registered_operators: TOptional[Dict[str, Dict[Union[int, None], OpRunTraining]]] = (
+    None
+)

--- a/onnx/reference/ops/aionnx_preview_training/_op_list.py
+++ b/onnx/reference/ops/aionnx_preview_training/_op_list.py
@@ -84,6 +84,6 @@ def load_op(
     return cl
 
 
-_registered_operators: TOptional[Dict[str, Dict[Union[int, None], OpRunTraining]]] = (
-    None
-)
+_registered_operators: TOptional[
+    Dict[str, Dict[Union[int, None], OpRunTraining]]
+] = None

--- a/onnx/reference/ops/aionnxml/_op_list.py
+++ b/onnx/reference/ops/aionnxml/_op_list.py
@@ -100,6 +100,6 @@ def load_op(
     return cl
 
 
-_registered_operators: TOptional[Dict[str, Dict[Union[int, None], OpRunAiOnnxMl]]] = (
-    None
-)
+_registered_operators: TOptional[
+    Dict[str, Dict[Union[int, None], OpRunAiOnnxMl]]
+] = None

--- a/onnx/reference/ops/aionnxml/_op_list.py
+++ b/onnx/reference/ops/aionnxml/_op_list.py
@@ -37,7 +37,11 @@ def _build_registered_operators() -> Dict[str, Dict[Union[int, None], OpRunAiOnn
 
 
 def load_op(
-    domain: str, op_type: str, version: Union[None, int], custom: Any = None
+    domain: str,
+    op_type: str,
+    version: Union[None, int],
+    custom: Any = None,
+    evaluator_cls: TOptional[type] = None,
 ) -> Any:
     """Loads the implemented for a specified operator.
 
@@ -46,6 +50,7 @@ def load_op(
         op_type: oprator type
         version: requested version
         custom: custom implementation (like a function)
+        evaluator_cls: unused
 
     Returns:
         class
@@ -95,6 +100,6 @@ def load_op(
     return cl
 
 
-_registered_operators: TOptional[
-    Dict[str, Dict[Union[int, None], OpRunAiOnnxMl]]
-] = None
+_registered_operators: TOptional[Dict[str, Dict[Union[int, None], OpRunAiOnnxMl]]] = (
+    None
+)

--- a/onnx/reference/ops/aionnxml/op_tree_ensemble.py
+++ b/onnx/reference/ops/aionnxml/op_tree_ensemble.py
@@ -175,18 +175,22 @@ class TreeEnsemble(OpRunAiOnnxMl):
                     nodes_modes[current_node_index],
                     set_members,
                     nodes_featureids[current_node_index],
-                    nodes_missing_value_tracks_true[current_node_index]
-                    if nodes_missing_value_tracks_true is not None
-                    else False,
+                    (
+                        nodes_missing_value_tracks_true[current_node_index]
+                        if nodes_missing_value_tracks_true is not None
+                        else False
+                    ),
                 )
             else:
                 node = Node(
                     nodes_modes[current_node_index],
                     nodes_splits[current_node_index],
                     nodes_featureids[current_node_index],
-                    nodes_missing_value_tracks_true[current_node_index]
-                    if nodes_missing_value_tracks_true is not None
-                    else False,
+                    (
+                        nodes_missing_value_tracks_true[current_node_index]
+                        if nodes_missing_value_tracks_true is not None
+                        else False
+                    ),
                 )
 
             # recurse true and false branches

--- a/onnx/reference/ops/experimental/_op_list.py
+++ b/onnx/reference/ops/experimental/_op_list.py
@@ -21,7 +21,11 @@ def _build_registered_operators() -> (
 
 
 def load_op(
-    domain: str, op_type: str, version: Union[None, int], custom: Any = None
+    domain: str,
+    op_type: str,
+    version: Union[None, int],
+    custom: Any = None,
+    evaluator_cls: TOptional[type] = None,
 ) -> Any:
     """Loads the implemented for a specified operator.
 
@@ -30,6 +34,7 @@ def load_op(
         op_type: oprator type
         version: requested version
         custom: custom implementation (like a function)
+        evaluator_cls: unused
 
     Returns:
         class

--- a/onnx/reference/ops/op_rnn.py
+++ b/onnx/reference/ops/op_rnn.py
@@ -36,22 +36,30 @@ class CommonRNN(OpRun):
 
         self.f1 = self.choose_act(
             self.activations[0],  # type: ignore
-            self.activation_alpha[0]  # type: ignore
-            if self.activation_alpha is not None and len(self.activation_alpha) > 0  # type: ignore
-            else None,
-            self.activation_beta[0]  # type: ignore
-            if self.activation_beta is not None and len(self.activation_beta) > 0  # type: ignore
-            else None,
+            (
+                self.activation_alpha[0]  # type: ignore
+                if self.activation_alpha is not None and len(self.activation_alpha) > 0  # type: ignore
+                else None
+            ),
+            (
+                self.activation_beta[0]  # type: ignore
+                if self.activation_beta is not None and len(self.activation_beta) > 0  # type: ignore
+                else None
+            ),
         )
         if len(self.activations) > 1:  # type: ignore
             self.f2 = self.choose_act(
                 self.activations[1],  # type: ignore
-                self.activation_alpha[1]  # type: ignore
-                if self.activation_alpha is not None and len(self.activation_alpha) > 1  # type: ignore
-                else None,
-                self.activation_beta[1]  # type: ignore
-                if self.activation_beta is not None and len(self.activation_beta) > 1  # type: ignore
-                else None,
+                (
+                    self.activation_alpha[1]  # type: ignore
+                    if self.activation_alpha is not None and len(self.activation_alpha) > 1  # type: ignore
+                    else None
+                ),
+                (
+                    self.activation_beta[1]  # type: ignore
+                    if self.activation_beta is not None and len(self.activation_beta) > 1  # type: ignore
+                    else None
+                ),
             )
         self.n_outputs = len(onnx_node.output)
 

--- a/onnx/reference/ops/op_scan.py
+++ b/onnx/reference/ops/op_scan.py
@@ -16,10 +16,12 @@ class Scan(OpRun):
                 f"Parameter 'body' must have a method 'run', type {type(self.body)}."  # type: ignore
             )
         self.input_directions_ = [
-            0
-            if self.scan_input_directions is None  # type: ignore
-            or i >= len(self.scan_input_directions)  # type: ignore
-            else self.scan_input_directions[i]  # type: ignore
+            (
+                0
+                if self.scan_input_directions is None  # type: ignore
+                or i >= len(self.scan_input_directions)  # type: ignore
+                else self.scan_input_directions[i]
+            )  # type: ignore
             for i in range(self.num_scan_inputs)  # type: ignore
         ]
         max_dir_in = max(self.input_directions_)
@@ -28,9 +30,11 @@ class Scan(OpRun):
                 "Scan is not implemented for other output input_direction than 0."
             )
         self.input_axes_ = [
-            0
-            if self.scan_input_axes is None or i >= len(self.scan_input_axes)  # type: ignore
-            else self.scan_input_axes[i]  # type: ignore
+            (
+                0
+                if self.scan_input_axes is None or i >= len(self.scan_input_axes)  # type: ignore
+                else self.scan_input_axes[i]
+            )  # type: ignore
             for i in range(self.num_scan_inputs)  # type: ignore
         ]
         max_axe_in = max(self.input_axes_)
@@ -44,10 +48,12 @@ class Scan(OpRun):
         num_scan_outputs = len(args) - num_loop_state_vars
 
         output_directions = [
-            0
-            if self.scan_output_directions is None  # type: ignore
-            or i >= len(self.scan_output_directions)  # type: ignore
-            else self.scan_output_directions[i]  # type: ignore
+            (
+                0
+                if self.scan_output_directions is None  # type: ignore
+                or i >= len(self.scan_output_directions)  # type: ignore
+                else self.scan_output_directions[i]
+            )  # type: ignore
             for i in range(num_scan_outputs)
         ]
         max_dir_out = max(output_directions)
@@ -56,9 +62,11 @@ class Scan(OpRun):
                 "Scan is not implemented for other output output_direction than 0."
             )
         output_axes = [
-            0
-            if self.scan_output_axes is None or i >= len(self.scan_output_axes)  # type: ignore
-            else self.scan_output_axes[i]  # type: ignore
+            (
+                0
+                if self.scan_output_axes is None or i >= len(self.scan_output_axes)  # type: ignore
+                else self.scan_output_axes[i]
+            )  # type: ignore
             for i in range(num_scan_outputs)
         ]
         max_axe_out = max(output_axes)

--- a/onnx/reference/reference_evaluator.py
+++ b/onnx/reference/reference_evaluator.py
@@ -284,7 +284,7 @@ class ReferenceEvaluator:
         if functions is not None:
             for f in functions:  # type: ignore
                 if isinstance(f, FunctionProto):
-                    self.functions_[f.domain, f.name] = ReferenceEvaluator(
+                    self.functions_[f.domain, f.name] = self.__class__(
                         f, verbose=verbose, functions=list(self.functions_.values())
                     )
                 elif isinstance(f, ReferenceEvaluator):

--- a/onnx/reference/reference_evaluator.py
+++ b/onnx/reference/reference_evaluator.py
@@ -411,6 +411,7 @@ class ReferenceEvaluator:
             "verbose": self.verbose,
             "new_ops": self.new_ops_,
             "existing_functions": self.functions_.copy(),
+            "evaluator_cls": self.__class__,
         }
         if self.input_types_:
             all_types = {i.name: i.type for i in self.onnx_graph_.input}
@@ -477,7 +478,13 @@ class ReferenceEvaluator:
             from onnx.reference.ops import load_op
 
             try:
-                return load_op(node.domain, node.op_type, version, expand=expand)
+                return load_op(
+                    node.domain,
+                    node.op_type,
+                    version,
+                    expand=expand,
+                    evaluator_cls=self.__class__,
+                )
             except RuntimeContextError:
                 if input_types is None:
                     raise
@@ -488,6 +495,7 @@ class ReferenceEvaluator:
                     node=node,
                     input_types=input_types,  # type: ignore[arg-type]
                     expand=expand,
+                    evaluator_cls=self.__class__,
                 )
 
         if expand:
@@ -499,24 +507,36 @@ class ReferenceEvaluator:
         if node.domain == "ai.onnx.preview.training":
             from onnx.reference.ops.aionnx_preview_training import load_op as load_op_pt
 
-            return load_op_pt(node.domain, node.op_type, version)
+            return load_op_pt(
+                node.domain, node.op_type, version, evaluator_cls=self.__class__
+            )
 
         if node.domain == "experimental":
             from onnx.reference.ops.experimental import load_op as load_op_exp
 
-            return load_op_exp(node.domain, node.op_type, version)
+            return load_op_exp(
+                node.domain, node.op_type, version, evaluator_cls=self.__class__
+            )
 
         if node.domain == "ai.onnx.ml":
             from onnx.reference.ops.aionnxml import load_op as load_op_ml
 
-            return load_op_ml(node.domain, node.op_type, version)
+            return load_op_ml(
+                node.domain, node.op_type, version, evaluator_cls=self.__class__
+            )
 
         # It has to be a function.
         if key in self.functions_:
             from onnx.reference.ops import load_op
 
             impl = self.functions_[key]
-            return load_op(node.domain, node.op_type, version, custom=impl)
+            return load_op(
+                node.domain,
+                node.op_type,
+                version,
+                custom=impl,
+                evaluator_cls=self.__class__,
+            )
         raise NotImplementedError(
             f"Node type {node.op_type!r} from domain {node.domain!r} "
             f"is unknown, known functions: {sorted(self.functions_)}."


### PR DESCRIPTION
### Description
The current implementation still uses ReferenceEvaluator even when this evaluator was overloaded in a subclass. This PR makes sure that every local function or subgraph uses the new class to execute the local functions and sub graphs.

