### PR TITLE
Support node labels in parser and printer

### DIFF
--- a/docs/Syntax.md
+++ b/docs/Syntax.md
@@ -81,8 +81,9 @@ The grammar below describes the syntax:
    attr-type ::= ':' id
    attr ::= id attr-type? '=' attr-value
    attr-list ::= '<' attr (',' attr)* '>'
-   node ::= quotable-id-list? '=' qualified-id attr-list? '(' quotable-id-list? ')'
-         |  quotable-id-list? '=' qualified-id '(' quotable-id-list? ')' attr-list
+   node-label ::= '[' quotable-id ']'
+   node ::= node-label? quotable-id-list? '=' qualified-id attr-list? '(' quotable-id-list? ')'
+         |  node-label? quotable-id-list? '=' qualified-id '(' quotable-id-list? ')' attr-list
    node-list ::= '{' node* '}'
    graph ::= quotable-id input-list '=>' output-list initializer-list node-list
    other-data ::= id ':' value

--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -150,12 +150,12 @@ bool ParserBase::NextIsValidFloatString() {
 Status OnnxParser::Parse(IdList& idlist) {
   idlist.Clear();
   std::string id;
-  ParseQuotableIdentifier(id);
+  CHECK_PARSER_STATUS(ParseOptionalQuotableIdentifier(id));
   if (id.empty())
     return Status::OK(); // Treat as empty list of identifiers
   *idlist.Add() = id;
   while (Matches(',')) {
-    ParseQuotableIdentifier(id);
+    CHECK_PARSER_STATUS(ParseQuotableIdentifier(id));
     *idlist.Add() = id;
   }
   return Status::OK();
@@ -175,7 +175,7 @@ Status OnnxParser::Parse(IdList& idlist, AttrList& attrlist) {
   attrlist.Clear();
   do {
     std::string id;
-    ParseQuotableIdentifier(id);
+    CHECK_PARSER_STATUS(ParseQuotableIdentifier(id));
     auto next = NextChar();
     if (next == ':' || next == '=')
       Parse(*attrlist.Add(), id);
@@ -549,7 +549,7 @@ Status OnnxParser::ParseSingleAttributeValue(AttributeProto& attr, AttributeProt
       if ((next == '{') || (next == '=') || (NextIsIdentifier())) {
         attr.set_type(AttributeProto_AttributeType_TENSOR);
         auto& tensorProto = *attr.mutable_t();
-        ParseQuotableIdentifier(*tensorProto.mutable_name());
+        CHECK_PARSER_STATUS(ParseOptionalQuotableIdentifier(*tensorProto.mutable_name()));
         (void)Matches('='); // Optional, to unify handling of initializers
         Parse(tensorProto, typeProto);
       } else {
@@ -713,7 +713,7 @@ Status OnnxParser::Parse(AttrList& attrlist) {
 
 Status OnnxParser::Parse(NodeProto& node) {
   if (Matches('[')) {
-    ParseQuotableIdentifier(node.mutable_name());
+    CHECK_PARSER_STATUS(ParseQuotableIdentifier(*node.mutable_name()));
     MATCH(']');
   }
   PARSE(*node.mutable_output());
@@ -757,7 +757,7 @@ Status OnnxParser::Parse(NodeList& nodelist) {
 
 Status OnnxParser::Parse(GraphProto& graph) {
   std::string id;
-  ParseQuotableIdentifier(id);
+  CHECK_PARSER_STATUS(ParseQuotableIdentifier(id));
   return Parse(id, graph);
 }
 
@@ -803,7 +803,7 @@ Status OnnxParser::Parse(FunctionProto& fn) {
     MATCH('>');
   }
   std::string id;
-  ParseQuotableIdentifier(id);
+  CHECK_PARSER_STATUS(ParseQuotableIdentifier(id));
   fn.set_name(id);
 
   PARSE('<', *fn.mutable_attribute(), *fn.mutable_attribute_proto(), '>');

--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -149,7 +149,7 @@ Status OnnxParser::Parse(IdList& idlist) {
     return Status::OK(); // Treat as empty list of identifiers
   *idlist.Add() = id;
   while (Matches(',')) {
-    CHECK_PARSER_STATUS(ParseQuotableIdentifier(id));
+    CHECK_PARSER_STATUS(ParseOptionalQuotableIdentifier(id));
     *idlist.Add() = id;
   }
   return Status::OK();
@@ -707,7 +707,7 @@ Status OnnxParser::Parse(AttrList& attrlist) {
 
 Status OnnxParser::Parse(NodeProto& node) {
   if (Matches('[')) {
-    CHECK_PARSER_STATUS(ParseQuotableIdentifier(*node.mutable_name()));
+    CHECK_PARSER_STATUS(ParseOptionalQuotableIdentifier(*node.mutable_name()));
     MATCH(']');
   }
   PARSE(*node.mutable_output());

--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -712,6 +712,10 @@ Status OnnxParser::Parse(AttrList& attrlist) {
 }
 
 Status OnnxParser::Parse(NodeProto& node) {
+  if (Matches('[')) {
+    ParseQuotableIdentifier(node.mutable_name());
+    MATCH(']');
+  }
   PARSE(*node.mutable_output());
   MATCH('=');
   std::string domain("");

--- a/onnx/defs/parser.h
+++ b/onnx/defs/parser.h
@@ -371,6 +371,13 @@ class ParserBase {
     return ParseIdentifier(id);
   }
 
+  Status ParseOptionalQuotableIdentifier(std::string& id) {
+    if (NextChar() == '"') {
+      return Parse(id);
+    }
+    return ParseOptionalIdentifier(id);
+  }
+
   Status PeekIdentifier(std::string& id) {
     SavePos();
     ParseOptionalIdentifier(id);

--- a/onnx/defs/printer.cc
+++ b/onnx/defs/printer.cc
@@ -366,6 +366,11 @@ void ProtoPrinter::print(const AttrList& attrlist) {
 
 void ProtoPrinter::print(const NodeProto& node) {
   output_ << std::setw(indent_level) << ' ';
+  if (node.has_name()) {
+    output_ << "[";
+    printId(node.name());
+    output_ << "] ";
+  }
   printIdSet("", ", ", "", node.output());
   output_ << " = ";
   if (node.domain() != "")

--- a/onnx/test/cpp/parser_test.cc
+++ b/onnx/test/cpp/parser_test.cc
@@ -256,6 +256,23 @@ TEST(ParserTest, NodeTest) {
        )ONNX");
 }
 
+TEST(ParserTest, NodeLabelTest) {
+  const char* code = "[node1] x = foo(y, z)";
+  NodeProto n;
+  Parse(n, code);
+  EXPECT_EQ(n.name(), "node1");
+
+  NodeList nl;
+  Parse(nl, R"ONNX( {
+     [node1] x = foo(y, z)
+     [node2] w = bar(x, y)
+     s = foobar(x, w)
+  } )ONNX");
+  EXPECT_EQ(nl.Get(0).name(), "node1");
+  EXPECT_EQ(nl.Get(1).name(), "node2");
+  EXPECT_FALSE(nl.Get(2).has_name());
+}
+
 TEST(ParserTest, QualifiedOpNameTest) {
   const char* code = "x = com.example.foo(y, z)";
   NodeProto n;

--- a/onnx/test/cpp/parser_test.cc
+++ b/onnx/test/cpp/parser_test.cc
@@ -228,6 +228,26 @@ TEST(ParserTest, DomainOpCallTest) {
   Parse(n, code);
 }
 
+TEST(ParserTest, OptionalInputTest) {
+  const char* code = "x = SomeOp(y, , z)";
+  NodeProto n;
+  Parse(n, code);
+  EXPECT_EQ(n.input_size(), 3);
+  EXPECT_EQ(n.input(0), "y");
+  EXPECT_EQ(n.input(1), "");
+  EXPECT_EQ(n.input(2), "z");
+}
+
+TEST(ParserTest, OptionalInputTest2) {
+  const char* code = "x = SomeOp(y, \"\", z)";
+  NodeProto n;
+  Parse(n, code);
+  EXPECT_EQ(n.input_size(), 3);
+  EXPECT_EQ(n.input(0), "y");
+  EXPECT_EQ(n.input(1), "");
+  EXPECT_EQ(n.input(2), "z");
+}
+
 TEST(ParserTest, NodeTest) {
   const char* code = "x = foo(y, z)";
   NodeProto n;


### PR DESCRIPTION
### Description

1) Adds support for node label in parser and printer
2) Adds some status-checks that were missed in recent addition to support invalid identifiers.

Node labels are now supported with the following syntax:

```
   [a_node_label] y = MatMul (x, w)
```

However, we have a couple of options to choose from here:

(a) The ONNX spec says that the node label must be a valid identifier. So, we can allow for a valid identifier between the `[...]`, relying on a quoted string inside if the user wants to use something that is not a valid identifier.

(b) Alternatively, since `[` and `]` act as end-markers, like quotes, we can allow any string in-between, that is taken to be the node label. (Users will need to use an escape backslash if they want `]` in the label.)

Option (b) is better if users want to use non-identifier labels, eg., numbers, etc. I am inclined to go with (b), even though it is extra code. However, it won't be friendly to the use of white-space inside if users want to use identifier labels. Eg., `[ mylabel ]` will include the blank spaces in the label.

The implementation currently does only (a), which is simpler.