### PR TITLE
Fix reference implementation for Unique

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -34937,6 +34937,44 @@ This version of the operator has been available since version 11 of the default 
 #### Examples
 
 <details>
+<summary>length_1</summary>
+
+```python
+node_sorted = onnx.helper.make_node(
+    "Unique",
+    inputs=["X"],
+    outputs=["Y", "indices", "inverse_indices", "counts"],
+    sorted=1,
+)
+
+x = np.array([0], dtype=np.int64)
+y, indices, inverse_indices, counts = np.unique(x, True, True, True)
+indices, inverse_indices, counts = specify_int64(
+    indices, inverse_indices, counts
+)
+# behavior changed with numpy >= 2.0
+inverse_indices = inverse_indices.reshape(-1)
+# print(y)
+# [0]
+# print(indices)
+# [0]
+# print(inverse_indices)
+# [0]
+# print(counts)
+# [1]
+
+expect(
+    node_sorted,
+    inputs=[x],
+    outputs=[y, indices, inverse_indices, counts],
+    name="test_unique_length_1",
+)
+```
+
+</details>
+
+
+<details>
 <summary>not_sorted_without_axis</summary>
 
 ```python
@@ -35005,7 +35043,7 @@ indices, inverse_indices, counts = specify_int64(
     indices, inverse_indices, counts
 )
 # behavior changed with numpy >= 2.0
-inverse_indices = inverse_indices.squeeze()
+inverse_indices = inverse_indices.reshape(-1)
 # print(y)
 # [[1. 0. 0.]
 #  [2. 3. 4.]]
@@ -35051,7 +35089,7 @@ indices, inverse_indices, counts = specify_int64(
     indices, inverse_indices, counts
 )
 # behavior changed with numpy >= 2.0
-inverse_indices = inverse_indices.squeeze()
+inverse_indices = inverse_indices.reshape(-1)
 # print(y)
 # [[[0. 1.]
 #  [1. 1.]
@@ -35094,7 +35132,7 @@ indices, inverse_indices, counts = specify_int64(
     indices, inverse_indices, counts
 )
 # behavior changed with numpy >= 2.0
-inverse_indices = inverse_indices.squeeze()
+inverse_indices = inverse_indices.reshape(-1)
 # print(y)
 # [[0. 1.]
 #  [0. 1.]

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -24223,6 +24223,42 @@ expect(node, inputs=[x, k], outputs=[y], name="test_triu_zero")
 ### Unique
 There are 6 test cases, listed as following:
 <details>
+<summary>length_1</summary>
+
+```python
+node_sorted = onnx.helper.make_node(
+    "Unique",
+    inputs=["X"],
+    outputs=["Y", "indices", "inverse_indices", "counts"],
+    sorted=1,
+)
+
+x = np.array([0], dtype=np.int64)
+y, indices, inverse_indices, counts = np.unique(x, True, True, True)
+indices, inverse_indices, counts = specify_int64(
+    indices, inverse_indices, counts
+)
+# behavior changed with numpy >= 2.0
+inverse_indices = inverse_indices.reshape(-1)
+# print(y)
+# [0]
+# print(indices)
+# [0]
+# print(inverse_indices)
+# [0]
+# print(counts)
+# [1]
+
+expect(
+    node_sorted,
+    inputs=[x],
+    outputs=[y, indices, inverse_indices, counts],
+    name="test_unique_length_1",
+)
+```
+
+</details>
+<details>
 <summary>not_sorted_without_axis</summary>
 
 ```python
