### PR TITLE
Fixes s390x byteswapping issues

### DIFF
--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -1563,6 +1563,16 @@ def tensor_dtype_to_storage_tensor_dtype(tensor_dtype: int) -> int:
     """
     return mapping.TENSOR_TYPE_MAP[tensor_dtype].storage_dtype
 
+def tensor_dtype_to_storage_np_dtype(tensor_dtype: int) -> int:
+    """Convert a TensorProto's data_type to corresponding data_type for raw storage.
+    
+    Args:
+        tensor_dtype: TensorProto's data_type
+        
+    Returns:
+        numpy's data_type for the raw storage
+    """
+    return mapping.TENSOR_TYPE_MAP[tensor_dtype].storage_np_dtype
 
 def tensor_dtype_to_string(tensor_dtype: int) -> str:
     """Get the name of given TensorProto's data_type.

--- a/onnx/mapping.py
+++ b/onnx/mapping.py
@@ -13,6 +13,7 @@ from onnx import OptionalProto, SequenceProto, TensorProto
 
 class TensorDtypeMap(NamedTuple):
     np_dtype: np.dtype
+    storage_np_dtype: np.dtype
     storage_dtype: int
     name: str
 
@@ -20,73 +21,74 @@ class TensorDtypeMap(NamedTuple):
 # tensor_dtype: (numpy type, storage type, string name)
 TENSOR_TYPE_MAP = {
     int(TensorProto.FLOAT): TensorDtypeMap(
-        np.dtype("float32"), int(TensorProto.FLOAT), "TensorProto.FLOAT"
+        np.dtype("float32"), np.dtype("float32"), int(TensorProto.FLOAT), "TensorProto.FLOAT"
     ),
     int(TensorProto.UINT8): TensorDtypeMap(
-        np.dtype("uint8"), int(TensorProto.INT32), "TensorProto.UINT8"
+        np.dtype("uint8"), np.dtype("uint8"), int(TensorProto.INT32), "TensorProto.UINT8"
     ),
     int(TensorProto.INT8): TensorDtypeMap(
-        np.dtype("int8"), int(TensorProto.INT32), "TensorProto.INT8"
+        np.dtype("int8"), np.dtype("int8"), int(TensorProto.INT32), "TensorProto.INT8"
     ),
     int(TensorProto.UINT16): TensorDtypeMap(
-        np.dtype("uint16"), int(TensorProto.INT32), "TensorProto.UINT16"
+        np.dtype("uint16"), np.dtype("uint16"), int(TensorProto.INT32), "TensorProto.UINT16"
     ),
     int(TensorProto.INT16): TensorDtypeMap(
-        np.dtype("int16"), int(TensorProto.INT32), "TensorProto.INT16"
+        np.dtype("int16"), np.dtype("int16"), int(TensorProto.INT32), "TensorProto.INT16"
     ),
     int(TensorProto.INT32): TensorDtypeMap(
-        np.dtype("int32"), int(TensorProto.INT32), "TensorProto.INT32"
+        np.dtype("int32"), np.dtype("int32"), int(TensorProto.INT32), "TensorProto.INT32"
     ),
     int(TensorProto.INT64): TensorDtypeMap(
-        np.dtype("int64"), int(TensorProto.INT64), "TensorProto.INT64"
+        np.dtype("int64"), np.dtype("int64"), int(TensorProto.INT64), "TensorProto.INT64"
     ),
     int(TensorProto.BOOL): TensorDtypeMap(
-        np.dtype("bool"), int(TensorProto.INT32), "TensorProto.BOOL"
+        np.dtype("bool"), np.dtype("bool"), int(TensorProto.INT32), "TensorProto.BOOL"
     ),
     int(TensorProto.FLOAT16): TensorDtypeMap(
-        np.dtype("float16"), int(TensorProto.UINT16), "TensorProto.FLOAT16"
+        np.dtype("float16"), np.dtype("float16"), int(TensorProto.UINT16), "TensorProto.FLOAT16"
     ),
-    # Native numpy does not support bfloat16 so now use float32.
+    # Native numpy does not support bfloat16 so now use float32. It is saved as a uin16 field.
     int(TensorProto.BFLOAT16): TensorDtypeMap(
-        np.dtype("float32"), int(TensorProto.UINT16), "TensorProto.BFLOAT16"
+        np.dtype("float32"), np.dtype("uint16"), int(TensorProto.UINT16), "TensorProto.BFLOAT16"
     ),
     int(TensorProto.DOUBLE): TensorDtypeMap(
-        np.dtype("float64"), int(TensorProto.DOUBLE), "TensorProto.DOUBLE"
+        np.dtype("float64"), np.dtype("float64"), int(TensorProto.DOUBLE), "TensorProto.DOUBLE"
     ),
     int(TensorProto.COMPLEX64): TensorDtypeMap(
-        np.dtype("complex64"), int(TensorProto.FLOAT), "TensorProto.COMPLEX64"
+        np.dtype("complex64"), np.dtype("complex64"), int(TensorProto.FLOAT), "TensorProto.COMPLEX64"
     ),
     int(TensorProto.COMPLEX128): TensorDtypeMap(
-        np.dtype("complex128"), int(TensorProto.DOUBLE), "TensorProto.COMPLEX128"
+        np.dtype("complex128"), np.dtype("complex128"), int(TensorProto.DOUBLE), "TensorProto.COMPLEX128"
     ),
     int(TensorProto.UINT32): TensorDtypeMap(
-        np.dtype("uint32"), int(TensorProto.UINT32), "TensorProto.UINT32"
+        np.dtype("uint32"), np.dtype("uint32"), int(TensorProto.UINT32), "TensorProto.UINT32"
     ),
     int(TensorProto.UINT64): TensorDtypeMap(
-        np.dtype("uint64"), int(TensorProto.UINT64), "TensorProto.UINT64"
+        np.dtype("uint64"), np.dtype("uint64"), int(TensorProto.UINT64), "TensorProto.UINT64"
     ),
     int(TensorProto.STRING): TensorDtypeMap(
-        np.dtype("object"), int(TensorProto.STRING), "TensorProto.STRING"
+        np.dtype("object"), np.dtype("object"), int(TensorProto.STRING), "TensorProto.STRING"
     ),
     # Native numpy does not support float8 types, so now use float32 for these types.
+    # As raw data, it is viewed as a collection of bytes.
     int(TensorProto.FLOAT8E4M3FN): TensorDtypeMap(
-        np.dtype("float32"), int(TensorProto.UINT8), "TensorProto.FLOAT8E4M3FN"
+        np.dtype("float32"), np.dtype("uint8"), int(TensorProto.UINT8), "TensorProto.FLOAT8E4M3FN"
     ),
     int(TensorProto.FLOAT8E4M3FNUZ): TensorDtypeMap(
-        np.dtype("float32"), int(TensorProto.UINT8), "TensorProto.FLOAT8E4M3FNUZ"
+        np.dtype("float32"), np.dtype("uint8"), int(TensorProto.UINT8), "TensorProto.FLOAT8E4M3FNUZ"
     ),
     int(TensorProto.FLOAT8E5M2): TensorDtypeMap(
-        np.dtype("float32"), int(TensorProto.UINT8), "TensorProto.FLOAT8E5M2"
+        np.dtype("float32"), np.dtype("uint8"), int(TensorProto.UINT8), "TensorProto.FLOAT8E5M2"
     ),
     int(TensorProto.FLOAT8E5M2FNUZ): TensorDtypeMap(
-        np.dtype("float32"), int(TensorProto.UINT8), "TensorProto.FLOAT8E5M2FNUZ"
+        np.dtype("float32"), np.dtype("uint8"), int(TensorProto.UINT8), "TensorProto.FLOAT8E5M2FNUZ"
     ),
     # Native numpy does not support uint4/int4 so now use uint8/int8 for these types.
     int(TensorProto.UINT4): TensorDtypeMap(
-        np.dtype("uint8"), int(TensorProto.INT32), "TensorProto.UINT4"
+        np.dtype("uint8"), np.dtype("uint8"), int(TensorProto.INT32), "TensorProto.UINT4"
     ),
     int(TensorProto.INT4): TensorDtypeMap(
-        np.dtype("int8"), int(TensorProto.INT32), "TensorProto.INT4"
+        np.dtype("int8"), np.dtype("uint8"), int(TensorProto.INT32), "TensorProto.INT4"
     ),
 }
 

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -7,6 +7,7 @@ import itertools
 import math
 import random
 import struct
