### PR TITLE
Check graph outputs are defined

### DIFF
--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -709,6 +709,12 @@ void check_graph(const GraphProto& graph, const CheckerContext& ctx, const Lexic
       lex_ctx.add(output);
     }
   }
+  for (const auto& value_info : graph.output()) {
+    if (!lex_ctx.this_graph_has(value_info.name())) {
+      fail_check("Graph output '", value_info.name(), "' is not an output of any node in graph.");
+    }
+  }
+
   print_warning_if_has_experimental(used_experimental_ops);
 }
 

--- a/onnx/test/compose_test.py
+++ b/onnx/test/compose_test.py
@@ -87,7 +87,7 @@ M2_DEF = """
     {
         C0 = Add(B01, B11)
         C1 = Sub(B11, B21)
-        M1 = Mul(C0, C1)
+        D0 = Mul(C0, C1)
     }
     """
 


### PR DESCRIPTION
The current checker does not check that all graph outputs are defined. This PR adds such a check. (See issue https://github.com/onnx/onnx/issues/6040 ).

Note: We probably also want a separate check to ensure that a graph-input is not used as a graph-output. But leaving that for a separate PR, since it is a distinctly different check (and perhaps might require a different discussion).

Redo of PR #6070 