### PR TITLE
Avoid returning const vectors

### DIFF
--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -423,9 +423,9 @@ compute_output_dim_for_range(const TensorProto* start, const TensorProto* limit,
     fail_shape_inference("Input to 'Range' op should be scalars (Tensor with only one element and shape empty)");
   }
 
-  const auto& start_data = ParseData<T>(start);
-  const auto& limit_data = ParseData<T>(limit);
-  const auto& delta_data = ParseData<T>(delta);
+  const auto start_data = ParseData<T>(start);
+  const auto limit_data = ParseData<T>(limit);
+  const auto delta_data = ParseData<T>(delta);
 
   int64_t n = static_cast<int64_t>(ceil((1.0 * (limit_data[0] - start_data[0])) / delta_data[0]));
 

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -1479,7 +1479,7 @@ ONNX_OPERATOR_SET_SCHEMA(
               fail_shape_inference("K input must be a one-dimensional tensor of size 1.");
             }
             if (k->data_type() == TensorProto::INT64) {
-              const auto& data = ParseData<int64_t>(k);
+              const auto data = ParseData<int64_t>(k);
               k_value = data[0];
             } else {
               fail_shape_inference("K input must be of type int64.");

--- a/onnx/defs/math/old.cc
+++ b/onnx/defs/math/old.cc
@@ -1834,7 +1834,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             const auto& input_shape = ctx.getInputType(0)->tensor_type().shape();
             TensorShapeProto second_shape;
             if (nullptr != shape_initializer) {
-              const auto& shape_data = ParseData<int64_t>(shape_initializer);
+              const auto shape_data = ParseData<int64_t>(shape_initializer);
 
               for (const auto& e : shape_data) {
                 auto* dim = second_shape.add_dim();
@@ -3756,7 +3756,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
 
             if (k->data_type() == TensorProto::INT64) {
-              const auto& data = ParseData<int64_t>(k);
+              const auto data = ParseData<int64_t>(k);
               k_value = data[0];
             } else {
               fail_shape_inference("K input must be of type int64.");

--- a/onnx/defs/sequence/defs.cc
+++ b/onnx/defs/sequence/defs.cc
@@ -345,10 +345,10 @@ ONNX_OPERATOR_SET_SCHEMA(
 
               std::vector<int64_t> splitSizes;
               if (splitInitializer->data_type() == TensorProto::INT64) {
-                const auto& data = ParseData<int64_t>(splitInitializer);
+                const auto data = ParseData<int64_t>(splitInitializer);
                 splitSizes.insert(splitSizes.end(), data.begin(), data.end());
               } else if (splitInitializer->data_type() == TensorProto::INT32) {
-                const auto& data = ParseData<int32_t>(splitInitializer);
+                const auto data = ParseData<int32_t>(splitInitializer);
                 splitSizes.insert(splitSizes.end(), data.begin(), data.end());
               } else {
                 // unaccepted data type

--- a/onnx/defs/shape_inference.cc
+++ b/onnx/defs/shape_inference.cc
@@ -464,7 +464,7 @@ TensorShapeProto getShapeInput(const InferenceContext& ctx, size_t input_index, 
   // First, check initializer.
   const TensorProto* shape_initializer = ctx.getInputData(input_index);
   if (shape_initializer) {
-    const std::vector<int64_t>& shape_data = ParseData<int64_t>(shape_initializer);
+    const std::vector<int64_t> shape_data = ParseData<int64_t>(shape_initializer);
     for (const int64_t& e : shape_data) {
       shape_input.add_dim()->set_dim_value(e);
     }

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -906,10 +906,10 @@ ONNX_OPERATOR_SET_SCHEMA(
           auto get_initializer_data = [](const TensorProto* initializer) -> std::vector<int64_t> {
             std::vector<int64_t> vec;
             if (initializer->data_type() == TensorProto::INT64) {
-              const auto& data = ParseData<int64_t>(initializer);
+              const auto data = ParseData<int64_t>(initializer);
               vec.insert(vec.end(), data.begin(), data.end());
             } else if (initializer->data_type() == TensorProto::INT32) {
-              const auto& data = ParseData<int32_t>(initializer);
+              const auto data = ParseData<int32_t>(initializer);
               vec.insert(vec.end(), data.begin(), data.end());
             } else {
               // unaccepted data type
@@ -2067,7 +2067,7 @@ ONNX_OPERATOR_SET_SCHEMA(
               fail_shape_inference("'Repeats' input must be 1D tensor of type int64");
             }
 
-            const auto& repeats_data = ParseData<int64_t>(repeats_inputs);
+            const auto repeats_data = ParseData<int64_t>(repeats_inputs);
 
             if (repeats_data.size() != static_cast<size_t>(input_rank)) {
               fail_shape_inference(
@@ -3803,10 +3803,10 @@ ONNX_OPERATOR_SET_SCHEMA(
 
           std::vector<int64_t> shape;
           if (cropShapeInitializer->data_type() == TensorProto::INT64) {
-            const auto& data = ParseData<int64_t>(cropShapeInitializer);
+            const auto data = ParseData<int64_t>(cropShapeInitializer);
             shape.insert(shape.end(), data.begin(), data.end());
           } else if (cropShapeInitializer->data_type() == TensorProto::INT32) {
-            const auto& data = ParseData<int32_t>(cropShapeInitializer);
+            const auto data = ParseData<int32_t>(cropShapeInitializer);
             shape.insert(shape.end(), data.begin(), data.end());
           } else {
             // unaccepted data type

--- a/onnx/defs/tensor/old.cc
+++ b/onnx/defs/tensor/old.cc
@@ -1848,10 +1848,10 @@ ONNX_OPERATOR_SET_SCHEMA(
           auto get_initializer_data = [](const TensorProto* initializer) -> std::vector<int64_t> {
             std::vector<int64_t> vec;
             if (initializer->data_type() == TensorProto::INT64) {
-              const auto& data = ParseData<int64_t>(initializer);
+              const auto data = ParseData<int64_t>(initializer);
               vec.insert(vec.end(), data.begin(), data.end());
             } else if (initializer->data_type() == TensorProto::INT32) {
-              const auto& data = ParseData<int32_t>(initializer);
+              const auto data = ParseData<int32_t>(initializer);
               vec.insert(vec.end(), data.begin(), data.end());
             } else {
               // unaccepted data type
@@ -3625,7 +3625,7 @@ ONNX_OPERATOR_SET_SCHEMA(
               fail_shape_inference("'Repeats' input must be 1D tensor of type int64");
             }
 
-            const auto& repeats_data = ParseData<int64_t>(repeats_inputs);
+            const auto repeats_data = ParseData<int64_t>(repeats_inputs);
 
             if (repeats_data.size() != static_cast<size_t>(input_rank)) {
               fail_shape_inference(
@@ -4571,7 +4571,7 @@ ONNX_OPERATOR_SET_SCHEMA(
               fail_shape_inference("'pads' input must be a 1D (shape: [2 * input_rank]) tensor of type int64");
             }
 
-            const auto& pads_data = ParseData<int64_t>(pads_initializer);
+            const auto pads_data = ParseData<int64_t>(pads_initializer);
             if (pads_data.size() != static_cast<size_t>(2 * input_rank)) {
               fail_shape_inference("Pads has incorrect number of values");
             }
@@ -5278,10 +5278,10 @@ ONNX_OPERATOR_SET_SCHEMA(
           auto get_initializer_data = [](const TensorProto* initializer) -> std::vector<int64_t> {
             std::vector<int64_t> vec;
             if (initializer->data_type() == TensorProto::INT64) {
-              const auto& data = ParseData<int64_t>(initializer);
+              const auto data = ParseData<int64_t>(initializer);
               vec.insert(vec.end(), data.begin(), data.end());
             } else if (initializer->data_type() == TensorProto::INT32) {
-              const auto& data = ParseData<int32_t>(initializer);
+              const auto data = ParseData<int32_t>(initializer);
               vec.insert(vec.end(), data.begin(), data.end());
             } else {
               // unaccepted data type
@@ -6375,7 +6375,7 @@ ONNX_OPERATOR_SET_SCHEMA(
               fail_shape_inference("'pads' input must be a 1D (shape: [2 * input_rank]) tensor of type int64");
             }
 
-            const auto& pads_data = ParseData<int64_t>(pads_initializer);
+            const auto pads_data = ParseData<int64_t>(pads_initializer);
             if (pads_data.size() != static_cast<size_t>(2 * input_rank)) {
               fail_shape_inference("Pads has incorrect number of values");
             }

--- a/onnx/defs/tensor/utils.cc
+++ b/onnx/defs/tensor/utils.cc
@@ -381,7 +381,7 @@ void resizeShapeInference_opset7_to_10(InferenceContext& ctx) {
   if (nullptr != scales) {
     // Infer output shape's dimension value if 'scales' is known.
     if (scales->data_type() == TensorProto::FLOAT) {
-      const auto& scales_data = ParseData<float>(scales);
+      const auto scales_data = ParseData<float>(scales);
       if (scales_data.size() != static_cast<size_t>(input_shape.dim_size())) {
         fail_shape_inference("Number of elements of input 'scales' must be same as rank of input 'X'");
       }
@@ -484,7 +484,7 @@ std::function<void(OpSchema&)> PadDocGenerator(
           fail_shape_inference("'pads' input must be a 1D (shape: [2 * num_axes]) tensor of type int64");
         }
 
-        const auto& pads_data = ParseData<int64_t>(pads_initializer);
+        const auto pads_data = ParseData<int64_t>(pads_initializer);
         if (pads_data.size() != static_cast<size_t>(2 * num_axes)) {
           fail_shape_inference(
               "Pads has incorrect number of values. Expected 2 * ",

--- a/onnx/defs/tensor_proto_util.cc
+++ b/onnx/defs/tensor_proto_util.cc
@@ -36,7 +36,7 @@ namespace ONNX_NAMESPACE {
 
 #define DEFINE_PARSE_DATA(type, typed_data_fetch, tensorproto_datatype)                                            \
   template <>                                                                                                      \
-  const std::vector<type> ParseData(const TensorProto* tensor_proto) {                                             \
+  std::vector<type> ParseData(const TensorProto* tensor_proto) {                                                   \
     if (!tensor_proto->has_data_type() || tensor_proto->data_type() == TensorProto_DataType_UNDEFINED) {           \
       fail_shape_inference("The type of tensor: ", tensor_proto->name(), " is undefined so it cannot be parsed."); \
     } else if (tensor_proto->data_type() != tensorproto_datatype) {                                                \

--- a/onnx/defs/tensor_proto_util.h
+++ b/onnx/defs/tensor_proto_util.h
@@ -6,7 +6,7 @@
 
 #include <vector>
 
-#include "onnx/onnx-operators_pb.h"
+#include "onnx/onnx_pb.h"
 
 namespace ONNX_NAMESPACE {
 
@@ -17,6 +17,6 @@ template <typename T>
 TensorProto ToTensor(const std::vector<T>& values);
 
 template <typename T>
-const std::vector<T> ParseData(const TensorProto* tensor_proto);
+std::vector<T> ParseData(const TensorProto* tensor_proto);
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/tensor_util.cc
+++ b/onnx/defs/tensor_util.cc
@@ -13,7 +13,7 @@ namespace ONNX_NAMESPACE {
 
 #define DEFINE_PARSE_DATA(type, typed_data_fetch)                          \
   template <>                                                              \
-  const std::vector<type> ParseData(const Tensor* tensor) {                \
+  std::vector<type> ParseData(const Tensor* tensor) {                      \
     std::vector<type> res;                                                 \
     if (!tensor->is_raw_data()) {                                          \
       const auto& data = tensor->typed_data_fetch();                       \

--- a/onnx/defs/tensor_util.h
+++ b/onnx/defs/tensor_util.h
@@ -6,11 +6,11 @@
 
 #include <vector>
 
-#include "onnx/common/ir.h"
+#include "onnx/common/tensor.h"
 
 namespace ONNX_NAMESPACE {
 
 template <typename T>
-const std::vector<T> ParseData(const Tensor* tensor);
+std::vector<T> ParseData(const Tensor* tensor);
 
 } // namespace ONNX_NAMESPACE


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
This PR fixed returning const vectors, which prevents compiler optimisations, some dangling references to them were also fixed.
### Motivation and Context
For better code.
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
