### PR TITLE
Update broken URLs

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -3857,7 +3857,7 @@ This version of the operator has been available since version 1 of the default O
 ### <a name="Slice-1"></a>**Slice-1**</a>
 
   Produces a slice of the input tensor along multiple axes. Similar to numpy:
-  https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html
+  https://numpy.org/doc/stable/reference/routines.indexing.html
   Slices uses `axes`, `starts` and `ends` attributes to specify the start and end
   dimension for each axis in the list of axes, it uses this information to
   slice the input `data` tensor. If a negative value is passed for any of the
@@ -10083,7 +10083,7 @@ This version of the operator has been available since version 10 of the default 
 ### <a name="Slice-10"></a>**Slice-10**</a>
 
   Produces a slice of the input tensor along multiple axes. Similar to numpy:
-  https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html
+  https://numpy.org/doc/stable/reference/routines.indexing.html
   Slices uses `starts`, `ends`, `axes` and `steps` inputs to specify the start and end
   dimension and step for each axis in the list of axes, it uses this information to
   slice the input `data` tensor. If a negative value is passed for any of the
@@ -13415,7 +13415,7 @@ This version of the operator has been available since version 11 of the default 
 ### <a name="Slice-11"></a>**Slice-11**</a>
 
   Produces a slice of the input tensor along multiple axes. Similar to numpy:
-  https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html
+  https://numpy.org/doc/stable/reference/routines.indexing.html
   Slices uses `starts`, `ends`, `axes` and `steps` inputs to specify the start and end
   dimension and step for each axis in the list of axes, it uses this information to
   slice the input `data` tensor. If a negative value is passed for any of the
@@ -28712,4 +28712,3 @@ This version of the operator has been available since version 1 of the 'ai.onnx.
 <dt><tt>T3</tt> : tensor(float), tensor(double)</dt>
 <dd>Constrain input types to float tensors.</dd>
 </dl>
-

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -28712,3 +28712,4 @@ This version of the operator has been available since version 1 of the 'ai.onnx.
 <dt><tt>T3</tt> : tensor(float), tensor(double)</dt>
 <dd>Constrain input types to float tensors.</dd>
 </dl>
+

--- a/onnx/defs/tensor/old.cc
+++ b/onnx/defs/tensor/old.cc
@@ -1479,7 +1479,7 @@ ONNX_OPERATOR_SET_SCHEMA(
 
 static const char* Slice_ver11_doc = R"DOC(
 Produces a slice of the input tensor along multiple axes. Similar to numpy:
-https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html
+https://numpy.org/doc/stable/reference/routines.indexing.html
 Slices uses `starts`, `ends`, `axes` and `steps` inputs to specify the start and end
 dimension and step for each axis in the list of axes, it uses this information to
 slice the input `data` tensor. If a negative value is passed for any of the
@@ -4542,7 +4542,7 @@ ONNX_OPERATOR_SET_SCHEMA(
 
 static const char* Slice_ver1_doc = R"DOC(
 Produces a slice of the input tensor along multiple axes. Similar to numpy:
-https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html
+https://numpy.org/doc/stable/reference/routines.indexing.html
 Slices uses `axes`, `starts` and `ends` attributes to specify the start and end
 dimension for each axis in the list of axes, it uses this information to
 slice the input `data` tensor. If a negative value is passed for any of the
@@ -4658,7 +4658,7 @@ ONNX_OPERATOR_SET_SCHEMA(
 
 static const char* Slice_ver10_doc = R"DOC(
 Produces a slice of the input tensor along multiple axes. Similar to numpy:
-https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html
+https://numpy.org/doc/stable/reference/routines.indexing.html
 Slices uses `starts`, `ends`, `axes` and `steps` inputs to specify the start and end
 dimension and step for each axis in the list of axes, it uses this information to
 slice the input `data` tensor. If a negative value is passed for any of the

--- a/onnx/tools/net_drawer.py
+++ b/onnx/tools/net_drawer.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # A library and utility for drawing ONNX nets. Most of this implementation has
 # been borrowed from the caffe2 implementation
-# https://github.com/pytorch/pytorch/blob/master/caffe2/python/net_drawer.py
+# https://github.com/pytorch/pytorch/blob/v2.3.1/caffe2/python/net_drawer.py
 #
 # The script takes two required arguments:
 #   -input: a path to a serialized ModelProto .pb file.


### PR DESCRIPTION
### Description
Fix some broken URLs that failed test when I tried to create rel-1.16.2 branch.

### Motivation and Context
* https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html
    * Automatically redirects to https://numpy.org/doc/stable/reference/arrays.indexing.html which now 404's
    * Based on web.archive.org search, https://numpy.org/doc/stable/reference/routines.indexing.html has the same information as the old URL so updating to use that link instead.
* https://github.com/pytorch/pytorch/blob/master/caffe2/python/net_drawer.py
    * Automatically redirects to main, but that file no longer exists in that branch. The last tag with the file was https://github.com/pytorch/pytorch/blob/v2.3.1/caffe2/python/net_drawer.py. 
    * Based on the v2.3.1 version, I tried searching for a couple of the method names but got no hits. So I think the file was deleted rather than renamed. Updated the URL in the comment to the last version available. 