### PR TITLE
Fix reference implementation for CumSum

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -6938,6 +6938,24 @@ expect(node, inputs=[x, axis], outputs=[y], name="test_cumsum_1d_exclusive")
 
 
 <details>
+<summary>cumsum_1d_int32_exclusive</summary>
+
+```python
+node = onnx.helper.make_node(
+    "CumSum", inputs=["x", "axis"], outputs=["y"], exclusive=1
+)
+x = np.array([1, 2, 3, 4, 5]).astype(np.int32)
+axis = np.int32(0)
+y = np.array([0, 1, 3, 6, 10]).astype(np.int32)
+expect(
+    node, inputs=[x, axis], outputs=[y], name="test_cumsum_1d_int32_exclusive"
+)
+```
+
+</details>
+
+
+<details>
 <summary>cumsum_1d_reverse</summary>
 
 ```python
@@ -7002,6 +7020,24 @@ x = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).astype(np.float64).reshape((2, 3))
 axis = np.int32(1)
 y = np.array([1.0, 3.0, 6.0, 4.0, 9.0, 15.0]).astype(np.float64).reshape((2, 3))
 expect(node, inputs=[x, axis], outputs=[y], name="test_cumsum_2d_axis_1")
+```
+
+</details>
+
+
+<details>
+<summary>cumsum_2d_int32</summary>
+
+```python
+node = onnx.helper.make_node(
+    "CumSum",
+    inputs=["x", "axis"],
+    outputs=["y"],
+)
+x = np.array([1, 2, 3, 4, 5, 6]).astype(np.int32).reshape((2, 3))
+axis = np.int32(0)
+y = np.array([1, 2, 3, 5, 7, 9]).astype(np.int32).reshape((2, 3))
+expect(node, inputs=[x, axis], outputs=[y], name="test_cumsum_2d_int32")
 ```
 
 </details>

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -4919,7 +4919,7 @@ expect(node, inputs=[x], outputs=[y], name="test_cosh")
 
 
 ### CumSum
-There are 7 test cases, listed as following:
+There are 9 test cases, listed as following:
 <details>
 <summary>cumsum_1d</summary>
 
@@ -4943,6 +4943,20 @@ x = np.array([1.0, 2.0, 3.0, 4.0, 5.0]).astype(np.float64)
 axis = np.int32(0)
 y = np.array([0.0, 1.0, 3.0, 6.0, 10.0]).astype(np.float64)
 expect(node, inputs=[x, axis], outputs=[y], name="test_cumsum_1d_exclusive")
