### PR TITLE
Limit numpy version to <2 in tests to pass ci-piplines for 1.16.2

### DIFF
--- a/.github/workflows/release_linux_aarch64.yml
+++ b/.github/workflows/release_linux_aarch64.yml
@@ -90,14 +90,14 @@ jobs:
         python -m pip install -q twine
         twine upload --verbose dist/*.whl --repository-url https://upload.pypi.org/legacy/ -u ${{ secrets.ONNXWEEKLY_USERNAME }} -p ${{ secrets.ONNXWEEKLY_TOKEN }}
 
-    - name: Verify ONNX with the latest numpy and protobuf
+    - name: Verify ONNX with the latest numpy (below version 2) and protobuf
       if: ${{ always() }}
       run: |
          docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
           ${{ env.img }} \
           bash -exc '\
           source .env/bin/activate && \
-          python -m pip uninstall -y numpy onnx protobuf && python -m pip install numpy protobuf && \
+          python -m pip uninstall -y numpy onnx protobuf && python -m pip install "numpy<2" protobuf && \
           python -m pip install dist/*manylinux2014_aarch64.whl && \
           pytest && \
           deactivate'

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -72,10 +72,10 @@ jobs:
         twine upload --verbose dist/*.whl --repository-url https://upload.pypi.org/legacy/ -u ${{ secrets.ONNXWEEKLY_USERNAME }} -p ${{ secrets.ONNXWEEKLY_TOKEN }}
         TEST_HUB=1 pytest
 
-    - name: Verify ONNX with the latest numpy
+    - name: Verify ONNX with the latest numpy (below version 2)
       if: ${{ always() }}
       run: |
-        python -m pip uninstall -y numpy onnx && python -m pip install numpy
+        python -m pip uninstall -y numpy onnx && python -m pip install "numpy<2"
         python -m pip install dist/*manylinux2014_x86_64.whl
         pytest
 

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -104,11 +104,11 @@ jobs:
       run: |
         twine upload --verbose dist/*.whl --repository-url https://upload.pypi.org/legacy/ -u ${{ secrets.ONNXWEEKLY_USERNAME }} -p ${{ secrets.ONNXWEEKLY_TOKEN }}
 
-    - name: Verify ONNX with the latest numpy
+    - name: Verify ONNX with the latest numpy (below version 2)
       if: ${{ always() }}
       run: |
         arch -${{ matrix.target-architecture }} python -m pip uninstall -y numpy onnx
-        arch -${{ matrix.target-architecture }} python -m pip install numpy
+        arch -${{ matrix.target-architecture }} python -m pip install "numpy<2"
         arch -${{ matrix.target-architecture }}  python -m pip install --upgrade dist/*.whl
         arch -${{ matrix.target-architecture }} pytest
 

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -96,11 +96,11 @@ jobs:
       run: |
         twine upload --verbose onnx/dist/*.whl --repository-url https://upload.pypi.org/legacy/ -u ${{ secrets.ONNXWEEKLY_USERNAME }} -p ${{ secrets.ONNXWEEKLY_TOKEN }}
 
-    - name: Verify ONNX with the latest numpy
+    - name: Verify ONNX with the latest numpy (below version 2)
       if: ${{ always() }}
       run: |
         cd onnx
-        python -m pip uninstall -y numpy onnx && python -m pip install numpy
+        python -m pip uninstall -y numpy onnx && python -m pip install "numpy<2"
         Get-ChildItem -Path dist/*.whl | foreach {python -m pip install --upgrade $_.fullname}
         pytest
 

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,7 +1,7 @@
 # Minimum package versions that ONNX supports
 protobuf==3.20.2; python_version<"3.12"
 protobuf==4.25.1; python_version>="3.12"
-numpy==1.20.3; python_version<"3.10"
+numpy==1.21.0; python_version<"3.10"
 numpy==1.23.2; python_version=="3.10"
 numpy==1.23.2; python_version=="3.11"
 numpy==1.26.0; python_version>="3.12"

--- a/requirements-reference.txt
+++ b/requirements-reference.txt
@@ -1,2 +1,2 @@
 google-re2
-Pillow
+pillow


### PR DESCRIPTION
### Description
Limit numpy version to <2 in tests to pass ci-piplines for 1.16.2. 

The change in requirements-min.txt is also needed to get the CI's to pass. There's an issue with the https://github.com/python-pillow/Pillow/pull/8187. We did try downgrading the version of pillow but that then failed to build for some reason. 

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
