### PR TITLE
Expose cxx standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,6 +492,7 @@ else()
   set_target_properties(onnx_proto PROPERTIES VISIBILITY_INLINES_HIDDEN 1)
 endif()
 target_compile_definitions(onnx_proto PRIVATE ${ONNX_API_DEFINE})
+target_compile_features(onnx_proto PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
 
 if(ONNX_USE_LITE_PROTO)
   if(TARGET protobuf::libprotobuf-lite)


### PR DESCRIPTION
### Description
- Expose cxx standard

### Motivation and Context

CXX standard exposure is required to properly build against ONNX library.

Example of the issue https://github.com/microsoft/vcpkg/pull/42942#discussion_r1903814682

Generated target will have new property:
![{33169E2C-86D0-4E3A-BFF6-E27E436043BC}](https://github.com/user-attachments/assets/0fffaf33-dcb6-4f7b-b402-7605ddc7e73a)
