### PR TITLE
Add the missing python api docs

### DIFF
--- a/docs/docsgen/source/api/external_data_helper.md
+++ b/docs/docsgen/source/api/external_data_helper.md
@@ -48,6 +48,12 @@
 .. autofunction:: onnx.external_data_helper.set_external_data
 ```
 
+## uses_external_data
+
+```{eval-rst}
+.. autofunction:: onnx.external_data_helper.uses_external_data
+```
+
 ## write_external_data_tensors
 
 ```{eval-rst}

--- a/docs/docsgen/source/api/helper.md
+++ b/docs/docsgen/source/api/helper.md
@@ -12,18 +12,24 @@
     find_min_ir_version_for
     get_all_tensor_dtypes
     get_attribute_value
+    get_node_attr_value
+    set_metadata_props
+    set_model_props
     float32_to_bfloat16
     float32_to_float8e4m3
     float32_to_float8e5m2
     make_attribute
+    make_attribute_ref
     make_empty_tensor_value_info
     make_function
     make_graph
     make_map
+    make_map_type_proto
     make_model
     make_node
     make_operatorsetid
     make_opsetid
+    make_model_gen_version
     make_optional
     make_optional_type_proto
     make_sequence
@@ -46,6 +52,9 @@
     printable_type
     printable_value_info
     split_complex_to_pairs
+    create_op_set_id_version_map
+    strip_doc_string
+    pack_float32_to_4bit
     tensor_dtype_to_np_dtype
     tensor_dtype_to_storage_tensor_dtype
     tensor_dtype_to_string
@@ -56,6 +65,20 @@
 
 ```{eval-rst}
 .. autofunction:: onnx.helper.get_attribute_value
+```
+
+```{eval-rst}
+.. autofunction:: onnx.helper.get_node_attr_value
+```
+
+## setter
+
+```{eval-rst}
+.. autofunction:: onnx.helper.set_metadata_props
+```
+
+```{eval-rst}
+.. autofunction:: onnx.helper.set_model_props
 ```
 
 ## print
@@ -98,6 +121,18 @@
 .. autofunction:: onnx.helper.split_complex_to_pairs
 ```
 
+```{eval-rst}
+.. autofunction:: onnx.helper.create_op_set_id_version_map
+```
+
+```{eval-rst}
+.. autofunction:: onnx.helper.strip_doc_string
+```
+
+```{eval-rst}
+.. autofunction:: onnx.helper.pack_float32_to_4bit
+```
+
 (l-onnx-make-function)=
 
 ## make function
@@ -106,6 +141,10 @@ All functions uses to create an ONNX graph.
 
 ```{eval-rst}
 .. autofunction:: onnx.helper.make_attribute
+```
+
+```{eval-rst}
+.. autofunction:: onnx.helper.make_attribute_ref
 ```
 
 ```{eval-rst}
@@ -125,6 +164,10 @@ All functions uses to create an ONNX graph.
 ```
 
 ```{eval-rst}
+.. autofunction:: onnx.helper.make_map_type_proto
+```
+
+```{eval-rst}
 .. autofunction:: onnx.helper.make_model
 ```
 
@@ -141,7 +184,11 @@ All functions uses to create an ONNX graph.
 ```
 
 ```{eval-rst}
-.. autofunction:: onnx.helper.make_optional
+.. autofunction:: onnx.helper.make_model_gen_version
+```
+
+```{eval-rst}
+.. autofunction:: onnx.helper.make_optionalmake_optional
 ```
 
 ```{eval-rst}
@@ -190,42 +237,6 @@ All functions uses to create an ONNX graph.
 
 ```{eval-rst}
 .. autofunction:: onnx.helper.make_value_info
