### PR TITLE
Handle the optional input in infer_node_outputs

### DIFF
--- a/onnx/shape_inference.py
+++ b/onnx/shape_inference.py
@@ -118,7 +118,7 @@ def infer_node_outputs(
 
     # catch KeyError if node's input does not exist in input_types
     passed_input_types = {
-        key: input_types[key].SerializeToString() for key in node.input
+        key: input_types[key].SerializeToString() for key in node.input if key != ""
     }
     # input_types will also be used as outer_scope_value_types so do not filter by node's input here
     for key in input_types:


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Fix https://github.com/onnx/onnx/issues/6249

This PR handle the optional input in `onnx.shape_inference.infer_node_outputs` via skip the optional input type. The following modification are introduced:
- `onnx/shape_inference.py` Skip the input type if the input name is "".
- `onnx/test/inference_function_test.py` Add a unit test case of optioal input for `infer_node_outputs`

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->

See https://github.com/onnx/onnx/issues/6249 for more detail.