+import sys
 import unittest
 from typing import Any
 
@@ -29,6 +30,10 @@ from onnx import (
     numpy_helper,
 )
 from onnx.reference.op_run import to_array_extended
+
+
+def convert(data: np.ndarray) -> np.ndarray:
+    return data.byteswap() if sys.byteorder == 'big' else data
 
 
 class TestHelperAttributeFunctions(unittest.TestCase):
@@ -562,7 +567,7 @@ class TestHelperTensorFunctions(unittest.TestCase):
             return x >> 16
 
         values_as_ints = np_array.astype(np.float32).view(np.uint32).flatten()
-        packed_values = truncate(values_as_ints).astype(np.uint16).tobytes()
+        packed_values = convert(truncate(values_as_ints).astype(np.uint16)).tobytes()
         tensor = helper.make_tensor(
             name="test",
             data_type=TensorProto.BFLOAT16,
@@ -951,7 +956,7 @@ def test_make_tensor_raw(tensor_dtype: int) -> None:
         name="test",
         data_type=tensor_dtype,
         dims=np_array.shape,
-        vals=np_array.tobytes(),
+        vals=convert(np_array).tobytes(),
         raw=True,
     )
     np.testing.assert_equal(np_array, numpy_helper.to_array(tensor))

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -7,6 +7,7 @@ import itertools
 import os
 import pathlib
 import tempfile
