### PR TITLE
Replace rank inference with shape inference for Einsum op

### DIFF
--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -2561,7 +2561,7 @@ ONNX_OPERATOR_SET_SCHEMA(
 
 void einsumShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string const& equation) {
   // Only accept letters for indices
-  auto is_lowercase_letter = [](char c) { return c >= 'a' && c <= 'z'; };
+  auto is_letter = [](char c) { return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'); };
 
   const size_t num_inputs = ctx.getNumInputs();
   if (num_inputs < 1 || !hasNInputShapes(ctx, static_cast<int>(num_inputs))) {
@@ -2606,7 +2606,7 @@ void einsumShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string con
     size_t num_illegal_char = 0; // number of illegal char before the current 'index' in the current term
 
     for (size_t index = 0; index < term.size(); ++index) {
-      if (is_lowercase_letter(term[index])) {
+      if (is_letter(term[index])) {
         term_size += 1;
       }
     }
@@ -2634,7 +2634,7 @@ void einsumShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string con
         num_illegal_char += 3;
         continue;
 
-      } else if (!is_lowercase_letter(term[index])) {
+      } else if (!is_letter(term[index])) {
         num_illegal_char += 1;
         continue;
       }
@@ -2690,7 +2690,7 @@ void einsumShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string con
         continue;
       }
 
-      if (is_lowercase_letter(right_equation[index])) {
+      if (is_letter(right_equation[index])) {
         *output_shape.add_dim() = dims_value.dim(label_maps[right_equation[index]]);
       }
     }

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -2559,19 +2559,17 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
         }));
 
