### PR TITLE
Fix SegFault bug in shape inference

### DIFF
--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -108,10 +108,10 @@ OpSchemaRegistry* OpSchemaRegistry::Instance() {
 void OpSchema::CheckInputOutputType(struct InferenceContext& ctx) const {
   std::unordered_map<std::string, std::string> type_constraints;
   if (inputs_.empty() && ctx.getNumInputs() > 0) {
-    fail_check("Node with name: \"", Name(), "\" need empty inputs, but got ", ctx.getNumInputs(), " in graph");
+    fail_check("Node with type: \"", Name(), "\" need empty inputs, but got ", ctx.getNumInputs(), " in graph");
   }
   if (outputs_.empty() && ctx.getNumOutputs() > 0) {
-    fail_check("Node with name: \"", Name(), "\" need empty outputs, but got ", ctx.getNumInputs(), " in graph");
+    fail_check("Node with type: \"", Name(), "\" need empty outputs, but got ", ctx.getNumInputs(), " in graph");
   }
   // check all input types
   for (size_t in_idx = 0; in_idx < ctx.getNumInputs(); ++in_idx) {

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -107,6 +107,12 @@ OpSchemaRegistry* OpSchemaRegistry::Instance() {
 
 void OpSchema::CheckInputOutputType(struct InferenceContext& ctx) const {
   std::unordered_map<std::string, std::string> type_constraints;
+  if (inputs_.empty() && ctx.getNumInputs() > 0) {
+    fail_check("Node with name: \"", Name(), "\" need empty inputs, but got ", ctx.getNumInputs(), " in graph");
+  }
+  if (outputs_.empty() && ctx.getNumOutputs() > 0) {
+    fail_check("Node with name: \"", Name(), "\" need empty outputs, but got ", ctx.getNumInputs(), " in graph");
+  }
   // check all input types
   for (size_t in_idx = 0; in_idx < ctx.getNumInputs(); ++in_idx) {
     // If the last input is Variadic by definition, checker still needs to check the rest of actual input's type

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -108,10 +108,28 @@ OpSchemaRegistry* OpSchemaRegistry::Instance() {
 void OpSchema::CheckInputOutputType(struct InferenceContext& ctx) const {
   std::unordered_map<std::string, std::string> type_constraints;
   if (inputs_.empty() && ctx.getNumInputs() > 0) {
-    fail_check("Node with type: \"", Name(), "\" need empty inputs, but got ", ctx.getNumInputs(), " in graph");
+    fail_check(
+        "Node (",
+        domain(),
+        "::",
+        Name(),
+        ":",
+        since_version(),
+        ") need empty inputs, but got ",
+        ctx.getNumInputs(),
+        " in graph");
   }
   if (outputs_.empty() && ctx.getNumOutputs() > 0) {
-    fail_check("Node with type: \"", Name(), "\" need empty outputs, but got ", ctx.getNumInputs(), " in graph");
+    fail_check(
+        "Node (",
+        domain(),
+        "::",
+        Name(),
+        ":",
+        since_version(),
+        ") need empty outputs, but got ",
+        ctx.getNumOutputs(),
+        " in graph");
   }
   // check all input types
   for (size_t in_idx = 0; in_idx < ctx.getNumInputs(); ++in_idx) {

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -115,7 +115,7 @@ void OpSchema::CheckInputOutputType(struct InferenceContext& ctx) const {
         Name(),
         ":",
         since_version(),
-        ") need empty inputs, but got ",
+        ") takes zero inputs, but got ",
         ctx.getNumInputs(),
         " in graph");
   }
@@ -127,7 +127,7 @@ void OpSchema::CheckInputOutputType(struct InferenceContext& ctx) const {
         Name(),
         ":",
         since_version(),
-        ") need empty outputs, but got ",
+        ") yields zero outputs, but got ",
         ctx.getNumOutputs(),
         " in graph");
   }

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -9898,6 +9898,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         onnx.defs.register_schema(op_schema)
         with self.assertRaises(onnx.shape_inference.InferenceError):
             onnx.shape_inference.infer_shapes(model, True)
+        onnx.defs.deregister_schema(op_schema.name, op_schema.since_version, op_schema.domain)
 
 
 if __name__ == "__main__":

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -9898,7 +9898,9 @@ class TestShapeInference(TestShapeInferenceHelper):
         onnx.defs.register_schema(op_schema)
         with self.assertRaises(onnx.shape_inference.InferenceError):
             onnx.shape_inference.infer_shapes(model, True)
-        onnx.defs.deregister_schema(op_schema.name, op_schema.since_version, op_schema.domain)
+        onnx.defs.deregister_schema(
+            op_schema.name, op_schema.since_version, op_schema.domain
+        )
 
 
 if __name__ == "__main__":

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -9875,6 +9875,30 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("output", TensorProto.INT64, (2, "N", 3, None))])  # type: ignore
 
+    def test_check_type_when_schema_has_empty_io(self):
+        input = """
+            <
+                ir_version: 7,
+                opset_import: ["" : 1]
+            >
+            agraph (X, Y) => (Z)
+            {
+                Z = CustomOp(X, Y)
+            }
+           """
+        model = onnx.parser.parse_model(input)
+
+        op_schema = defs.OpSchema(
+            "CustomOp",
+            "",
+            1,
+            inputs=[],
+            outputs=[],
+        )
+        onnx.defs.register_schema(op_schema)
+        with self.assertRaises(onnx.shape_inference.InferenceError):
+            onnx.shape_inference.infer_shapes(model, True)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description

The bug is SegFault during shape inference if the schema not be set inference function.

The schema has `CheckInputOutputType` for shape inference and `Verify` for raw node proto. And the behavior is not fully aligned.

### Motivation and Context

fixes #5989 
