### PR TITLE
Fix wrong comparison between numpy dtypes to None

### DIFF
--- a/onnx/reference/custom_element_types.py
+++ b/onnx/reference/custom_element_types.py
@@ -46,7 +46,8 @@ def convert_from_ml_dtypes(array: np.ndarray) -> np.ndarray:
     if not ml_dtypes:
         return array
     for dtype, _, ml_name in _supported_types:
-        if array.dtype == getattr(ml_dtypes, ml_name, None):
+        ml_dtype = getattr(ml_dtypes, ml_name, None)
+        if ml_dtype is not None and array.dtype == ml_dtype:
             return array.view(dtype=dtype)
     return array
 

--- a/onnx/test/reference_evaluator_test.py
+++ b/onnx/test/reference_evaluator_test.py
@@ -6243,6 +6243,21 @@ class TestReferenceEvaluator(unittest.TestCase):
         output = evaluator.run(["preprocessed"], {"images": [imageIn]})[0]
         self.assertEqual((1, 5, 5), output.shape)
 
+    def test_convert_ml_dtypes(self):
+        model = make_model(
+            make_graph(
+                [make_node("LeakyRelu", ["X"], ["Y"], alpha=1.5)],
+                "name",
+                [make_tensor_value_info("X", TensorProto.DOUBLE, None)],
+                [make_tensor_value_info("Y", TensorProto.DOUBLE, None)],
+            ),
+            opset_imports=[make_opsetid("", 18)],
+        )
+        x = np.random.randn(3, 4).astype(np.float64)
+        ref = ReferenceEvaluator(model)
+        got = ref.run(None, {"X": x})
+        self.assertEqual(x.dtype, got[0].dtype)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
### Description
With python 3.12, numpy==2.2.0,  ``np.float64 == None is True``. The PR address one place where this affects the results.

### Motivation and Context
The happens when ml_dtypes is installed.
