### PR TITLE
Allow scale type in QuantizeLinear and DequantizeLinear to be different from the high-precision type

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -7582,8 +7582,10 @@ expect(node, inputs=[x], outputs=[y], name="test_depthtospace_example")
 
   `x_zero_point` and `x` must have the same type. `x` and `y` must have the same shape. In the case of dequantizing
   `int32`, there's no zero point (zero point is supposed to be 0).
-  `zero-point` is usually not used in the case of float8 types quantization, but the dequantization formula remains the same
-  for consistency, and `x_scale` still determines the output type.
+  `zero-point` is usually not used in the case of float8 and 4-bit types quantization, but the dequantization formula remains the same
+  for consistency. The output type is determined by the attribute `output_dtype`. If `output_dtype` is not supplied then the output type
+  is the same as `x_scale`. The output type also determines the precision of the multiplication operation.
+
 
 #### Version
 
@@ -7598,6 +7600,8 @@ Other versions of this operator: <a href="Changelog.md#DequantizeLinear-10">10</
 <dd>(Optional) The axis of the dequantizing dimension of the input tensor. Used for per-axis and blocked quantization. Negative value means counting dimensions from the back. Accepted range is `[-r, r-1]` where `r = rank(input)`.</dd>
 <dt><tt>block_size</tt> : int (default is 0)</dt>
 <dd>(Optional) The size of the quantization block (number of times every scale is replicated). Used only for blocked quantization. The block size is a positive integer. Given `x` shape `(D0, ..., Di, ..., Dn)`, `y_scale` shape `(S0, ... Si, ...Sn)` and `axis=i`, the accepted range is `[ceil(Di/Si), ceil(Di/(Si-1))-1]`</dd>
+<dt><tt>output_dtype</tt> : int (default is 0)</dt>
+<dd>(Optional) The output data type. If not supplied, the output data type is inferred from `x_scale` data type (`T2`)</dd>
 </dl>
 
 #### Inputs (2 - 3)
@@ -7614,8 +7618,8 @@ Other versions of this operator: <a href="Changelog.md#DequantizeLinear-10">10</
 #### Outputs
 
 <dl>
-<dt><tt>y</tt> : T2</dt>
-<dd>N-D full precision output tensor. It has same shape as input `x`.</dd>
+<dt><tt>y</tt> : T3</dt>
+<dd>N-D full precision output tensor. It has the same shape as input `x`. The data type is specified by the `output_dtype` attribute or, in its absence, the type of `x_scale`.</dd>
 </dl>
 
 #### Type Constraints
@@ -7624,7 +7628,9 @@ Other versions of this operator: <a href="Changelog.md#DequantizeLinear-10">10</
 <dt><tt>T1</tt> : tensor(int8), tensor(uint8), tensor(int16), tensor(uint16), tensor(int32), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(uint4), tensor(int4), tensor(float4e2m1)</dt>
 <dd>The type of the inputs 'x_zero_point' and 'x'.</dd>
 <dt><tt>T2</tt> : tensor(float), tensor(float16), tensor(bfloat16)</dt>
-<dd>'x_scale' determines the output type.</dd>
+<dd>The type of the input 'x_scale'.</dd>
+<dt><tt>T3</tt> : tensor(float), tensor(float16), tensor(bfloat16)</dt>
+<dd>The type of the output 'y'.</dd>
 </dl>
 
 
@@ -20553,8 +20559,10 @@ for quant_type_name in ["uint8", "int8"]:
 
   For `(x / y_scale)`, it rounds to the nearest even. Refer to https://en.wikipedia.org/wiki/Rounding for details.
 
-  `y_zero_point` and `y` must have the same type. `y_zero_point` is usually not used for quantization to float8 types, but the quantization
+  `y_zero_point` and `y` must have the same type. `y_zero_point` is usually not used for quantization to float8 and 4bit types, but the quantization
   formula remains the same for consistency, and the type of the attribute `y_zero_point` still determines the quantization type.
