### PR TITLE
Bump ai.onnx opset to 22

### DIFF
--- a/onnx/defs/operator_sets.h
+++ b/onnx/defs/operator_sets.h
@@ -1192,6 +1192,8 @@ class OpSet_Onnx_ver21 {
 class OpSet_Onnx_ver22 {
  public:
   static void ForEachSchema(std::function<void(OpSchema&&)> fn) {
+    // TODO: Remove after introducing the first schema to opset 22
+    (void)fn;
   }
 };
 

--- a/onnx/defs/operator_sets.h
+++ b/onnx/defs/operator_sets.h
@@ -1185,6 +1185,16 @@ class OpSet_Onnx_ver21 {
   }
 };
 
+
+// Forward declarations for ai.onnx version 22
+
+// Iterate over schema from ai.onnx version 22
+class OpSet_Onnx_ver22 {
+ public:
+  static void ForEachSchema(std::function<void(OpSchema&&)> fn) {
+  }
+};
+
 inline void RegisterOnnxOperatorSetSchema() {
   RegisterOpSetSchema<OpSet_Onnx_ver1>();
   RegisterOpSetSchema<OpSet_Onnx_ver2>();
@@ -1207,6 +1217,7 @@ inline void RegisterOnnxOperatorSetSchema() {
   RegisterOpSetSchema<OpSet_Onnx_ver19>();
   RegisterOpSetSchema<OpSet_Onnx_ver20>();
   RegisterOpSetSchema<OpSet_Onnx_ver21>();
+  RegisterOpSetSchema<OpSet_Onnx_ver22>();
   // 0 means all versions of ONNX schema have been loaded
   OpSchemaRegistry::Instance()->SetLoadedSchemaVersion(0);
 }
@@ -1216,6 +1227,7 @@ inline void RegisterOnnxOperatorSetSchema(int target_version, bool fail_duplicat
   // These calls for schema registration here are required to be in descending order for this to work correctly
   //
   // Version-sepcific registration sees duplicate schema version request as error if fail_duplicate_schema
+  RegisterOpSetSchema<OpSet_Onnx_ver22>(target_version, fail_duplicate_schema);
   RegisterOpSetSchema<OpSet_Onnx_ver21>(target_version, fail_duplicate_schema);
   RegisterOpSetSchema<OpSet_Onnx_ver20>(target_version, fail_duplicate_schema);
   RegisterOpSetSchema<OpSet_Onnx_ver19>(target_version, fail_duplicate_schema);

--- a/onnx/defs/operator_sets.h
+++ b/onnx/defs/operator_sets.h
@@ -1185,7 +1185,6 @@ class OpSet_Onnx_ver21 {
   }
 };
 
-
 // Forward declarations for ai.onnx version 22
 
 // Iterate over schema from ai.onnx version 22

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -1153,7 +1153,7 @@ class OpSchemaRegistry final : public ISchemaRegistry {
       // Increase the highest version when you make BC-breaking changes to the
       // operator schema on specific domain. Update the lowest version when it's
       // determined to remove too old version history.
-      map_[ONNX_DOMAIN] = std::make_pair(1, 21);
+      map_[ONNX_DOMAIN] = std::make_pair(1, 22);
       map_[AI_ONNX_ML_DOMAIN] = std::make_pair(1, 5);
       map_[AI_ONNX_TRAINING_DOMAIN] = std::make_pair(1, 1);
       // ONNX's preview domain contains operators subject to change, so


### PR DESCRIPTION
### Description
* Bump ai.onnx opset to 22

### Motivation and Context
* Bump opset to 22 for future 1.17.0 release now that 1.16 branch has been cut.