### PR TITLE
Optimize dfs in extract_model by dict

### DIFF
--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -60,22 +60,22 @@ class Extractor:
             reachable (set of int): The set of indexes to reachable nodes in `nodes`
             output_to_index (dict of str to int): The dictionary that maps output name to corresponding node index.
         """
-        stack = [output_to_index[node_output_name]]
+        stack = [node_output_name]
         while stack:
-            current_index = stack.pop()
-            if current_index in reachable:
+            current_output_name = stack.pop()
+
+            # finish search at inputs
+            if current_output_name in graph_input_names:
                 continue
-            reachable.add(current_index)
-            # finish search at graph_input_names
-            current_node = self.graph.node[current_index]
-            if set(current_node.input) & graph_input_names:
-                continue
-            # add nodes connected to this node to stack
-            for input_name in current_node.input:
-                if input_name in output_to_index:
-                    next_index = output_to_index[input_name]
-                    if next_index not in reachable:
-                        stack.append(next_index)
+
+            # find nodes connected to this output
+            if current_output_name in output_to_index:
+                index = output_to_index[current_output_name]
+                if index in reachable:
+                    continue
+                # add nodes connected to this output to sets
+                reachable.add(index)
+                stack += self.graph.node[index].input
 
     def _collect_reachable_nodes(
         self,

--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -86,7 +86,9 @@ class Extractor:
                 assert output_name not in output_to_index_node
                 output_to_index_node[output_name] = (index, node)
         for output_name in output_names:
-            self._dfs_search_reachable_nodes(output_name, input_names, reachable, output_to_index_node)
+            self._dfs_search_reachable_nodes(
+                output_name, input_names, reachable, output_to_index_node
+            )
         # needs to be topologically sorted
         return [self.graph.node[index] for index in sorted(reachable)]
 
@@ -105,7 +107,11 @@ class Extractor:
             for node in nodes:
                 # check if the node is a function op
                 match_function = next(
-                    (f for f in self.model.functions if f.name == node.op_type and f.domain == node.domain),
+                    (
+                        f
+                        for f in self.model.functions
+                        if f.name == node.op_type and f.domain == node.domain
+                    ),
                     None,
                 )
                 if match_function and match_function not in referred_local_functions:
@@ -135,10 +141,14 @@ class Extractor:
         value_info = [self.vimap[t] for t in self.vimap if t in all_tensors_names]
         len_sparse_initializer = len(self.graph.sparse_initializer)
         if len_sparse_initializer != 0:
-            raise ValueError(f"len_sparse_initializer is {len_sparse_initializer}, it must be 0.")
+            raise ValueError(
+                f"len_sparse_initializer is {len_sparse_initializer}, it must be 0."
+            )
         len_quantization_annotation = len(self.graph.quantization_annotation)
         if len_quantization_annotation != 0:
-            raise ValueError(f"len_quantization_annotation is {len_quantization_annotation}, it must be 0.")
+            raise ValueError(
+                f"len_quantization_annotation is {len_quantization_annotation}, it must be 0."
+            )
         return initializer, value_info
 
     def _make_model(
@@ -151,7 +161,9 @@ class Extractor:
         local_functions: list[FunctionProto],
     ) -> ModelProto:
         name = "Extracted from {" + self.graph.name + "}"
-        graph = onnx.helper.make_graph(nodes, name, inputs, outputs, initializer=initializer, value_info=value_info)
+        graph = onnx.helper.make_graph(
+            nodes, name, inputs, outputs, initializer=initializer, value_info=value_info
+        )
 
         meta = {
             "ir_version": self.model.ir_version,
@@ -171,7 +183,9 @@ class Extractor:
         nodes = self._collect_reachable_nodes(input_names, output_names)
         initializer, value_info = self._collect_reachable_tensors(nodes)
         local_functions = self._collect_referred_local_functions(nodes)
-        model = self._make_model(nodes, inputs, outputs, initializer, value_info, local_functions)
+        model = self._make_model(
+            nodes, inputs, outputs, initializer, value_info, local_functions
+        )
 
         return model
 
@@ -217,7 +231,9 @@ def extract_model(
         raise ValueError("Duplicate names found in the output tensor names.")
 
     if set(input_names) & set(output_names):
-        raise ValueError("Input tensor names shall not be included in the output tensor names.")
+        raise ValueError(
+            "Input tensor names shall not be included in the output tensor names."
+        )
 
     if check_model:
         onnx.checker.check_model(input_path)
@@ -243,7 +259,9 @@ def extract_model(
         onnx.checker.check_model(output_path)
 
 
-def _tar_members_filter(tar: tarfile.TarFile, base: str | os.PathLike) -> list[tarfile.TarInfo]:
+def _tar_members_filter(
+    tar: tarfile.TarFile, base: str | os.PathLike
+) -> list[tarfile.TarInfo]:
     """Check that the content of ``tar`` will be extracted safely
 
     Args:
