### PR TITLE
Use std::unordered_{map,set}

### DIFF
--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -4,8 +4,6 @@
 
 #include "onnx/checker.h"
 
-#include <functional>
-#include <set>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -1065,7 +1063,7 @@ std::string resolve_external_data_location(
 #endif
 }
 
-std::set<std::string> experimental_ops = {
+std::unordered_set<std::string> experimental_ops = {
     "ATen",
     "Affine",
     "ConstantFill",

--- a/onnx/checker.h
+++ b/onnx/checker.h
@@ -125,7 +125,7 @@ class LexicalScopeContext final {
   }
 
   bool this_graph_has(const std::string& name) const {
-    return output_names.find(name) != output_names.cend();
+    return output_names.count(name) > 0;
   }
 
   bool this_or_ancestor_graph_has(const std::string& name) const {

--- a/onnx/defs/function.cc
+++ b/onnx/defs/function.cc
@@ -69,7 +69,7 @@ void FunctionExpandHelper(
 
   const OpSchemaRegistry* schema_registry = OpSchemaRegistry::Instance();
   const auto schema = schema_registry->GetSchema(node.op_type(), domain_version, node.domain());
-  std::map<std::string, OpSchema::Attribute> default_attrs = schema->attributes();
+  auto default_attrs = schema->attributes();
 
   for (const auto& pair : default_attrs) {
     const auto& attr_name = pair.first;

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -3,7 +3,7 @@
  */
 
 #include <algorithm>
-#include <functional>
+#include <map>
 
 #include "onnx/common/assertions.h"
 #include "onnx/defs/function.h"
@@ -2521,7 +2521,7 @@ void einsumShapeInference(ONNX_NAMESPACE::InferenceContext& ctx, std::string con
   // Parse the left-hand side
   std::stringstream str(left_equation);
   std::map<char, size_t> label_maps;
-  std::set<char> repeated_labels;
+  std::unordered_set<char> repeated_labels;
   ONNX_NAMESPACE::TensorShapeProto dims_value, ellipsis_dims_value;
   size_t num_labels = 0;
   bool ellipsis_flag = true;

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -12,7 +12,6 @@
 #include <map>
 #include <memory>
 #include <ostream>
-#include <set>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -366,12 +365,12 @@ class OpSchema final {
   /**
    * @brief Input could be one of the values specified in allowed_input_nums.
    */
-  OpSchema& NumInputs(std::set<int> allowed_input_nums);
+  OpSchema& NumInputs(std::unordered_set<int> allowed_input_nums);
 
   /**
    * @brief Output could be one of the values specified in allowed_output_nums.
    */
-  OpSchema& NumOutputs(std::set<int> allowed_output_nums);
+  OpSchema& NumOutputs(std::unordered_set<int> allowed_output_nums);
 
   // Shape Inference
   //
@@ -1061,7 +1060,7 @@ class OpSchema final {
     return domain_;
   }
 
-  const std::map<std::string, Attribute>& attributes() const {
+  const std::unordered_map<std::string, Attribute>& attributes() const {
     return attributes_;
   }
 
@@ -1122,9 +1121,8 @@ class OpSchema final {
 
   std::vector<int> function_opset_versions() const {
     std::vector<int> opset_versions;
-    std::map<int, std::shared_ptr<FunctionProto>>::const_iterator it = opset_version_to_function_body_.cbegin();
-    for (; it != opset_version_to_function_body_.cend(); ++it) {
-      opset_versions.push_back(it->first);
+    for (const auto& pair : opset_version_to_function_body_) {
+      opset_versions.push_back(pair.first);
     }
     return opset_versions;
   }
@@ -1165,9 +1163,8 @@ class OpSchema final {
 
   std::vector<int> context_dependent_function_opset_versions() const {
     std::vector<int> opset_versions;
-    std::map<int, ContextDependentFunctionBodyBuilder>::const_iterator it = opset_version_to_function_builder_.cbegin();
-    for (; it != opset_version_to_function_builder_.cend(); ++it) {
-      opset_versions.push_back(it->first);
+    for (const auto& pair : opset_version_to_function_builder_) {
+      opset_versions.push_back(pair.first);
     }
     return opset_versions;
   }
@@ -1205,7 +1202,7 @@ class OpSchema final {
       const FunctionProto* function,
       int requested_opset_version,
       int function_since_version,
-      std::set<std::string>* updated_ops = nullptr) const;
+      std::unordered_set<std::string>* updated_ops = nullptr) const;
   void UpdateFunctionProtoOpsetImportVersion(FunctionProto& function_proto, int opset_version) const;
 
   /**
@@ -1234,7 +1231,7 @@ class OpSchema final {
   std::string doc_;
   // Default domain value ("") means it's ONNX domain.
   std::string domain_ = ONNX_DOMAIN;
-  std::map<std::string, Attribute> attributes_{};
+  std::unordered_map<std::string, Attribute> attributes_{};
   bool allows_unchecked_attributes_ = false;
   std::vector<FormalParameter> inputs_;
   std::vector<FormalParameter> outputs_;


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Switch some usage of std::{map,set}  to unordered counterparts.
### Motivation and Context
For faster search operations.
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
