### PR TITLE
Fix numpy_helper to_array

### DIFF
--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -439,6 +439,10 @@ def to_array(tensor: TensorProto, base_dir: str = "") -> np.ndarray:  # noqa: PL
         data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint8)
         return _unpack_int4(data, dims).view(custom_np_types.int4)
 
+    if tensor_dtype == TensorProto.FLOAT4E2M1:
+        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint8)
+        return _unpack_uint4(data, dims).view(custom_np_types.float4e2m1)
+
     data = getattr(tensor, storage_field)
     if tensor_dtype in (TensorProto.COMPLEX64, TensorProto.COMPLEX128):
         data = combine_pairs_to_complex(data)  # type: ignore[assignment,arg-type]

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -353,7 +353,7 @@ def to_array(tensor: TensorProto, base_dir: str = "") -> np.ndarray:  # noqa: PL
             # Convert endian from little to big
             raw_data = np.frombuffer(raw_data, dtype=np_dtype).byteswap().tobytes()
 
-        # manually convert bf16 since there's no numpy support
+        data: np.ndarray[Any, Any]
         if tensor_dtype == TensorProto.BFLOAT16:
             data = np.frombuffer(raw_data, dtype=np.int16).reshape(dims)
             return data.view(custom_np_types.bfloat16)

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -349,23 +349,23 @@ def to_array(tensor: TensorProto, base_dir: str = "") -> np.ndarray:
         )
 
     if tensor_dtype == TensorProto.BFLOAT16:
-        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint16)
+        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint16).reshape(dims)
         return data.view(custom_np_types.bfloat16)
 
     if tensor_dtype == TensorProto.FLOAT8E4M3FN:
-        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint8)
+        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint8).reshape(dims)
         return data.view(custom_np_types.float8e4m3fn)
 
     if tensor_dtype == TensorProto.FLOAT8E4M3FNUZ:
-        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint8)
+        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint8).reshape(dims)
         return data.view(custom_np_types.float8e4m3fnuz)
 
     if tensor_dtype == TensorProto.FLOAT8E5M2:
-        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint8)
+        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint8).reshape(dims)
         return data.view(custom_np_types.float8e5m2)
 
     if tensor_dtype == TensorProto.FLOAT8E5M2FNUZ:
-        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint8)
+        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint8).reshape(dims)
         return data.view(custom_np_types.float8e5m2fnuz)
 
     if tensor_dtype == TensorProto.UINT4:
@@ -375,10 +375,6 @@ def to_array(tensor: TensorProto, base_dir: str = "") -> np.ndarray:
     if tensor_dtype == TensorProto.INT4:
         data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.int8)
         return unpack_int4(data, dims, signed=True).view(custom_np_types.int4)
-
-    if tensor_dtype == TensorProto.FLOAT4E2M1:
-        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint8)
-        return unpack_float4e2m1(data, dims).view(custom_np_types.float4e2m1)
 
     data = getattr(tensor, storage_field)
     if tensor_dtype in (TensorProto.COMPLEX64, TensorProto.COMPLEX128):

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -433,10 +433,6 @@ class TestHelperTensorFunctions(unittest.TestCase):
         )
         self.assertEqual(string_list, list(tensor.string_data))
 
-    @unittest.skipIf(
-        version_utils.numpy_older_than("1.26.0"),
-        "The test requires numpy 1.26.0 or later",
-    )
     def test_make_bfloat16_tensor(self) -> None:
         # numpy doesn't support bf16, so we have to compute the correct result manually
         np_array = np.array(
@@ -502,10 +498,6 @@ class TestHelperTensorFunctions(unittest.TestCase):
         )
         np.testing.assert_equal(ynp.view(np.uint8), expected.view(np.uint8))
 
-    @unittest.skipIf(
-        version_utils.numpy_older_than("1.26.0"),
-        "The test requires numpy 1.26.0 or later",
-    )
     def test_make_bfloat16_tensor_raw(self) -> None:
         array = np.array(
             [

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -684,7 +684,6 @@ class TestHelperTensorFunctions(unittest.TestCase):
         ynp = numpy_helper.to_array(y)
         np.testing.assert_equal(ynp.view(np.uint8), expected)
 
-    @unittest.expectedFailure
     def test_make_float4e2m1_tensor(self) -> None:
         # float4e2m1 can be stored as raw data only according to the proto definition
         y = helper.make_tensor(

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -685,7 +685,6 @@ class TestHelperTensorFunctions(unittest.TestCase):
         np.testing.assert_equal(ynp.view(np.uint8), expected)
 
     def test_make_float4e2m1_tensor(self) -> None:
-        # float4e2m1 can be stored as raw data only according to the proto definition
         y = helper.make_tensor(
             "zero_point",
             TensorProto.FLOAT4E2M1,


### PR DESCRIPTION
### Description

Refactor `to_array` to simplify and fix conversion logic.

- The `_to_array` function was renamed back to `to_array`, consolidating with existing logic that leverages custom dtypes.
- Created an unpack_4bit helper to unpack packed 4bit dtype data, replacing usage of the 4bit->float32 conversion functions because the original logic was not actually needed.
- Removed test skips because bugs were fixed.
- Type casting functions for custom dtypes will be marked private in the next PR. Public versions of them will be scheduled for deprecation. (#6639) Users should use other libraries like ml_dtypes for efficient type conversion in numpy.

### Motivation and Context

Fix https://github.com/onnx/onnx/issues/6604