### PR TITLE
Fix getsize bug in extract_model

### DIFF
--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -220,12 +220,12 @@ def extract_model(
     if check_model:
         onnx.checker.check_model(input_path)
 
-    if infer_shapes and os.path.getsize(input_path) > onnx.checker.MAXIMUM_PROTOBUF:
-        onnx.shape_inference.infer_shapes_path(input_path, output_path)
-        model = onnx.load(output_path)
-    else:
-        model = onnx.load(input_path)
-        if infer_shapes:
+    model = onnx.load(input_path)
+    if infer_shapes:
+        if model.ByteSize() > onnx.checker.MAXIMUM_PROTOBUF:
+            onnx.shape_inference.infer_shapes_path(input_path, output_path)
+            model = onnx.load(output_path)
+        else:
             model = onnx.shape_inference.infer_shapes(model)
 
     e = Extractor(model)

--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -220,13 +220,11 @@ def extract_model(
     if check_model:
         onnx.checker.check_model(input_path)
 
-    model = onnx.load(input_path)
     if infer_shapes:
-        if model.ByteSize() > onnx.checker.MAXIMUM_PROTOBUF:
-            onnx.shape_inference.infer_shapes_path(input_path, output_path)
-            model = onnx.load(output_path)
-        else:
-            model = onnx.shape_inference.infer_shapes(model)
+        onnx.shape_inference.infer_shapes_path(input_path, output_path)
+        model = onnx.load(output_path)
+    else:
+        model = onnx.load(input_path)
 
     e = Extractor(model)
     extracted = e.extract_model(input_names, output_names)


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->

Always use `infer_shapes_path` to infer the model.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->

In the previous version, the os.path.getsize() function call can only count the size of the onnx file, not the external data.
For example, an onnx file is only 1.2M but the external data is 3.3G. `infer_shapes` will return an empty model.
```
1.2M model.onnx
3.3G model.onnx_data
```