### PR TITLE
fix: install google-re2 with `--only-binary` option

### DIFF
--- a/.github/workflows/manylinux/entrypoint.sh
+++ b/.github/workflows/manylinux/entrypoint.sh
@@ -16,12 +16,12 @@ export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
 # Compile wheels
 # Need to be updated if there is a new Python Version
 if [ "$(uname -m)" == "aarch64" ]; then
- PIP_INSTALL_COMMAND="$PY_VERSION -m pip install --only-binary :all: --no-cache-dir -q"
+ PIP_INSTALL_COMMAND="$PY_VERSION -m pip install --only-binary google-re2 --no-cache-dir -q"
  PYTHON_COMMAND="$PY_VERSION"
 else
  declare -A python_map=( ["3.8"]="cp38-cp38" ["3.9"]="cp39-cp39" ["3.10"]="cp310-cp310" ["3.11"]="cp311-cp311" ["3.12"]="cp312-cp312")
  PY_VER=${python_map[$PY_VERSION]}
- PIP_INSTALL_COMMAND="/opt/python/${PY_VER}/bin/pip install --only-binary :all: --no-cache-dir -q"
+ PIP_INSTALL_COMMAND="/opt/python/${PY_VER}/bin/pip install --only-binary google-re2 --no-cache-dir -q"
  PYTHON_COMMAND="/opt/python/${PY_VER}/bin/python"
 fi
 

--- a/.github/workflows/release_linux_aarch64.yml
+++ b/.github/workflows/release_linux_aarch64.yml
@@ -50,7 +50,7 @@ jobs:
           ${{ env.img }} \
           bash -exc '${{ env.py }} -m pip install -q virtualenv && ${{ env.py }} -m venv .env && \
           source .env/bin/activate && \
-          ${{ env.py }} -m pip install --only-binary :all: -q -r requirements-release.txt && \
+          ${{ env.py }} -m pip install -q --only-binary google-re2 -r requirements-release.txt && \
           yum install -y protobuf-compiler protobuf-devel
           deactivate'
 
@@ -74,7 +74,7 @@ jobs:
           bash -exc '\
           source .env/bin/activate && \
           python -m pip install -q --upgrade pip && \
-          python -m pip install --only-binary :all: -q -r requirements-release.txt && \
+          python -m pip install -q --only-binary google-re2 -r requirements-release.txt && \
           pip install dist/*manylinux2014_aarch64.whl && \
           pytest && \
           deactivate'


### PR DESCRIPTION
### Description

Only install google-re2 from wheels.

### Motivation and Context

The latest version of google-re2 dropped support for manylinux2014.
google-re2 fails to build from sources thus failing the Linux release pipelines.

This PR forces installation from wheels on manylinux which thus fallback on the latest version of google-re2 with a wheel for manylinux2014.
It reverts https://github.com/onnx/onnx/pull/6120 which forced all dependencies to be available as wheels (psutil is not which forbids installing recent versions of jupyter/ipykernel).

Another solution would be to bump the manylinux images to manylinux_2_28 but that could have impact on downstream users (e.g. impossible to install wheel from rh7, amazon linux 2, ubuntu 18.04).
