### PR TITLE
Use enum class for StatusCategory and StatusCode

### DIFF
--- a/onnx/common/model_helpers.cc
+++ b/onnx/common/model_helpers.cc
@@ -15,7 +15,8 @@ Common::Status BuildNode(
     std::vector<std::string> const& outputs,
     NodeProto* node) {
   if (node == nullptr) {
-    return Common::Status(Common::CHECKER, Common::INVALID_ARGUMENT, "node_proto should not be nullptr.");
+    return Common::Status(
+        Common::StatusCategory::CHECKER, Common::StatusCode::INVALID_ARGUMENT, "node_proto should not be nullptr.");
   }
   node->set_name(name);
   node->set_domain(domain);

--- a/onnx/common/status.cc
+++ b/onnx/common/status.cc
@@ -14,12 +14,12 @@
 namespace ONNX_NAMESPACE {
 namespace Common {
 
-Status::Status(StatusCategory category, int code, const std::string& msg) {
-  assert(static_cast<int>(StatusCode::OK) != code);
+Status::Status(StatusCategory category, StatusCode code, const std::string& msg) {
+  assert(StatusCode::OK != code);
   state_ = std::make_unique<State>(category, code, msg);
 }
 
-Status::Status(StatusCategory category, int code) : Status(category, code, EmptyString()) {}
+Status::Status(StatusCategory category, StatusCode code) : Status(category, code, EmptyString()) {}
 
 bool Status::IsOK() const noexcept {
   return (state_ == nullptr);
@@ -29,8 +29,8 @@ StatusCategory Status::Category() const noexcept {
   return IsOK() ? StatusCategory::NONE : state_->category;
 }
 
-int Status::Code() const noexcept {
-  return IsOK() ? static_cast<int>(StatusCode::OK) : state_->code;
+StatusCode Status::Code() const noexcept {
+  return IsOK() ? StatusCode::OK : state_->code;
 }
 
 const std::string& Status::ErrorMessage() const {
@@ -51,17 +51,17 @@ std::string Status::ToString() const {
   }
 
   result += " : ";
-  result += ONNX_NAMESPACE::to_string(Code());
+  result += ONNX_NAMESPACE::to_string(static_cast<int>(Code()));
   std::string msg;
 
-  switch (static_cast<StatusCode>(Code())) {
-    case INVALID_ARGUMENT:
+  switch (Code()) {
+    case StatusCode::INVALID_ARGUMENT:
       msg = "INVALID_ARGUMENT";
       break;
-    case INVALID_PROTOBUF:
+    case StatusCode::INVALID_PROTOBUF:
       msg = "INVALID_PROTOBUF";
       break;
-    case FAIL:
+    case StatusCode::FAIL:
       msg = "FAIL";
       break;
     default:

--- a/onnx/common/status.h
+++ b/onnx/common/status.h
@@ -14,13 +14,13 @@
 namespace ONNX_NAMESPACE {
 namespace Common {
 
-enum StatusCategory {
+enum class StatusCategory {
   NONE = 0,
   CHECKER = 1,
   OPTIMIZER = 2,
 };
 
-enum StatusCode {
+enum class StatusCode {
   OK = 0,
   FAIL = 1,
   INVALID_ARGUMENT = 2,
@@ -31,9 +31,9 @@ class Status {
  public:
   Status() noexcept = default;
 
-  Status(StatusCategory category, int code, const std::string& msg);
+  Status(StatusCategory category, StatusCode code, const std::string& msg);
 
-  Status(StatusCategory category, int code);
+  Status(StatusCategory category, StatusCode code);
 
   Status(const Status& other) {
     *this = other;
@@ -56,7 +56,7 @@ class Status {
 
   bool IsOK() const noexcept;
 
-  int Code() const noexcept;
+  StatusCode Code() const noexcept;
 
   StatusCategory Category() const noexcept;
 
@@ -76,10 +76,11 @@ class Status {
 
  private:
   struct State {
-    State(StatusCategory cat_, int code_, std::string msg_) : category(cat_), code(code_), msg(std::move(msg_)) {}
+    State(StatusCategory cat_, StatusCode code_, std::string msg_)
+        : category(cat_), code(code_), msg(std::move(msg_)) {}
 
     StatusCategory category = StatusCategory::NONE;
-    int code = 0;
+    StatusCode code{};
     std::string msg;
   };
 

--- a/onnx/defs/parser.h
+++ b/onnx/defs/parser.h
@@ -229,8 +229,8 @@ class ParserBase {
   template <typename... Args>
   Status ParseError(const Args&... args) {
     return Status(
-        NONE,
-        FAIL,
+        StatusCategory::NONE,
+        StatusCode::FAIL,
         ONNX_NAMESPACE::MakeString(
             "[ParseError at position ", GetCurrentPos(), "]\n", "Error context: ", GetErrorContext(), "\n", args...));
   }


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Change StatusCategory and StatusCode to enum classes for better type checking. 
### Motivation and Context
For better type checking.
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
