### PR TITLE
[Cherry-Pick] Fix protobuf pkg 5.28.0 failing on Windows (#6342)

### DIFF
--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -109,7 +109,10 @@ jobs:
       run: |
         cd onnx
         python -m pip uninstall -y protobuf onnx
-        python -m pip install protobuf
+        # https://github.com/protocolbuffers/protobuf/issues/18045
+        # The protobuf Python package version 5.28.0 is broken on Windows.
+        # Use the version prior to it until it gets fixed or a newer version is available.
+        python -m pip install protobuf!=5.28.0
         Get-ChildItem -Path dist/*.whl | foreach {python -m pip install --upgrade $_.fullname}
         pytest
 


### PR DESCRIPTION
### Description
Cherry-Pick (#6342) - The latest protobuf pkg 5.28.0 is failing on Windows. use the one pre… into the `rel-1.17.0` branch

### Motivation and Context
Cherry pick commit to `rel-1.17.0` to fix protobuf package issue in windows testing
