### PR TITLE
BugFix: make sure that unique files names are used before uploading the wheels 

### DIFF
--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -64,7 +64,7 @@ jobs:
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
       with:
-        name: wheels-${{ inputs.os }}-${{ matrix.python-version }}
+        name: wheels-${{ inputs.os }}-${{ matrix.python-version }}-${{ matrix.target-architecture }}
         path: dist/*.whl
 
   test:
@@ -89,7 +89,7 @@ jobs:
 
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
       with:
-        name:  wheels-${{ inputs.os }}-${{ matrix.python-version }}-${{ matrix.target-architecture }}
+        name: wheels-${{ inputs.os }}-${{ matrix.python-version }}-${{ matrix.target-architecture }}
         path: dist
 
     - name: Test the wheel


### PR DESCRIPTION
### Description

make sure that unique files names are used before uploading the wheels 

### Motivation and Context

```
Run actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
With the provided path, there will be 1 file uploaded
Artifact name is valid!
Root directory input is valid!
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```