-void einsumShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string equation) {
+void einsumShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string const& equation) {
   // Only accept letters for indices
-  auto isLetter = [](char c) { return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'); };
+  auto is_letter = [](char c) { return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'); };
 
-  const size_t numInputs = ctx.getNumInputs();
-  if (numInputs < 1 || !hasNInputShapes(ctx, static_cast<int>(numInputs))) {
+  const size_t num_inputs = ctx.getNumInputs();
+  if (num_inputs < 1 || !hasNInputShapes(ctx, static_cast<int>(num_inputs))) {
     return;
   }
   ONNX_NAMESPACE::TensorShapeProto output_shape;
   std::string left_equation;
 
-  equation.erase(std::remove(equation.begin(), equation.end(), ' '),
-                 equation.end()); // Remove space char
   auto mid_index = equation.find("->");
   if (mid_index != std::string::npos) {
     // Separate right and left hand sides of the equation
@@ -2597,7 +2595,7 @@ void einsumShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string equ
   while (!str.eof()) {
     std::getline(str, term, ',');
     auto ellipsis_index = term.find("...");
-    if (numInputs <= num_operands) {
+    if (num_inputs <= num_operands) {
       fail_shape_inference("Number of input tensors does not match the operands in the equation.");
     }
     const auto& shape = ctx.getInputType(num_operands)->tensor_type().shape();
@@ -2608,7 +2606,7 @@ void einsumShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string equ
     size_t num_illegal_char = 0; // number of illegal char before the current 'index' in the current term
 
     for (size_t index = 0; index < term.size(); ++index) {
-      if (isLetter(term[index])) {
+      if (is_letter(term[index])) {
         term_size += 1;
       }
     }
@@ -2627,7 +2625,7 @@ void einsumShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string equ
         num_illegal_char += 3;
         continue;
 
-      } else if (!isLetter(term[index])) {
+      } else if (!is_letter(term[index])) {
         num_illegal_char += 1;
         continue;
       }
@@ -2664,7 +2662,7 @@ void einsumShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string equ
     num_operands++;
   }
 
-  if (numInputs != num_operands) {
+  if (num_inputs != num_operands) {
     fail_shape_inference("Number of input tensors does not match the operands in the equation.");
   }
 
@@ -2683,7 +2681,7 @@ void einsumShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string equ
         continue;
       }
 
-      if (isLetter(right_equation[index])) {
+      if (is_letter(right_equation[index])) {
         *output_shape.add_dim() = dims_value.dim(label_maps[right_equation[index]]);
       }
     }
@@ -2752,6 +2750,9 @@ ONNX_OPERATOR_SET_SCHEMA(
           if (equation.compare("") == 0) {
             return;
           }
+
+          equation.erase(std::remove(equation.begin(), equation.end(), ' '),
+                         equation.end()); // Remove space char
           einsumShapeInference(ctx, equation);
         }));
 

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -2706,7 +2706,6 @@ void einsumShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string equ
   }
   
   updateOutputShape(ctx, 0, output_shape);
-  // *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape() = output_shape;
 }
 
 static const char* Einsum_ver12_doc = R"DOC(

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -2632,7 +2632,7 @@ void einsumShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string equ
         continue;
       }
 
-      const auto [_, inserted] = label_maps.insert({term[index], num_labels});
+      const auto inserted = label_maps.insert({term[index], num_labels}).second;
       if (inserted) {
         *dims_value.add_dim() = shape.dim(index + ellipsis_dims - num_illegal_char);
         ++num_labels;

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -2632,7 +2632,7 @@ void einsumShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string equ
         continue;
       }
 
-      const auto [i, inserted] = label_maps.insert({term[index], num_labels});
+      const auto [_, inserted] = label_maps.insert({term[index], num_labels});
       if (inserted) {
         *dims_value.add_dim() = shape.dim(index + ellipsis_dims - num_illegal_char);
         ++num_labels;

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -2561,9 +2561,7 @@ ONNX_OPERATOR_SET_SCHEMA(
 
 void einsumShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string equation) {
   // Only accept letters for indices
-  auto isLetter = [](char c) {
-    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
-  };
+  auto isLetter = [](char c) { return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'); };
 
   const size_t numInputs = ctx.getNumInputs();
   if (numInputs < 1 || !hasNInputShapes(ctx, static_cast<int>(numInputs))) {
@@ -2605,11 +2603,10 @@ void einsumShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string equ
     const auto& shape = ctx.getInputType(num_operands)->tensor_type().shape();
     size_t rank = shape.dim_size();
     size_t ellipsis_dims = 0;
-    
+
     size_t term_size = 0; // number of legal indices for the current term
     size_t num_illegal_char = 0; // number of illegal char before the current 'index' in the current term
 
-    
     for (size_t index = 0; index < term.size(); ++index) {
       if (isLetter(term[index])) {
         term_size += 1;
@@ -2623,13 +2620,13 @@ void einsumShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string equ
         if (ellipsis_flag) {
           ellipsis_flag = false;
           for (size_t i = 0; i < ellipsis_dims; i++) {
-            *ellipsis_dims_value.add_dim() = shape.dim(index+i-num_illegal_char);
+            *ellipsis_dims_value.add_dim() = shape.dim(index + i - num_illegal_char);
           }
         }
         index += 2; // skip the rest of dots
         num_illegal_char += 3;
         continue;
-        
+
       } else if (!isLetter(term[index])) {
         num_illegal_char += 1;
         continue;
@@ -2637,7 +2634,7 @@ void einsumShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string equ
 
       const auto [i, inserted] = label_maps.insert({term[index], num_labels});
       if (inserted) {
-        *dims_value.add_dim() = shape.dim(index+ellipsis_dims-num_illegal_char);
+        *dims_value.add_dim() = shape.dim(index + ellipsis_dims - num_illegal_char);
         ++num_labels;
       } else {
         repeated_labels.insert(term[index]);
@@ -2677,7 +2674,7 @@ void einsumShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string equ
     auto right_ellipsis_index = right_equation.find("...");
 
     for (size_t index = 0; index < right_equation.size(); ++index) {
-      // If there's an ellipsis, add it's corresponding dimensions
+      // If there's an ellipsis, add its corresponding dimensions
       if (index == right_ellipsis_index) {
         for (size_t i = 0; i < num_ellipsis_indices; i++) {
           *output_shape.add_dim() = ellipsis_dims_value.dim(i);
@@ -2685,13 +2682,13 @@ void einsumShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string equ
         index += 2; // skip the rest of dots
         continue;
       }
-      
+
       if (isLetter(right_equation[index])) {
         *output_shape.add_dim() = dims_value.dim(label_maps[right_equation[index]]);
       }
     }
   } else { // Infer the dimension for right-hand side
-    // If there's an ellipsis, add it's corresponding dimensions
+    // If there's an ellipsis, add its corresponding dimensions
     for (size_t i = 0; i < num_ellipsis_indices; i++) {
       *output_shape.add_dim() = ellipsis_dims_value.dim(i);
     }
@@ -2704,7 +2701,7 @@ void einsumShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string equ
       }
     }
   }
-  
+
   updateOutputShape(ctx, 0, output_shape);
 }
 

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -7026,7 +7026,7 @@ class TestShapeInference(TestShapeInferenceHelper):
             [make_node("Einsum", ["x"], ["y"], equation="ij->ji")],
             [],
         )
-        self._assert_inferred(graph, [make_tensor_value_info("y", TensorProto.FLOAT, (None, None))])  # type: ignore
+        self._assert_inferred(graph, [make_tensor_value_info("y", TensorProto.FLOAT, (4, 3))])  # type: ignore
 
     def test_einsum_dot(self) -> None:
         graph = self._make_graph(
@@ -7050,7 +7050,7 @@ class TestShapeInference(TestShapeInferenceHelper):
             [make_node("Einsum", ["x", "y"], ["z"], equation="ij,ab->ijab")],
             [],
         )
-        self._assert_inferred(graph, [make_tensor_value_info("z", TensorProto.FLOAT, (None, None, None, None))])  # type: ignore
+        self._assert_inferred(graph, [make_tensor_value_info("z", TensorProto.FLOAT, (3, 5, 7, 9))])  # type: ignore
 
     def test_einsum_sum_along_dim(self) -> None:
         graph = self._make_graph(
@@ -7058,7 +7058,7 @@ class TestShapeInference(TestShapeInferenceHelper):
             [make_node("Einsum", ["x"], ["y"], equation="i j->i ")],
             [],
         )
-        self._assert_inferred(graph, [make_tensor_value_info("y", TensorProto.FLOAT, (None,))])  # type: ignore
+        self._assert_inferred(graph, [make_tensor_value_info("y", TensorProto.FLOAT, (3,))])  # type: ignore
 
     def test_einsum_ellipsis(self) -> None:
         graph = self._make_graph(
@@ -7066,26 +7066,26 @@ class TestShapeInference(TestShapeInferenceHelper):
             [make_node("Einsum", ["x"], ["y"], equation="... ii ->... i")],
             [],
         )
-        self._assert_inferred(graph, [make_tensor_value_info("y", TensorProto.FLOAT, (None, None))])  # type: ignore
+        self._assert_inferred(graph, [make_tensor_value_info("y", TensorProto.FLOAT, (3, 4))])  # type: ignore
 
     def test_einsum_ellipsis_2(self) -> None:
         graph = self._make_graph(
-            [("x", TensorProto.FLOAT, (2, 2, 2)), ("y", TensorProto.FLOAT, (2, 2, 2))],
+            [("x", TensorProto.FLOAT, (2, 3, 4)), ("y", TensorProto.FLOAT, (2, 4, 5))],
             [make_node("Einsum", ["x", "y"], ["z"], equation="...ij,...jk->...ik")],
             [],
         )
         self._assert_inferred(
-            graph, [make_tensor_value_info("z", TensorProto.FLOAT, (None, None, None))]
+            graph, [make_tensor_value_info("z", TensorProto.FLOAT, (2, 3, 5))]
         )  # type: ignore
 
     def test_einsum_ellipsis_3(self) -> None:
         graph = self._make_graph(
-            [("x", TensorProto.FLOAT, (2, 2, 2)), ("y", TensorProto.FLOAT, (2, 2, 2))],
+            [("x", TensorProto.FLOAT, (2, 3, 4)), ("y", TensorProto.FLOAT, (2, 4, 5))],
             [make_node("Einsum", ["x", "y"], ["z"], equation="...ij,...jk")],
             [],
         )
         self._assert_inferred(
-            graph, [make_tensor_value_info("z", TensorProto.FLOAT, (None, None, None))]
+            graph, [make_tensor_value_info("z", TensorProto.FLOAT, (2, 3, 5))]
         )  # type: ignore
 
     def test_einsum_contraction(self) -> None:
@@ -7101,7 +7101,7 @@ class TestShapeInference(TestShapeInferenceHelper):
             graph,
             [
                 make_tensor_value_info(
-                    "z", TensorProto.FLOAT, (None, None, None, None, None)
+                    "z", TensorProto.FLOAT, (5, 6, 7, 9, 10)
                 )
             ],
         )  # type: ignore
@@ -7113,7 +7113,7 @@ class TestShapeInference(TestShapeInferenceHelper):
             [],
         )
         self._assert_inferred(
-            graph, [make_tensor_value_info("z", TensorProto.FLOAT, (None, None))]
+            graph, [make_tensor_value_info("z", TensorProto.FLOAT, (4, 5))]
         )  # type: ignore
 
     def test_einsum_batch_matmul(self) -> None:
@@ -7122,7 +7122,7 @@ class TestShapeInference(TestShapeInferenceHelper):
             [make_node("Einsum", ["x", "y"], ["z"], equation="bij , b jk-> bik")],
             [],
         )
-        self._assert_inferred(graph, [make_tensor_value_info("z", TensorProto.FLOAT, (None, None, None))])  # type: ignore
+        self._assert_inferred(graph, [make_tensor_value_info("z", TensorProto.FLOAT, (5, 2, 4))])  # type: ignore
 
     def test_einsum_left_hand_eqn(self) -> None:
         graph = self._make_graph(
@@ -7130,7 +7130,7 @@ class TestShapeInference(TestShapeInferenceHelper):
             [make_node("Einsum", ["x", "y"], ["z"], equation="ij,kl")],
             [],
         )
-        self._assert_inferred(graph, [make_tensor_value_info("z", TensorProto.FLOAT, (None, None, None, None))])  # type: ignore
+        self._assert_inferred(graph, [make_tensor_value_info("z", TensorProto.FLOAT, (2, 3, 3, 4))])  # type: ignore
 
     def test_einsum_incorrect_num_inputs(self) -> None:
         graph = self._make_graph(

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -7099,11 +7099,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(
             graph,
-            [
-                make_tensor_value_info(
-                    "z", TensorProto.FLOAT, (5, 6, 7, 9, 10)
-                )
-            ],
+            [make_tensor_value_info("z", TensorProto.FLOAT, (5, 6, 7, 9, 10))],
         )  # type: ignore
 
     def test_einsum_contraction_2(self) -> None:
@@ -7144,7 +7140,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self.assertRaises(onnx.shape_inference.InferenceError, self._inferred, graph)
 
-    def test_einsum_view_A1(self) -> None: # returns a view of A1
+    def test_einsum_view_A1(self) -> None:  # returns a view of A1
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3,))],
             [make_node("Einsum", ["x"], ["y"], equation="i")],