+import sys
 import unittest
 import uuid
 from typing import Any
@@ -24,6 +25,10 @@ from onnx.external_data_helper import (
     set_external_data,
 )
 from onnx.numpy_helper import from_array, to_array
+
+
+def convert(data: np.ndarray) -> np.ndarray:
+    return data.byteswap() if sys.byteorder == 'big' else data
 
 
 class TestLoadExternalDataBase(unittest.TestCase):
@@ -584,7 +589,7 @@ class TestExternalDataToArray(unittest.TestCase):
             name="X",
             data_type=TensorProto.FLOAT,
             dims=self.large_data.shape,
-            vals=self.large_data.tobytes(),
+            vals=convert(self.large_data).tobytes(),
             raw=True,
         )
 
@@ -593,7 +598,7 @@ class TestExternalDataToArray(unittest.TestCase):
             name="Shape",
             data_type=TensorProto.INT64,
             dims=shape_data.shape,
-            vals=shape_data.tobytes(),
+            vals=convert(shape_data).tobytes(),
             raw=True,
         )
         C = helper.make_tensor_value_info("C", TensorProto.INT64, self.small_data)


### PR DESCRIPTION
### Description
Updates the mapping of the datatypes to also indicate the element size when stored as a raw tensor. This is separate from the storage dtype, which appears to correspond to the type used when the data is an attribute.

This also updates the testcases which use make_tensor with raw=True to perform byteswapping on big endian systems if the datatype is at least 2 bytes.

### Motivation and Context
This fixes the failures identified in issue #6181 as well as a handful of other related s390x specific failures not otherwise identified in the issue. This will be one step closer to a clean testsuite on s390x.
