### PR TITLE
ExternalData - On Windows document proper offset for memory mapping support

### DIFF
--- a/docs/ExternalData.md
+++ b/docs/ExternalData.md
@@ -85,7 +85,7 @@ There are two fields related to the external data in TensorProto message type.
 Recognized keys are:
 
 * `"location"` (required) - file path relative to the filesystem directory where the ONNX protobuf model was stored. Up-directory path components such as .. are disallowed and should be stripped when parsing.
-* `"offset"` (optional) - position of byte at which stored data begins. Integer stored as string. Offset values SHOULD be multiples 4096 (page size) to enable mmap support.
+* `"offset"` (optional) - position of byte at which stored data begins. Integer stored as string. Offset values SHOULD be multiples of the page size (usually 4kb) to enable mmap support. On Windows, offset values SHOULD be multiples of the VirtualAlloc [allocation granularity](https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info) (usually 64kb) to enable [memory mapping](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-mapviewoffile).
 * `"length"` (optional) - number of bytes containing data. Integer stored as string.
 * `"checksum"` (optional) - SHA1 digest of file specified in under 'location' key.
 


### PR DESCRIPTION
### Description
On Windows, it is incorrect to say that offset needs to be multiple of page size. Instead offset needs to be multiple of VirtualAlloc allocation granularity.

You can see an error returned in ORT code if this is not the case https://github.com/microsoft/onnxruntime/blob/4e75605eec985e579ee1e8db9a2bb2fd441a4837/onnxruntime/core/platform/windows/env.cc#L453

### Motivation and Context
We debugged an issue with ORT team where memory mapping was not working. Even when aligned to page_size, on Windows, memory mapping did not work until aligned to 64kb.
See [MapViewOfFile](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-mapviewoffile)

Related: #6226 