### PR TITLE
Extend printer and parser to support invalid identifiers

### DIFF
--- a/docs/Syntax.md
+++ b/docs/Syntax.md
@@ -49,29 +49,31 @@ The grammar below describes the syntax:
 
 ```
    id-list ::= id (',' id)*
+   quotable-id-list ::= quotable-id (',' quotable-id)*
    tensor-dim ::= '?' | id | int-constant
    tensor-dims ::= tensor-dim (',' tensor-dim)*
    tensor-type ::= prim-type | prim-type '[' ']' | prim-type '[' tensor-dims ']'
    type ::= tensor-type | 'seq' '(' type ')' | 'map' '(' prim-type ',' type ')'
             | 'optional' '(' type ')' | 'sparse_tensor' '(' tensor-type ')'
-   value-info ::= type id
+   value-info ::= type quotable-id
    value-infos ::= value-info (',' value-info)*
    value-info-list ::= '(' value-infos? ')
-   id-or-value-info ::= type? id
+   id-or-value-info ::= type? quotable-id
    id-or-value-infos ::= id-or-value-info (',' id-or-value-info)*
    quoted-str :== '"' ([^"])* '"'
+   quotable-id :== id | quoted-str
    str-str :== quoted-str ':' quoted-str
    str-str-list :== '[' str-str (',' str-str)* ']'
    internal-data ::= '{' prim-constants '}'
    external-data ::= str-str-list
    constant-data ::= internal-data | external-data
-   value-info-or-initializer ::= type id [ '=' constant-data ]
+   value-info-or-initializer ::= type quotable-id [ '=' constant-data ]
    value-info-or-initializers ::= value-info-or-initializer (',' value-info-or-initializer)*
    input-list ::= '(' value-info-or-initializers? ')'
    output-list ::= '(' value-infos? ')'
    initializer-list ::= '<' value-info-or-initializers? '>'
    prim-constants ::= prim-constant (',' prim-constant)*
-   tensor-constant ::= tensor-type (id)? ('=')? '{' prim-constants '}'
+   tensor-constant ::= tensor-type (quotable-id)? ('=')? '{' prim-constants '}'
    attr-ref ::= '@' id
    single-attr-value ::= tensor-constant | graph | prim-constant | attr-ref
    attr-value-list ::= '[' single-attr-value (',' single-attr-value)* ']'
@@ -79,16 +81,16 @@ The grammar below describes the syntax:
    attr-type ::= ':' id
    attr ::= id attr-type? '=' attr-value
    attr-list ::= '<' attr (',' attr)* '>'
-   node ::= id-list? '=' qualified-id attr-list? '(' id-list? ')'
-         |  id-list? '=' qualified-id '(' id-list? ')' attr-list
+   node ::= quotable-id-list? '=' qualified-id attr-list? '(' quotable-id-list? ')'
+         |  quotable-id-list? '=' qualified-id '(' quotable-id-list? ')' attr-list
    node-list ::= '{' node* '}'
-   graph ::= id input-list '=>' output-list initializer-list node-list
+   graph ::= quotable-id input-list '=>' output-list initializer-list node-list
    other-data ::= id ':' value
    other-data-list ::= '<' other-data (',' other-data)* '>'
    fun-attr-list ::= '<' id | attr (',' id | attr)* '>'
    fun-input-list ::= '(' id-or-value-infos ')'
    fun-output-list ::= '(' id-or-value-infos ')'
    fun-value-infos ::= ( '<' value-infos '>' )?
-   function ::= other-data-list? id fun-attr-list?  fun-input-list '=>' fun-output-list fun-value-infos node-list
+   function ::= other-data-list? id fun-attr-list? quotable-id fun-input-list '=>' fun-output-list fun-value-infos node-list
    model ::= other-data-list? graph function*
 ```