@@ -272,7 +290,9 @@ def _tar_members_filter(tar: tarfile.TarFile, base: str | os.PathLike) -> list[t
     return result
 
 
-def _extract_model_safe(model_tar_path: str | os.PathLike, local_model_with_data_dir_path: str | os.PathLike) -> None:
+def _extract_model_safe(
+    model_tar_path: str | os.PathLike, local_model_with_data_dir_path: str | os.PathLike
+) -> None:
     """Safely extracts a tar file to a specified directory.
 
     This function ensures that the extraction process mitigates against
@@ -289,9 +309,13 @@ def _extract_model_safe(model_tar_path: str | os.PathLike, local_model_with_data
     with tarfile.open(model_tar_path) as model_with_data_zipped:
         # Mitigate tarball directory traversal risks
         if hasattr(tarfile, "data_filter"):
-            model_with_data_zipped.extractall(path=local_model_with_data_dir_path, filter="data")
+            model_with_data_zipped.extractall(
+                path=local_model_with_data_dir_path, filter="data"
+            )
         else:
             model_with_data_zipped.extractall(
                 path=local_model_with_data_dir_path,
-                members=_tar_members_filter(model_with_data_zipped, local_model_with_data_dir_path),
+                members=_tar_members_filter(
+                    model_with_data_zipped, local_model_with_data_dir_path
+                ),
             )

--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -231,11 +231,6 @@ def extract_model(
     if len(output_names) != len(set(output_names)):
         raise ValueError("Duplicate names found in the output tensor names.")
 
-    if set(input_names) & set(output_names):
-        raise ValueError(
-            "Input tensor names shall not be included in the output tensor names."
-        )
-
     if check_model:
         onnx.checker.check_model(input_path)
 

--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -69,9 +69,10 @@ class Extractor:
                 continue
             # add nodes connected to this node to stack
             for input_name in current_node.input:
-                next_index, next_node = output_to_index_node[input_name]
-                if next_index not in reachable:
-                    stack.append((next_index, next_node))
+                if input_name in output_to_index_node:
+                    next_index, next_node = output_to_index_node[input_name]
+                    if next_index not in reachable:
+                        stack.append((next_index, next_node))
 
     def _collect_reachable_nodes(
         self,
@@ -85,9 +86,7 @@ class Extractor:
                 assert output_name not in output_to_index_node
                 output_to_index_node[output_name] = (index, node)
         for output_name in output_names:
-            self._dfs_search_reachable_nodes(
-                output_name, input_names, reachable, output_to_index_node
-            )
+            self._dfs_search_reachable_nodes(output_name, input_names, reachable, output_to_index_node)
         # needs to be topologically sorted
         return [self.graph.node[index] for index in sorted(reachable)]
 
@@ -106,11 +105,7 @@ class Extractor:
             for node in nodes:
                 # check if the node is a function op
                 match_function = next(
-                    (
-                        f
-                        for f in self.model.functions
-                        if f.name == node.op_type and f.domain == node.domain
-                    ),
+                    (f for f in self.model.functions if f.name == node.op_type and f.domain == node.domain),
                     None,
                 )
                 if match_function and match_function not in referred_local_functions:
@@ -140,14 +135,10 @@ class Extractor:
         value_info = [self.vimap[t] for t in self.vimap if t in all_tensors_names]
         len_sparse_initializer = len(self.graph.sparse_initializer)
         if len_sparse_initializer != 0:
-            raise ValueError(
-                f"len_sparse_initializer is {len_sparse_initializer}, it must be 0."
-            )
+            raise ValueError(f"len_sparse_initializer is {len_sparse_initializer}, it must be 0.")
         len_quantization_annotation = len(self.graph.quantization_annotation)
         if len_quantization_annotation != 0:
-            raise ValueError(
-                f"len_quantization_annotation is {len_quantization_annotation}, it must be 0."
-            )
+            raise ValueError(f"len_quantization_annotation is {len_quantization_annotation}, it must be 0.")
         return initializer, value_info
 
     def _make_model(
@@ -160,9 +151,7 @@ class Extractor:
         local_functions: list[FunctionProto],
     ) -> ModelProto:
         name = "Extracted from {" + self.graph.name + "}"
-        graph = onnx.helper.make_graph(
-            nodes, name, inputs, outputs, initializer=initializer, value_info=value_info
-        )
+        graph = onnx.helper.make_graph(nodes, name, inputs, outputs, initializer=initializer, value_info=value_info)
 
         meta = {
             "ir_version": self.model.ir_version,
@@ -182,9 +171,7 @@ class Extractor:
         nodes = self._collect_reachable_nodes(input_names, output_names)
         initializer, value_info = self._collect_reachable_tensors(nodes)
         local_functions = self._collect_referred_local_functions(nodes)
-        model = self._make_model(
-            nodes, inputs, outputs, initializer, value_info, local_functions
-        )
+        model = self._make_model(nodes, inputs, outputs, initializer, value_info, local_functions)
 
         return model
 
@@ -230,9 +217,7 @@ def extract_model(
         raise ValueError("Duplicate names found in the output tensor names.")
 
     if set(input_names) & set(output_names):
-        raise ValueError(
-            "Input tensor names shall not be included in the output tensor names."
-        )
+        raise ValueError("Input tensor names shall not be included in the output tensor names.")
 
     if check_model:
         onnx.checker.check_model(input_path)
@@ -258,9 +243,7 @@ def extract_model(
         onnx.checker.check_model(output_path)
 
 
-def _tar_members_filter(
-    tar: tarfile.TarFile, base: str | os.PathLike
-) -> list[tarfile.TarInfo]:
+def _tar_members_filter(tar: tarfile.TarFile, base: str | os.PathLike) -> list[tarfile.TarInfo]:
     """Check that the content of ``tar`` will be extracted safely
 
     Args:
@@ -289,9 +272,7 @@ def _tar_members_filter(
     return result
 
 
-def _extract_model_safe(
-    model_tar_path: str | os.PathLike, local_model_with_data_dir_path: str | os.PathLike
-) -> None:
+def _extract_model_safe(model_tar_path: str | os.PathLike, local_model_with_data_dir_path: str | os.PathLike) -> None:
     """Safely extracts a tar file to a specified directory.
 
     This function ensures that the extraction process mitigates against
@@ -308,13 +289,9 @@ def _extract_model_safe(
     with tarfile.open(model_tar_path) as model_with_data_zipped:
         # Mitigate tarball directory traversal risks
         if hasattr(tarfile, "data_filter"):
-            model_with_data_zipped.extractall(
-                path=local_model_with_data_dir_path, filter="data"
-            )
+            model_with_data_zipped.extractall(path=local_model_with_data_dir_path, filter="data")
         else:
             model_with_data_zipped.extractall(
                 path=local_model_with_data_dir_path,
-                members=_tar_members_filter(
-                    model_with_data_zipped, local_model_with_data_dir_path
-                ),
+                members=_tar_members_filter(model_with_data_zipped, local_model_with_data_dir_path),
             )

--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -50,6 +50,7 @@ class Extractor:
         node_output_name: str,
         graph_input_names: list[str],
         reachable: set[int],
+        output_to_index_node: dict[str, tuple[int, NodeProto]],
     ) -> None:
         """Helper function to find nodes which are connected to an output
 
@@ -57,13 +58,8 @@ class Extractor:
             node_output_name (str): The name of the output
             graph_input_names (list of string): The names of all inputs of the graph
             reachable (set of int): The set of indexes to reachable nodes in `nodes`
+            output_to_index_node (dict of str to tuple): The dictionary that maps output name to corresponding node index and node.
         """
-        output_to_index_node = {}
-        for index, node in enumerate(self.graph.node):
-            for output_name in node.output:
-                assert output_name not in output_to_index_node
-                output_to_index_node[output_name] = (index, node)
-
         stack = [output_to_index_node[node_output_name]]
         while stack:
             current_index, current_node = stack.pop()
@@ -83,8 +79,15 @@ class Extractor:
         output_names: list[str],
     ) -> list[NodeProto]:
         reachable: set[int] = set()
+        output_to_index_node: dict[str, tuple[int, NodeProto]] = {}
+        for index, node in enumerate(self.graph.node):
+            for output_name in node.output:
+                assert output_name not in output_to_index_node
+                output_to_index_node[output_name] = (index, node)
         for output_name in output_names:
-            self._dfs_search_reachable_nodes(output_name, input_names, reachable)
+            self._dfs_search_reachable_nodes(
+                output_name, input_names, reachable, output_to_index_node
+            )
         # needs to be topologically sorted
         return [self.graph.node[index] for index in sorted(reachable)]
 

--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -82,6 +82,7 @@ class Extractor:
         input_names: list[str],
         output_names: list[str],
     ) -> list[NodeProto]:
+        _input_names = set(input_names)
         reachable: set[int] = set()
         output_to_index: dict[str, int] = {}
         for index, node in enumerate(self.graph.node):
@@ -90,7 +91,7 @@ class Extractor:
                 output_to_index[output_name] = index
         for name in output_names:
             self._dfs_search_reachable_nodes(
-                name, set(input_names), reachable, output_to_index
+                name, _input_names, reachable, output_to_index
             )
         # needs to be topologically sorted
         return [self.graph.node[index] for index in sorted(reachable)]

--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -88,9 +88,9 @@ class Extractor:
             for output_name in node.output:
                 assert output_name not in output_to_index  # output_name is unique
                 output_to_index[output_name] = index
-        for output_name in output_names:
+        for name in output_names:
             self._dfs_search_reachable_nodes(
-                output_name, set(input_names), reachable, output_to_index
+                name, set(input_names), reachable, output_to_index
             )
         # needs to be topologically sorted
         return [self.graph.node[index] for index in sorted(reachable)]

--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -63,19 +63,16 @@ class Extractor:
         stack = [node_output_name]
         while stack:
             current_output_name = stack.pop()
-
             # finish search at inputs
             if current_output_name in graph_input_names:
                 continue
-
             # find nodes connected to this output
             if current_output_name in output_to_index:
                 index = output_to_index[current_output_name]
-                if index in reachable:
-                    continue
-                # add nodes connected to this output to sets
-                reachable.add(index)
-                stack += self.graph.node[index].input
+                if index not in reachable:
+                    # add nodes connected to this output to sets
+                    reachable.add(index)
+                    stack += self.graph.node[index].input
 
     def _collect_reachable_nodes(
         self,

--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -63,6 +63,8 @@ class Extractor:
         stack = [output_to_index_node[node_output_name]]
         while stack:
             current_index, current_node = stack.pop()
+            if current_index in reachable:
+                continue
             reachable.add(current_index)
             # finish search at graph_input_names
             if set(current_node.input) & set(graph_input_names):


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->

Use a dictionary `output_to_index` to map an output name to the index of the corresponding node.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->

There are some facts:
1. `reachable` and `unreachable` are mutually exclusive sets. `reachable` union `unreachable` equals to all nodes.
2. In onnx, output name is unique. `len(nodes_to_search)` is either 0 or 1.
```
nodes_to_search = [
    index
    for index in unreachable
    if current_output_name in nodes[index].output
]
```
This step can be speed up by using a `dict` to map an output name to a node.
After introducing a dict, there's no reason to keep `unreachable`, all unreachable checks can be done by `reachable`

### Experiment Results

I did an experiment to extract a unet model (around 3.3GB, 4900 nodes).
```
extract_model(
    input_path=model_path,
    output_path=model_path + ".tmp",
    input_names=[node.name for node in model.graph.input],
    output_names=[node.name for node in model.graph.output],
)
```
The execution time of the `Extractor.extract_model` function is reduced from 7.24 seconds to 1.15 seconds.
The `Extractor.extract_model` function is no longer the slowest part of the extract model process.
```
check_model 3.31s
infer_shapes 6.15s
Extractor.extract_model 1.16s
onnx.save 5.60s
check_model 2.40s

real    0m20.376s
user    0m7.284s
sys     0m14.980s
```