### PR TITLE
Fix `MAXIMUM_PROTOBUF` size (2GiB, not 2GB)

### DIFF
--- a/onnx/checker.py
+++ b/onnx/checker.py
@@ -42,8 +42,8 @@ from onnx import (
     ValueInfoProto,
 )
 
-# Limitation of single protobuf file is 2GB
-MAXIMUM_PROTOBUF = 2000000000
+# Limitation of single protobuf file is 2GiB
+MAXIMUM_PROTOBUF = 2147483648
 
 # TODO: This thing where we reserialize the protobuf back into the
 # string, only to deserialize it at the call site, is really goofy.
@@ -170,11 +170,11 @@ def check_model(
         protobuf_string = (
             model if isinstance(model, bytes) else model.SerializeToString()
         )
-        # If the protobuf is larger than 2GB,
+        # If the protobuf is larger than 2GiB,
         # remind users should use the model path to check
         if sys.getsizeof(protobuf_string) > MAXIMUM_PROTOBUF:
             raise ValueError(
-                "This protobuf of onnx model is too large (>2GB). Call check_model with model path instead."
+                "This protobuf of onnx model is too large (>2GiB). Call check_model with model path instead."
             )
         C.check_model(
             protobuf_string,


### PR DESCRIPTION
### Description
While saving a model that was just barely under the 2GiB limit (using Optimum), I noticed that it was saved with the external data format, even though it should be able to be saved in a single file.

After further investigation, it was related to [these lines](https://github.com/huggingface/optimum/blob/65a8a94adaf136dd677d28cfc837c0acfe993031/optimum/onnx/graph_transformations.py#L135-L138), where the value of `onnx.MAXIMUM_PROTOBUF` is used to determine whether to use the external data format. This value is hardcoded to 2GB (=`2*10^9` bytes), even though it should be 2GiB (=`2*1024^3`), according to the [protobuf documentation](https://protobuf.dev/programming-guides/proto-limits/#:~:text=form%20must%20be-,%3C2GiB%2C,-as%20that%20is):
![image](https://github.com/user-attachments/assets/6b59ccaa-2099-4d4e-9a34-7c79ba8dce8e).

Unless there is a specific onnx specification which limits this to 2GB (and not 2GiB), this PR may potentially fix a problem which has existed for a long time.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->

Allows certain models to be saved as a single `.onnx` file without the external data format, which were previously saved separately due to this misconfiguration.