### PR TITLE
Clarify that FLOAT4E2M1 can be in int32_data

### DIFF
--- a/onnx/onnx.in.proto
+++ b/onnx/onnx.in.proto
@@ -579,13 +579,13 @@ message TensorProto {
   // When this field is present, the data_type field MUST be FLOAT or COMPLEX64.
   repeated float float_data = 4 [packed = true];
 
-  // For int32, uint8, int8, uint16, int16, uint4, int4, bool, float8 and float16 values
-  // float16 and float8 values must be bit-wise converted to an uint16_t prior
-  // to writing to the buffer.
-  // uint4 and int4 values must be packed to 4bitx2 prior to writing to the buffer, the first element is stored in
-  // the 4 LSB and the second element is stored in the 4 MSB.
+  // For int32, uint8, int8, uint16, int16, uint4, int4, bool, (b)float16, float8 and float4 values.
+  // - (b)float16 and float8 values MUST be bit-wise converted to an unsigned int
+  //   representation prior to writing to the buffer.
+  // - uint4, int4, float4 values MUST be packed to 4bitx2 prior to writing to the buffer,
+  //   the first element is stored in the 4 LSB and the second element is stored in the 4 MSB.
   // When this field is present, the data_type field MUST be
-  // INT32, INT16, INT8, INT4, UINT16, UINT8, UINT4, BOOL, FLOAT16, BFLOAT16, FLOAT8E4M3FN, FLOAT8E4M3FNUZ, FLOAT8E5M2, FLOAT8E5M2FNUZ
+  // INT32, INT16, INT8, INT4, UINT16, UINT8, UINT4, BOOL, FLOAT16, BFLOAT16, FLOAT8E4M3FN, FLOAT8E4M3FNUZ, FLOAT8E5M2, FLOAT8E5M2FNUZ, FLOAT4E2M1
   repeated int32 int32_data = 5 [packed = true];
 
   // For strings.

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -580,13 +580,13 @@ message TensorProto {
   // When this field is present, the data_type field MUST be FLOAT or COMPLEX64.
   repeated float float_data = 4 [packed = true];
 
-  // For int32, uint8, int8, uint16, int16, uint4, int4, bool, float8 and float16 values
-  // float16 and float8 values must be bit-wise converted to an uint16_t prior
-  // to writing to the buffer.
-  // uint4 and int4 values must be packed to 4bitx2 prior to writing to the buffer, the first element is stored in
-  // the 4 LSB and the second element is stored in the 4 MSB.
+  // For int32, uint8, int8, uint16, int16, uint4, int4, bool, (b)float16, float8 and float4 values.
+  // - (b)float16 and float8 values MUST be bit-wise converted to an unsigned int
+  //   representation prior to writing to the buffer.
+  // - uint4, int4, float4 values MUST be packed to 4bitx2 prior to writing to the buffer,
+  //   the first element is stored in the 4 LSB and the second element is stored in the 4 MSB.
   // When this field is present, the data_type field MUST be
-  // INT32, INT16, INT8, INT4, UINT16, UINT8, UINT4, BOOL, FLOAT16, BFLOAT16, FLOAT8E4M3FN, FLOAT8E4M3FNUZ, FLOAT8E5M2, FLOAT8E5M2FNUZ
+  // INT32, INT16, INT8, INT4, UINT16, UINT8, UINT4, BOOL, FLOAT16, BFLOAT16, FLOAT8E4M3FN, FLOAT8E4M3FNUZ, FLOAT8E5M2, FLOAT8E5M2FNUZ, FLOAT4E2M1
   repeated int32 int32_data = 5 [packed = true];
 
   // For strings.

--- a/onnx/onnx.proto3
+++ b/onnx/onnx.proto3
@@ -580,13 +580,13 @@ message TensorProto {
   // When this field is present, the data_type field MUST be FLOAT or COMPLEX64.
   repeated float float_data = 4 [packed = true];
 
-  // For int32, uint8, int8, uint16, int16, uint4, int4, bool, float8 and float16 values
-  // float16 and float8 values must be bit-wise converted to an uint16_t prior
-  // to writing to the buffer.
-  // uint4 and int4 values must be packed to 4bitx2 prior to writing to the buffer, the first element is stored in
-  // the 4 LSB and the second element is stored in the 4 MSB.
+  // For int32, uint8, int8, uint16, int16, uint4, int4, bool, (b)float16, float8 and float4 values.
+  // - (b)float16 and float8 values MUST be bit-wise converted to an unsigned int
+  //   representation prior to writing to the buffer.
+  // - uint4, int4, float4 values MUST be packed to 4bitx2 prior to writing to the buffer,
+  //   the first element is stored in the 4 LSB and the second element is stored in the 4 MSB.
   // When this field is present, the data_type field MUST be
-  // INT32, INT16, INT8, INT4, UINT16, UINT8, UINT4, BOOL, FLOAT16, BFLOAT16, FLOAT8E4M3FN, FLOAT8E4M3FNUZ, FLOAT8E5M2, FLOAT8E5M2FNUZ
+  // INT32, INT16, INT8, INT4, UINT16, UINT8, UINT4, BOOL, FLOAT16, BFLOAT16, FLOAT8E4M3FN, FLOAT8E4M3FNUZ, FLOAT8E5M2, FLOAT8E5M2FNUZ, FLOAT4E2M1
   repeated int32 int32_data = 5 [packed = true];
 
   // For strings.


### PR DESCRIPTION
### Description
Clarify in spec proto that FLOAT4E2M1 can be in int32_data, according to test usage.
Updated text in the spec for int32_data for better readability and accuracy.

### Motivation and Context

Previously the spec was incomplete according to the added tests. FLOAT4E2M1 was not yet released so the change should not require a new IR version.