@@ -7152,7 +7148,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("y", TensorProto.FLOAT, (3,))])  # type: ignore
 
-    def test_einsum_sum_A1(self) -> None: # sums the values of A1
+    def test_einsum_sum_A1(self) -> None:  # sums the values of A1
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3,))],
             [make_node("Einsum", ["x"], ["y"], equation="i->")],
@@ -7160,7 +7156,9 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("y", TensorProto.FLOAT, ())])  # type: ignore
 
-    def test_einsum_element_wise_multiplication_A1_B1(self) -> None: # element-wise multiplication of A1 and B1
+    def test_einsum_element_wise_multiplication_A1_B1(
+        self,
+    ) -> None:  # element-wise multiplication of A1 and B1
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3,)), ("y", TensorProto.FLOAT, (3,))],
             [make_node("Einsum", ["x", "y"], ["z"], equation="i,i->i")],
@@ -7168,7 +7166,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("z", TensorProto.FLOAT, (3,))])  # type: ignore
 
-    def test_einsum_inner_product_A1_B1(self) -> None: # inner product of A1 and B1
+    def test_einsum_inner_product_A1_B1(self) -> None:  # inner product of A1 and B1
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3,)), ("y", TensorProto.FLOAT, (3,))],
             [make_node("Einsum", ["x", "y"], ["z"], equation="i,i->")],