+  `x` and `y_scale` are allowed to have different types. The type of `y_scale` determines the precision of the division operation between `x` and
+  `y_scale`, unless the `precision` attribute is specified.
 
   There are three supported quantization granularities, determined by the shape of `y_scale`.
   In all cases, `y_zero_point` must have the same shape as `y_scale`.
@@ -20579,7 +20587,9 @@ Other versions of this operator: <a href="Changelog.md#QuantizeLinear-10">10</a>
 <dt><tt>block_size</tt> : int (default is 0)</dt>
 <dd>(Optional) The size of the quantization block (number of times every scale is replicated). Used only for blocked quantization. The block size is a positive integer. Given `x` shape `(D0, ..., Di, ..., Dn)`, `y_scale` shape `(S0, ... Si, ...Sn)` and `axis=i`, the accepted range is `[ceil(Di/Si), ceil(Di/(Si-1))-1]`</dd>
 <dt><tt>output_dtype</tt> : int (default is 0)</dt>
-<dd>(Optional) The output data type. If not supplied, the output data type is inferred from `y_zero_point` data type (`T2`). If neither `output_dtype` nor `y_zero_point` are supplied, output data type is uint8. If both `output_dtype` and `y_zero_point` are specified, `output_dtype` must be `T2`.</dd>
+<dd>(Optional) The output data type. If not supplied, the output data type is inferred from `y_zero_point` data type (`T3`). If neither `output_dtype` nor `y_zero_point` are supplied, output data type is uint8. If both `output_dtype` and `y_zero_point` are specified, `output_dtype` must be `T3`.</dd>
+<dt><tt>precision</tt> : int (default is 0)</dt>
+<dd>(Optional) The precision of the division operation between `x` and `y_scale`. If not provided, it will be the same as the type of `y_scale`.</dd>
 <dt><tt>saturate</tt> : int (default is 1)</dt>
 <dd>The parameter defines how the conversion behaves if an input value is out of range of the destination type. It only applies for float 8 quantization (float8e4m3fn, float8e4m3fnuz, float8e5m2, float8e5m2fnuz). It is true by default. All cases are fully described in two tables inserted in the operator description.</dd>
 </dl>
@@ -20589,16 +20599,16 @@ Other versions of this operator: <a href="Changelog.md#QuantizeLinear-10">10</a>
 <dl>
 <dt><tt>x</tt> : T1</dt>
 <dd>N-D full precision Input tensor to be quantized.</dd>
-<dt><tt>y_scale</tt> : T1</dt>
+<dt><tt>y_scale</tt> : T2</dt>
 <dd>Scale for doing quantization to get `y`. For per-tensor/layer quantization the scale is a scalar, for per-axis quantization it is a 1-D Tensor and for blocked quantization it has the same shape as the input, except for one dimension in which blocking is performed.</dd>
-<dt><tt>y_zero_point</tt> (optional) : T2</dt>
+<dt><tt>y_zero_point</tt> (optional) : T3</dt>
 <dd>Zero point for doing quantization to get `y`. Shape must match `y_scale`.Default is uint8 with zero point of 0 if it's not specified.</dd>
 </dl>
 
 #### Outputs
 
 <dl>
-<dt><tt>y</tt> : T2</dt>
+<dt><tt>y</tt> : T3</dt>
 <dd>N-D quantized output tensor. It has same shape as input `x`.</dd>
 </dl>
 
@@ -20607,7 +20617,9 @@ Other versions of this operator: <a href="Changelog.md#QuantizeLinear-10">10</a>
 <dl>
 <dt><tt>T1</tt> : tensor(float), tensor(float16), tensor(bfloat16), tensor(int32)</dt>
 <dd>The type of the input 'x'.</dd>
-<dt><tt>T2</tt> : tensor(int8), tensor(uint8), tensor(int16), tensor(uint16), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(uint4), tensor(int4), tensor(float4e2m1)</dt>
+<dt><tt>T2</tt> : tensor(float), tensor(float16), tensor(bfloat16), tensor(int32)</dt>
+<dd>The type of the input 'y_scale'.</dd>
+<dt><tt>T3</tt> : tensor(int8), tensor(uint8), tensor(int16), tensor(uint16), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(uint4), tensor(int4), tensor(float4e2m1)</dt>
 <dd>The type of the input `y_zero_point` and the output `y`.</dd>
 </dl>
 

