### PR TITLE
Deprecate all type casting functions

### DIFF
--- a/docs/docsgen/source/api/helper.md
+++ b/docs/docsgen/source/api/helper.md
@@ -6,136 +6,9 @@
 .. currentmodule:: onnx.helper
 ```
 
-```{eval-rst}
-.. autosummary::
-
-    find_min_ir_version_for
-    get_all_tensor_dtypes
-    get_attribute_value
-    get_node_attr_value
-    set_metadata_props
-    set_model_props
-    float32_to_bfloat16
-    float32_to_float8e4m3
-    float32_to_float8e5m2
-    make_attribute
-    make_attribute_ref
-    make_empty_tensor_value_info
-    make_function
-    make_graph
-    make_map
-    make_map_type_proto
-    make_model
-    make_node
-    make_operatorsetid
-    make_opsetid
-    make_model_gen_version
-    make_optional
-    make_optional_type_proto
-    make_sequence
-    make_sequence_type_proto
-    make_sparse_tensor
-    make_sparse_tensor_type_proto
-    make_sparse_tensor_value_info
-    make_tensor
-    make_tensor_sequence_value_info
-    make_tensor_type_proto
-    make_training_info
-    make_tensor_value_info
-    make_value_info
-    np_dtype_to_tensor_dtype
-    printable_attribute
-    printable_dim
-    printable_graph
-    printable_node
-    printable_tensor_proto
-    printable_type
-    printable_value_info
-    split_complex_to_pairs
-    create_op_set_id_version_map
-    strip_doc_string
-    pack_float32_to_4bit
-    tensor_dtype_to_np_dtype
-    tensor_dtype_to_storage_tensor_dtype
-    tensor_dtype_to_string
-    tensor_dtype_to_field
-```
-
-## getter
-
-```{eval-rst}
-.. autofunction:: onnx.helper.get_attribute_value
-```
-
-```{eval-rst}
-.. autofunction:: onnx.helper.get_node_attr_value
-```
-
-## setter
-
-```{eval-rst}
-.. autofunction:: onnx.helper.set_metadata_props
-```
-
-```{eval-rst}
-.. autofunction:: onnx.helper.set_model_props
-```
-
-## print
-
-```{eval-rst}
-.. autofunction:: onnx.helper.printable_attribute
-```
-
-```{eval-rst}
-.. autofunction:: onnx.helper.printable_dim
-```
-
-```{eval-rst}
-.. autofunction:: onnx.helper.printable_graph
-```
-
-```{eval-rst}
-.. autofunction:: onnx.helper.printable_node
-```
-
-```{eval-rst}
-.. autofunction:: onnx.helper.printable_tensor_proto
-```
-
-```{eval-rst}
-.. autofunction:: onnx.helper.printable_type
-```
-
-```{eval-rst}
-.. autofunction:: onnx.helper.printable_value_info
-```
-
-## tools
-
-```{eval-rst}
-.. autofunction:: onnx.helper.find_min_ir_version_for
-```
-
-```{eval-rst}
-.. autofunction:: onnx.helper.split_complex_to_pairs
-```
-
-```{eval-rst}
-.. autofunction:: onnx.helper.create_op_set_id_version_map
-```
-
-```{eval-rst}
-.. autofunction:: onnx.helper.strip_doc_string
-```
-
-```{eval-rst}
-.. autofunction:: onnx.helper.pack_float32_to_4bit
-```
-
 (l-onnx-make-function)=
 
-## make function
+## Helper functions to make ONNX graph components
 
 All functions used to create an ONNX graph.
 
@@ -239,7 +112,7 @@ All functions used to create an ONNX graph.
 .. autofunction:: onnx.helper.make_value_info
 ```
 
-## type mappings
+## Type Mappings
 
 ```{eval-rst}
 .. autofunction:: onnx.helper.get_all_tensor_dtypes
@@ -265,16 +138,30 @@ All functions used to create an ONNX graph.
 .. autofunction:: onnx.helper.tensor_dtype_to_string
 ```
 