@@ -7176,7 +7174,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("z", TensorProto.FLOAT, ())])  # type: ignore
 
-    def test_einsum_outer_product_A1_B1(self) -> None: # outer product of A1 and B1
+    def test_einsum_outer_product_A1_B1(self) -> None:  # outer product of A1 and B1
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3,)), ("y", TensorProto.FLOAT, (3,))],
             [make_node("Einsum", ["x", "y"], ["z"], equation="i,j->ij")],
@@ -7184,15 +7182,15 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("z", TensorProto.FLOAT, (3, 3))])  # type: ignore
 
-    def test_einsum_view_A2(self) -> None: # returns a view of A2
+    def test_einsum_view_A2(self) -> None:  # returns a view of A2
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3, 3))],
             [make_node("Einsum", ["x"], ["y"], equation="ij->ij")],
             [],
         )
         self._assert_inferred(graph, [make_tensor_value_info("y", TensorProto.FLOAT, (3, 3))])  # type: ignore
-    
-    def test_einsum_view_A2_2(self) -> None: # returns a view of A2, another case
+
+    def test_einsum_view_A2_2(self) -> None:  # returns a view of A2, another case
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3, 3))],
             [make_node("Einsum", ["x"], ["y"], equation="ij")],
@@ -7200,7 +7198,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("y", TensorProto.FLOAT, (3, 3))])  # type: ignore
 