@@ -24267,43 +24303,6 @@ expect(
     inputs=[x],
     outputs=[y, indices, inverse_indices, counts],
     name="test_unique_not_sorted_without_axis",
-)
-```
-
-</details>
-<details>
-<summary>size_1</summary>
-
-```python
-node_sorted = onnx.helper.make_node(
-    "Unique",
-    inputs=["X"],
-    outputs=["Y", "indices", "inverse_indices", "counts"],
-    sorted=1,
-    axis=-1,
-)
-
-x = np.array([0], dtype=np.float32)
-y, indices, inverse_indices, counts = np.unique(x, True, True, True, axis=-1)
-indices, inverse_indices, counts = specify_int64(
-    indices, inverse_indices, counts
-)
-# behavior changed with numpy >= 2.0
-inverse_indices = inverse_indices.reshape(-1)
-# print(y)
-# [0.]
-# print(indices)
-# [0]
-# print(inverse_indices)
-# [0 0 0 0 0 0]
-# print(counts)
-# [6]
-
-expect(
-    node_sorted,
-    inputs=[x],
-    outputs=[y, indices, inverse_indices, counts],
-    name="test_size_1",
 )
 ```
 

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -24221,7 +24221,7 @@ expect(node, inputs=[x, k], outputs=[y], name="test_triu_zero")
 
 
 ### Unique
-There are 5 test cases, listed as following:
+There are 6 test cases, listed as following:
 <details>
 <summary>not_sorted_without_axis</summary>
 
@@ -24272,6 +24272,43 @@ expect(
 
 </details>
 <details>
+<summary>size_1</summary>
+
+```python
+node_sorted = onnx.helper.make_node(
+    "Unique",
+    inputs=["X"],
+    outputs=["Y", "indices", "inverse_indices", "counts"],
+    sorted=1,
+    axis=-1,
+)
+
+x = np.array([0], dtype=np.float32)
+y, indices, inverse_indices, counts = np.unique(x, True, True, True, axis=-1)
+indices, inverse_indices, counts = specify_int64(
+    indices, inverse_indices, counts
+)
+# behavior changed with numpy >= 2.0
+inverse_indices = inverse_indices.reshape(-1)
+# print(y)
+# [0.]
+# print(indices)
+# [0]
+# print(inverse_indices)
+# [0 0 0 0 0 0]
+# print(counts)
+# [6]
+
+expect(
+    node_sorted,
+    inputs=[x],
+    outputs=[y, indices, inverse_indices, counts],
+    name="test_size_1",
+)
+```
+
+</details>
+<details>
 <summary>sorted_with_axis</summary>
 
 ```python
@@ -24289,7 +24326,7 @@ indices, inverse_indices, counts = specify_int64(
     indices, inverse_indices, counts
 )
 # behavior changed with numpy >= 2.0
-inverse_indices = inverse_indices.squeeze()
+inverse_indices = inverse_indices.reshape(-1)
 # print(y)
 # [[1. 0. 0.]
 #  [2. 3. 4.]]
@@ -24333,7 +24370,7 @@ indices, inverse_indices, counts = specify_int64(
     indices, inverse_indices, counts
 )
 # behavior changed with numpy >= 2.0
-inverse_indices = inverse_indices.squeeze()
+inverse_indices = inverse_indices.reshape(-1)
 # print(y)
 # [[[0. 1.]
 #  [1. 1.]
@@ -24374,7 +24411,7 @@ indices, inverse_indices, counts = specify_int64(
     indices, inverse_indices, counts
 )
 # behavior changed with numpy >= 2.0
-inverse_indices = inverse_indices.squeeze()
+inverse_indices = inverse_indices.reshape(-1)
 # print(y)
 # [[0. 1.]
 #  [0. 1.]

--- a/onnx/backend/test/case/node/unique.py
+++ b/onnx/backend/test/case/node/unique.py
@@ -100,7 +100,7 @@ class Unique(Base):
             indices, inverse_indices, counts
         )
         # behavior changed with numpy >= 2.0
-        inverse_indices = inverse_indices.squeeze()
+        inverse_indices = inverse_indices.reshape(-1)
         # print(y)
         # [[1. 0. 0.]
         #  [2. 3. 4.]]
@@ -140,7 +140,7 @@ class Unique(Base):
             indices, inverse_indices, counts
         )
         # behavior changed with numpy >= 2.0
-        inverse_indices = inverse_indices.squeeze()
+        inverse_indices = inverse_indices.reshape(-1)
         # print(y)
         # [[[0. 1.]
         #  [1. 1.]
@@ -177,7 +177,7 @@ class Unique(Base):
             indices, inverse_indices, counts
         )
         # behavior changed with numpy >= 2.0
-        inverse_indices = inverse_indices.squeeze()
+        inverse_indices = inverse_indices.reshape(-1)
         # print(y)
         # [[0. 1.]
         #  [0. 1.]