--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -150,12 +150,12 @@ bool ParserBase::NextIsValidFloatString() {
 Status OnnxParser::Parse(IdList& idlist) {
   idlist.Clear();
   std::string id;
-  ParseOptionalIdentifier(id);
+  ParseQuotableIdentifier(id);
   if (id.empty())
     return Status::OK(); // Treat as empty list of identifiers
   *idlist.Add() = id;
   while (Matches(',')) {
-    ParseOptionalIdentifier(id);
+    ParseQuotableIdentifier(id);
     *idlist.Add() = id;
   }
   return Status::OK();
@@ -175,7 +175,7 @@ Status OnnxParser::Parse(IdList& idlist, AttrList& attrlist) {
   attrlist.Clear();
   do {
     std::string id;
-    ParseIdentifier(id);
+    ParseQuotableIdentifier(id);
     auto next = NextChar();
     if (next == ':' || next == '=')
       Parse(*attrlist.Add(), id);
@@ -311,7 +311,7 @@ Status OnnxParser::Parse(ValueInfoProto& valueinfo) {
   if (NextIsType())
     PARSE(*valueinfo.mutable_type());
   std::string name;
-  CHECK_PARSER_STATUS(ParseIdentifier(name));
+  CHECK_PARSER_STATUS(ParseQuotableIdentifier(name));
   valueinfo.set_name(name);
   return Status::OK();
 }
@@ -351,7 +351,7 @@ Status OnnxParser::ParseFunctionInputOutput(IdList& idlist, ValueInfoList& vilis
         vi = vilist.Add();
         PARSE(*(vi->mutable_type()));
       }
-      CHECK_PARSER_STATUS(ParseIdentifier(*name));
+      CHECK_PARSER_STATUS(ParseQuotableIdentifier(*name));
       if (vi != nullptr)
         vi->set_name(*name);
     } while (Matches(','));
@@ -549,7 +549,7 @@ Status OnnxParser::ParseSingleAttributeValue(AttributeProto& attr, AttributeProt
       if ((next == '{') || (next == '=') || (NextIsIdentifier())) {
         attr.set_type(AttributeProto_AttributeType_TENSOR);
         auto& tensorProto = *attr.mutable_t();
-        ParseOptionalIdentifier(*tensorProto.mutable_name());
+        ParseQuotableIdentifier(*tensorProto.mutable_name());
         (void)Matches('='); // Optional, to unify handling of initializers
         Parse(tensorProto, typeProto);
       } else {
@@ -569,7 +569,7 @@ Status OnnxParser::ParseSingleAttributeValue(AttributeProto& attr, AttributeProt
     }
   } else if (Matches('@')) {
     std::string name;
-    CHECK_PARSER_STATUS(ParseIdentifier(name));
+    CHECK_PARSER_STATUS(ParseQuotableIdentifier(name));
     attr.set_ref_attr_name(name);
   } else {
     Literal literal;
@@ -753,7 +753,7 @@ Status OnnxParser::Parse(NodeList& nodelist) {
 
 Status OnnxParser::Parse(GraphProto& graph) {
   std::string id;
-  ParseIdentifier(id);
+  ParseQuotableIdentifier(id);
   return Parse(id, graph);
 }
 
@@ -799,7 +799,7 @@ Status OnnxParser::Parse(FunctionProto& fn) {
     MATCH('>');
   }
   std::string id;
-  ParseIdentifier(id);
+  ParseQuotableIdentifier(id);
   fn.set_name(id);
 
   PARSE('<', *fn.mutable_attribute(), *fn.mutable_attribute_proto(), '>');

--- a/onnx/defs/parser.h
+++ b/onnx/defs/parser.h
@@ -364,6 +364,13 @@ class ParserBase {
     return Status::OK();
   }
 
+  Status ParseQuotableIdentifier(std::string& id) {
+    if (NextChar() == '"') {
+      return Parse(id);
+    }
+    return ParseIdentifier(id);
+  }
+
   Status PeekIdentifier(std::string& id) {
     SavePos();
     ParseOptionalIdentifier(id);

--- a/onnx/defs/printer.cc
+++ b/onnx/defs/printer.cc
@@ -14,17 +14,17 @@ namespace ONNX_NAMESPACE {
 using StringStringEntryProtos = google::protobuf::RepeatedPtrField<StringStringEntryProto>;
 
 bool IsValidIdentifier(const std::string& str) {
-    // Check if str is a valid identifier
-    const char* next_ = str.c_str();
-    const char* end_ = next_ + str.size();
-    if (next_ == end_)
-      return false; // empty string is not a valid identifier
-    if (! (isalpha(*next_) || (*next_ == '_')))
-      return false; // first character must be a letter or '_'
+  // Check if str is a valid identifier
+  const char* next_ = str.c_str();
+  const char* end_ = next_ + str.size();
+  if (next_ == end_)
+    return false; // empty string is not a valid identifier
+  if (!(isalpha(*next_) || (*next_ == '_')))
+    return false; // first character must be a letter or '_'
+  ++next_;
+  while ((next_ < end_) && (isalnum(*next_) || (*next_ == '_')))
     ++next_;
-    while ((next_ < end_) && (isalnum(*next_) || (*next_ == '_')))
-      ++next_;
-    return next_ == end_;
+  return next_ == end_;
 }
 
 class ProtoPrinter {

--- a/onnx/defs/printer.cc
+++ b/onnx/defs/printer.cc
@@ -13,6 +13,20 @@ namespace ONNX_NAMESPACE {
 
 using StringStringEntryProtos = google::protobuf::RepeatedPtrField<StringStringEntryProto>;
 
+bool IsValidIdentifier(const std::string& str) {
+    // Check if str is a valid identifier
+    const char* next_ = str.c_str();
+    const char* end_ = next_ + str.size();
+    if (next_ == end_)
+      return false; // empty string is not a valid identifier
+    if (! (isalpha(*next_) || (*next_ == '_')))
+      return false; // first character must be a letter or '_'
+    ++next_;
+    while ((next_ < end_) && (isalnum(*next_) || (*next_ == '_')))
+      ++next_;
+    return next_ == end_;
+}
+
 class ProtoPrinter {
  public:
   ProtoPrinter(std::ostream& os) : output_(os) {}
@@ -68,6 +82,13 @@ class ProtoPrinter {
   }
 
  private:
+  void printId(const std::string& str) {
+    if (IsValidIdentifier(str))
+      output_ << str;
+    else
+      printQuoted(str);
+  }
+
   template <typename T>
   inline void print(T prim) {
     output_ << prim;
@@ -104,6 +125,18 @@ class ProtoPrinter {
     for (auto& elt : coll) {
       output_ << sep;
       print(elt);
+      sep = separator;
+    }
+    output_ << close;
+  }
+
+  template <typename Collection>
+  inline void printIdSet(const char* open, const char* separator, const char* close, Collection coll) {
+    const char* sep = "";
+    output_ << open;
+    for (auto& elt : coll) {
+      output_ << sep;
+      printId(elt);
       sep = separator;
     }
     output_ << close;
@@ -191,7 +224,8 @@ void ProtoPrinter::print(const TensorProto& tensor, bool is_initializer) {
     printSet("[", ",", "]", tensor.dims());
 
   if (!tensor.name().empty()) {
-    output_ << " " << tensor.name();
+    output_ << " ";
+    printId(tensor.name());
   }
   if (is_initializer) {
     output_ << " = ";
@@ -258,7 +292,8 @@ void ProtoPrinter::print(const TensorProto& tensor, bool is_initializer) {
 
 void ProtoPrinter::print(const ValueInfoProto& value_info) {
   print(value_info.type());
-  output_ << " " << value_info.name();
+  output_ << " ";
+  printId(value_info.name());
 }
 
 void ProtoPrinter::print(const ValueInfoList& vilist) {
@@ -331,7 +366,7 @@ void ProtoPrinter::print(const AttrList& attrlist) {
 
 void ProtoPrinter::print(const NodeProto& node) {
   output_ << std::setw(indent_level) << ' ';
-  printSet("", ", ", "", node.output());
+  printIdSet("", ", ", "", node.output());
   output_ << " = ";
   if (node.domain() != "")
     output_ << node.domain() << ".";
@@ -344,7 +379,7 @@ void ProtoPrinter::print(const NodeProto& node) {
       has_subgraph = true;
   if ((!has_subgraph) && (node.attribute_size() > 0))
     print(node.attribute());
-  printSet(" (", ", ", ")", node.input());
+  printIdSet(" (", ", ", ")", node.input());
   if ((has_subgraph) && (node.attribute_size() > 0))
     print(node.attribute());
   output_ << "\n";
@@ -361,7 +396,8 @@ void ProtoPrinter::print(const NodeList& nodelist) {
 }
 
 void ProtoPrinter::print(const GraphProto& graph) {
-  output_ << graph.name() << " " << graph.input() << " => " << graph.output() << " ";
+  printId(graph.name());
+  output_ << " " << graph.input() << " => " << graph.output() << " ";
   if ((graph.initializer_size() > 0) || (graph.value_info_size() > 0)) {
     output_ << std::endl << std::setw(indent_level) << ' ' << '<';
     const char* sep = "";
@@ -425,12 +461,13 @@ void ProtoPrinter::print(const FunctionProto& fn) {
           << "opset_import: ";
   printSet("[", ",", "]", fn.opset_import());
   output_ << "\n>\n";
-  output_ << fn.name() << " ";
+  printId(fn.name());
+  output_ << " ";
   if (fn.attribute_size() > 0)
     printSet("<", ",", ">", fn.attribute());
-  printSet("(", ", ", ")", fn.input());
+  printIdSet("(", ", ", ")", fn.input());
   output_ << " => ";
-  printSet("(", ", ", ")", fn.output());
+  printIdSet("(", ", ", ")", fn.output());
   output_ << "\n";
   print(fn.node());
 }

--- a/onnx/test/cpp/parser_test.cc
+++ b/onnx/test/cpp/parser_test.cc
@@ -685,5 +685,25 @@ TEST(ParserTest, QuotedIdentifiersTest) {
   EXPECT_EQ(graph.node(0).output(0), "some/temp");
 }
 
+TEST(ParserTest, QuotedIdentifierTest2) {
+  const char* code = R"ONNX(
+<
+  opset_import: [ "" : 10 ],
+  domain: "ai.onnx.ml",
+  doc_string: "A function test case."
+>
+"a function name" (float[N] "#y", "$z") => (float[N] "!w")
+<float[N] "/layer/x", float[N] t>
+{
+    "/layer/x" = Add("#y", "$z")
+    t = Add("/layer/x", "/layer/x")
+    "!w" = Mul(t, "#y")
+}
+)ONNX";
+
+  FunctionProto fp;
+  Parse(fp, code);
+}
+
 } // namespace Test
 } // namespace ONNX_NAMESPACE

--- a/onnx/test/cpp/parser_test.cc
+++ b/onnx/test/cpp/parser_test.cc
@@ -663,5 +663,27 @@ agraph (float y = {1.0}, float[N] z) => (w) <
   EXPECT_EQ(graph.initializer().Get(1).external_data().Get(1).value(), "17");
 }
 
+TEST(ParserTest, QuotedIdentifiersTest) {
+  const char* code = R"ONNX(
+"a graph name" (float[N, 128] "input/X", float[128,10] "input W", float[10] B) => (float[N] C)
+{
+    "some/temp" = MatMul("input/X", "input W")
+    S = Add("some/temp", B)
+    C = Softmax(S)
+}
+)ONNX";
+
+  GraphProto graph;
+  Parse(graph, code);
+
+  EXPECT_EQ(graph.name(), "a graph name");
+  EXPECT_EQ(graph.input_size(), 3);
+  EXPECT_EQ(graph.output_size(), 1);
+  EXPECT_EQ(graph.node_size(), 3);
+  EXPECT_EQ(graph.node(0).input(0), "input/X");
+  EXPECT_EQ(graph.node(0).input(1), "input W");
+  EXPECT_EQ(graph.node(0).output(0), "some/temp");
+}
+
 } // namespace Test
 } // namespace ONNX_NAMESPACE


### PR DESCRIPTION
Many onnx models used in practice use tensor names that are not valid C identifiers (as required by the ONNX standard). This PR extends the printer and parser to support such identifiers.

(It may be useful to relax the ONNX standard's requirements in this regard, but that's a separate issue, requiring some community discussion.)
