### PR TITLE
Fix more clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -41,7 +41,8 @@ Checks: >-
   modernize-use-equals-delete,
   modernize-use-nullptr,
   modernize-use-override,
-  modernize-use-emplace
+  modernize-use-emplace,
+  readability-container-size-empty
 
 CheckOptions:
   # `cppcoreguidelines-special-member-functions` is enabled, refer to https://en.cppreference.com/w/cpp/language/rule_of_three

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ option(ONNX_DISABLE_EXCEPTIONS "Disable exception handling." OFF)
 option(ONNX_DISABLE_STATIC_REGISTRATION "Disable static registration for onnx operator schemas." OFF)
 option(ONNX_USE_UNITY_BUILD "Enable Unity (Jumbo) build for" OFF)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 if(NOT DEFINED ONNX_ML)
   if(DEFINED ENV{ONNX_ML})
     set(DEFAULT_ONNX_ML $ENV{ONNX_ML})

--- a/onnx/defs/data_type_utils.cc
+++ b/onnx/defs/data_type_utils.cc
@@ -95,12 +95,14 @@ std::mutex& DataTypeUtils::GetTypeStrLock() {
 DataType DataTypeUtils::ToType(const TypeProto& type_proto) {
   auto typeStr = ToString(type_proto);
   std::lock_guard<std::mutex> lock(GetTypeStrLock());
-  if (GetTypeStrToProtoMap().find(typeStr) == GetTypeStrToProtoMap().end()) {
+  auto it = GetTypeStrToProtoMap().find(typeStr);
+  if (it == GetTypeStrToProtoMap().end()) {
     TypeProto type;
     FromString(typeStr, type);
     GetTypeStrToProtoMap()[typeStr] = type;
+    it = GetTypeStrToProtoMap().find(typeStr);
   }
-  return &(GetTypeStrToProtoMap().find(typeStr)->first);
+  return &(it->first);
 }
 
 DataType DataTypeUtils::ToType(const std::string& type_str) {

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -2349,7 +2349,7 @@ void col2imShapeInference(InferenceContext& ctx) {
   // Image dimensions are dynamic
   for (auto i = 0; i < n_input_dims.dim_value(); ++i) {
     Dim image_dim_i;
-    if (image_shape.size() > 0) {
+    if (!image_shape.empty()) {
       image_dim_i.set_dim_value(image_shape[i]); // Otherwise, spatial dimensions are unknown
     }
     *final_image_shape->add_dim() = image_dim_i;

--- a/onnx/defs/printer.cc
+++ b/onnx/defs/printer.cc
@@ -372,10 +372,10 @@ void ProtoPrinter::print(const NodeProto& node) {
   }
   printIdSet("", ", ", "", node.output());
   output_ << " = ";
-  if (node.domain() != "")
+  if (!node.domain().empty())
     output_ << node.domain() << ".";
   output_ << node.op_type();
-  if (node.overload() != "")
+  if (!node.overload().empty())
     output_ << ":" << node.overload();
   bool has_subgraph = false;
   for (const auto& attr : node.attribute())

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -42,7 +42,7 @@ struct FunctionBodyBuildContextImpl : public FunctionBodyBuildContext {
   // The default value for input_types is included only for backward compatibility.
   // It can be used for functions that do not depend on the type-context, but
   // will not be sufficient for functions that do use the type-context.
-  FunctionBodyBuildContextImpl(const NodeProto& node_proto, const std::vector<TypeProto>& input_types = {})
+  explicit FunctionBodyBuildContextImpl(const NodeProto& node_proto, const std::vector<TypeProto>& input_types = {})
       : node_proto_(node_proto), input_types_(input_types) {
     for (auto& attr : node_proto.attribute()) {
       attributesByName_[attr.name()] = &attr;
@@ -61,13 +61,13 @@ struct FunctionBodyBuildContextImpl : public FunctionBodyBuildContext {
   bool hasInput(int inputIndex) const override {
     if (inputIndex >= node_proto_.input_size())
       return false;
-    return node_proto_.input(inputIndex) != "";
+    return !node_proto_.input(inputIndex).empty();
   }
 
   bool hasOutput(int inputIndex) const override {
     if (inputIndex >= node_proto_.output_size())
       return false;
-    return node_proto_.output(inputIndex) != "";
+    return !node_proto_.output(inputIndex).empty();
   }
 
   const TypeProto* getInputType(int inputIndex) const override {
@@ -98,7 +98,7 @@ class SchemaError final : public std::runtime_error {
  public:
   using std::runtime_error::runtime_error;
 
-  SchemaError(const std::string& message) : std::runtime_error(message) {}
+  explicit SchemaError(const std::string& message) : std::runtime_error(message) {}
 
   const char* what() const noexcept override {
     if (!expanded_message_.empty()) {

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -790,7 +790,7 @@ result = [
 ```
 )DOC";
 
-inline void processSliceInputs(const int64_t input_rank, int64_t& start, int64_t& end, int64_t& step) {
+inline void processSliceInputs(const int64_t input_rank, int64_t& start, int64_t& end, int64_t step) {
   auto clamp = [](int64_t val, int64_t min, int64_t max) -> int64_t {
     return (val < min) ? min : (val > max) ? max : val;
   };

--- a/onnx/shape_inference/implementation.cc
+++ b/onnx/shape_inference/implementation.cc
@@ -481,7 +481,7 @@ class ShapeInferenceImplBase {
         if (options.check_type) {
           schema->CheckInputOutputType(ctx);
         }
-      } else if (model_local_functions_map.size() > 0) {
+      } else if (!model_local_functions_map.empty()) {
         auto iter = model_local_functions_map.find(GetFunctionIdentifier(n));
         if (iter != model_local_functions_map.end()) {
           ProcessCall(n, *(iter->second), ctx);

--- a/onnx/version_converter/convert.cc
+++ b/onnx/version_converter/convert.cc
@@ -58,7 +58,7 @@ void DefaultVersionConverter::convert_graph(
   // Identify index of this domain in g.opset_versions
   unsigned int domain_index = 0;
   for (unsigned int i = 0; i < g->opset_versions_mutable().size(); i++) {
-    if (g->opset_versions_mutable()[i].domain() == "") {
+    if (g->opset_versions_mutable()[i].domain().empty()) {
       domain_index = i;
     }
   }
@@ -83,7 +83,7 @@ void DefaultVersionConverter::convert_graph(
                  "experimental op."
               << std::endl;
         }
-      } else if (cur_op->domain() != "" && cur_op->domain() != "ai.onnx") {
+      } else if (!cur_op->domain().empty() && cur_op->domain() != "ai.onnx") {
         if (DEBUG) {
           std::cerr << "Warning: opset domain '" << cur_op->domain() << "' is not supported." << std::endl;
         }


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
This PR enabled readability-container-size-empty check in clang-tidy, fixed violations.
### Motivation and Context
Better code.
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
