### PR TITLE
Unify the behavior of infer_shapes and check_model

### DIFF
--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -87,7 +87,9 @@ class Extractor:
                 assert output_name not in output_to_index  # output_name is unique
                 output_to_index[output_name] = index
         for name in output_names:
-            self._dfs_search_reachable_nodes(name, _input_names, reachable, output_to_index)
+            self._dfs_search_reachable_nodes(
+                name, _input_names, reachable, output_to_index
+            )
         # needs to be topologically sorted
         return [self.graph.node[index] for index in sorted(reachable)]
 
@@ -106,7 +108,11 @@ class Extractor:
             for node in nodes:
                 # check if the node is a function op
                 match_function = next(
-                    (f for f in self.model.functions if f.name == node.op_type and f.domain == node.domain),
+                    (
+                        f
+                        for f in self.model.functions
+                        if f.name == node.op_type and f.domain == node.domain
+                    ),
                     None,
                 )
                 if match_function and match_function not in referred_local_functions:
@@ -136,10 +142,14 @@ class Extractor:
         value_info = [self.vimap[t] for t in self.vimap if t in all_tensors_names]
         len_sparse_initializer = len(self.graph.sparse_initializer)
         if len_sparse_initializer != 0:
-            raise ValueError(f"len_sparse_initializer is {len_sparse_initializer}, it must be 0.")
+            raise ValueError(
+                f"len_sparse_initializer is {len_sparse_initializer}, it must be 0."
+            )
         len_quantization_annotation = len(self.graph.quantization_annotation)
         if len_quantization_annotation != 0:
-            raise ValueError(f"len_quantization_annotation is {len_quantization_annotation}, it must be 0.")
+            raise ValueError(
+                f"len_quantization_annotation is {len_quantization_annotation}, it must be 0."
+            )
         return initializer, value_info
 
     def _make_model(
@@ -152,7 +162,9 @@ class Extractor:
         local_functions: list[FunctionProto],
     ) -> ModelProto:
         name = "Extracted from {" + self.graph.name + "}"
