### PR TITLE
Corrected the ReduceSumSqure op to match the reference

### DIFF
--- a/onnx/reference/ops/op_reduce_sum_square.py
+++ b/onnx/reference/ops/op_reduce_sum_square.py
@@ -21,7 +21,7 @@ class ReduceSumSquare_1(OpRunReduceNumpy):
 class ReduceSumSquare_18(OpRunReduceNumpy):
     def _run(self, data, axes=None, keepdims=1, noop_with_empty_axes=0):  # type: ignore
         if self.is_axes_empty(axes) and noop_with_empty_axes != 0:  # type: ignore
-            return (np.square(data),)
+            return (data,)
 
         axes = self.handle_axes(axes)
         keepdims = keepdims != 0  # type: ignore

--- a/onnx/test/reference_evaluator_test.py
+++ b/onnx/test/reference_evaluator_test.py
@@ -738,7 +738,7 @@ class TestReferenceEvaluator(unittest.TestCase):
         x = np.arange(60).reshape((3, 4, 5)).astype(np.float32)
         sess = ReferenceEvaluator(onnx_model)
         got = sess.run(None, {"X": x})[0]
-        assert_allclose(x * x, got)
+        assert_allclose(x, got)
 
     def test_greater(self):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None])


### PR DESCRIPTION
### Description
This PR aligns the op implementation for `ReduceSumSquare18` when `axes` are not specified and `noop_with_empty_axes != 0` with that of the reference.

### Motivation and Context
Current implementation of `ReduceSumSquare18` when axes are empty and `noop_with_empty_axes != 1` squares the input data and then returns it, when according to the reference it should just return the input data with no changes.  

This addresses issue #6103 
