### PR TITLE
fix: Shape inference fails on Concat when first tensor is initialized empty 

### DIFF
--- a/onnx/defs/tensor_proto_util.cc
+++ b/onnx/defs/tensor_proto_util.cc
@@ -69,6 +69,12 @@ namespace ONNX_NAMESPACE {
             " does not match the actual size",                                                                     \
             data.size());                                                                                          \
       }                                                                                                            \
+      if (tensor_proto->dims_size() != 0 && data.size() == 0) {                                                    \
+        for (int i = 0; i < tensor_proto->dims_size(); ++i) {                                                      \
+          res.push_back(0);                                                                                        \
+        }                                                                                                          \
+        return res;                                                                                                \
+      }                                                                                                            \
       res.insert(res.end(), data.begin(), data.end());                                                             \
       return res;                                                                                                  \
     }                                                                                                              \


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Fix issue #6276 
Fix shape inference fails on Concat when first tensor is initialized empty.
### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Testing modified code against @MatejUrbanQC and @Yosshi999. third test sample

![image](https://github.com/user-attachments/assets/5bf0c36a-098f-421b-9341-515ec22c3188)

