### PR TITLE
Simplify create_release.yml

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -5,7 +5,7 @@
 name: Create Releases
 on:
   schedule:
-    # Run weekly on Monday 00:00
+    # Run weekly on Monday 00:00 UTC 
     - cron:  '00 00 * * MON'
   push:
     branches: [main, rel-*]
@@ -58,11 +58,10 @@ jobs:
 
 
   publish_to_testpypi: 
-    # TODO Add a deployment step for reviewing https://docs.github.com/en/actions/managing-workflow-runs/reviewing-deployments
     name: Release (Publish to testpypi, onnxweekly)
     runs-on: ubuntu-latest
     needs: [call-workflow-ubuntu_x86, call-workflow-ubuntu_aarch64, call-workflow-mac, call-workflow-win]
-    if: (github.ref == 'refs/heads/main') && (github.event_name != 'pull_request') && ((needs.call-workflow-mac.result == 'success') || (needs.call-workflow-ubuntu_x86.result == 'success') || (needs.call-workflow-ubuntu_aarch64.result == 'success') || (needs.call-workflow-win.result == 'success'))
+    if: (github.event_name == 'schedule') && ((needs.call-workflow-mac.result == 'success') || (needs.call-workflow-ubuntu_x86.result == 'success') || (needs.call-workflow-ubuntu_aarch64.result == 'success') || (needs.call-workflow-win.result == 'success'))
 
     environment:      
       name: testpypi 
@@ -81,7 +80,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish distribution to TestPyPI
-        if: (github.event_name == 'schedule') && (github.repository_owner == 'onnx')
+        if: github.repository_owner == 'onnx'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:   
           repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
### Description
 Scheduled workflows will only run on the default branch. 

(https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule)

### Motivation and Context
Currently, the artifacts are also downloaded if they are not published to testpypi
