### PR TITLE
[Cherry-pick]Fix SegFault bug in shape inference

### DIFF
--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -107,6 +107,30 @@ OpSchemaRegistry* OpSchemaRegistry::Instance() {
 
 void OpSchema::CheckInputOutputType(struct InferenceContext& ctx) const {
   std::unordered_map<std::string, std::string> type_constraints;
+  if (inputs_.empty() && ctx.getNumInputs() > 0) {
+    fail_check(
+        "Node (",
+        domain(),
+        "::",
+        Name(),
+        ":",
+        since_version(),
+        ") takes zero inputs, but got ",
+        ctx.getNumInputs(),
+        " in graph");
+  }
+  if (outputs_.empty() && ctx.getNumOutputs() > 0) {
+    fail_check(
+        "Node (",
+        domain(),
+        "::",
+        Name(),
+        ":",
+        since_version(),
+        ") yields zero outputs, but got ",
+        ctx.getNumOutputs(),
+        " in graph");
+  }
   // check all input types
   for (size_t in_idx = 0; in_idx < ctx.getNumInputs(); ++in_idx) {
     // If the last input is Variadic by definition, checker still needs to check the rest of actual input's type


### PR DESCRIPTION
### Description
Cherry-Pick #5990 into `rel-1.16.0` branch

The bug is SegFault during shape inference if the schema not be set inference function.

The schema has `CheckInputOutputType` for shape inference and `Verify` for raw node proto. And the behavior is not fully aligned.

### Motivation and Context

fixes #5989