-## cast
+## Tools
 
 ```{eval-rst}
-.. autofunction:: onnx.helper.float32_to_bfloat16
+.. autofunction:: onnx.helper.find_min_ir_version_for
 ```
 
 ```{eval-rst}
-.. autofunction:: onnx.helper.float32_to_float8e4m3
+.. autofunction:: onnx.helper.create_op_set_id_version_map
 ```
 
+## Other functions
+
 ```{eval-rst}
-.. autofunction:: onnx.helper.float32_to_float8e5m2
+.. autosummary::
+
+    get_attribute_value
+    get_node_attr_value
+    set_metadata_props
+    set_model_props
+    printable_attribute
+    printable_dim
+    printable_graph
+    printable_node
+    printable_tensor_proto
+    printable_type
+    printable_value_info
 ```

--- a/docs/docsgen/source/api/numpy_helper.md
+++ b/docs/docsgen/source/api/numpy_helper.md
@@ -7,9 +7,6 @@
 ```{eval-rst}
 .. autosummary::
 
-    bfloat16_to_float32
-    float8e4m3_to_float32
-    float8e5m2_to_float32
     from_array
     from_dict
     from_list
@@ -64,36 +61,4 @@ these two functions use a custom dtype defined in :mod:`onnx._custom_element_typ
 
 ```{eval-rst}
 .. autofunction:: onnx.numpy_helper.from_optional
-```
-
-## tools
-
-```{eval-rst}
-.. autofunction:: onnx.numpy_helper.convert_endian
-```
-
-```{eval-rst}
-.. autofunction:: onnx.numpy_helper.combine_pairs_to_complex
-```
-
-```{eval-rst}
-.. autofunction:: onnx.numpy_helper.create_random_int
-```
-
-```{eval-rst}
-.. autofunction:: onnx.numpy_helper.unpack_int4
-```
-
-## cast
-
-```{eval-rst}
-.. autofunction:: onnx.numpy_helper.bfloat16_to_float32
-```
-
-```{eval-rst}
-.. autofunction:: onnx.numpy_helper.float8e4m3_to_float32
-```
-
-```{eval-rst}
-.. autofunction:: onnx.numpy_helper.float8e5m2_to_float32
 ```

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -357,7 +357,7 @@ def set_model_props(model: ModelProto, dict_value: dict[str, str]) -> None:
     set_metadata_props(model, dict_value)
 
 