@@ -194,4 +194,37 @@ class Unique(Base):
             inputs=[x],
             outputs=[y, indices, inverse_indices, counts],
             name="test_unique_sorted_with_negative_axis",
+        )
+
+    @staticmethod
+    def export_size_1() -> None:
+        node_sorted = onnx.helper.make_node(
+            "Unique",
+            inputs=["X"],
+            outputs=["Y", "indices", "inverse_indices", "counts"],
+            sorted=1,
+            axis=-1,
+        )
+
+        x = np.array([0], dtype=np.float32)
+        y, indices, inverse_indices, counts = np.unique(x, True, True, True, axis=-1)
+        indices, inverse_indices, counts = specify_int64(
+            indices, inverse_indices, counts
+        )
+        # behavior changed with numpy >= 2.0
+        inverse_indices = inverse_indices.reshape(-1)
+        # print(y)
+        # [0.]
+        # print(indices)
+        # [0]
+        # print(inverse_indices)
+        # [0]
+        # print(counts)
+        # [1]
+
+        expect(
+            node_sorted,
+            inputs=[x],
+            outputs=[y, indices, inverse_indices, counts],
+            name="test_size_1",
         )

--- a/onnx/backend/test/case/node/unique.py
+++ b/onnx/backend/test/case/node/unique.py
@@ -197,24 +197,23 @@ class Unique(Base):
         )
 
     @staticmethod
-    def export_size_1() -> None:
+    def export_length_1() -> None:
         node_sorted = onnx.helper.make_node(
             "Unique",
             inputs=["X"],
             outputs=["Y", "indices", "inverse_indices", "counts"],
             sorted=1,
-            axis=-1,
         )
 
-        x = np.array([0], dtype=np.float32)
-        y, indices, inverse_indices, counts = np.unique(x, True, True, True, axis=-1)
+        x = np.array([0], dtype=np.int64)
+        y, indices, inverse_indices, counts = np.unique(x, True, True, True)
         indices, inverse_indices, counts = specify_int64(
             indices, inverse_indices, counts
         )
         # behavior changed with numpy >= 2.0
         inverse_indices = inverse_indices.reshape(-1)
         # print(y)
-        # [0.]
+        # [0]
         # print(indices)
         # [0]
         # print(inverse_indices)
@@ -226,5 +225,5 @@ class Unique(Base):
             node_sorted,
             inputs=[x],
             outputs=[y, indices, inverse_indices, counts],
-            name="test_size_1",
+            name="test_unique_length_1",
         )

--- a/onnx/backend/test/runner/__init__.py
+++ b/onnx/backend/test/runner/__init__.py
@@ -213,12 +213,13 @@ class Runner:
                     if ref_outputs[i].tolist() != outputs[i].tolist():
                         raise AssertionError(f"{ref_outputs[i]} != {outputs[i]}")
                     continue
-                np.testing.assert_equal(outputs[i].dtype, ref_outputs[i].dtype)
                 if ref_outputs[i].dtype == object:  # type: ignore[attr-defined]
-                    np.testing.assert_array_equal(outputs[i], ref_outputs[i])
+                    np.testing.assert_array_equal(
+                        outputs[i], ref_outputs[i], strict=True
+                    )
                 else:
                     np.testing.assert_allclose(
-                        outputs[i], ref_outputs[i], rtol=rtol, atol=atol
+                        outputs[i], ref_outputs[i], rtol=rtol, atol=atol, strict=True
                     )
 
     @classmethod

--- a/onnx/backend/test/runner/__init__.py
+++ b/onnx/backend/test/runner/__init__.py
@@ -215,13 +215,15 @@ class Runner:
                     if ref_outputs[i].tolist() != outputs[i].tolist():
                         raise AssertionError(f"{ref_outputs[i]} != {outputs[i]}")
                     continue
