### PR TITLE
Add cmake dependency only when system cmake is not available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
-requires = ["setuptools>=64", "protobuf>=3.20.2", "cmake>=3.18"]
+requires = ["setuptools>=64", "protobuf>=3.20.2"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -56,10 +56,12 @@ COVERAGE = os.getenv("COVERAGE", "0") == "1"
 ONNX_WHEEL_PLATFORM_NAME = os.getenv("ONNX_WHEEL_PLATFORM_NAME")
 
 ################################################################################
-# Pre Check
+# Add cmake requirement if no system CMake is available
 ################################################################################
 
-assert CMAKE, "Could not find cmake in PATH"
+SETUP_REQUIRES = []
+if not CMAKE:
+    SETUP_REQUIRES.append("cmake>=3.18")
 
 ################################################################################
 # Version
@@ -171,6 +173,8 @@ class CmakeBuild(setuptools.Command):
             self.jobs = multiprocessing.cpu_count()
 
     def run(self):
+        assert CMAKE, "Could not find cmake in PATH"
+
         os.makedirs(CMAKE_BUILD_DIR, exist_ok=True)
 
         with cd(CMAKE_BUILD_DIR):
@@ -325,6 +329,7 @@ EXT_MODULES = [setuptools.Extension(name="onnx.onnx_cpp2py_export", sources=[])]
 ################################################################################
 
 setuptools.setup(
+    setup_requires=SETUP_REQUIRES,
     ext_modules=EXT_MODULES,
     cmdclass=CMD_CLASS,
     version=VERSION_INFO["version"],


### PR DESCRIPTION
### Description
Instead of unconditionally pulling `cmake` PyPI package in, check whether `cmake` is available first and add the dependency only when it is not available.  This is the same approach as used by the `scikit-build-core` package, and it improves portability, especially given that CMake frequently requires downstream patching to work.

### Motivation and Context
Currently, having an unconditional `cmake` dependency means that `pip` or `uv` will install a local PyPI-packaged version of `cmake` to build the package. Besides being unnecessary, this can be particularly problematic, given that CMake is buggy in general and sometimes relies on downstream patching, that is carried in system CMake but not (yet) in PyPI's CMake. Ensuring that system CMake is used when available generally improves interoperability and consistency.