### PR TITLE
Function to check if an input has a rank within a range for shape inferencing

### DIFF
--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -740,7 +740,7 @@ static constexpr T narrow_cast(U&& u) noexcept {
   return static_cast<T>(std::forward<U>(u));
 }
 
-inline void checkInputRankRange(InferenceContext& ctx, size_t input_index, int expected_rank) {
+inline void checkInputRank(InferenceContext& ctx, size_t input_index, int expected_rank) {
   // We check the rank only if a rank is known for the input:
   if (hasInputShape(ctx, input_index)) {
     auto rank = getInputShape(ctx, input_index).dim_size();
@@ -750,7 +750,8 @@ inline void checkInputRankRange(InferenceContext& ctx, size_t input_index, int e
   }
 }
 
-inline void checkInputRank(InferenceContext& ctx, size_t input_index, int min_expected_rank, int max_expected_rank) {
+inline void
+checkInputRankRange(InferenceContext& ctx, size_t input_index, int min_expected_rank, int max_expected_rank) {
   if (hasInputShape(ctx, input_index)) {
     auto rank = getInputShape(ctx, input_index).dim_size();
     if (rank < min_expected_rank || rank > max_expected_rank) {

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -740,12 +740,29 @@ static constexpr T narrow_cast(U&& u) noexcept {
   return static_cast<T>(std::forward<U>(u));
 }
 
-inline void checkInputRank(InferenceContext& ctx, size_t input_index, int expected_rank) {
+inline void checkInputRankRange(InferenceContext& ctx, size_t input_index, int expected_rank) {
   // We check the rank only if a rank is known for the input:
   if (hasInputShape(ctx, input_index)) {
     auto rank = getInputShape(ctx, input_index).dim_size();
     if (rank != expected_rank) {
       fail_shape_inference("Input ", input_index, " expected to have rank ", expected_rank, " but has rank ", rank);
+    }
+  }
+}
+
+inline void checkInputRank(InferenceContext& ctx, size_t input_index, int min_expected_rank, int max_expected_rank) {
+  if (hasInputShape(ctx, input_index)) {
+    auto rank = getInputShape(ctx, input_index).dim_size();
+    if (rank < min_expected_rank || rank > max_expected_rank) {
+      fail_shape_inference(
+          "Input ",
+          input_index,
+          " expected to have rank between ",
+          min_expected_rank,
+          " and ",
+          max_expected_rank,
+          " but has rank ",
+          rank);
     }
   }
 }


### PR DESCRIPTION
### Description
Just a small function check if an input rank is within a certain range, rather than a single rank. 

### Motivation and Context
https://github.com/onnx/onnx/issues/6008

So for example if I want to extend `GridSampling` to accept 5D input and not just 4D, downstream code can rely on this rather than roll out their own. 

Not a big deal either way but figured couldn't hurt pushing a PR. Just trying to learn. 