### PR TITLE
Fix reference implementation for TopK

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -34064,6 +34064,112 @@ expect(
 
 
 <details>
+<summary>top_k_same_values</summary>
+
+```python
+axis = 0
+largest = 0
+
+k = 3
+node = onnx.helper.make_node(
+    "TopK", inputs=["x", "k"], outputs=["values", "indices"], axis=axis
+)
+X = np.array(
+    [0, 0, 0, 0],
+    dtype=np.int64,
+)
+K = np.array([k], dtype=np.int64)
+values_ref, indices_ref = topk_sorted_implementation(X, k, axis, largest)
+
+# (Pdb) print(values_ref)
+# [0 0 0]
+# (Pdb) print(indices_ref)
+# [0 1 2]
+
+expect(
+    node,
+    inputs=[X, K],
+    outputs=[values_ref, indices_ref],
+    name="test_top_k_same_values",
+)
+```
+
+</details>
+
+
+<details>
+<summary>top_k_same_values_2d</summary>
+
+```python
+axis = 1
+largest = 1
+
+k = 3
+node = onnx.helper.make_node(
+    "TopK", inputs=["x", "k"], outputs=["values", "indices"], axis=axis
+)
+X = np.array(
+    [[0, 0, 0, 0], [1, 1, 1, 1], [2, 2, 1, 1]],
+    dtype=np.int64,
+)
+K = np.array([k], dtype=np.int64)
+values_ref, indices_ref = topk_sorted_implementation(X, k, axis, largest)
+
+# print(values_ref)
+# [[0 0 0]
+# [1 1 1]
+# [1 1 2]]
+# print(indices_ref)
+# [[0 1 2]
+# [0 1 2]
+# [2 3 0]]
+
+expect(
+    node,
+    inputs=[X, K],
+    outputs=[values_ref, indices_ref],
+    name="test_top_k_same_values_2d",
+)
+```
+
+</details>
+
+
+<details>
+<summary>top_k_same_values_largest</summary>
+
+```python
+axis = 0
+largest = 1
+
+k = 3
+node = onnx.helper.make_node(
+    "TopK", inputs=["x", "k"], outputs=["values", "indices"], axis=axis
+)
+X = np.array(
+    [0, 0, 0, 0],
+    dtype=np.int64,
+)
+K = np.array([k], dtype=np.int64)
+values_ref, indices_ref = topk_sorted_implementation(X, k, axis, largest)
+
+# print(values_ref)
+# [0 0 0]
+# print(indices_ref)
+# [0 1 2]
+
+expect(
+    node,
+    inputs=[X, K],
+    outputs=[values_ref, indices_ref],
+    name="test_top_k_same_values_largest",
+)
+```
+
+</details>
+
+
+<details>
 <summary>top_k_smallest</summary>
 
 ```python
@@ -34106,6 +34212,48 @@ expect(
     inputs=[X, K],
     outputs=[values_ref, indices_ref],
     name="test_top_k_smallest",
+)
+```
+
+</details>
+
+
+<details>
+<summary>top_k_uint64</summary>
+
+```python
+axis = 1
+largest = 1
+
+k = 3
+node = onnx.helper.make_node(
+    "TopK", inputs=["x", "k"], outputs=["values", "indices"], axis=axis
+)
+X = np.array(
+    [
+        [0, 1, 2, 3],
+        [4, 5, 6, 7],
+        [8, 9, 10, 11],
+    ],
+    dtype=np.uint64,
+)
+K = np.array([k], dtype=np.int64)
+values_ref, indices_ref = topk_sorted_implementation(X, k, axis, largest)
+
+# print(values_ref)
+# [[ 3  2  1]
+# [ 7  6  5]
+# [11 10  9]]
+# print(indices_ref)
+# [[3 2 1]
+# [3 2 1]
+# [3 2 1]]
+
+expect(
+    node,
+    inputs=[X, K],
+    outputs=[values_ref, indices_ref],
+    name="test_top_k_uint64",
 )
 ```
 

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -23539,7 +23539,7 @@ expect(node, inputs=[x, repeats], outputs=[z], name="test_tile_precomputed")
 
 
 ### TopK
-There are 3 test cases, listed as following:
+There are 7 test cases, listed as following:
 <details>
 <summary>top_k</summary>
 
@@ -23618,6 +23618,101 @@ expect(
 
 </details>
 <details>
+<summary>top_k_same_values</summary>
+
+```python
+axis = 0
+largest = 0
+
+k = 3
+node = onnx.helper.make_node(
+    "TopK", inputs=["x", "k"], outputs=["values", "indices"], axis=axis
+)
+X = np.array(
+    [0, 0, 0, 0],
+    dtype=np.int64,
+)
+K = np.array([k], dtype=np.int64)
+values_ref, indices_ref = topk_sorted_implementation(X, k, axis, largest)
+
+# (Pdb) print(values_ref)
+# [0 0 0]
+# (Pdb) print(indices_ref)
+# [0 1 2]
+
+expect(
+    node, inputs=[X, K], outputs=[values_ref, indices_ref], name="test_top_k_same_values"
+)
+```
+
+</details>
+<details>
+<summary>top_k_same_values_2d</summary>
+
+```python
+axis = 1
+largest = 1
+
+k = 3
+node = onnx.helper.make_node(
+    "TopK", inputs=["x", "k"], outputs=["values", "indices"], axis=axis
+)
+X = np.array(
+    [
+        [0, 0, 0, 0],
+        [1, 1, 1, 1],
+        [2, 2, 1, 1]
+    ],
+    dtype=np.int64,
+)
+K = np.array([k], dtype=np.int64)
+values_ref, indices_ref = topk_sorted_implementation(X, k, axis, largest)
+
+# print(values_ref)
+# [[0 0 0]
+#  [1 1 1]
+#  [1 1 2]]
+# print(indices_ref)
+# [[0 1 2]
+#  [0 1 2]
+#  [2 3 0]]
+
+expect(
+    node, inputs=[X, K], outputs=[values_ref, indices_ref], name="test_top_k_same_values_2d"
+)
+```
+
+</details>
+<details>
+<summary>top_k_same_values_largest</summary>
+
+```python
+axis = 0
+largest = 1
+
+k = 3
+node = onnx.helper.make_node(
+    "TopK", inputs=["x", "k"], outputs=["values", "indices"], axis=axis
+)
+X = np.array(
+    [0, 0, 0, 0],
+    dtype=np.int64,
+)
+K = np.array([k], dtype=np.int64)
+values_ref, indices_ref = topk_sorted_implementation(X, k, axis, largest)
+
+# print(values_ref)
+# [0 0 0]
+# print(indices_ref)
+# [0 1 2]
+
+expect(
+    node, inputs=[X, K], outputs=[values_ref, indices_ref], name="test_top_k_same_values_largest"
+)
+```
+
+</details>
+<details>
 <summary>top_k_smallest</summary>
 
 ```python
@@ -23660,6 +23755,43 @@ expect(
     inputs=[X, K],
     outputs=[values_ref, indices_ref],
     name="test_top_k_smallest",
+)
+```
+
+</details>
+<details>
+<summary>top_k_uint64</summary>
+
+```python
+axis = 1
+largest = 1
+
+k = 3
+node = onnx.helper.make_node(
+    "TopK", inputs=["x", "k"], outputs=["values", "indices"], axis=axis
+)
+X = np.array(
+    [
+        [0, 1, 2, 3],
+        [4, 5, 6, 7],
+        [8, 9, 10, 11],
+    ],
+    dtype=np.uint64,
+)
+K = np.array([k], dtype=np.int64)
+values_ref, indices_ref = topk_sorted_implementation(X, k, axis, largest)
+
+# print(values_ref)
+# [[ 3  2  1]
+# [ 7  6  5]
+# [11 10  9]]
+# print(indices_ref)
+# [[3 2 1]
+# [3 2 1]
+# [3 2 1]]
+
+expect(
+    node, inputs=[X, K], outputs=[values_ref, indices_ref], name="test_top_k_uint64"
 )
 ```
 

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -23641,7 +23641,10 @@ values_ref, indices_ref = topk_sorted_implementation(X, k, axis, largest)
 # [0 1 2]
 
 expect(
-    node, inputs=[X, K], outputs=[values_ref, indices_ref], name="test_top_k_same_values"
+    node,
+    inputs=[X, K],
+    outputs=[values_ref, indices_ref],
+    name="test_top_k_same_values",
 )
 ```
 
@@ -23658,11 +23661,7 @@ node = onnx.helper.make_node(
     "TopK", inputs=["x", "k"], outputs=["values", "indices"], axis=axis
 )
 X = np.array(
-    [
-        [0, 0, 0, 0],
-        [1, 1, 1, 1],
-        [2, 2, 1, 1]
-    ],
+    [[0, 0, 0, 0], [1, 1, 1, 1], [2, 2, 1, 1]],
     dtype=np.int64,
 )
 K = np.array([k], dtype=np.int64)
@@ -23670,15 +23669,18 @@ values_ref, indices_ref = topk_sorted_implementation(X, k, axis, largest)
 
 # print(values_ref)
 # [[0 0 0]
-#  [1 1 1]
-#  [1 1 2]]
+# [1 1 1]
+# [1 1 2]]
 # print(indices_ref)
 # [[0 1 2]
-#  [0 1 2]
-#  [2 3 0]]
+# [0 1 2]
+# [2 3 0]]
 
 expect(
-    node, inputs=[X, K], outputs=[values_ref, indices_ref], name="test_top_k_same_values_2d"
+    node,
+    inputs=[X, K],
+    outputs=[values_ref, indices_ref],
+    name="test_top_k_same_values_2d",
 )
 ```
 
@@ -23707,7 +23709,10 @@ values_ref, indices_ref = topk_sorted_implementation(X, k, axis, largest)
 # [0 1 2]
 
 expect(
-    node, inputs=[X, K], outputs=[values_ref, indices_ref], name="test_top_k_same_values_largest"
+    node,
+    inputs=[X, K],
+    outputs=[values_ref, indices_ref],
+    name="test_top_k_same_values_largest",
 )
 ```
 
@@ -23791,7 +23796,10 @@ values_ref, indices_ref = topk_sorted_implementation(X, k, axis, largest)
 # [3 2 1]]
 
 expect(
-    node, inputs=[X, K], outputs=[values_ref, indices_ref], name="test_top_k_uint64"
+    node,
+    inputs=[X, K],
+    outputs=[values_ref, indices_ref],
+    name="test_top_k_uint64",
 )
 ```
 

--- a/onnx/backend/test/case/node/topk.py
+++ b/onnx/backend/test/case/node/topk.py
@@ -168,12 +168,12 @@ class TopK(Base):
 
         # print(values_ref)
         # [[0 0 0]
-        #  [1 1 1]
-        #  [1 1 2]]
+        # [1 1 1]
+        # [1 1 2]]
         # print(indices_ref)
         # [[0 1 2]
-        #  [0 1 2]
-        #  [2 3 0]]
+        # [0 1 2]
+        # [2 3 0]]
 
         expect(
             node,

--- a/onnx/backend/test/case/node/topk.py
+++ b/onnx/backend/test/case/node/topk.py
@@ -11,7 +11,10 @@ from onnx.backend.test.case.node import expect
 
 
 def topk_sorted_implementation(X, k, axis, largest):  # type: ignore
-    sorted_indices = np.argsort(X, axis=axis)
+    ind_axis = np.indices(X.shape)[axis]
+    if largest:
+        ind_axis = -ind_axis
+    sorted_indices = np.lexsort((ind_axis, X), axis=axis)
     sorted_values = np.sort(X, axis=axis)
     if largest:
         sorted_indices = np.flip(sorted_indices, axis=axis)
@@ -53,6 +56,130 @@ class TopK(Base):
 
         expect(
             node, inputs=[X, K], outputs=[values_ref, indices_ref], name="test_top_k"
+        )
+
+    @staticmethod
+    def export_top_k_uint64() -> None:
+        axis = 1
+        largest = 1
+
+        k = 3
+        node = onnx.helper.make_node(
+            "TopK", inputs=["x", "k"], outputs=["values", "indices"], axis=axis
+        )
+        X = np.array(
+            [
+                [0, 1, 2, 3],
+                [4, 5, 6, 7],
+                [8, 9, 10, 11],
+            ],
+            dtype=np.uint64,
+        )
+        K = np.array([k], dtype=np.int64)
+        values_ref, indices_ref = topk_sorted_implementation(X, k, axis, largest)
+
+        # print(values_ref)
+        # [[ 3  2  1]
+        # [ 7  6  5]
+        # [11 10  9]]
+        # print(indices_ref)
+        # [[3 2 1]
+        # [3 2 1]
+        # [3 2 1]]
+
+        expect(
+            node,
+            inputs=[X, K],
+            outputs=[values_ref, indices_ref],
+            name="test_top_k_uint64",
+        )
+
+    @staticmethod
+    def export_top_k_same_values() -> None:
+        axis = 0
+        largest = 0
+
+        k = 3
+        node = onnx.helper.make_node(
+            "TopK", inputs=["x", "k"], outputs=["values", "indices"], axis=axis
+        )
+        X = np.array(
+            [0, 0, 0, 0],
+            dtype=np.int64,
+        )
+        K = np.array([k], dtype=np.int64)
+        values_ref, indices_ref = topk_sorted_implementation(X, k, axis, largest)
+
+        # (Pdb) print(values_ref)
+        # [0 0 0]
+        # (Pdb) print(indices_ref)
+        # [0 1 2]
+
+        expect(
+            node,
+            inputs=[X, K],
+            outputs=[values_ref, indices_ref],
+            name="test_top_k_same_values",
+        )
+
+    @staticmethod
+    def export_top_k_same_values_largest() -> None:
+        axis = 0
+        largest = 1
+
+        k = 3
+        node = onnx.helper.make_node(
+            "TopK", inputs=["x", "k"], outputs=["values", "indices"], axis=axis
+        )
+        X = np.array(
+            [0, 0, 0, 0],
+            dtype=np.int64,
+        )
+        K = np.array([k], dtype=np.int64)
+        values_ref, indices_ref = topk_sorted_implementation(X, k, axis, largest)
+
+        # print(values_ref)
+        # [0 0 0]
+        # print(indices_ref)
+        # [0 1 2]
+
+        expect(
+            node,
+            inputs=[X, K],
+            outputs=[values_ref, indices_ref],
+            name="test_top_k_same_values_largest",
+        )
+
+    @staticmethod
+    def export_top_k_same_values_2d() -> None:
+        axis = 1
+        largest = 1
+
+        k = 3
+        node = onnx.helper.make_node(
+            "TopK", inputs=["x", "k"], outputs=["values", "indices"], axis=axis
+        )
+        X = np.array(
+            [[0, 0, 0, 0], [1, 1, 1, 1], [2, 2, 1, 1]],
+            dtype=np.int64,
+        )
+        K = np.array([k], dtype=np.int64)
+        values_ref, indices_ref = topk_sorted_implementation(X, k, axis, largest)
+
+        # print(values_ref)
+        # [[0 0 0]
+        #  [1 1 1]
+        #  [1 1 2]]
+        # print(indices_ref)
+        # [[0 1 2]
+        #  [0 1 2]
+        #  [2 3 0]]
+
+        expect(
+            node,
+            inputs=[X, K],
+            outputs=[values_ref, indices_ref],
+            name="test_top_k_same_values_2d",
         )
 
     @staticmethod

--- a/onnx/reference/ops/op_topk.py
+++ b/onnx/reference/ops/op_topk.py
@@ -24,7 +24,7 @@ def topk_sorted_implementation(X, k, axis, largest):  # type: ignore
     if largest:
         ind_axis = -ind_axis
     sorted_indices = np.lexsort((ind_axis, X), axis=axis)
-    sorted_values = np.sort(X, axis=axis)
+    sorted_values = np.take_along_axis(X, sorted_indices, axis=axis)
     if largest:
         sorted_indices = np.flip(sorted_indices, axis=axis)
         sorted_values = np.flip(sorted_values, axis=axis)

--- a/onnx/reference/ops/op_topk.py
+++ b/onnx/reference/ops/op_topk.py
@@ -19,26 +19,11 @@ def topk_sorted_implementation(X, k, axis, largest):  # type: ignore
         k = k[0]
     # This conversion is needed for distribution x86.
     k = int(k)
-    if len(X.shape) == 2 and axis == 1:
-        sample_range = np.arange(X.shape[0])[:, None]
-        if largest == 0:
-            sorted_indices = np.argpartition(X, axis=axis, kth=k - 1)
-            sorted_indices = sorted_indices[:, :k]
-            # argpartition doesn't guarantee sorted order, so we sort again
-            sorted_indices = sorted_indices[
-                sample_range, np.argsort(X[sample_range, sorted_indices])
-            ]
-        else:
-            sorted_indices = np.argpartition(-X, axis=axis, kth=k - 1)
-            sorted_indices = sorted_indices[:, :k]
-            # argpartition doesn't guarantee sorted order, so we sort again
-            sorted_indices = sorted_indices[
-                sample_range, np.argsort(-X[sample_range, sorted_indices])
-            ]
-        sorted_distances = X[sample_range, sorted_indices]
-        return sorted_distances, sorted_indices
-
-    sorted_indices = np.argsort(X, axis=axis)
+    # Used to tiebreak
+    ind_axis = np.indices(X.shape)[axis]
+    if largest:
+        ind_axis = -ind_axis
+    sorted_indices = np.lexsort((ind_axis, X), axis=axis)
     sorted_values = np.sort(X, axis=axis)
     if largest:
         sorted_indices = np.flip(sorted_indices, axis=axis)

--- a/onnx/test/test_backend_onnxruntime.py
+++ b/onnx/test/test_backend_onnxruntime.py
@@ -168,6 +168,7 @@ if ort is not None:
         "|test_cast_FLOAT4E2M1_to_"  # No corresponding Numpy type for Tensor Type.
         "|_to_FLOAT4E2M1"  # No corresponding Numpy type for Tensor Type.
         "|test_maxpool_2d_ceil_output_size_reduce_by_one"  # TODO: remove after https://github.com/microsoft/onnxruntime/pull/18377 in Ort release.
+        "|test_top_k_uint64"
         ")"
     )
 


### PR DESCRIPTION
### Description
This PR fixes problems in the reference implementation of TopK in the following cases by rewriting the tiebreaker mechanism and unifying logic for all cases. 

### Motivation and Context
The ONNX [documentation](https://onnx.ai/onnx/operators/onnx__TopK.html) states:
> Given two equivalent values, this operator uses the indices along the axis as a tiebreaker. That is, the element with the lower index will appear first.

This was not the case currently as the `flip` after the `argsort` changes the order of the same-valued elements. 
Additionally the logic around 2d shaped inputs introduces a bug for unsigned inputs as the negation overflowed.

This mismatch between the reference implementation and `onnxruntime` was found by running the [array-api](https://data-apis.org/array-api/latest/) test suite through [ndonnx](https://github.com/Quantco/ndonnx) on both.
