### PR TITLE
change onnx-weekly destination from test.pypi to pypi

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -61,17 +61,15 @@ jobs:
       os: "macos"
     secrets: inherit
 
-
-
-  publish_to_testpypi: 
-    name: Publish to testpypi, onnx-weekly
+  publish_to_pypi-onnx-weekly: 
+    name: Publish to pypi-onnx-weekly
     runs-on: ubuntu-latest
     needs: [call-workflow-ubuntu_x86, call-workflow-ubuntu_aarch64, call-workflow-mac, call-workflow-win]
     if: ${{ always() }} # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-not-requiring-successful-dependent-jobs
     
     environment:      
-      name: testpypi 
-      url: https://test.pypi.org/p/onnx-weekly
+      name: pypi-weekly 
+      url: https://pypi.org/p/onnx-weekly
 
     permissions:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases
@@ -86,11 +84,11 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - name: Publish distribution to TestPyPI
+      - name: Publish onnx-weekly to PyPI
         if: (github.event_name == 'schedule') && (github.repository_owner == 'onnx')
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@f7600683efdcb7656dec5b29656edb7bc586e597
         with:   
-          repository-url: https://test.pypi.org/legacy/
+          repository-url: https://pypi.org/legacy/
           verbose: true     
           print-hash: true  
 

--- a/docs/CIPipelines.md
+++ b/docs/CIPipelines.md
@@ -26,7 +26,7 @@ Every PR
 
   * (1) When the release CIs will run:
     * After a PR has been merged into main/rel-* branch
-    * Run weekly (Sunday midnight) and release Python wheel to [onnx-weekly](https://pypi.org/project/onnx-weekly/) package on PyPI.
+    * Run weekly (Sunday midnight) and publish Python wheel to [onnx-weekly](https://pypi.org/project/onnx-weekly/) package on PyPI [2024.10.23: The current consideration is to delete the packages on pypi only due to running out of disk space. Starting with the oldest packages.]
     * Any PR targeting rel-* branch
     * To manually run them, add a PR label "run release CIs" (only maintainers have permission).
   * (2) Minimum supported versions are listed [here](/requirements.txt).


### PR DESCRIPTION
### Description
change onnx-weekly destination from test.pypi to pypi

### Motivation and Context
Now that the CI revision and subsequent tests with the separate publishing step in a separate step have been successful, it is time to switch to pypi. So that this can also be used again in productive operation. 