### PR TITLE
Not to install cmake in pyproject.toml on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
-requires = ["setuptools>=64", "protobuf>=3.20.2", "cmake"]
+requires = ["setuptools>=64", "protobuf>=3.20.2", 'cmake; os_name != "nt"']
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
### Description
Current fix of https://github.com/onnx/onnx/issues/5194 forces out system installed cmake. It forces to use a cmake installed via pyproject.toml in a python environment. The cmake in python environment fails on Windows - onnx.sln cannot be built with visual studio due to protobuf code generation error.

This PR skip cmake install in pyproject.toml in Windows. It is better only include cmake in pyproject.toml if needed.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
