### PR TITLE
Support official Python launcher on Windows

### DIFF
--- a/tools/protoc-gen-mypy.bat
+++ b/tools/protoc-gen-mypy.bat
@@ -1,4 +1,4 @@
 :: SPDX-License-Identifier: Apache-2.0
 
 @echo off
-python -u "%~dp0\protoc-gen-mypy.py"
+python -u "%~dp0\protoc-gen-mypy.py" || py -u "%~dp0\protoc-gen-mypy.py"


### PR DESCRIPTION
### Description

This change modifies the mypy protoc plugin batch file to attempt to use the `py` executable if the `python` executable isn't found.

### Motivation and Context

The full context and motivation is covered in https://github.com/onnx/onnx/issues/6406, but the summary is that different installers on Windows give the Python executable different names (`python` or `py`) and without this change this script blocks ONNX installation on Arm-based PCs, or any other Windows machines that use the official Python dot org installer.