### PR TITLE
Fix missing secrets for publishing of onnxweekly 

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -26,6 +26,7 @@ jobs:
     uses: ./.github/workflows/release_linux_x86_64.yml
     with:            
       os: "linux_x86_64" 
+    secrets: inherit
 
   call-workflow-ubuntu_aarch64:    
     strategy:
@@ -34,6 +35,7 @@ jobs:
     uses: ./.github/workflows/release_linux_aarch64.yml
     with:            
       os: "linux_aarch64"      
+    secrets: inherit
 
   call-workflow-win:    
     strategy:
@@ -41,7 +43,8 @@ jobs:
         os: ['windows-latest']    
     uses: ./.github/workflows/release_win.yml
     with:      
-      os: "win"      
+      os: "win"
+    secrets: inherit
 
   call-workflow-mac:    
     strategy:
@@ -49,7 +52,8 @@ jobs:
         os: ['mac-latest']    
     uses: ./.github/workflows/release_mac.yml
     with:            
-      os: "macos"   
+      os: "macos"
+    secrets: inherit
 
 
 
@@ -70,7 +74,7 @@ jobs:
 
     steps:
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           pattern: wheels* 
           path: dist


### PR DESCRIPTION
### Description
After the release-pipeline upgrade (https://github.com/onnx/onnx/pull/6277)
the publishing the weekly does not work any more as the secrets are not available at the resuable workflows (
https://github.com/onnx/onnx/actions/runs/10551283959/job/29228497156 )

Link for the option I used for the secrets:
https://github.blog/changelog/2022-05-03-github-actions-simplify-using-secrets-with-reusable-workflows

### Motivation and Context

In my opinion, we no longer need these secrets at the end. 

In the future, the publishing of the Onnx weekly builds will be solved via “trusted publishing” outside the individual OS release pipelines. This is already included in create_release.yml. Currently, the previous weeklys are published at pypi.org, in the test via trusted publishing at test.pypi.org

After a successful schedule test (next Monday), we could adjust the publishing. a) e.g. throw out the upload steps with twine and adjust the target of separate steps... b) or leave it as it is for now...
