### PR TITLE
Generalize input/output number check in shape inference

### DIFF
--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -6,6 +6,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 #include <utility>
 

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -109,8 +109,10 @@ OpSchemaRegistry* OpSchemaRegistry::Instance() {
 void OpSchema::CheckInputOutputType(struct InferenceContext& ctx) const {
   std::unordered_map<std::string, std::string> type_constraints;
   // Check the number of inputs / output.
-  VerifyInputNum(ctx.getNumInputs());
-  VerifyOutputNum(ctx.getNumOutputs());
+  std::string node_info =
+      std::string("Node with schema(") + domain() + "::" + Name() + ":" + std::to_string(since_version()) + ")";
+  VerifyInputNum(ctx.getNumInputs(), node_info);
+  VerifyOutputNum(ctx.getNumOutputs(), node_info);
 
   // check all input types
   for (size_t in_idx = 0; in_idx < ctx.getNumInputs(); ++in_idx) {
@@ -331,7 +333,7 @@ void OpSchema::Verify(const NodeProto& node) const {
   // Phew. All verifications passed.
 }
 
-void OpSchema::VerifyInputNum(int input_num, const std::string& node_info) const {
+void OpSchema::VerifyInputNum(int input_num, std::string_view node_info) const {
   if (input_num < min_input_ || input_num > max_input_) {
     fail_check(node_info, " has input size ", input_num, " not in range [min=", min_input_, ", max=", max_input_, "].");
   }
@@ -341,7 +343,7 @@ void OpSchema::VerifyInputNum(int input_num, const std::string& node_info) const
   }
 }
 
-void OpSchema::VerifyOutputNum(int output_num, const std::string& node_info) const {
+void OpSchema::VerifyOutputNum(int output_num, std::string_view node_info) const {
   if (output_num < min_output_ || output_num > max_output_) {
     fail_check(
         node_info, " has output size ", output_num, " not in range [min=", min_output_, ", max=", max_output_, "].");

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -1100,18 +1100,25 @@ class OpSchema final {
   void UpdateFunctionProtoOpsetImportVersion(FunctionProto& function_proto, int opset_version) const;
 
   /**
-   * @brief Verifies if the input number matches the pattern specified in the schema
+   * @brief A common function to generate a prefix string for use in fail_check during the verify function.
+   * @param  node_name If empty, the returned string will not include the node name.
+   * @return std::string The prefix string.
+   */
+  std::string VerifyFailPrefix(std::string_view node_name) const;
+
+  /**
+   * @brief Verifies if the input number matches the pattern specified in the schema.
    * @param input_num The number of inputs to be verified against the schema.
    * @param node_info The prefix string used if the check fails.
    */
-  void VerifyInputNum(int input_num, std::string_view node_info = "Node") const;
+  void VerifyInputNum(int input_num, std::string_view node_name = "") const;
 
   /**
-   * @brief Verifies if the output number matches the pattern specified in the schema
+   * @brief Verifies if the output number matches the pattern specified in the schema.
    * @param output_num The number of outputs to be verified against the schema.
    * @param node_info The prefix string used if the check fails.
    */
-  void VerifyOutputNum(int output_num, std::string_view node_info = "Node") const;
+  void VerifyOutputNum(int output_num, std::string_view node_name = "") const;
 
   std::string name_;
   std::string file_;

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -15,6 +15,7 @@
 #include <ostream>
 #include <set>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -335,6 +335,16 @@ class OpSchema final {
    */
   void Verify(const NodeProto& node) const;
 
+  /**
+   * @brief Verifies if the input number matches the pattern specified in the schema
+   */
+  void VerifyInputNum(int input_num, const std::string& node_info = "Node") const;
+
+  /**
+   * @brief Verifies if the output number matches the pattern specified in the schema
+   */
+  void VerifyOutputNum(int output_num, const std::string& node_info = "Node") const;
+
   // Functions to set the property of the operator schemas.
   // Sets the number of inputs, either a fixed number or a min and a max.
 

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -335,16 +335,6 @@ class OpSchema final {
    */
   void Verify(const NodeProto& node) const;
 
-  /**
-   * @brief Verifies if the input number matches the pattern specified in the schema
-   */
-  void VerifyInputNum(int input_num, const std::string& node_info = "Node") const;
-
-  /**
-   * @brief Verifies if the output number matches the pattern specified in the schema
-   */
-  void VerifyOutputNum(int output_num, const std::string& node_info = "Node") const;
-
   // Functions to set the property of the operator schemas.
   // Sets the number of inputs, either a fixed number or a min and a max.
 
@@ -1107,6 +1097,20 @@ class OpSchema final {
       int function_since_version,
       std::set<std::string>* updated_ops = nullptr) const;
   void UpdateFunctionProtoOpsetImportVersion(FunctionProto& function_proto, int opset_version) const;
+
+  /**
+   * @brief Verifies if the input number matches the pattern specified in the schema
+   * @param input_num The number of inputs to be verified against the schema.
+   * @param node_info The prefix string used if the check fails.
+   */
+  void VerifyInputNum(int input_num, std::string_view node_info = "Node") const;
+
+  /**
+   * @brief Verifies if the output number matches the pattern specified in the schema
+   * @param output_num The number of outputs to be verified against the schema.
+   * @param node_info The prefix string used if the check fails.
+   */
+  void VerifyOutputNum(int output_num, std::string_view node_info = "Node") const;
 
   std::string name_;
   std::string file_;


### PR DESCRIPTION
### Description

 - Add `OpSchema::VerifyInputNum` and `OpSchema::VerifyOutputNum` methods. The logic has been moved from `OpSchema::Verify`.
 - Replaced the input/output number check logic in `OpSchema::CheckInputOutputType` with calls to the new interfaces.
 - Without using the `Node(domain::op_type::version)` string pattern in `OpSchema::CheckInputOutputType` when calling `fail_check`, as the `op_type` will be displayed by the shape inference common exception. Otherwise, it would appear redundant.

### Motivation and Context

follow-up #5990

resolve #5993 
