### PR TITLE
Update op_pool_common.py, add missing "| None"

### DIFF
--- a/onnx/reference/ops/op_pool_common.py
+++ b/onnx/reference/ops/op_pool_common.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import itertools
 import math
-from typing import Sequence
+from typing import Sequence, Optionalt
 
 import numpy as np
 
@@ -51,7 +51,7 @@ def get_pad_with_auto_pad(auto_pad: str, pad_shape: Sequence[int]) -> Sequence[i
 
 
 def get_output_shape_explicit_padding(
-    pads: Sequence[int],
+    pads: Sequence[int] | None,
     input_spatial_shape: Sequence[int],
     kernel_spatial_shape: Sequence[int],
     strides_spatial: Sequence[int],

--- a/onnx/reference/ops/op_pool_common.py
+++ b/onnx/reference/ops/op_pool_common.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import itertools
 import math
-from typing import Sequence, Optionalt
+from typing import Sequence
 
 import numpy as np
 


### PR DESCRIPTION
for example

onnx/backend/test/case/node/averagepool.py
uses 
pads = None

### Description
<!-- - Describe your changes. -->

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