+```
+
+</details>
+<details>
+<summary>cumsum_1d_int32_exclusive</summary>
+
+```python
+node = onnx.helper.make_node(
+    "CumSum", inputs=["x", "axis"], outputs=["y"], exclusive=1
+)
+x = np.array([1, 2, 3, 4, 5]).astype(np.int32)
+axis = np.int32(0)
+y = np.array([0, 1, 3, 6, 10]).astype(np.int32)
+expect(node, inputs=[x, axis], outputs=[y], name="test_cumsum_1d_int32_exclusive")
 ```
 
 </details>
@@ -5005,6 +5019,22 @@ x = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).astype(np.float64).reshape((2, 3))
 axis = np.int32(1)
 y = np.array([1.0, 3.0, 6.0, 4.0, 9.0, 15.0]).astype(np.float64).reshape((2, 3))
 expect(node, inputs=[x, axis], outputs=[y], name="test_cumsum_2d_axis_1")
+```
+
+</details>
+<details>
+<summary>cumsum_2d_int32</summary>
+
+```python
+node = onnx.helper.make_node(
+    "CumSum",
+    inputs=["x", "axis"],
+    outputs=["y"],
+)
+x = np.array([1, 2, 3, 4, 5, 6]).astype(np.int32).reshape((2, 3))
+axis = np.int32(0)
+y = np.array([1, 2, 3, 5, 7, 9]).astype(np.int32).reshape((2, 3))
+expect(node, inputs=[x, axis], outputs=[y], name="test_cumsum_2d_int32")
 ```
 
 </details>

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -4956,7 +4956,9 @@ node = onnx.helper.make_node(
 x = np.array([1, 2, 3, 4, 5]).astype(np.int32)
 axis = np.int32(0)
 y = np.array([0, 1, 3, 6, 10]).astype(np.int32)
-expect(node, inputs=[x, axis], outputs=[y], name="test_cumsum_1d_int32_exclusive")
+expect(
+    node, inputs=[x, axis], outputs=[y], name="test_cumsum_1d_int32_exclusive"
+)
 ```
 
 </details>

--- a/onnx/backend/test/case/node/cumsum.py
+++ b/onnx/backend/test/case/node/cumsum.py
@@ -86,3 +86,27 @@ class CumSum(Base):
         axis = np.int32(-1)
         y = np.array([1.0, 3.0, 6.0, 4.0, 9.0, 15.0]).astype(np.float64).reshape((2, 3))
         expect(node, inputs=[x, axis], outputs=[y], name="test_cumsum_2d_negative_axis")
+
+    @staticmethod
+    def export_cumsum_2d_int32() -> None:
+        node = onnx.helper.make_node(
+            "CumSum",
+            inputs=["x", "axis"],
+            outputs=["y"],
+        )
+        x = np.array([1, 2, 3, 4, 5, 6]).astype(np.int32).reshape((2, 3))
+        axis = np.int32(0)
+        y = np.array([1, 2, 3, 5, 7, 9]).astype(np.int32).reshape((2, 3))
+        expect(node, inputs=[x, axis], outputs=[y], name="test_cumsum_2d_int32")
+
+    @staticmethod
+    def export_cumsum_1d_int32_exclusive() -> None:
+        node = onnx.helper.make_node(
+            "CumSum", inputs=["x", "axis"], outputs=["y"], exclusive=1
+        )
+        x = np.array([1, 2, 3, 4, 5]).astype(np.int32)
+        axis = np.int32(0)
+        y = np.array([0, 1, 3, 6, 10]).astype(np.int32)
+        expect(
+            node, inputs=[x, axis], outputs=[y], name="test_cumsum_1d_int32_exclusive"
+        )

--- a/onnx/reference/ops/op_cum_sum.py
+++ b/onnx/reference/ops/op_cum_sum.py
@@ -9,12 +9,7 @@ from onnx.reference.op_run import OpRun
 
 
 class CumSum(OpRun):
-    def _run(self, x, *axis, exclusive=None, reverse=None):  # type: ignore
-        axis = None if not axis else axis[0]  # type: ignore
-        if axis is None:  # type: ignore
-            if reverse or exclusive:
-                raise NotImplementedError("reverse=1 or exclusive=1 not implemented")
-            return np.cumsum(x, dtype=x.dtype)
+    def _run(self, x, axis, exclusive=None, reverse=None):  # type: ignore
         if not isinstance(axis, (np.int32, np.int64)):
             if len(axis.shape) > 1 or (len(axis.shape) > 0 and axis.shape[0] != 1):  # type: ignore
                 raise RuntimeError(

--- a/onnx/reference/ops/op_cum_sum.py
+++ b/onnx/reference/ops/op_cum_sum.py
@@ -14,7 +14,7 @@ class CumSum(OpRun):
         if axis is None:  # type: ignore
             if reverse or exclusive:
                 raise NotImplementedError("reverse=1 or exclusive=1 not implemented")
-            return (np.cumsum(x),)
+            return np.cumsum(x, dtype=x.dtype)
         if not isinstance(axis, (np.int32, np.int64)):
             if len(axis.shape) > 1 or (len(axis.shape) > 0 and axis.shape[0] != 1):  # type: ignore
                 raise RuntimeError(
@@ -34,7 +34,7 @@ class CumSum(OpRun):
             res = np.zeros(x.shape, dtype=x.dtype)
             np.cumsum(x[tuple(indices_c)], axis=axis, out=res[tuple(indices_d)])  # type: ignore
         else:
-            res = np.cumsum(x, axis=axis)  # type: ignore
+            res = np.cumsum(x, axis=axis, dtype=x.dtype)  # type: ignore
         if reverse:
             res = res[tuple(rev_indices)]
         return (res,)


### PR DESCRIPTION
### Description
This PR fixes the `dtype` returned from `CumSum` to be the same as the input. The tests included demonstrate that the change fixes the inconsistency. 

### Motivation and Context
The ONNX [documentation](https://onnx.ai/onnx/operators/onnx__CumSum.html) states:
> - y (heterogeneous) - T:
> Output tensor of the same type as ‘x’ with cumulative sums of the x’s elements

This mismatch between the reference implementation and `onnxruntime` was found by running the [array-api](https://data-apis.org/array-api/latest/) test suite through [ndonnx](https://github.com/Quantco/ndonnx) on both.