### PR TITLE
Add alternative approach in ONNX converter section

### DIFF
--- a/docs/docsgen/source/intro/converters.md
+++ b/docs/docsgen/source/intro/converters.md
@@ -64,6 +64,9 @@ on numpy or scipy. The user must implement
 its transformer or predictor with ONNX primitives, whether or
 not it was implemented with numpy.
 
+## Alternatives
+One alternative for implementing ONNX export capability is to leverage standard protocols such as the [Array API standard](https://data-apis.org/array-api/latest/), which standardizes a common set of array operations. It enables code reuse across libraries like NumPy, JAX, PyTorch, CuPy and more. [ndonnx](https://github.com/Quantco/ndonnx) enables execution with an ONNX backend and instant ONNX export for Array API compliant code. This diminishes the need for dedicated converter library code since the same code used to implement most of a library can reused in ONNX conversion. It also provides a convenient primitive for converter authors looking for a NumPy-like experience when constructing ONNX graphs.
+
 ## Opsets
 
 ONNX releases packages with version numbers like


### PR DESCRIPTION
### Description
This adds a short section explaining an alternative approach to dedicated converter libraries for library authors looking to implement ONNX export capability for their library. This approach leverages a standardised protocol (in this case the [Array API standard](https://data-apis.org/array-api/latest/)) and an ONNX based implementation of it (in this case [ndonnx](https://github.com/Quantco/ndonnx)).

### Motivation and Context
This adds some broader context to the different ways libraries may want to explore ONNX export beyond the traditional approach with dedicated converter libraries.
