### PR TITLE
Improve 'unpack_int4' speed

### DIFF
--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -205,10 +205,7 @@ def unpack_int4(
     Returns:
         A numpy array of float32 reshaped to dims.
     """
-    single_func = lambda x: subbyte.unpack_single_4bitx2(x, signed)  # noqa: E731
-    func = np.frompyfunc(single_func, 1, 2)
-
-    res_high, res_low = func(data.ravel())
+    res_high, res_low = subbyte.unpack_single_4bitx2(data.ravel(), signed)
     res = np.empty((res_high.size + res_low.size,), dtype=np.float32)
     res[0::2] = res_high
     res[1::2] = res_low


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Improve the performance of `unpack_int4` by avoiding the use of `np.frompyfunc`

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Fix the issue: https://github.com/onnx/onnx/issues/6292