### PR TITLE
Bump Protobuf to 5.29.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04, windows-latest, macos-latest]
         python_version: ['3.13', '3.12', '3.11', '3.10', '3.9']
-        include:        
+        include:
           - python_version: '3.13'
             onnx_ml: 1
             debug_build: 1
@@ -95,7 +95,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements-release.txt
-          python -m pip install protobuf==5.28.3
+          python -m pip install protobuf==5.29.2
           git submodule update --init --recursive
 
 
@@ -203,14 +203,14 @@ jobs:
         continue-on-error: false
 
       - name: Run Python tests with numpy<2.0 (win, mac)
-        # Python 3.13 support was added at numpy 2.1.0 
+        # Python 3.13 support was added at numpy 2.1.0
         if: (matrix.python_version == '3.11' || matrix.python_version == '3.12') &&  (matrix.os == 'windows-latest' || matrix.os == 'macos-latest')
         run: |
           pip install "numpy<2.0" pillow
           pytest -s
 
       - name: Run Python tests with numpy<2.0 (ubuntu, python<3.13)
-        # python 3.13 support was added at numpy 2.1.0 
+        # python 3.13 support was added at numpy 2.1.0
         if: (matrix.python_version == '3.11' || matrix.python_version == '3.12') && startsWith(matrix.os,'ubuntu')
         run: |
           # 2024.10.15: Error message: The headers or library files could not be found for jpeg, a required dependency when compiling Pillow from source.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,8 +270,8 @@ else()
     # ABSL_ROOT_DIR is required by Protobuf.
     set(ABSL_ROOT_DIR ${abseil_SOURCE_DIR})
     message(STATUS "Abseil source dir:" ${ABSL_ROOT_DIR})
-    set(ProtobufURL https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protobuf-28.3.tar.gz)
-    set(ProtobufSHA1 269759bed3ef7fa7f04648bacdcfd3c26e3e50a8)
+    set(ProtobufURL https://github.com/protocolbuffers/protobuf/releases/download/v29.2/protobuf-29.2.tar.gz)
+    set(ProtobufSHA1 a5639ffb17e3743d696baf16bf377fbe752b6a1f)
     FetchContent_Declare(
       Protobuf
       URL ${ProtobufURL}
@@ -281,7 +281,7 @@ else()
     message(STATUS "Download and build Protobuf from ${ProtobufURL}")
     FetchContent_MakeAvailable(Protobuf Abseil)
     set(ONNX_PROTOC_EXECUTABLE $<TARGET_FILE:protobuf::protoc>)
-    set(Protobuf_VERSION "5.28.3")
+    set(Protobuf_VERSION "5.29.2")
     # Change back the BUILD_SHARED_LIBS to control the onnx project.
     set(BUILD_SHARED_LIBS ${ONNX_BUILD_SHARED_LIBS})
     set(PROTOBUF_DIR "${protobuf_BINARY_DIR}")

--- a/requirements-lintrunner.txt
+++ b/requirements-lintrunner.txt
@@ -4,7 +4,7 @@ lintrunner-adapters>=0.12.3
 ruff==0.8.4
 # MYPY
 mypy==1.13.0
-types-protobuf==5.28.0.20240924
+types-protobuf==5.29.1.20241207
 # BLACK-ISORT
 black==24.10.0
 isort==5.13.2


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Update protobuf to 5.29.2, which is latest before protobuf 6.30.x, which has more breaking changes. The related changes to ONNX are some C++ cleanups.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
Newer dependency.
<!-- - If it fixes an open issue, please link to the issue here. -->
