### PR TITLE
Fix: skip empty input output names in Extractor

### DIFF
--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -83,9 +83,11 @@ class Extractor:
                 if index not in reachable:
                     # add nodes connected to this output to sets
                     reachable.add(index)
-                    for input_name in self.graph.node[index].input:
-                        if input_name != "":
-                            stack.append(input_name)
+                    stack += [
+                        input_name
+                        for input_name in self.graph.node[index].input
+                        if input_name != ""
+                    ]
 
     def _collect_reachable_nodes(
         self,

--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -32,6 +32,8 @@ class Extractor:
         output_to_index: dict[str, int] = {}
         for index, node in enumerate(graph.node):
             for output_name in node.output:
+                if output_name == "":
+                    continue
                 assert output_name not in output_to_index  # output_name is unique
                 output_to_index[output_name] = index
         return output_to_index
@@ -81,7 +83,9 @@ class Extractor:
                 if index not in reachable:
                     # add nodes connected to this output to sets
                     reachable.add(index)
-                    stack += self.graph.node[index].input
+                    for input_name in self.graph.node[index].input:
+                        if input_name != "":
+                            stack.append(input_name)
 
     def _collect_reachable_nodes(
         self,


### PR DESCRIPTION
### Description
In the extractor, when building the mapping from output names to node index, skip empty outputs. When searching reachable nodes, skip empty inputs.

### Motivation and Context

![image](https://github.com/user-attachments/assets/ee3fa184-6d2f-401d-bc39-72228341586e)

![image](https://github.com/user-attachments/assets/4b74ac4a-42a8-4f8d-acc2-2855c061913c)

For example, in the LLMs (e.g. Llama3) onnx model generated by onnxruntime-genai, there are nodes with optional inputs and outputs which are not used. Extracting a subgraph including these nodes will have an incorrect result.

