### PR TITLE
Do not check hasShape(*input_type) in getInputShape

### DIFF
--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -340,9 +340,8 @@ inline const TensorShapeProto& getInputShape(const InferenceContext& ctx, size_t
   if (value_case != TypeProto::kTensorType && value_case != TypeProto::kSparseTensorType) {
     fail_type_inference("Input ", n, "expected to be a tensor or a sparse tensor type in ", ctx.getDisplayName(), ".");
   }
-  if (!hasShape(*input_type)) {
-    fail_shape_inference("Input ", n, " must have a non null shape in ", ctx.getDisplayName(), ".");
-  }
+
+  // do not check hasShape(*input_type) here, as scalar input is valid and it will return a default empty TensorShapeProto
   if (value_case == TypeProto::kTensorType) {
     return input_type->tensor_type().shape();
   } else {

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -341,7 +341,8 @@ inline const TensorShapeProto& getInputShape(const InferenceContext& ctx, size_t
     fail_type_inference("Input ", n, "expected to be a tensor or a sparse tensor type in ", ctx.getDisplayName(), ".");
   }
 
-  // do not check hasShape(*input_type) here, as scalar input is valid and it will return a default empty TensorShapeProto
+  // do not check hasShape(*input_type) here, as scalar input is valid and it will return a default empty
+  // TensorShapeProto
   if (value_case == TypeProto::kTensorType) {
     return input_type->tensor_type().shape();
   } else {


### PR DESCRIPTION
### Description
do not check hasShape(*input_type) in getInputShape. This is to work with input as a scalar cases.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