--- a/onnx/defs/quantization/defs.cc
+++ b/onnx/defs/quantization/defs.cc
@@ -7,7 +7,7 @@
 
 namespace ONNX_NAMESPACE {
 
-static const char* QuantizeLinear_ver21_doc = R"DOC(
+static const char* QuantizeLinear_ver23_doc = R"DOC(
 The linear quantization operator consumes a high-precision tensor, a scale, and a zero point to compute the
 low-precision/quantized tensor. The scale factor and zero point must have the same shape, determining the quantization
 granularity. The quantization formula is `y = saturate((x / y_scale) + y_zero_point)`.
@@ -22,8 +22,10 @@ Saturation is done according to:
 
 For `(x / y_scale)`, it rounds to the nearest even. Refer to https://en.wikipedia.org/wiki/Rounding for details.
 
-`y_zero_point` and `y` must have the same type. `y_zero_point` is usually not used for quantization to float8 types, but the quantization
+`y_zero_point` and `y` must have the same type. `y_zero_point` is usually not used for quantization to float8 and 4bit types, but the quantization
 formula remains the same for consistency, and the type of the attribute `y_zero_point` still determines the quantization type.
+`x` and `y_scale` are allowed to have different types. The type of `y_scale` determines the precision of the division operation between `x` and
+`y_scale`, unless the `precision` attribute is specified.
 
 There are three supported quantization granularities, determined by the shape of `y_scale`.
 In all cases, `y_zero_point` must have the same shape as `y_scale`.
@@ -46,15 +48,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Scale for doing quantization to get `y`. For per-tensor/layer quantization the scale is a scalar, for "
             "per-axis quantization it is a 1-D Tensor and for blocked quantization it has the same shape as the "
             "input, except for one dimension in which blocking is performed.",
-            "T1")
+            "T2")
         .Input(
             2,
             "y_zero_point",
             "Zero point for doing quantization to get `y`. Shape must match `y_scale`."
             "Default is uint8 with zero point of 0 if it's not specified.",
-            "T2",
+            "T3",
             OpSchema::Optional)
