### PR TITLE
Remove pypi publishing inside "release_"

### DIFF
--- a/.github/workflows/release_linux_aarch64.yml
+++ b/.github/workflows/release_linux_aarch64.yml
@@ -81,12 +81,6 @@ jobs:
         name: wheels-${{ inputs.os }}-${{ matrix.python-version }}
         path: |
             ./dist/*.whl
-            
-    - name: Upload wheel to PyPI weekly
-      if: (github.event_name == 'schedule') # Only triggered by weekly event
-      run: |
-        python -m pip install -q twine
-        twine upload --verbose dist/*.whl --repository-url https://upload.pypi.org/legacy/ -u ${{ secrets.ONNXWEEKLY_USERNAME }} -p ${{ secrets.ONNXWEEKLY_TOKEN }}
 
     - name: Verify ONNX with the latest numpy and protobuf
       if: ${{ always() }}

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -65,10 +65,9 @@ jobs:
             ./dist/*.whl
         
 
-    - name: Upload wheel to PyPI weekly
+    - name: TEST_HUB=1 pytest
       if: (github.event_name == 'schedule') # Only triggered by weekly event
       run: |
-        twine upload --verbose dist/*.whl --repository-url https://upload.pypi.org/legacy/ -u ${{ secrets.ONNXWEEKLY_USERNAME }} -p ${{ secrets.ONNXWEEKLY_TOKEN }}
         TEST_HUB=1 pytest
 
     - name: Verify ONNX with the latest numpy

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -95,12 +95,7 @@ jobs:
     - name: Test the wheel
       run: |
         arch -${{ matrix.target-architecture }} python -m pip install --upgrade dist/*.whl
-        arch -${{ matrix.target-architecture }} pytest
-
-    - name: Upload wheel to PyPI weekly
-      if: github.event_name == 'schedule' && matrix.target-architecture == 'arm64'  # Only triggered by weekly event
-      run: |
-        twine upload --verbose dist/*.whl --repository-url https://upload.pypi.org/legacy/ -u ${{ secrets.ONNXWEEKLY_USERNAME }} -p ${{ secrets.ONNXWEEKLY_TOKEN }}
+        arch -${{ matrix.target-architecture }} pytest   
 
     - name: Verify ONNX with the latest numpy
       if: ${{ always() }}

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -82,11 +82,6 @@ jobs:
         name: wheels-${{ inputs.os }}-${{ matrix.python-version }}-${{matrix.architecture}}
         path: ./onnx/dist
 
-    - name: Upload onnx-weekly wheel to PyPI/PyPI weekly
-      if: (github.event_name == 'schedule') # Only triggered by weekly event
-      run: |
-        twine upload --verbose onnx/dist/*.whl --repository-url https://upload.pypi.org/legacy/ -u ${{ secrets.ONNXWEEKLY_USERNAME }} -p ${{ secrets.ONNXWEEKLY_TOKEN }}
-
     - name: Verify ONNX with the latest numpy
       if: ${{ always() }}
       run: |


### PR DESCRIPTION
### Description
Remove Pypi Publishing inside release_*.yml jobs... 
create_release publishes wheels

### Motivation and Context
Makes the release publines clearer/simpler. Publishing is carried out in a separate step. 

Possibly breaks something with the community, because different target repos (pypi vs testpypi)