### PR TITLE
build from source instruction with latest cmake change

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ msbuild INSTALL.vcxproj /p:Configuration=Release
 Then it will be built as a static library and installed to <protobuf_install_dir>. Please add the bin directory(which contains protoc.exe) to your PATH.
 
 ```bat
-set CMAKE_PREFIX_PATH=<protobuf_install_dir>/bin;%CMAKE_PREFIX_PATH%
+set CMAKE_PREFIX_PATH=<protobuf_install_dir>;%CMAKE_PREFIX_PATH%
 ```
 
 Please note: if your protobuf_install_dir contains spaces, **do not** add quotation marks around it.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ msbuild INSTALL.vcxproj /p:Configuration=Release
 Then it will be built as a static library and installed to <protobuf_install_dir>. Please add the bin directory(which contains protoc.exe) to your PATH.
 
 ```bat
-set PATH=<protobuf_install_dir>/bin;%PATH%
+set CMAKE_PREFIX_PATH=<protobuf_install_dir>/bin;%CMAKE_PREFIX_PATH%
 ```
 
 Please note: if your protobuf_install_dir contains spaces, **do not** add quotation marks around it.


### PR DESCRIPTION
### Description
latest cmake requires to set CMAKE_PREFIX_PATH (https://gitlab.kitware.com/cmake/cmake/-/issues/25704)

### Motivation and Context
