### PR TITLE
Trigger release pipeline when label "run release..." was added to PR

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -11,6 +11,8 @@ on:
     branches: [main, rel-*]
   pull_request:
     branches: [main, rel-*]
+    types: 
+      - labeled  # Trigger when a label is added to a PR, more information: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request
   workflow_dispatch:    
 
 concurrency:


### PR DESCRIPTION
### Description

Last commit was incomplete:  Activity type has to be added

Add activity types: label
https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request

### Motivation and Context

"By default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened. To trigger workflows by different activity types, use the types keyword. For more information, see "[Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onevent_nametypes)."
