### PR TITLE
Use rank in data propagation

### DIFF
--- a/onnx/test/cpp/data_propagation_test.cc
+++ b/onnx/test/cpp/data_propagation_test.cc
@@ -298,6 +298,23 @@ agraph (int32[1,2] x, int32[3,4] y) => (int32[4] w)
   EXPECT_TRUE(CompareShape(propagated_tsp, expected_tsp));
 }
 
+TEST(DataPropagationImplTest, DynamicConcatTest) {
+  const char* code = R"ONNX(
+agraph (float[32, 1024] x, int64[2] dynamic_shape) => (int64[4] z)
+{
+    xs = Shape(x)   # [32, 1024]
+    z = Concat<axis = 0>(xs, dynamic_shape)  # [32, 1024, ?, ?]
+}
+)ONNX";
+  TensorShapeProto expected_tsp;
+  expected_tsp.mutable_dim()->Add()->set_dim_value(32);
+  expected_tsp.mutable_dim()->Add()->set_dim_value(1024);
+  expected_tsp.mutable_dim()->Add();
+  expected_tsp.mutable_dim()->Add();
+  const auto propagated_tsp = RunDataPropagation(code);
+  EXPECT_TRUE(CompareShape(propagated_tsp, expected_tsp));
+}
+
 TEST(DataPropagationImplTest, GatherTest) {
   const char* code = R"ONNX(
 agraph (int32[1,2,3,4,5,6] x) => (int32[3] w)


### PR DESCRIPTION
### Description

Redo of #6553 (due to DCO/signoff issues)

Extend the implementation of partial data propagation to make use of the rank of a tensor, if known. 

### Motivation and Context

This enables more precise shape inference, especially in the presence of dynamic shapes involving some unknown dimensions. Generated models often use computed shapes that mix statically known and statically unknown dimensions (for example, in an expression such as `Concat (BatchSize, SequenceLength, OtherKnownDimensions)`). Even if `BatchSize` and `SequenceLength` are unknown, the other dimensions may be known, and it useful to track them to enable certain optimizations.