### PR TITLE
The latest Cmake 3.28.3 is failing with "Could NOT find Protobuf (missing: Protobuf_LIBRARIES)". Use Cmake 3.27.9

### DIFF
--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -56,6 +56,13 @@ jobs:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Add conda to PATH
 
+  # cmake 3.28.3 failed to find protobuf installed from conda-forge
+  - name: Install specific version of CMake
+    run: choco install cmake --version 3.27.9 -y
+
+  - name: Check CMake version
+    run: cmake --version
+
   - script: |
       conda create --yes --quiet --name py$(python.version) python=$(python.version)
       if '$(protobuf_type)' == 'External' (

--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -59,9 +59,9 @@ jobs:
   # cmake 3.28.3 failed to find protobuf installed from conda-forge
   # https://gitlab.kitware.com/cmake/cmake/-/issues/25704
   - script: |
-    choco install cmake --version 3.27.9 -y
-    cmake --version
-  displayName: Install specific version of CMake and check version
+      choco install cmake --version 3.27.9 -y
+      cmake --version
+    displayName: Install specific version of CMake and check version
 
   - script: |
       conda create --yes --quiet --name py$(python.version) python=$(python.version)

--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -57,11 +57,11 @@ jobs:
     displayName: Add conda to PATH
 
   # cmake 3.28.3 failed to find protobuf installed from conda-forge
-  - name: Install specific version of CMake
-    run: choco install cmake --version 3.27.9 -y
+  - script: choco install cmake --version 3.27.9 -y
+    displayName: Install specific version of CMake
 
-  - name: Check CMake version
-    run: cmake --version
+  - script: cmake --version
+    displayName: Check CMake version
 
   - script: |
       conda create --yes --quiet --name py$(python.version) python=$(python.version)

--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -58,7 +58,7 @@ jobs:
 
   # cmake 3.28.3 failed to find protobuf installed from conda-forge
   # https://gitlab.kitware.com/cmake/cmake/-/issues/25704
-- script: |
+  - script: |
     choco install cmake --version 3.27.9 -y
     cmake --version
   displayName: Install specific version of CMake and check version

--- a/.azure-pipelines/Windows-CI.yml
+++ b/.azure-pipelines/Windows-CI.yml
@@ -57,11 +57,11 @@ jobs:
     displayName: Add conda to PATH
 
   # cmake 3.28.3 failed to find protobuf installed from conda-forge
-  - script: choco install cmake --version 3.27.9 -y
-    displayName: Install specific version of CMake
-
-  - script: cmake --version
-    displayName: Check CMake version
+  # https://gitlab.kitware.com/cmake/cmake/-/issues/25704
+- script: |
+    choco install cmake --version 3.27.9 -y
+    cmake --version
+  displayName: Install specific version of CMake and check version
 
   - script: |
       conda create --yes --quiet --name py$(python.version) python=$(python.version)


### PR DESCRIPTION
### Description
https://gitlab.kitware.com/cmake/cmake/-/issues/25704

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