-    def test_einsum_transpose_A2(self) -> None: # view transpose of A2
+    def test_einsum_transpose_A2(self) -> None:  # view transpose of A2
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3, 3))],
             [make_node("Einsum", ["x"], ["y"], equation="ji")],
@@ -7208,7 +7206,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("y", TensorProto.FLOAT, (3, 3))])  # type: ignore
 
-    def test_einsum_transpose_A2_to_ij(self) -> None: # view transpose of A2
+    def test_einsum_transpose_A2_to_ij(self) -> None:  # view transpose of A2
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3, 3))],
             [make_node("Einsum", ["x"], ["y"], equation="ji->ij")],
@@ -7216,7 +7214,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("y", TensorProto.FLOAT, (3, 3))])  # type: ignore
 
-    def test_einsum_diag_A2(self) -> None: # view main diagonal of A2
+    def test_einsum_diag_A2(self) -> None:  # view main diagonal of A2
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3, 3))],
             [make_node("Einsum", ["x"], ["y"], equation="ii->i")],
@@ -7224,7 +7222,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("y", TensorProto.FLOAT, (3,))])  # type: ignore
 
-    def test_einsum_trace_A2(self) -> None: # sums main diagonal of A2
+    def test_einsum_trace_A2(self) -> None:  # sums main diagonal of A2
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3, 3))],
             [make_node("Einsum", ["x"], ["y"], equation="ii->")],
@@ -7232,7 +7230,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("y", TensorProto.FLOAT, ())])  # type: ignore
 
-    def test_einsum_sum_A2(self) -> None: # sums the values of A2
+    def test_einsum_sum_A2(self) -> None:  # sums the values of A2
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3, 3))],
             [make_node("Einsum", ["x"], ["y"], equation="ij->")],
@@ -7240,7 +7238,9 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("y", TensorProto.FLOAT, ())])  # type: ignore
 
-    def test_einsum_sum_columns_A2(self) -> None: # sum down the columns of A2 (across rows)
+    def test_einsum_sum_columns_A2(
+        self,
+    ) -> None:  # sum down the columns of A2 (across rows)
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3, 3))],
             [make_node("Einsum", ["x"], ["y"], equation="ij->j")],
@@ -7248,7 +7248,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("y", TensorProto.FLOAT, (3,))])  # type: ignore
 
-    def test_einsum_sum_rows_A2(self) -> None: # sum horizontally along the rows of A2
+    def test_einsum_sum_rows_A2(self) -> None:  # sum horizontally along the rows of A2
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3, 3))],
             [make_node("Einsum", ["x"], ["y"], equation="ij->i")],
@@ -7256,7 +7256,9 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("y", TensorProto.FLOAT, (3,))])  # type: ignore
 
