### PR TITLE
Prepare for rel-1.16.0

### DIFF
--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -94,10 +94,10 @@ Changes to the semantics of an operator or function MUST be introduced in a new 
 >    step (1).
 > 4. Register the new operator in the corresponding `operator_sets`
 >    header file.
-> 5. Add a version adapter to `convert.h` so that the version 
->    converter can upgrade the old version of the operator to the new 
+> 5. Add a version adapter to `convert.h` so that the version
+>    converter can upgrade the old version of the operator to the new
 >    one. This can be a `CompatibleAdapter` in case operators following
->    the old schema are still valid under the new one (which is usually 
+>    the old schema are still valid under the new one (which is usually
 >    true).
 > 6. A version adapter to downgrade the new operator to the older version
 >    can also be added to `convert.h` but it's not mandatory.
@@ -189,6 +189,7 @@ ONNX version|IR version|Opset version ai.onnx|Opset version ai.onnx.ml|Opset ver
 1.14.0|9|19|3|1
 1.14.1|9|19|3|1
 1.15.0|9|20|4|1
+1.16.0|10|21|5|1
 
 A programmatically accessible version of the above table is available [here](../onnx/helper.py). Limited version number
 information is also maintained in [version.h](../onnx/common/version.h) and [schema.h](../onnx/defs/schema.h).

--- a/onnx/common/version.h
+++ b/onnx/common/version.h
@@ -9,6 +9,6 @@
 namespace ONNX_NAMESPACE {
 
 // Represents the most recent release version. Updated with every release.
-constexpr const char* LAST_RELEASE_VERSION = "1.15.0";
+constexpr const char* LAST_RELEASE_VERSION = "1.16.0";
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -1164,7 +1164,7 @@ class OpSchemaRegistry final : public ISchemaRegistry {
       // the max version above in a *release* version of ONNX. But in other
       // versions, the max version may be ahead of the last-release-version.
       last_release_version_map_[ONNX_DOMAIN] = 21;
-      last_release_version_map_[AI_ONNX_ML_DOMAIN] = 4;
+      last_release_version_map_[AI_ONNX_ML_DOMAIN] = 5;
       last_release_version_map_[AI_ONNX_TRAINING_DOMAIN] = 1;
       last_release_version_map_[AI_ONNX_PREVIEW_TRAINING_DOMAIN] = 1;
     }

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -75,7 +75,7 @@ VERSION_TABLE: VersionTableType = [
     ("1.14.0", 9, 19, 3, 1),
     ("1.14.1", 9, 19, 3, 1),
     ("1.15.0", 9, 20, 4, 1),
-    ("1.16.0", 9, 20, 5, 1),
+    ("1.16.0", 10, 21, 5, 1),
 ]
 
 VersionMapType = Dict[Tuple[str, int], int]

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -406,11 +406,13 @@ class TestHelperNodeFunctions(unittest.TestCase):
         test([("", 18)], 8)
         test([("", 19)], 9)
         test([("", 20)], 9)
+        test([("", 21)], 10)
         # standard opset can be referred to using empty-string or "ai.onnx"
         test([("ai.onnx", 9)], 4)
         test([("ai.onnx.ml", 2)], 6)
         test([("ai.onnx.ml", 3)], 8)
         test([("ai.onnx.ml", 4)], 9)
+        test([("ai.onnx.ml", 5)], 10)
         test([("ai.onnx.training", 1)], 7)
         # helper should pick *max* IR version required from all opsets specified.
         test([("", 10), ("ai.onnx.ml", 2)], 6)


### PR DESCRIPTION
### Description
prepare for rel-1.16.0 branch cut (planned for 02/26 https://github.com/onnx/onnx/wiki/Logistics-for-ONNX-Release-1.16.0)

### Motivation and Context
ONNX 1.16.0 is planned to be released on 3/18
