### PR TITLE
Support models larger than 2GB

### DIFF
--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -213,6 +213,8 @@ def extract_model(
     which is defined by the input and output tensors, should not _cut through_ the
     subgraph that is connected to the _main graph_ as attributes of these operators.
 
+    Note: When the extracted model size is larger than 2GB, the extra data will be saved in "output_path.data".
+
     Arguments:
         input_path (str | os.PathLike): The path to original ONNX model.
         output_path (str | os.PathLike): The path to save the extracted ONNX model.

--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -10,7 +10,6 @@ import onnx.checker
 import onnx.helper
 import onnx.shape_inference
 from onnx import FunctionProto, ModelProto, NodeProto, TensorProto, ValueInfoProto
-from onnx.checker import MAXIMUM_PROTOBUF
 
 
 class Extractor:
@@ -232,7 +231,7 @@ def extract_model(
     if check_model:
         onnx.checker.check_model(input_path)
 
-    if infer_shapes and os.path.getsize(input_path) > MAXIMUM_PROTOBUF:
+    if infer_shapes and os.path.getsize(input_path) > onnx.checker.MAXIMUM_PROTOBUF:
         onnx.shape_inference.infer_shapes_path(input_path, output_path)
         model = onnx.load(output_path)
     else:
@@ -243,8 +242,8 @@ def extract_model(
     e = Extractor(model)
     extracted = e.extract_model(input_names, output_names)
 
-    if extracted.ByteSize() > MAXIMUM_PROTOBUF:
-        location = os.path.basename(output_path) + "_data"
+    if extracted.ByteSize() > onnx.checker.MAXIMUM_PROTOBUF:
+        location = os.path.basename(output_path) + ".data"
         onnx.save(extracted, output_path, save_as_external_data=True, location=location)
     else:
         onnx.save(extracted, output_path)


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->

1. Check model.ByteSize() to decide whether to use `infer_shapes_path` or `infer_shapes`.
2. Check model.ByteSize() to decide whether to use `save_as_external_data` on `onnx.save`.

Note that if `save_as_external_data=False`, the following `check_model` may fail.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->

Current `extract_model` function does not support models larger than 2GB.
For example, issue https://github.com/onnx/onnx/issues/6368 is caused by large models like an UNet.
This PR improves the existing function by checking the size of the model.