-        .Output(0, "y", "N-D quantized output tensor. It has same shape as input `x`.", "T2")
+        .Output(0, "y", "N-D quantized output tensor. It has same shape as input `x`.", "T3")
         .Attr(
             "axis",
             "(Optional) The axis of the dequantizing dimension of the input tensor. Used only for per-axis and blocked "
@@ -81,9 +83,15 @@ ONNX_OPERATOR_SET_SCHEMA(
             static_cast<int64_t>(0))
         .Attr(
             "output_dtype",
-            "(Optional) The output data type. If not supplied, the output data type is inferred from `y_zero_point` data type (`T2`). "
+            "(Optional) The output data type. If not supplied, the output data type is inferred from `y_zero_point` data type (`T3`). "
             "If neither `output_dtype` nor `y_zero_point` are supplied, output data type is uint8. "
-            "If both `output_dtype` and `y_zero_point` are specified, `output_dtype` must be `T2`.",
+            "If both `output_dtype` and `y_zero_point` are specified, `output_dtype` must be `T3`.",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Attr(
+            "precision",
+            "(Optional) The precision of the division operation between `x` and `y_scale`. If not provided, "
+            "it will be the same as the type of `y_scale`.",
             AttributeProto::INT,
             static_cast<int64_t>(0))
         .TypeConstraint(
@@ -92,6 +100,10 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The type of the input 'x'.")
         .TypeConstraint(
             "T2",
+            {"tensor(float)", "tensor(float16)", "tensor(bfloat16)", "tensor(int32)"},
+            "The type of the input 'y_scale'.")
+        .TypeConstraint(
+            "T3",
             {"tensor(int8)",
              "tensor(uint8)",
              "tensor(int16)",
@@ -104,7 +116,7 @@ ONNX_OPERATOR_SET_SCHEMA(
              "tensor(int4)",
              "tensor(float4e2m1)"},
             "The type of the input `y_zero_point` and the output `y`.")
-        .SetDoc(QuantizeLinear_ver21_doc)
+        .SetDoc(QuantizeLinear_ver23_doc)
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
           auto const zp_type = ctx.hasInput(2) ? ctx.getInputType(2) : nullptr;
           auto const output_dtype =
@@ -133,7 +145,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           updateOutputShape(ctx, 0, input_shape);
         }));
 
-static const char* DequantizeLinear_ver21_doc = R"DOC(
+static const char* DequantizeLinear_ver23_doc = R"DOC(
 The linear dequantization operator. It consumes a quantized tensor, a scale, and a zero point to compute the
 full-precision tensor. The dequantization formula is `y = (x - x_zero_point) * x_scale`. `x_scale` and `x_zero_point`
 must have the same shape, determining the quantization's granularity: a scalar for per-tensor/per-layer quantization,
@@ -142,8 +154,10 @@ See QuantizeLinear for details on quantization granularity.
 
 `x_zero_point` and `x` must have the same type. `x` and `y` must have the same shape. In the case of dequantizing
 `int32`, there's no zero point (zero point is supposed to be 0).
-`zero-point` is usually not used in the case of float8 types quantization, but the dequantization formula remains the same
-for consistency, and `x_scale` still determines the output type.
+`zero-point` is usually not used in the case of float8 and 4-bit types quantization, but the dequantization formula remains the same
+for consistency. The output type is determined by the attribute `output_dtype`. If `output_dtype` is not supplied then the output type
+is the same as `x_scale`. The output type also determines the precision of the multiplication operation.
+
 )DOC";
 
 ONNX_OPERATOR_SET_SCHEMA(
@@ -165,7 +179,12 @@ ONNX_OPERATOR_SET_SCHEMA(
             "It's optional. Zero point is 0 when it's not specified.",
             "T1",
             OpSchema::Optional)
-        .Output(0, "y", "N-D full precision output tensor. It has same shape as input `x`.", "T2")
+        .Output(
+            0,
+            "y",
+            "N-D full precision output tensor. It has the same shape as input `x`. The data type is specified "
+            "by the `output_dtype` attribute or, in its absence, the type of `x_scale`.",
+            "T3")
         .Attr(
             "axis",
             "(Optional) The axis of the dequantizing dimension of the input tensor. Used for per-axis and blocked "
@@ -179,6 +198,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             "blocked quantization. The block size is a positive integer. Given `x` shape `(D0, ..., Di, ..., Dn)`, "
             "`y_scale` shape `(S0, ... Si, ...Sn)` and `axis=i`, the accepted range is "
             "`[ceil(Di/Si), ceil(Di/(Si-1))-1]`",
+            AttributeProto::INT,
+            static_cast<int64_t>(0))
+        .Attr(
+            "output_dtype",
+            "(Optional) The output data type. If not supplied, the output data type is inferred from `x_scale` data type (`T2`)",
             AttributeProto::INT,
             static_cast<int64_t>(0))
         .TypeConstraint(
@@ -199,10 +223,17 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint(
             "T2",
             {"tensor(float)", "tensor(float16)", "tensor(bfloat16)"},
-            "'x_scale' determines the output type.")
-        .SetDoc(DequantizeLinear_ver21_doc)
+            "The type of the input 'x_scale'.")
+        .TypeConstraint("T3", {"tensor(float)", "tensor(float16)", "tensor(bfloat16)"}, "The type of the output 'y'.")
+        .SetDoc(DequantizeLinear_ver23_doc)
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
-          propagateElemTypeFromInputToOutput(ctx, 1, 0);
+          auto const output_dtype =
+              static_cast<TensorProto_DataType>(getAttribute(ctx, "output_dtype", TensorProto::UNDEFINED));
+          if (output_dtype != TensorProto::UNDEFINED) {
+            propagateElemTypeFromAttributeToOutput(ctx, "output_dtype", 0);
+          } else {
+            propagateElemTypeFromInputToOutput(ctx, 1, 0);
+          }
           if (!hasInputShape(ctx, 0)) {
             return;
           }

--- a/onnx/reference/ops/op_dequantize_linear.py
+++ b/onnx/reference/ops/op_dequantize_linear.py
@@ -123,4 +123,6 @@ class DequantizeLinear_21(_CommonDequantizeLinear):
 class DequantizeLinear_23(_CommonDequantizeLinear):
     def _run(self, *args, axis=None, block_size=None, output_dtype=None):  # type: ignore
         # args: x, y_scale, zero_point
-        return super()._run(*args, axis=axis, block_size=block_size, output_dtype=output_dtype)  # type: ignore
+        return super()._run(
+            *args, axis=axis, block_size=block_size, output_dtype=output_dtype
+        )  # type: ignore

--- a/onnx/reference/ops/op_quantize_linear.py
+++ b/onnx/reference/ops/op_quantize_linear.py
@@ -248,7 +248,15 @@ class QuantizeLinear_21(_CommonQuantizeLinear):
 
 
 class QuantizeLinear_23(_CommonQuantizeLinear):
-    def _run(self, *args, axis=None, saturate=None, block_size=None, output_dtype=None, precision=None):  # type: ignore
+    def _run(
+        self,
+        *args,
+        axis=None,
+        saturate=None,
+        block_size=None,
+        output_dtype=None,
+        precision=None,
+    ):  # type: ignore
         # args: x, y_scale, zero_point
         return super()._run(
             *args,

--- a/onnx/reference/ops/op_quantize_linear.py
+++ b/onnx/reference/ops/op_quantize_linear.py
@@ -141,7 +141,8 @@ class _CommonQuantizeLinear(OpRun):
         axis: int = 1,
         saturate: bool = True,
         block_size: int | None = None,
-        output_dtype: np.dtype | None = None,
+        output_dtype: int | None = None,
+        precision: int | None = None,
     ) -> tuple[np.ndarray]:
         y_scale = reshape_input(y_scale, x.shape, axis, block_size)
 
@@ -167,7 +168,11 @@ class _CommonQuantizeLinear(OpRun):
             if zero_point is not None
             else 0
         )
