### PR TITLE
Fix `onnx.compose` when connecting subgraphs

### DIFF
--- a/onnx/compose.py
+++ b/onnx/compose.py
@@ -215,7 +215,7 @@ def merge_graphs(
     g2_nodes_end = len(g.node)
 
     # Search inputs of the subgraph recursively
-    def connect_io(sub_graph: GraphProto, start, end):
+    def connect_io(sub_graph: GraphProto, start: int, end: int) -> None:
         for node_idx in range(start, end):
             node = sub_graph.node[node_idx]
             for attr in node.attribute:

--- a/onnx/compose.py
+++ b/onnx/compose.py
@@ -5,7 +5,16 @@
 
 from typing import Dict, List, MutableMapping, Optional, Set, Tuple
 
-from onnx import GraphProto, ModelProto, TensorProto, AttributeProto, checker, helper, utils
+from onnx import (
+    AttributeProto,
+    GraphProto,
+    ModelProto,
+    TensorProto,
+    checker,
+    helper,
+    utils,
+)
+
 
 def check_overlapping_names(
     g1: GraphProto, g2: GraphProto, io_map: Optional[List[Tuple[str, str]]] = None
@@ -218,8 +227,6 @@ def merge_graphs(
                     node.input[index] = reversed_io_map[name_]
 
     # Connecting outputs of the first graph with the inputs of the second
-    # for node_idx in range(g2_nodes_begin, g2_nodes_end):
-    #     node = g.node[node_idx]
     connect_io(g, g2_nodes_begin, g2_nodes_end)
 
     if inputs:

--- a/onnx/compose.py
+++ b/onnx/compose.py
@@ -5,9 +5,7 @@
 
 from typing import Dict, List, MutableMapping, Optional, Set, Tuple
 
-from onnx import GraphProto, ModelProto, TensorProto, checker, helper, utils
-from onnx.onnx_ml_pb2 import AttributeProto
-
+from onnx import GraphProto, ModelProto, TensorProto, AttributeProto, checker, helper, utils
 
 def check_overlapping_names(
     g1: GraphProto, g2: GraphProto, io_map: Optional[List[Tuple[str, str]]] = None

--- a/onnx/compose.py
+++ b/onnx/compose.py
@@ -214,7 +214,7 @@ def merge_graphs(
     g.node.extend(g2.node)
     g2_nodes_end = len(g.node)
 
-    # Searching inputs of the subgraph recursively.
+    # Search inputs of the subgraph recursively
     def connect_io(sub_graph: GraphProto, start, end):
         for node_idx in range(start, end):
             node = sub_graph.node[node_idx]


### PR DESCRIPTION
### Description
Recursively searching through the nodes for input in merge graphs function.

### Motivation and Context
While connecting and merging two models in which there is subgraph in one of them, inputs and outputs of subgraph was being overlooked and were left dangling. 

This fixes https://github.com/onnx/onnx/issues/5985
