### PR TITLE
Update page deployment CI to test building pages in PRs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,6 +5,8 @@
 name: Generate and publish ONNX docs
 
 on:
+  pull_request:
+    branches: ["main"]
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
@@ -18,11 +20,7 @@ permissions:
   id-token: write
 
 jobs:
-  # Single deploy job since we're just deploying
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -31,8 +29,6 @@ jobs:
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: '3.10'
-      - name: Setup Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Install Dependencies
         run: |
           python -m pip install --quiet --upgrade pip setuptools wheel
@@ -52,9 +48,20 @@ jobs:
           cd docs/docsgen
           make html
       - name: Upload artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: 'docs/docsgen/build/html'
+  deploy:
+    needs: 'build'
+    if: github.event_name != 'pull_request'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,7 +48,6 @@ jobs:
           cd docs/docsgen
           make html
       - name: Upload artifact
-        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: 'docs/docsgen/build/html'


### PR DESCRIPTION
### Description

Separate the page build to two steps: build and deploy. This way we build pages for every PR and deploy when the PR is merged.


### Motivation and Context

This change allows us to ensure pages build is green before merging changes.