-```
-
-## getter
-
-```{eval-rst}
-.. autofunction:: onnx.helper.get_attribute_value
-```
-
-## print
-
-```{eval-rst}
-.. autofunction:: onnx.helper.printable_attribute
-```
-
-```{eval-rst}
-.. autofunction:: onnx.helper.printable_dim
-```
-
-```{eval-rst}
-.. autofunction:: onnx.helper.printable_graph
-```
-
-```{eval-rst}
-.. autofunction:: onnx.helper.printable_node
-```
-
-```{eval-rst}
-.. autofunction:: onnx.helper.printable_tensor_proto
-```
-
-```{eval-rst}
-.. autofunction:: onnx.helper.printable_type
-```
-
-```{eval-rst}
-.. autofunction:: onnx.helper.printable_value_info
 ```
 
 ## type mappings

--- a/docs/docsgen/source/api/helper.md
+++ b/docs/docsgen/source/api/helper.md
@@ -188,7 +188,7 @@ All functions uses to create an ONNX graph.
 ```
 
 ```{eval-rst}
-.. autofunction:: onnx.helper.make_optionalmake_optional
+.. autofunction:: onnx.helper.make_optional
 ```
 
 ```{eval-rst}

--- a/docs/docsgen/source/api/hub.md
+++ b/docs/docsgen/source/api/hub.md
@@ -36,3 +36,15 @@
 ```{eval-rst}
 .. autofunction:: onnx.hub.load_composite_model
 ```
+
+## set_dir
+
+```{eval-rst}
+.. autofunction:: onnx.hub.set_dir
+```
+
+## get_dir
+
+```{eval-rst}
+.. autofunction:: onnx.hub.get_dir
+```

--- a/docs/docsgen/source/api/numpy_helper.md
+++ b/docs/docsgen/source/api/numpy_helper.md
@@ -17,7 +17,7 @@
     to_array
     to_dict
     to_list
-    to_optionalto_optional
+    to_optional
 
 ```
 

--- a/docs/docsgen/source/api/numpy_helper.md
+++ b/docs/docsgen/source/api/numpy_helper.md
@@ -17,7 +17,7 @@
     to_array
     to_dict
     to_list
-    to_optional
+    to_optionalto_optional
 
 ```
 
@@ -78,6 +78,10 @@ these two functions use a custom dtype defined in :mod:`onnx._custom_element_typ
 
 ```{eval-rst}
 .. autofunction:: onnx.numpy_helper.create_random_int
+```
+
+```{eval-rst}
+.. autofunction:: onnx.numpy_helper.unpack_int4
 ```
 
 ## cast

--- a/docs/docsgen/source/api/parser.md
+++ b/docs/docsgen/source/api/parser.md
@@ -1,5 +1,11 @@
 # onnx.parser
 
+## parse_node
+
+```{eval-rst}
+.. autofunction:: onnx.parser.parse_node
+```
+
 ## parse_function
 
 ```{eval-rst}

--- a/docs/docsgen/source/api/reference.md
+++ b/docs/docsgen/source/api/reference.md
@@ -9,7 +9,7 @@
     :members:
 ```
 
-## Inference
+## ReferenceEvaluator
 
 ```{eval-rst}
 .. autoclass:: onnx.reference.ReferenceEvaluator

--- a/docs/docsgen/source/api/shape_inference.md
+++ b/docs/docsgen/source/api/shape_inference.md
@@ -12,6 +12,12 @@
 .. autofunction:: onnx.shape_inference.infer_shapes_path
 ```
 
+## infer_node_outputs
+
+```{eval-rst}
+.. autofunction:: onnx.shape_inference.infer_node_outputs
+```
+
 ## infer_function_output_types
 
 ```{eval-rst}


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->

Add the  missing python api docs:
- docs/docsgen/source/api/external_data_helper.md
  - uses_external_data
- docs/docsgen/source/api/helper.md
  - get_node_attr_value
  - set_metadata_props
  - set_model_props
  - make_attribute_ref
  - make_map_type_proto
  - make_model_gen_version
  - create_op_set_id_version_map
  - strip_doc_string
  - pack_float32_to_4bit
- docs/docsgen/source/api/hub.md
  - set_dir
  - get_dir
 - docs/docsgen/source/api/numpy_helper.md
   - unpack_int4
- docs/docsgen/source/api/parser.md
  - parse_node
- docs/docsgen/source/api/shape_inference.md
  - infer_node_outputs

It also fixes the repeated docs in `docs/docsgen/source/api/helper.md`.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
I was looking through the onnx python API documentation and noticed that there were some Python interfaces missing from the list, so I added them in.