-        x = x / y_scale
+        if precision:
+            precision_np = tensor_dtype_to_np_dtype(precision)
+            x = x.astype(precision_np) / y_scale.astype(precision_np)
+        else:
+            x = x / y_scale
 
         if tensor_type in _CommonQuantizeLinear.quant_integer_ranges:
             xi = np.rint(x).astype(np.int32)
@@ -239,4 +244,17 @@ class QuantizeLinear_21(_CommonQuantizeLinear):
             saturate=saturate,
             block_size=block_size,
             output_dtype=output_dtype,
+        )  # type: ignore
+
+
+class QuantizeLinear_23(_CommonQuantizeLinear):
+    def _run(self, *args, axis=None, saturate=None, block_size=None, output_dtype=None, precision=None):  # type: ignore
+        # args: x, y_scale, zero_point
+        return super()._run(
+            *args,
+            axis=axis,
+            saturate=saturate,
+            block_size=block_size,
+            output_dtype=output_dtype,
+            precision=precision,
         )  # type: ignore


### PR DESCRIPTION
### Description
Allow the scale type in Q/DQ ops to be different from the high-precision type.

- For Q, an additional optional attribute `precision` is introduced to control the precision of the division operation. The default precision is `y_scale` type.
- For DQ, an additional optional attribute `output_dtype` is introduced. The default is to set the output type to `x_scale` type. The output type is also the precision of the multiplication operation. The user can always add a cast node after DQ to cast to another desired type.

### Motivation and Context
A motivating example is when the high-precision data type of Q/DQ is fp16, sometimes it can be beneficial to have fp32 scale to preserve more precision. 

Another example is for [OCP’s MX-compliant formats](https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf) the scale type is always E8M0. 
In such cases, we would like to loosen the current constraint in the ONNX spec that the scale type and the high precision type should always be the same.