+                np.testing.assert_equal(outputs[i].dtype, ref_outputs[i].dtype)
+                np.testing.assert_array_equal(outputs[i].shape, ref_outputs[i].shape)
                 if ref_outputs[i].dtype == object:  # type: ignore[attr-defined]
                     np.testing.assert_array_equal(
-                        outputs[i], ref_outputs[i], strict=True
+                        outputs[i], ref_outputs[i]
                     )
                 else:
                     np.testing.assert_allclose(
-                        outputs[i], ref_outputs[i], rtol=rtol, atol=atol, strict=True
+                        outputs[i], ref_outputs[i], rtol=rtol, atol=atol
                     )
 
     @classmethod

--- a/onnx/backend/test/runner/__init__.py
+++ b/onnx/backend/test/runner/__init__.py
@@ -216,7 +216,11 @@ class Runner:
                         raise AssertionError(f"{ref_outputs[i]} != {outputs[i]}")
                     continue
                 np.testing.assert_equal(outputs[i].dtype, ref_outputs[i].dtype)
-                np.testing.assert_array_equal(outputs[i].shape, ref_outputs[i].shape)
+                np.testing.assert_array_equal(
+                    outputs[i].shape,
+                    ref_outputs[i].shape,
+                    err_msg=f"Output {i} has incorrect shape",
+                )
                 if ref_outputs[i].dtype == object:  # type: ignore[attr-defined]
                     np.testing.assert_array_equal(outputs[i], ref_outputs[i])
                 else:

--- a/onnx/backend/test/runner/__init__.py
+++ b/onnx/backend/test/runner/__init__.py
@@ -218,9 +218,7 @@ class Runner:
                 np.testing.assert_equal(outputs[i].dtype, ref_outputs[i].dtype)
                 np.testing.assert_array_equal(outputs[i].shape, ref_outputs[i].shape)
                 if ref_outputs[i].dtype == object:  # type: ignore[attr-defined]
-                    np.testing.assert_array_equal(
-                        outputs[i], ref_outputs[i]
-                    )
+                    np.testing.assert_array_equal(outputs[i], ref_outputs[i])
                 else:
                     np.testing.assert_allclose(
                         outputs[i], ref_outputs[i], rtol=rtol, atol=atol

--- a/onnx/reference/ops/op_unique.py
+++ b/onnx/reference/ops/op_unique.py
@@ -43,7 +43,7 @@ class Unique(OpRun):
             indices, inverse_indices, counts
         )
         # numpy 2.0 has a different behavior than numpy 1.x.
-        inverse_indices = inverse_indices.squeeze()
+        inverse_indices = inverse_indices.reshape(-1)
         if len(self.onnx_node.output) == 2:
             return (y, indices)
         if len(self.onnx_node.output) == 3:

--- a/onnx/reference/ops/op_unique.py
+++ b/onnx/reference/ops/op_unique.py
@@ -39,7 +39,6 @@ class Unique(OpRun):
             )
             counts = counts[argsorted_indices]
 
-        print("-----------------------------------------------", inverse_indices)
         indices, inverse_indices, counts = _specify_int64(
             indices, inverse_indices, counts
         )

--- a/onnx/reference/ops/op_unique.py
+++ b/onnx/reference/ops/op_unique.py
@@ -39,6 +39,7 @@ class Unique(OpRun):
             )
             counts = counts[argsorted_indices]
 
+        print("-----------------------------------------------", inverse_indices)
         indices, inverse_indices, counts = _specify_int64(
             indices, inverse_indices, counts
         )


### PR DESCRIPTION
### Description
This PR uses the [recommended way](https://numpy.org/doc/stable/reference/generated/numpy.unique.html) to ensure compatibility with `numpy.unique`.

Additionally the `strict` parameter is turned on for `numpy.testing.assert_allclose` to ensure that the `dtype`-s and `shape`-s match, this fortunately does not introduce additional test failures. 

### Motivation and Context
The [shape inference](https://github.com/onnx/onnx/blob/b50fb874f71325030d93dae4ae04a2647de7a30e/onnx/defs/tensor/defs.cc#L3371) defined for `Unique`, tells us the fact that the `inverse_indices` output should be 1d. This was not the case when the input was of length 1, since the `squeeze` made it a scalar. 

This mismatch between the reference implementation and `onnxruntime` was found by running the [array-api](https://data-apis.org/array-api/latest/) test suite through [ndonnx](https://github.com/Quantco/ndonnx) on both.