-    def test_einsum_element_wise_multiplication_A2_B2(self) -> None: # element-wise multiplication of A2 and B2
+    def test_einsum_element_wise_multiplication_A2_B2(
+        self,
+    ) -> None:  # element-wise multiplication of A2 and B2
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3, 3)), ("y", TensorProto.FLOAT, (3, 3))],
             [make_node("Einsum", ["x", "y"], ["z"], equation="ij,ij->ij")],
@@ -7264,7 +7266,9 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("z", TensorProto.FLOAT, (3, 3))])  # type: ignore
 
-    def test_einsum_element_wise_multiplication_A2_B2_transpose(self) -> None: # element-wise multiplication of A2 and B2.T
+    def test_einsum_element_wise_multiplication_A2_B2_transpose(
+        self,
+    ) -> None:  # element-wise multiplication of A2 and B2.T
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3, 3)), ("y", TensorProto.FLOAT, (3, 3))],
             [make_node("Einsum", ["x", "y"], ["z"], equation="ij,ji->ij")],
@@ -7272,7 +7276,9 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("z", TensorProto.FLOAT, (3, 3))])  # type: ignore
 
-    def test_einsum_matrix_multiplication_A2_B2(self) -> None: # matrix multiplication of A2 and B2
+    def test_einsum_matrix_multiplication_A2_B2(
+        self,
+    ) -> None:  # matrix multiplication of A2 and B2
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3, 3)), ("y", TensorProto.FLOAT, (3, 3))],
             [make_node("Einsum", ["x", "y"], ["z"], equation="ij,jk")],
@@ -7280,7 +7286,9 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("z", TensorProto.FLOAT, (3, 3))])  # type: ignore
 
-    def test_einsum_matrix_multiplication_A2_B2_to_ik(self) -> None: # matrix multiplication of A2 and B2
+    def test_einsum_matrix_multiplication_A2_B2_to_ik(
+        self,
+    ) -> None:  # matrix multiplication of A2 and B2
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3, 3)), ("y", TensorProto.FLOAT, (3, 3))],
             [make_node("Einsum", ["x", "y"], ["z"], equation="ij,jk->ik")],
@@ -7288,7 +7296,9 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("z", TensorProto.FLOAT, (3, 3))])  # type: ignore
 
-    def test_einsum_matrix_multiplication_A3_B3(self) -> None: # matrix multiplication of A3 and B3 (a stack of 2D matrices)
+    def test_einsum_matrix_multiplication_A3_B3(
+        self,
+    ) -> None:  # matrix multiplication of A3 and B3 (a stack of 2D matrices)
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 3, 3)), ("y", TensorProto.FLOAT, (2, 3, 3))],
             [make_node("Einsum", ["x", "y"], ["z"], equation="bij,bjk->bik")],
@@ -7296,7 +7306,9 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("z", TensorProto.FLOAT, (2, 3, 3))])  # type: ignore
 
-    def test_einsum_matrix_multiplication_A3_B3_transpose(self) -> None: # matrix multiplication of A3 and B3 (a stack of 2D matrices)
+    def test_einsum_matrix_multiplication_A3_B3_transpose(
+        self,
+    ) -> None:  # matrix multiplication of A3 and B3 (a stack of 2D matrices)
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 3, 3)), ("y", TensorProto.FLOAT, (2, 3, 3))],
             [make_node("Einsum", ["x", "y"], ["z"], equation="bij,bkj->bik")],
@@ -7304,7 +7316,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("z", TensorProto.FLOAT, (2, 3, 3))])  # type: ignore
 
-    def test_einsum_inner_product_A2_B2(self) -> None: # inner product of A2 and B2
+    def test_einsum_inner_product_A2_B2(self) -> None:  # inner product of A2 and B2
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3, 3)), ("y", TensorProto.FLOAT, (3, 3))],
             [make_node("Einsum", ["x", "y"], ["z"], equation="ij,kj->ik")],
@@ -7312,7 +7324,9 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("z", TensorProto.FLOAT, (3, 3))])  # type: ignore
 