-def split_complex_to_pairs(ca: Sequence[np.complex64]) -> Sequence[int]:
+def _split_complex_to_pairs(ca: Sequence[np.complex64]) -> Sequence[int]:
     return [
         (ca[i // 2].real if (i % 2 == 0) else ca[i // 2].imag)  # type: ignore[misc]
         for i in range(len(ca) * 2)
@@ -800,7 +800,7 @@ def make_tensor(
         tensor.raw_data = vals
     else:
         if data_type in (TensorProto.COMPLEX64, TensorProto.COMPLEX128):
-            vals = split_complex_to_pairs(vals)
+            vals = _split_complex_to_pairs(vals)
         elif data_type == TensorProto.FLOAT16:
             vals = (
                 np.array(vals).astype(np_dtype).view(dtype=np.uint16).flatten().tolist()

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -365,7 +365,7 @@ def split_complex_to_pairs(ca: Sequence[np.complex64]) -> Sequence[int]:
 
 
 @typing_extensions.deprecated(
-    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
     category=FutureWarning,
 )
 def float32_to_bfloat16(*args, **kwargs) -> int:
@@ -392,7 +392,7 @@ def _float32_to_bfloat16(fval: float, truncate: bool = False) -> int:
 
 
 @typing_extensions.deprecated(
-    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
     category=FutureWarning,
 )
 def float32_to_float8e4m3(*args, **kwargs) -> int:
@@ -534,7 +534,7 @@ def _float32_to_float8e4m3(  # noqa: PLR0911
 
 
 @typing_extensions.deprecated(
-    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
     category=FutureWarning,
 )
 def float32_to_float8e5m2(*args: Any, **kwargs: Any) -> int:
@@ -668,7 +668,7 @@ def _float32_to_float8e5m2(  # noqa: PLR0911
 
 
 @typing_extensions.deprecated(
-    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
     category=FutureWarning,
 )
 def pack_float32_to_4bit(array: np.ndarray | Sequence, signed: bool) -> np.ndarray:
@@ -704,7 +704,7 @@ def _pack_float32_to_4bit(array: np.ndarray | Sequence, signed: bool) -> np.ndar
 
 
 @typing_extensions.deprecated(
-    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
     category=FutureWarning,
 )
 def pack_float32_to_float4e2m1(array: np.ndarray | Sequence) -> np.ndarray:

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -18,6 +18,7 @@ from typing import (
 
 import google.protobuf.message
 import numpy as np
+import typing_extensions
 
 import onnx._custom_element_types as custom_np_types
 from onnx import (
@@ -363,13 +364,21 @@ def split_complex_to_pairs(ca: Sequence[np.complex64]) -> Sequence[int]:
     ]
 
 
+@typing_extensions.deprecated(
+    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    category=FutureWarning,
+)
+def float32_to_bfloat16(*args, **kwargs) -> int:
+    return _float32_to_bfloat16(*args, **kwargs)
+
+
 # convert a float32 value to a bfloat16 (as int)
 # By default, this conversion rounds-to-nearest-even and supports NaN
 # Setting `truncate` to True enables a simpler conversion. In this mode the
 # conversion is performed by simply dropping the 2 least significant bytes of
 # the significand. In this mode an error of up to 1 bit may be introduced and
 # preservation of NaN values is not be guaranteed.
-def float32_to_bfloat16(fval: float, truncate: bool = False) -> int:
+def _float32_to_bfloat16(fval: float, truncate: bool = False) -> int:
     ival = int.from_bytes(struct.pack("<f", fval), "little")
     if truncate:
         return ival >> 16
@@ -382,7 +391,15 @@ def float32_to_bfloat16(fval: float, truncate: bool = False) -> int:
     return (ival + rounded) >> 16
 
 
-def float32_to_float8e4m3(  # noqa: PLR0911
+@typing_extensions.deprecated(
+    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    category=FutureWarning,
+)
+def float32_to_float8e4m3(*args, **kwargs) -> int:
+    return _float32_to_float8e4m3(*args, **kwargs)
+
+
+def _float32_to_float8e4m3(  # noqa: PLR0911
     fval: float,
     scale: float = 1.0,
     fn: bool = True,
@@ -516,7 +533,15 @@ def float32_to_float8e4m3(  # noqa: PLR0911
         return int(ret)
 
 
-def float32_to_float8e5m2(  # noqa: PLR0911
+@typing_extensions.deprecated(
+    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    category=FutureWarning,
+)
+def float32_to_float8e5m2(*args: Any, **kwargs: Any) -> int:
+    return _float32_to_float8e5m2(*args, **kwargs)
+
+
+def _float32_to_float8e5m2(  # noqa: PLR0911
     fval: float,
     scale: float = 1.0,
     fn: bool = False,
@@ -642,7 +667,15 @@ def float32_to_float8e5m2(  # noqa: PLR0911
         raise NotImplementedError("fn and uz must be both False or True.")
 
 
+@typing_extensions.deprecated(
+    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    category=FutureWarning,
+)
 def pack_float32_to_4bit(array: np.ndarray | Sequence, signed: bool) -> np.ndarray:
+    return _pack_float32_to_4bit(array, signed)
+
+
+def _pack_float32_to_4bit(array: np.ndarray | Sequence, signed: bool) -> np.ndarray:
     """Convert an array of float32 value to a 4bit data-type and pack every two concecutive elements in a byte.
     See :ref:`onnx-detail-int4` for technical details.
 
@@ -662,7 +695,7 @@ def pack_float32_to_4bit(array: np.ndarray | Sequence, signed: bool) -> np.ndarr
         array_flat = np.append(array_flat, np.array([0]))
 
     def single_func(x, y) -> np.ndarray:
-        return subbyte.float32x2_to_4bitx2(x, y, signed)
+        return subbyte._float32x2_to_4bitx2(x, y, signed)
 
     func = np.frompyfunc(single_func, 2, 1)
 
@@ -670,7 +703,15 @@ def pack_float32_to_4bit(array: np.ndarray | Sequence, signed: bool) -> np.ndarr
     return arr.astype(np.uint8)
 
 
+@typing_extensions.deprecated(
+    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    category=FutureWarning,
+)
 def pack_float32_to_float4e2m1(array: np.ndarray | Sequence) -> np.ndarray:
+    return _pack_float32_to_float4e2m1(array)
+
+
+def _pack_float32_to_float4e2m1(array: np.ndarray | Sequence) -> np.ndarray:
     """Convert an array of float32 value to float4e2m1 and pack every two concecutive elements in a byte.
     See :ref:`onnx-detail-float4` for technical details.
 
@@ -688,7 +729,7 @@ def pack_float32_to_float4e2m1(array: np.ndarray | Sequence) -> np.ndarray:
     if is_odd_volume:
         array_flat = np.append(array_flat, np.array([0]))
 
-    arr = subbyte.float32x2_to_float4e2m1x2(array_flat[0::2], array_flat[1::2])
+    arr = subbyte._float32x2_to_float4e2m1x2(array_flat[0::2], array_flat[1::2])
     return arr.astype(np.uint8)
 
 
@@ -772,13 +813,13 @@ def make_tensor(
             TensorProto.FLOAT8E5M2FNUZ,
         ):
             fcast = {
-                TensorProto.BFLOAT16: float32_to_bfloat16,
-                TensorProto.FLOAT8E4M3FN: float32_to_float8e4m3,
-                TensorProto.FLOAT8E4M3FNUZ: lambda *args: float32_to_float8e4m3(  # type: ignore[misc]
+                TensorProto.BFLOAT16: _float32_to_bfloat16,
+                TensorProto.FLOAT8E4M3FN: _float32_to_float8e4m3,
+                TensorProto.FLOAT8E4M3FNUZ: lambda *args: _float32_to_float8e4m3(  # type: ignore[misc]
                     *args, uz=True
                 ),
-                TensorProto.FLOAT8E5M2: float32_to_float8e5m2,
-                TensorProto.FLOAT8E5M2FNUZ: lambda *args: float32_to_float8e5m2(  # type: ignore[misc]
+                TensorProto.FLOAT8E5M2: _float32_to_float8e5m2,
+                TensorProto.FLOAT8E5M2FNUZ: lambda *args: _float32_to_float8e5m2(  # type: ignore[misc]
                     *args, fn=True, uz=True
                 ),
             }[
@@ -801,9 +842,9 @@ def make_tensor(
             # to uint8 regardless of the value of 'signed'. Using int8 would cause
             # the size of int4 tensors to increase ~5x if the tensor contains negative values (due to
             # the way negative values are serialized by protobuf).
-            vals = pack_float32_to_4bit(vals, signed=signed).flatten().tolist()
+            vals = _pack_float32_to_4bit(vals, signed=signed).flatten().tolist()
         elif data_type == TensorProto.FLOAT4E2M1:
-            vals = pack_float32_to_float4e2m1(vals).flatten().tolist()
+            vals = _pack_float32_to_float4e2m1(vals).flatten().tolist()
         elif data_type == TensorProto.BOOL:
             vals = np.array(vals).astype(int)
         elif data_type == TensorProto.STRING:

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -21,7 +21,7 @@ def combine_pairs_to_complex(fa: Sequence[int]) -> list[complex]:
 
 
 @typing_extensions.deprecated(
-    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
     category=FutureWarning,
 )
 def bfloat16_to_float32(
@@ -95,7 +95,7 @@ _float8e4m3_to_float32 = np.vectorize(
 
 
 @typing_extensions.deprecated(
-    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
     category=FutureWarning,
 )
 def float8e4m3_to_float32(
@@ -174,7 +174,7 @@ _float8e5m2_to_float32 = np.vectorize(
 
 
 @typing_extensions.deprecated(
-    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
     category=FutureWarning,
 )
 def float8e5m2_to_float32(
@@ -204,7 +204,7 @@ def float8e5m2_to_float32(
 
 
 @typing_extensions.deprecated(
-    "Deprecated since 1.18. Consider implementing your own unpack logic",
+    "Deprecated since 1.18. Scheduled to remove in 1.20. Consider implementing your own unpack logic",
     category=FutureWarning,
 )
 def unpack_int4(

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -16,7 +16,7 @@ from onnx import MapProto, OptionalProto, SequenceProto, TensorProto, helper, su
 from onnx.external_data_helper import load_external_data_for_tensor, uses_external_data
 
 
-def combine_pairs_to_complex(fa: Sequence[int]) -> list[complex]:
+def _combine_pairs_to_complex(fa: Sequence[int]) -> list[complex]:
     return [complex(fa[i * 2], fa[i * 2 + 1]) for i in range(len(fa) // 2)]
 
 
@@ -462,7 +462,7 @@ def to_array(tensor: TensorProto, base_dir: str = "") -> np.ndarray:  # noqa: PL
 
     data = getattr(tensor, storage_field)
     if tensor_dtype in (TensorProto.COMPLEX64, TensorProto.COMPLEX128):
-        data = combine_pairs_to_complex(data)  # type: ignore[assignment,arg-type]
+        data = _combine_pairs_to_complex(data)  # type: ignore[assignment,arg-type]
 
     return np.asarray(data, dtype=storage_np_dtype).astype(np_dtype).reshape(dims)
 
@@ -527,7 +527,7 @@ def _from_array(arr: np.ndarray, name: str | None = None) -> TensorProto:
     tensor.raw_data = arr.tobytes()  # note: tobytes() is only after 1.9.
     if sys.byteorder == "big":
         # Convert endian from big to little
-        convert_endian(tensor)
+        _convert_endian(tensor)
 
     return tensor
 
@@ -835,7 +835,7 @@ def from_optional(
     return optional
 
 
-def convert_endian(tensor: TensorProto) -> None:
+def _convert_endian(tensor: TensorProto) -> None:
     """Call to convert endianness of raw data in tensor.
 
     Args:

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -349,23 +349,23 @@ def to_array(tensor: TensorProto, base_dir: str = "") -> np.ndarray:
         )
 
     if tensor_dtype == TensorProto.BFLOAT16:
-        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint16)
+        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint16).reshape(dims)
         return data.view(custom_np_types.bfloat16)
 
     if tensor_dtype == TensorProto.FLOAT8E4M3FN:
-        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint8)
+        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint8).reshape(dims)
         return data.view(custom_np_types.float8e4m3fn)
 
     if tensor_dtype == TensorProto.FLOAT8E4M3FNUZ:
-        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint8)
+        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint8).reshape(dims)
         return data.view(custom_np_types.float8e4m3fnuz)
 
     if tensor_dtype == TensorProto.FLOAT8E5M2:
-        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint8)
+        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint8).reshape(dims)
         return data.view(custom_np_types.float8e5m2)
 
     if tensor_dtype == TensorProto.FLOAT8E5M2FNUZ:
-        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint8)
+        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint8).reshape(dims)
         return data.view(custom_np_types.float8e5m2fnuz)
 
     if tensor_dtype == TensorProto.UINT4:
@@ -375,10 +375,6 @@ def to_array(tensor: TensorProto, base_dir: str = "") -> np.ndarray:
     if tensor_dtype == TensorProto.INT4:
         data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.int8)
         return unpack_int4(data, dims, signed=True).view(custom_np_types.int4)
-
-    if tensor_dtype == TensorProto.FLOAT4E2M1:
-        data = np.asarray(tensor.int32_data, dtype=np.int32).astype(np.uint8)
-        return unpack_float4e2m1(data, dims).view(custom_np_types.float4e2m1)
 
     data = getattr(tensor, storage_field)
     if tensor_dtype in (TensorProto.COMPLEX64, TensorProto.COMPLEX128):

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -224,7 +224,7 @@ def unpack_int4(
     Returns:
         A numpy array of float32 reshaped to dims.
     """
-    single_func = lambda x: subbyte.unpack_single_4bitx2(x, signed)  # noqa: E731
+    single_func = lambda x: subbyte._unpack_single_4bitx2(x, signed)  # noqa: E731
     func = np.frompyfunc(single_func, 1, 2)
 
     res_high, res_low = func(data.ravel())

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import numpy as np
 import numpy.typing as npt
+import typing_extensions
 
 import onnx._custom_element_types as custom_np_types
 from onnx import MapProto, OptionalProto, SequenceProto, TensorProto, helper, subbyte
@@ -19,6 +20,10 @@ def combine_pairs_to_complex(fa: Sequence[int]) -> list[complex]:
     return [complex(fa[i * 2], fa[i * 2 + 1]) for i in range(len(fa) // 2)]
 
 
+@typing_extensions.deprecated(
+    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    category=FutureWarning,
+)
 def bfloat16_to_float32(
     data: np.int16 | np.int32 | np.ndarray,
     dims: int | Sequence[int] | None = None,
@@ -89,6 +94,10 @@ _float8e4m3_to_float32 = np.vectorize(
 )
 
 
+@typing_extensions.deprecated(
+    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    category=FutureWarning,
+)
 def float8e4m3_to_float32(
     data: np.int16 | np.int32 | np.ndarray,
     dims: int | Sequence[int] | None = None,
@@ -164,6 +173,10 @@ _float8e5m2_to_float32 = np.vectorize(
 )
 
 
+@typing_extensions.deprecated(
+    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    category=FutureWarning,
+)
 def float8e5m2_to_float32(
     data: np.int16 | np.int32 | np.ndarray,
     dims: int | Sequence[int] | None = None,
@@ -190,6 +203,10 @@ def float8e5m2_to_float32(
     return res.reshape(dims)  # type: ignore[no-any-return]
 
 
+@typing_extensions.deprecated(
+    "Deprecated since 1.18. Consider implementing your own unpack logic",
+    category=FutureWarning,
+)
 def unpack_int4(
     data: np.int32 | np.ndarray,
     dims: int | Sequence[int],

--- a/onnx/subbyte.py
+++ b/onnx/subbyte.py
@@ -16,7 +16,7 @@ UINT4_MAX = 15
 
 
 @typing_extensions.deprecated(
-    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
     category=FutureWarning,
 )
 def float32_to_4bit_unpacked(*args, **kwargs):
@@ -46,7 +46,7 @@ def _float32_to_4bit_unpacked(
 
 
 @typing_extensions.deprecated(
-    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
     category=FutureWarning,
 )
 def float32x2_to_4bitx2(*args, **kwargs):
@@ -72,7 +72,7 @@ def _float32x2_to_4bitx2(
 
 
 @typing_extensions.deprecated(
-    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
     category=FutureWarning,
 )
 def unpack_4bitx2(*args, **kwargs):
@@ -107,7 +107,7 @@ def _unpack_4bitx2(
 
 
 @typing_extensions.deprecated(
-    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
     category=FutureWarning,
 )
 def unpack_single_4bitx2(*args, **kwargs):
@@ -138,7 +138,7 @@ def _unpack_single_4bitx2(
 
 
 @typing_extensions.deprecated(
-    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
     category=FutureWarning,
 )
 def float32_to_float4e2m1_unpacked(*args, **kwargs):
@@ -170,7 +170,7 @@ def _float32_to_float4e2m1_unpacked(values: np.ndarray) -> np.ndarray:
 
 
 @typing_extensions.deprecated(
-    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
     category=FutureWarning,
 )
 def float32x2_to_float4e2m1x2(*args, **kwargs):

--- a/onnx/subbyte.py
+++ b/onnx/subbyte.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 
 import numpy as np
 import numpy.typing as npt
+import typing_extensions
 
 INT4_MIN = -8
 INT4_MAX = 7
@@ -14,7 +15,15 @@ UINT4_MIN = 0
 UINT4_MAX = 15
 
 
-def float32_to_4bit_unpacked(
+@typing_extensions.deprecated(
+    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    category=FutureWarning,
+)
+def float32_to_4bit_unpacked(*args, **kwargs):
+    return _float32_to_4bit_unpacked(*args, **kwargs)
+
+
+def _float32_to_4bit_unpacked(
     x: np.ndarray | np.dtype | float, signed: bool
 ) -> np.ndarray:
     """Cast to 4bit via rounding and clipping (without packing).
@@ -36,7 +45,15 @@ def float32_to_4bit_unpacked(
     return np.rint(clipped).astype(dtype)  # type: ignore[no-any-return]
 
 
-def float32x2_to_4bitx2(
+@typing_extensions.deprecated(
+    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    category=FutureWarning,
+)
+def float32x2_to_4bitx2(*args, **kwargs):
+    return _float32x2_to_4bitx2(*args, **kwargs)
+
+
+def _float32x2_to_4bitx2(
     val_low: np.dtype, val_high: np.dtype, signed: bool
 ) -> np.ndarray:
     """Cast two elements to 4bit (via rounding and clipping) and pack
@@ -49,12 +66,20 @@ def float32x2_to_4bitx2(
     Returns:
         An ndarray with a single int8/uint8 element, containing both int4 elements
     """
-    i8_high = float32_to_4bit_unpacked(val_high, signed)
-    i8_low = float32_to_4bit_unpacked(val_low, signed)
+    i8_high = _float32_to_4bit_unpacked(val_high, signed)
+    i8_low = _float32_to_4bit_unpacked(val_low, signed)
     return i8_high << 4 | i8_low & 0x0F
 
 
-def unpack_4bitx2(
+@typing_extensions.deprecated(
+    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    category=FutureWarning,
+)
+def unpack_4bitx2(*args, **kwargs):
+    return _unpack_4bitx2(*args, **kwargs)
+
+
+def _unpack_4bitx2(
     x: npt.NDArray[np.uint8], dims: int | Sequence[int]
 ) -> npt.NDArray[np.uint8]:
     """Unpack an array of packed uint8 elements (4bitx2) into individual elements
@@ -81,7 +106,15 @@ def unpack_4bitx2(
     return res
 
 
-def unpack_single_4bitx2(
+@typing_extensions.deprecated(
+    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    category=FutureWarning,
+)
+def unpack_single_4bitx2(*args, **kwargs):
+    return _unpack_single_4bitx2(*args, **kwargs)
+
+
+def _unpack_single_4bitx2(
     x: np.ndarray | np.dtype | float, signed: bool
 ) -> tuple[np.ndarray, np.ndarray]:
     def unpack_signed(x):
@@ -104,7 +137,15 @@ def unpack_single_4bitx2(
     return (x_low.astype(dtype), x_high.astype(dtype))
 
 
-def float32_to_float4e2m1_unpacked(values: np.ndarray) -> np.ndarray:
+@typing_extensions.deprecated(
+    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    category=FutureWarning,
+)
+def float32_to_float4e2m1_unpacked(*args, **kwargs):
+    return _float32_to_float4e2m1_unpacked(*args, **kwargs)
+
+
+def _float32_to_float4e2m1_unpacked(values: np.ndarray) -> np.ndarray:
     """Cast float32 to float4e2m1 (without packing).
 
     Args:
@@ -128,7 +169,15 @@ def float32_to_float4e2m1_unpacked(values: np.ndarray) -> np.ndarray:
     return res
 
 
-def float32x2_to_float4e2m1x2(val_low: np.ndarray, val_high: np.ndarray) -> np.ndarray:
+@typing_extensions.deprecated(
+    "Deprecated since 1.18. Consider using libraries like ml_dtypes for dtype conversion",
+    category=FutureWarning,
+)
+def float32x2_to_float4e2m1x2(*args, **kwargs):
+    return _float32x2_to_float4e2m1x2(*args, **kwargs)
+
+
+def _float32x2_to_float4e2m1x2(val_low: np.ndarray, val_high: np.ndarray) -> np.ndarray:
     """Cast two elements to float4e2m1 and pack to a single byte
     Args:
         val_low: element to be packed in the 4 LSB
@@ -137,6 +186,6 @@ def float32x2_to_float4e2m1x2(val_low: np.ndarray, val_high: np.ndarray) -> np.n
     Returns:
         An ndarray with uint8 elements, containing both float4e2m1 elements
     """
-    i8_high = float32_to_float4e2m1_unpacked(val_high)
-    i8_low = float32_to_float4e2m1_unpacked(val_low)
+    i8_high = _float32_to_float4e2m1_unpacked(val_high)
+    i8_low = _float32_to_float4e2m1_unpacked(val_low)
     return i8_high << 4 | i8_low & 0x0F

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -684,9 +684,7 @@ class TestHelperTensorFunctions(unittest.TestCase):
         ynp = numpy_helper.to_array(y)
         np.testing.assert_equal(ynp.view(np.uint8), expected)
 
-    @unittest.expectedFailure
     def test_make_float4e2m1_tensor(self) -> None:
-        # float4e2m1 can be stored as raw data only according to the proto definition
         y = helper.make_tensor(
             "zero_point",
             TensorProto.FLOAT4E2M1,

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -433,10 +433,6 @@ class TestHelperTensorFunctions(unittest.TestCase):
         )
         self.assertEqual(string_list, list(tensor.string_data))
 
-    @unittest.skipIf(
-        version_utils.numpy_older_than("1.26.0"),
-        "The test requires numpy 1.26.0 or later",
-    )
     def test_make_bfloat16_tensor(self) -> None:
         # numpy doesn't support bf16, so we have to compute the correct result manually
         np_array = np.array(
@@ -502,10 +498,6 @@ class TestHelperTensorFunctions(unittest.TestCase):
         )
         np.testing.assert_equal(ynp.view(np.uint8), expected.view(np.uint8))
 
-    @unittest.skipIf(
-        version_utils.numpy_older_than("1.26.0"),
-        "The test requires numpy 1.26.0 or later",
-    )
     def test_make_bfloat16_tensor_raw(self) -> None:
         array = np.array(
             [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy>=1.20
 protobuf>=3.20.2
+typing_extensions>=4.7.1


### PR DESCRIPTION
Deprecate all type casting functions because they are mere utilities or reference implementations that should not be directly exposed to users. Users should leverage libraries like `ml_dtypes` for type conversion.

- Additionally turned convert_endian and split_complex_to_pairs into private. This is seen as low risk.
- Added typing_extensions as a dependency. This is a common dependency used by python packages as a polyfill for the typing module.