### PR TITLE
Install missing pytest; Update release_test_weekly_sdist.yml

### DIFF
--- a/.github/workflows/release_test_weekly_sdist.yml
+++ b/.github/workflows/release_test_weekly_sdist.yml
@@ -35,4 +35,5 @@ jobs:
             python -m pip uninstall -y onnx-weekly
             python -m pip install setuptools
             python -m pip install --use-deprecated=legacy-resolver --no-binary onnx-weekly onnx-weekly
+            python -m pip install pytest
             pytest


### PR DESCRIPTION
### Description
Add missing pytest
https://github.com/onnx/onnx/actions/runs/12343589760/job/34527736304

```

Collecting numpy>=1.20 (from onnx-weekly)
  Downloading numpy-2.2.0-cp313-cp313-macosx_14_0_arm64.whl (5.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 5.1/5.1 MB 83.0 MB/s eta 0:00:00
Collecting protobuf>=3.20.2 (from onnx-weekly)
  Using cached protobuf-5.29.1-cp38-abi3-macosx_10_9_universal2.whl (417 kB)
Building wheels for collected packages: onnx-weekly
  Building wheel for onnx-weekly (pyproject.toml): started
  Building wheel for onnx-weekly (pyproject.toml): still running...
  Building wheel for onnx-weekly (pyproject.toml): still running...
  Building wheel for onnx-weekly (pyproject.toml): still running...
  Building wheel for onnx-weekly (pyproject.toml): finished with status 'done'
  Created wheel for onnx-weekly: filename=onnx_weekly-1.18.0-cp313-cp313-macosx_12_0_universal2.whl size=15713772 sha256=3a714d3f4abaaedd047ff463c3729c580aa5a2c5b9d8adbc974cd2f139c86986
  Stored in directory: /Users/runner/Library/Caches/pip/wheels/ed/b7/1f/c32e9ba3f9aa2e95210[26](https://github.com/onnx/onnx/actions/runs/12343589760/job/34527736304#step:2:27)7ab65b139a663139d40e0514ffa25
Successfully built onnx-weekly
Installing collected packages: numpy, protobuf, onnx-weekly
Successfully installed numpy-2.2.0 onnx-weekly-1.18.0 protobuf-5.29.1
/Users/runner/work/_temp/6e92922a-0ca8-4bed-b210-7c0e929abab8.sh: line 4: pytest: command not found
Error: Process completed with exit code 1[27](https://github.com/onnx/onnx/actions/runs/12343589760/job/34527736304#step:2:28).
```