### PR TITLE
Handle functions in external data helper

### DIFF
--- a/onnx/external_data_helper.py
+++ b/onnx/external_data_helper.py
@@ -228,7 +228,7 @@ def _recursive_attribute_processor(
 
 
 def _get_initializer_tensors_from_graph(
-    graph_or_function: GraphProto | FunctionProto,
+    graph_or_function: GraphProto | FunctionProto, /
 ) -> Iterable[TensorProto]:
     """Create an iterator of initializer tensors from ONNX model graph/function."""
     if isinstance(graph_or_function, GraphProto):

--- a/onnx/external_data_helper.py
+++ b/onnx/external_data_helper.py
@@ -248,7 +248,7 @@ def _get_initializer_tensors(onnx_model_proto: ModelProto) -> Iterable[TensorPro
 
 
 def _get_attribute_tensors_from_graph(
-    graph_or_function: GraphProto | FunctionProto,
+    graph_or_function: GraphProto | FunctionProto, /
 ) -> Iterable[TensorProto]:
     """Create an iterator of tensors from node attributes of an ONNX model graph/function."""
     for node in graph_or_function.node:

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -9,13 +9,13 @@ import pathlib
 import tempfile
 import unittest
 import uuid
-from typing import Any
+from typing import Any, Sequence
 
 import numpy as np
 import parameterized
 
 import onnx
-from onnx import ModelProto, TensorProto, checker, helper, shape_inference
+from onnx import ModelProto, NodeProto, TensorProto, checker, helper, parser, shape_inference
 from onnx.external_data_helper import (
     convert_model_from_external_data,
     convert_model_to_external_data,
@@ -792,6 +792,76 @@ class TestExternalDataToArrayWithPath(TestExternalDataToArray):
     @property
     def model_file_path(self) -> pathlib.Path:
         return pathlib.Path(self._model_file_path)
+
+
+class TestFunctionsAndSubGraphs(unittest.TestCase):
+    def setUp(self) -> None:
+        self._temp_dir_obj = tempfile.TemporaryDirectory()
+        temp_dir = self._temp_dir_obj.name
+        self._model_file_path: str = os.path.join(temp_dir, "model.onnx")
+        array = np.arange(4096).astype(np.float32)
+        self._tensor = from_array(array, "tensor")
+
+    def tearDown(self) -> None:
+        self._temp_dir_obj.cleanup()
+
+    def _check_is_internal(self, tensor: TensorProto) -> None:
+        self.assertEqual(tensor.data_location, TensorProto.DEFAULT)
+
+    def _check_is_external(self, tensor: TensorProto) -> None:
+        self.assertEqual(tensor.data_location, TensorProto.EXTERNAL)
+
+    def _check (self, model: ModelProto, nodes: Sequence[NodeProto]) -> None:
+        for node in nodes:
+            self.assertEqual(node.op_type, "Constant")
+            tensor = node.attribute[0].t
+            tensor.CopyFrom(self._tensor)
+            self._check_is_internal(tensor)
+
+        convert_model_to_external_data(model, size_threshold=0, convert_attribute=True)
+
+        for node in nodes:
+            tensor = node.attribute[0].t
+            self._check_is_external(tensor)
+
+    
+    @unittest.skip("This test is not working")
+    def test_function(self) -> None:
+        model_text = """
+           <ir_version: 7,  opset_import: ["": 15, "local": 1]>
+           agraph (float[N] X) => (float[N] Y)
+            {
+              Y = local.add(X)
+            }
+            add (float[N] X) => (float[N] Y) {
+              C = Constant <value = float[1] {1.0}> ()
+              Y = Add (X, C)
+           }
+        """
+        model = parser.parse_model(model_text)
+        self._check(model, [model.functions[0].node[0]])
+
+    def test_subgraph(self) -> None:
+        model_text = """
+           <ir_version: 7,  opset_import: ["": 15, "local": 1]>
+           agraph (bool flag, float[N] X) => (float[N] Y)
+            {
+              Y = if (flag) <
+                then_branch = g1 () => (float[N] Y_then) {
+                    B = Constant <value = float[1] {0.0}> ()
+                    Y_then = Add (X, C)
+                },
+                else_branch = g2 () => (float[N] Y_else) {
+                    C = Constant <value = float[1] {1.0}> ()
+                    Y_else = Add (X, C)
+                }
+              >
+            }
+        """
+        model = parser.parse_model(model_text)
+        if_node = model.graph.node[0]
+        constant_nodes = [attr.g.node[0] for attr in if_node.attribute]
+        self._check(model, constant_nodes)
 
 
 if __name__ == "__main__":

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -15,7 +15,15 @@ import numpy as np
 import parameterized
 
 import onnx
-from onnx import ModelProto, NodeProto, TensorProto, checker, helper, parser, shape_inference
+from onnx import (
+    ModelProto,
+    NodeProto,
+    TensorProto,
+    checker,
+    helper,
+    parser,
+    shape_inference,
+)
 from onnx.external_data_helper import (
     convert_model_from_external_data,
     convert_model_to_external_data,
@@ -811,7 +819,18 @@ class TestFunctionsAndSubGraphs(unittest.TestCase):
     def _check_is_external(self, tensor: TensorProto) -> None:
         self.assertEqual(tensor.data_location, TensorProto.EXTERNAL)
 
-    def _check (self, model: ModelProto, nodes: Sequence[NodeProto]) -> None:
+    def _check(self, model: ModelProto, nodes: Sequence[NodeProto]) -> None:
+        """Check that the tensors in the model are externalized.
+
+        The tensors in the specified sequence of Constant nodes are set to self._tensor,
+        an internal tensor. The model is then converted to external data format.
+        The tensors are then checked to ensure that they are externalized.
+
+        Arguments:
+            model: The model to check.
+            nodes: A sequence of Constant nodes.
+
+        """
         for node in nodes:
             self.assertEqual(node.op_type, "Constant")
             tensor = node.attribute[0].t
@@ -824,8 +843,6 @@ class TestFunctionsAndSubGraphs(unittest.TestCase):
             tensor = node.attribute[0].t
             self._check_is_external(tensor)
 
-    
-    @unittest.skip("This test is not working")
     def test_function(self) -> None:
         model_text = """
            <ir_version: 7,  opset_import: ["": 15, "local": 1]>
@@ -833,6 +850,8 @@ class TestFunctionsAndSubGraphs(unittest.TestCase):
             {
               Y = local.add(X)
             }
+
+            <opset_import: ["" : 15],  domain: "local">
             add (float[N] X) => (float[N] Y) {
               C = Constant <value = float[1] {1.0}> ()
               Y = Add (X, C)


### PR DESCRIPTION
The `external_data_helper.py` utilities do not handle model-local functions. Extend them to handle model-local functions. Add a test-case to validate.