-    def test_einsum_row_multiplication_A2_B2(self) -> None: # each row of A2 multiplied by B2
+    def test_einsum_row_multiplication_A2_B2(
+        self,
+    ) -> None:  # each row of A2 multiplied by B2
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3, 3)), ("y", TensorProto.FLOAT, (3, 3))],
             [make_node("Einsum", ["x", "y"], ["z"], equation="ij,kj->ikj")],
@@ -7320,7 +7334,9 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("z", TensorProto.FLOAT, (3, 3, 3))])  # type: ignore
 
-    def test_einsum_value_multiplication_A2_B2(self) -> None: # each value of A2 multiplied by B2
+    def test_einsum_value_multiplication_A2_B2(
+        self,
+    ) -> None:  # each value of A2 multiplied by B2
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3, 3)), ("y", TensorProto.FLOAT, (3, 3))],
             [make_node("Einsum", ["x", "y"], ["z"], equation="ij,kl->ijkl")],
@@ -7328,7 +7344,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("z", TensorProto.FLOAT, (3, 3, 3, 3))])  # type: ignore
 
-    def test_einsum_scalar_times_array(self) -> None: # Scalar times array
+    def test_einsum_scalar_times_array(self) -> None:  # Scalar times array
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, ()), ("y", TensorProto.FLOAT, (3, 3))],
             [make_node("Einsum", ["x", "y"], ["z"], equation=",ij->ij")],
@@ -7336,7 +7352,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("z", TensorProto.FLOAT, (3, 3))])  # type: ignore
 
-    def test_einsum_matrix_vector_A2_B1(self) -> None: # Matrix and vector.
+    def test_einsum_matrix_vector_A2_B1(self) -> None:  # Matrix and vector.
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3, 3)), ("y", TensorProto.FLOAT, (3,))],
             [make_node("Einsum", ["x", "y"], ["z"], equation="ij,j->i")],
@@ -7344,7 +7360,9 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("z", TensorProto.FLOAT, (3,))])  # type: ignore
 
-    def test_einsum_diag_multiplication_A2_B2(self) -> None: # diagonals multiplied by each other
+    def test_einsum_diag_multiplication_A2_B2(
+        self,
+    ) -> None:  # diagonals multiplied by each other
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3, 3)), ("y", TensorProto.FLOAT, (3, 3))],
             [make_node("Einsum", ["x", "y"], ["z"], equation="ii,ii->i")],
@@ -7352,7 +7370,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [make_tensor_value_info("z", TensorProto.FLOAT, (3,))])  # type: ignore
 
-    def test_einsum_diag_dot_product_A2_B2(self) -> None: # dot product of diagonals
+    def test_einsum_diag_dot_product_A2_B2(self) -> None:  # dot product of diagonals
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3, 3)), ("y", TensorProto.FLOAT, (3, 3))],
             [make_node("Einsum", ["x", "y"], ["z"], equation="ii,ii->")],

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -7088,6 +7088,16 @@ class TestShapeInference(TestShapeInferenceHelper):
             graph, [make_tensor_value_info("z", TensorProto.FLOAT, (2, 3, 5))]
         )  # type: ignore
 
+    def test_einsum_ellipsis_broadcast(self) -> None:
+        graph = self._make_graph(
+            [("x", TensorProto.FLOAT, (1, 3, 4)), ("y", TensorProto.FLOAT, (32, 4, 5))],
+            [make_node("Einsum", ["x", "y"], ["z"], equation="...ij,...jk->...ik")],
+            [],
+        )
+        self._assert_inferred(
+            graph, [make_tensor_value_info("z", TensorProto.FLOAT, (32, 3, 5))]
+        )  # type: ignore
+
     def test_einsum_contraction(self) -> None:
         graph = self._make_graph(
             [


### PR DESCRIPTION
In the development of ONNX Runtime, we need know the output shape of each Op node for statical graph compilation. However, we found that we could use onnx shape inference to achieve almost all output shapes except the output shape of Einsum. In `onnx/defs/math/defs.cc`, we found that there was only Rank Inference function for Einsum instead of Shape Inference. 
Given the results of equation parsing and the input shapes of the Einsum operation, we can easily infer the output shape. As such, we have expanded the rank inference to include shape inference for Einsum.