### PR TITLE
Fix wrong test name (causing test files of previous test with same name to be overwritten)

### DIFF
--- a/onnx/backend/test/case/node/reducesum.py
+++ b/onnx/backend/test/case/node/reducesum.py
@@ -193,7 +193,7 @@ class ReduceSum(Base):
             node,
             inputs=[data, axes],
             outputs=[reduced],
-            name="test_reduce_sum_negative_axes_keepdims_random",
+            name="test_reduce_sum_empty_axes_input_noop",
         )
 
     @staticmethod


### PR DESCRIPTION
### Description

In test `empty_axes_input_noop`, correct the name of the name as passed on to `expect` function

### Motivation and Context

The passed name was previously `test_reduce_sum_negative_axes_keepdims_random`, which clashed with an earlier test with the same name, causing test files to be overwritten
