### PR TITLE
Fix parser to handle empty optional parameters in edge cases

### DIFF
--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -141,15 +141,31 @@ bool ParserBase::NextIsValidFloatString() {
   return false;
 }
 
+// Parsing an IdList (list of identifiers separated by commas, where identifiers are allowed to be empty).
+// Used to represent the list of inputs or outputs of a node.
+// An empty identifier may be represented by an empty string "" or by nothing followed by a single comma.
+// "Op()" has no operands
+// "Op(,x)"" has two operands, the first being empty.
+// 'Op("")' has one operand, which is an empty string.
+// 'Op(,)' has one operand, which is an empty string.
+// Thus, this will also allow a trailing comma after a non-empty identifier with no effect.
+// 'Op(x,)' has one operand, which is 'x'.
+//
+// This is mostly for some backward compatibility. "" is a simpler way to represent an
+// empty identifier that is less confusing and is recommended.
+
 Status OnnxParser::Parse(IdList& idlist) {
   idlist.Clear();
   std::string id;
-  CHECK_PARSER_STATUS(ParseOptionalQuotableIdentifier(id));
-  if (id.empty())
-    return Status::OK(); // Treat as empty list of identifiers
+  bool found;
+  CHECK_PARSER_STATUS(ParseOptionalQuotableIdentifier(id, found));
+  if (!found)
+    return Status::OK();
   *idlist.Add() = id;
   while (Matches(',')) {
-    CHECK_PARSER_STATUS(ParseOptionalQuotableIdentifier(id));
+    CHECK_PARSER_STATUS(ParseOptionalQuotableIdentifier(id, found));
+    if (!found)
+      break;
     *idlist.Add() = id;
   }
   return Status::OK();

--- a/onnx/defs/parser.h
+++ b/onnx/defs/parser.h
@@ -376,6 +376,29 @@ class ParserBase {
     return ParseOptionalIdentifier(id);
   }
 
+  // Parse an optional quotable identifier, and return whether an identifier was found
+  // in the output parameter 'id_found'.
+  // A empty string followed by a comma is considered to be a valid, but empty, identifier.
+  // This helps handle the following different cases:
+  // "Op()" has no operands
+  // "Op(,x)"" has two operands, the first being empty.
+  // 'Op("")' has one operand, which is an empty string.
+  // 'Op(,)' has one operand, which is an empty string.
+  // Thus, this will also allow a trailing comma after a non-empty identifier with no effect.
+  // 'Op(x,)' has one operand, which is 'x'.
+  //
+  // This is mostly for some backward compatibility. "" is a simpler way to represent an
+  // empty identifier that is less confusing and is recommended.
+  Status ParseOptionalQuotableIdentifier(std::string& id, bool& id_found) {
+    if (NextChar() == '"') {
+      id_found = true;
+      return Parse(id);
+    }
+    Status status = ParseOptionalIdentifier(id);
+    id_found = !id.empty() || NextChar() == ',';
+    return status;
+  }
+
   Status PeekIdentifier(std::string& id) {
     SavePos();
     ParseOptionalIdentifier(id);

--- a/onnx/test/cpp/parser_test.cc
+++ b/onnx/test/cpp/parser_test.cc
@@ -238,6 +238,24 @@ TEST(ParserTest, OptionalInputTest) {
   EXPECT_EQ(n.input(2), "z");
 }
 
+TEST(ParserTest, LeadingOptionalInputTest) {
+  const char* code = "x = SomeOp( , z)";
+  NodeProto n;
+  Parse(n, code);
+  EXPECT_EQ(n.input_size(), 2);
+  EXPECT_EQ(n.input(0), "");
+  EXPECT_EQ(n.input(1), "z");
+}
+
+TEST(ParserTest, LeadingOptionalInputTest2) {
+  const char* code = "x = SomeOp(\"\" , z)";
+  NodeProto n;
+  Parse(n, code);
+  EXPECT_EQ(n.input_size(), 2);
+  EXPECT_EQ(n.input(0), "");
+  EXPECT_EQ(n.input(1), "z");
+}
+
 TEST(ParserTest, OptionalInputTest2) {
   const char* code = "x = SomeOp(y, \"\", z)";
   NodeProto n;

--- a/onnx/test/parser_test.py
+++ b/onnx/test/parser_test.py
@@ -220,6 +220,28 @@ class TestBasicFunctions(unittest.TestCase):
         self.assertEqual(node.domain, "SomeDomain")
         self.assertEqual(node.op_type, "SomeOp")
 
+    def test_missing_identifier(self):
+        node = onnx.parser.parse_node("= SomeOp ()")
+        self.assertEqual(list(node.input), [])
+        self.assertEqual(list(node.output), [])
+        node = onnx.parser.parse_node(", = SomeOp (,)")
+        self.assertEqual(list(node.input), [""])
+        self.assertEqual(list(node.output), [""])
+        node = onnx.parser.parse_node("x, = SomeOp (y,)")
+        self.assertEqual(list(node.input), ["y"])
+        self.assertEqual(list(node.output), ["x"])
+        node = onnx.parser.parse_node(",x = SomeOp (,y)")
+        self.assertEqual(list(node.input), ["", "y"])
+        self.assertEqual(list(node.output), ["", "x"])
+
+    def test_quoted_empty_identifier(self):
+        node = onnx.parser.parse_node('"" = SomeOp ("")')
+        self.assertEqual(list(node.input), [""])
+        self.assertEqual(list(node.output), [""])
+        node = onnx.parser.parse_node('"",x = SomeOp ("",y)')
+        self.assertEqual(list(node.input), ["", "y"])
+        self.assertEqual(list(node.output), ["", "x"])
+
     @parameterized.expand(
         [
             ("not_a_good_float", True),


### PR DESCRIPTION
Fix parser to handle empty optional parameters in edge cases. Currently, it does not handle a missing optional parameter in the first position.

There are a few edge cases. We have to handle both the original way of specifying a missing optional parameter (with nothing followed by a comma, see examples below) and the added new way we have now with support for quoted identifiers (using an empty string "").

Examples:
* `Op()` has no operands
* `Op(,x)` has two operands, the first being empty.
* `Op("")` has one operand, which is an empty string.
* `Op(,)` has one operand, which is an empty string.

Thus, we allow a trailing comma after a non-empty identifier with no effect.
* `Op(x,)` has one operand, which is 'x'.