### PR TITLE
Remove __STDC_FORMAT_MACROS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -731,8 +731,5 @@ if(ONNX_BUILD_TESTS)
   include(${ONNX_ROOT}/cmake/unittest.cmake)
 endif()
 
-# Support older g++ to use PRId64
-add_definitions(-D__STDC_FORMAT_MACROS)
-
 include(cmake/summary.cmake)
 onnx_print_configuration_summary()


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
The code actually requires C++17, so newer g++ should not rely on __STDC_FORMAT_MACROS
### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
