### PR TITLE
Prepare for rel-1.17.0

### DIFF
--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -190,6 +190,7 @@ ONNX version|IR version|Opset version ai.onnx|Opset version ai.onnx.ml|Opset ver
 1.14.1|9|19|3|1
 1.15.0|9|20|4|1
 1.16.0|10|21|5|1
+1.17.0|10|22|6|1
 
 A programmatically accessible version of the above table is available [here](../onnx/helper.py). Limited version number
 information is also maintained in [version.h](../onnx/common/version.h) and [schema.h](../onnx/defs/schema.h).

--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -190,7 +190,7 @@ ONNX version|IR version|Opset version ai.onnx|Opset version ai.onnx.ml|Opset ver
 1.14.1|9|19|3|1
 1.15.0|9|20|4|1
 1.16.0|10|21|5|1
-1.17.0|10|22|6|1
+1.17.0|10|22|5|1
 
 A programmatically accessible version of the above table is available [here](../onnx/helper.py). Limited version number
 information is also maintained in [version.h](../onnx/common/version.h) and [schema.h](../onnx/defs/schema.h).

--- a/onnx/common/version.h
+++ b/onnx/common/version.h
@@ -9,6 +9,6 @@
 namespace ONNX_NAMESPACE {
 
 // Represents the most recent release version. Updated with every release.
-constexpr const char* LAST_RELEASE_VERSION = "1.16.2";
+constexpr const char* LAST_RELEASE_VERSION = "1.17.0";
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -1220,7 +1220,7 @@ class OpSchemaRegistry final : public ISchemaRegistry {
       // the max version above in a *release* version of ONNX. But in other
       // versions, the max version may be ahead of the last-release-version.
       last_release_version_map_[ONNX_DOMAIN] = 22;
-      last_release_version_map_[AI_ONNX_ML_DOMAIN] = 6;
+      last_release_version_map_[AI_ONNX_ML_DOMAIN] = 5;
       last_release_version_map_[AI_ONNX_TRAINING_DOMAIN] = 1;
       last_release_version_map_[AI_ONNX_PREVIEW_TRAINING_DOMAIN] = 1;
     }

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -1210,7 +1210,7 @@ class OpSchemaRegistry final : public ISchemaRegistry {
       // operator schema on specific domain. Update the lowest version when it's
       // determined to remove too old version history.
       map_[ONNX_DOMAIN] = std::make_pair(1, 22);
-      map_[AI_ONNX_ML_DOMAIN] = std::make_pair(1, 6);
+      map_[AI_ONNX_ML_DOMAIN] = std::make_pair(1, 5);
       map_[AI_ONNX_TRAINING_DOMAIN] = std::make_pair(1, 1);
       // ONNX's preview domain contains operators subject to change, so
       // versining is not meaningful and that domain should have only one

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -77,7 +77,7 @@ VERSION_TABLE: VersionTableType = [
     ("1.14.1", 9, 19, 3, 1),
     ("1.15.0", 9, 20, 4, 1),
     ("1.16.0", 10, 21, 5, 1),
-    ("1.17.0", 10, 22, 6, 1),
+    ("1.17.0", 10, 22, 5, 1),
 ]
 
 VersionMapType = Dict[Tuple[str, int], int]

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -410,12 +410,14 @@ class TestHelperNodeFunctions(unittest.TestCase):
         test([("", 19)], 9)
         test([("", 20)], 9)
         test([("", 21)], 10)
+        test([("", 22)], 10)
         # standard opset can be referred to using empty-string or "ai.onnx"
         test([("ai.onnx", 9)], 4)
         test([("ai.onnx.ml", 2)], 6)
         test([("ai.onnx.ml", 3)], 8)
         test([("ai.onnx.ml", 4)], 9)
         test([("ai.onnx.ml", 5)], 10)
+        test([("ai.onnx.ml", 6)], 10)
         test([("ai.onnx.training", 1)], 7)
         # helper should pick *max* IR version required from all opsets specified.
         test([("", 10), ("ai.onnx.ml", 2)], 6)

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -417,7 +417,6 @@ class TestHelperNodeFunctions(unittest.TestCase):
         test([("ai.onnx.ml", 3)], 8)
         test([("ai.onnx.ml", 4)], 9)
         test([("ai.onnx.ml", 5)], 10)
-        test([("ai.onnx.ml", 6)], 10)
         test([("ai.onnx.training", 1)], 7)
         # helper should pick *max* IR version required from all opsets specified.
         test([("", 10), ("ai.onnx.ml", 2)], 6)


### PR DESCRIPTION
### Description
Prepare for rel-1.17.0 branch cut (planned for 08/06 [https://github.com/onnx/onnx/wiki/Logistics-for-ONNX-Release-1.17.0](https://github.com/onnx/onnx/wiki/Logistics-for-ONNX-Release-1.17.0))

### Motivation and Context
ONNX 1.17.0 is planned to be released on 08/20
