### PR TITLE
[Cherry-pick] Fix builds from source and pip tar.gz on s390x systems

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
-requires = ["setuptools>=64", "protobuf>=3.20.2"]
+requires = ["setuptools>=64", "protobuf>=3.20.2", "cmake"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -214,18 +214,6 @@ class CmakeBuild(setuptools.Command):
                 raise RuntimeError(
                     "-DONNX_DISABLE_EXCEPTIONS=ON option is only available for c++ builds. Python binding require exceptions to be enabled."
                 )
-            if (
-                "PYTHONPATH" in os.environ
-                and "pip-build-env" in os.environ["PYTHONPATH"]
-            ):
-                # When the users use `pip install -e .` to install onnx and
-                # the cmake executable is a python entry script, there will be
-                # `Fix ModuleNotFoundError: No module named 'cmake'` from the cmake script.
-                # This is caused by the additional PYTHONPATH environment variable added by pip,
-                # which makes cmake python entry script not able to find correct python cmake packages.
-                # Actually, sys.path is well enough for `pip install -e .`.
-                # Therefore, we delete the PYTHONPATH variable.
-                del os.environ["PYTHONPATH"]
             subprocess.check_call(cmake_args)
 
             build_args = [CMAKE, "--build", os.curdir]


### PR DESCRIPTION
### Description
* Cherry-pick (#5984) - Fix builds from source and pip tar.gz on s390x systems
* Revert (#5195) and replace with fix from [this comment](https://github.com/onnx/onnx/issues/5194#issuecomment-1749336155) from the original issue (#5194)

### Motivation and Context
* Building on s390x (and other environments depending on python setup) fails * The issue also can also appear when installing `1.16.0rc1` from TestPyPI for environments where we don't have pre-built wheels * Failures include not being able to find pacakges despite them being installed ``` pip3 install -e . ... -- Could NOT find pybind11 (missing: pybind11_DIR) ...
        Traceback (most recent call last): File "/onnx/.setuptools-cmake-build/tools/protoc-gen-mypy.py", line 28, in <module>
        import google.protobuf.descriptor_pb2 as d_typed
        ```
* The issue is cased by (#5195) which was to fix (#5194) * The original fix bypasses the pip venv PYTHONPATH and attempts to rely on sys.path. However without the pip venv PYTHONPATH, some modules may not be found even if they are installed. * For reference, the pip venv PYTHONPATH gets set to  `/tmp/pip-build-env-bn_o_cjc/site` which contains `sitecustomize.py` which comes from https://github.com/pypa/pip/blob/main/tests/lib/venv.py#L171-L189 *  Instead of bypassing the pip venv PYTHONPATH, [this comment](https://github.com/onnx/onnx/issues/5194#issuecomment-1749336155) from the original issue shows how to address the issue using pyproject.toml's `[build-system]`
 * I replicated the origial issue and confirmed this fix resolves it.
 * I confirmed the builds work on s390x with this fix