-        graph = onnx.helper.make_graph(nodes, name, inputs, outputs, initializer=initializer, value_info=value_info)
+        graph = onnx.helper.make_graph(
+            nodes, name, inputs, outputs, initializer=initializer, value_info=value_info
+        )
 
         meta = {
             "ir_version": self.model.ir_version,
@@ -172,7 +184,9 @@ class Extractor:
         nodes = self._collect_reachable_nodes(input_names, output_names)
         initializer, value_info = self._collect_reachable_tensors(nodes)
         local_functions = self._collect_referred_local_functions(nodes)
-        model = self._make_model(nodes, inputs, outputs, initializer, value_info, local_functions)
+        model = self._make_model(
+            nodes, inputs, outputs, initializer, value_info, local_functions
+        )
 
         return model
 
@@ -241,7 +255,9 @@ def extract_model(
         onnx.checker.check_model(output_path)
 
 
-def _tar_members_filter(tar: tarfile.TarFile, base: str | os.PathLike) -> list[tarfile.TarInfo]:
+def _tar_members_filter(
+    tar: tarfile.TarFile, base: str | os.PathLike
+) -> list[tarfile.TarInfo]:
     """Check that the content of ``tar`` will be extracted safely
 
     Args:
@@ -270,7 +286,9 @@ def _tar_members_filter(tar: tarfile.TarFile, base: str | os.PathLike) -> list[t
     return result
 
 
-def _extract_model_safe(model_tar_path: str | os.PathLike, local_model_with_data_dir_path: str | os.PathLike) -> None:
+def _extract_model_safe(
+    model_tar_path: str | os.PathLike, local_model_with_data_dir_path: str | os.PathLike
+) -> None:
     """Safely extracts a tar file to a specified directory.
 
     This function ensures that the extraction process mitigates against
@@ -287,9 +305,13 @@ def _extract_model_safe(model_tar_path: str | os.PathLike, local_model_with_data
     with tarfile.open(model_tar_path) as model_with_data_zipped:
         # Mitigate tarball directory traversal risks
         if hasattr(tarfile, "data_filter"):
-            model_with_data_zipped.extractall(path=local_model_with_data_dir_path, filter="data")
+            model_with_data_zipped.extractall(
+                path=local_model_with_data_dir_path, filter="data"
+            )
         else:
             model_with_data_zipped.extractall(
                 path=local_model_with_data_dir_path,
-                members=_tar_members_filter(model_with_data_zipped, local_model_with_data_dir_path),
+                members=_tar_members_filter(
+                    model_with_data_zipped, local_model_with_data_dir_path
+                ),
             )

--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -234,13 +234,9 @@ def extract_model(
     if check_model:
         onnx.checker.check_model(input_path)
 
-    if infer_shapes and os.path.getsize(input_path) > onnx.checker.MAXIMUM_PROTOBUF:
+    if infer_shapes:
         onnx.shape_inference.infer_shapes(input_path, output_path=output_path)
         model = onnx.load(output_path)
-    else:
-        model = onnx.load(input_path)
-        if infer_shapes:
-            model = onnx.shape_inference.infer_shapes(model)
 
     e = Extractor(model)
     extracted = e.extract_model(input_names, output_names)

--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -87,9 +87,7 @@ class Extractor:
                 assert output_name not in output_to_index  # output_name is unique
                 output_to_index[output_name] = index
         for name in output_names:
-            self._dfs_search_reachable_nodes(
-                name, _input_names, reachable, output_to_index
-            )
+            self._dfs_search_reachable_nodes(name, _input_names, reachable, output_to_index)
         # needs to be topologically sorted
         return [self.graph.node[index] for index in sorted(reachable)]
 
@@ -108,11 +106,7 @@ class Extractor:
             for node in nodes:
                 # check if the node is a function op
                 match_function = next(
-                    (
-                        f
-                        for f in self.model.functions
-                        if f.name == node.op_type and f.domain == node.domain
-                    ),
+                    (f for f in self.model.functions if f.name == node.op_type and f.domain == node.domain),
                     None,
                 )
                 if match_function and match_function not in referred_local_functions:
@@ -142,14 +136,10 @@ class Extractor:
         value_info = [self.vimap[t] for t in self.vimap if t in all_tensors_names]
         len_sparse_initializer = len(self.graph.sparse_initializer)
         if len_sparse_initializer != 0:
-            raise ValueError(
-                f"len_sparse_initializer is {len_sparse_initializer}, it must be 0."
-            )
+            raise ValueError(f"len_sparse_initializer is {len_sparse_initializer}, it must be 0.")
         len_quantization_annotation = len(self.graph.quantization_annotation)
         if len_quantization_annotation != 0:
-            raise ValueError(
-                f"len_quantization_annotation is {len_quantization_annotation}, it must be 0."
-            )
+            raise ValueError(f"len_quantization_annotation is {len_quantization_annotation}, it must be 0.")
         return initializer, value_info
 
     def _make_model(
@@ -162,9 +152,7 @@ class Extractor:
         local_functions: list[FunctionProto],
     ) -> ModelProto:
         name = "Extracted from {" + self.graph.name + "}"
-        graph = onnx.helper.make_graph(
-            nodes, name, inputs, outputs, initializer=initializer, value_info=value_info
-        )
+        graph = onnx.helper.make_graph(nodes, name, inputs, outputs, initializer=initializer, value_info=value_info)
 
         meta = {
             "ir_version": self.model.ir_version,
@@ -184,9 +172,7 @@ class Extractor:
         nodes = self._collect_reachable_nodes(input_names, output_names)
         initializer, value_info = self._collect_reachable_tensors(nodes)
         local_functions = self._collect_referred_local_functions(nodes)
-        model = self._make_model(
-            nodes, inputs, outputs, initializer, value_info, local_functions
-        )
+        model = self._make_model(nodes, inputs, outputs, initializer, value_info, local_functions)
 
         return model
 
@@ -235,7 +221,7 @@ def extract_model(
         onnx.checker.check_model(input_path)
 
     if infer_shapes and os.path.getsize(input_path) > onnx.checker.MAXIMUM_PROTOBUF:
-        onnx.shape_inference.infer_shapes_path(input_path, output_path)
+        onnx.shape_inference.infer_shapes(input_path, output_path=output_path)
         model = onnx.load(output_path)
     else:
         model = onnx.load(input_path)
@@ -255,9 +241,7 @@ def extract_model(
         onnx.checker.check_model(output_path)
 
 
-def _tar_members_filter(
-    tar: tarfile.TarFile, base: str | os.PathLike
-) -> list[tarfile.TarInfo]:
+def _tar_members_filter(tar: tarfile.TarFile, base: str | os.PathLike) -> list[tarfile.TarInfo]:
     """Check that the content of ``tar`` will be extracted safely
 
     Args:
@@ -286,9 +270,7 @@ def _tar_members_filter(
     return result
 
 
-def _extract_model_safe(
-    model_tar_path: str | os.PathLike, local_model_with_data_dir_path: str | os.PathLike
-) -> None:
+def _extract_model_safe(model_tar_path: str | os.PathLike, local_model_with_data_dir_path: str | os.PathLike) -> None:
     """Safely extracts a tar file to a specified directory.
 
     This function ensures that the extraction process mitigates against
@@ -305,13 +287,9 @@ def _extract_model_safe(
     with tarfile.open(model_tar_path) as model_with_data_zipped:
         # Mitigate tarball directory traversal risks
         if hasattr(tarfile, "data_filter"):
-            model_with_data_zipped.extractall(
-                path=local_model_with_data_dir_path, filter="data"
-            )
+            model_with_data_zipped.extractall(path=local_model_with_data_dir_path, filter="data")
         else:
             model_with_data_zipped.extractall(
                 path=local_model_with_data_dir_path,
-                members=_tar_members_filter(
-                    model_with_data_zipped, local_model_with_data_dir_path
-                ),
+                members=_tar_members_filter(model_with_data_zipped, local_model_with_data_dir_path),
             )


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->

Merge `infer_shapes` and `infer_shapes_path`. 
Allows `infer_shapes` to take path as input.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->

`check_model` can take path or ModelProto, which is very convenient. Why not make `infer_shapes` the same?