### PR TITLE
Add cmake dependency only when system cmake is not available (backend version)

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1,0 +1,56 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""PEP 517 build backend for onnx
+
+This is a thin wrapper over setuptools' PEP 517 build backend that
+automatically adds ``cmake`` to build dependencies if there is no CMake
+executable in PATH.  This approach ensures that the package uses system
+CMake (that may contain downstream patches) when one is available,
+and pulls in the CMake package from PyPI when it is not.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+from setuptools.build_meta import (
+    build_editable,
+    build_sdist,
+    build_wheel,
+    get_requires_for_build_sdist,
+    prepare_metadata_for_build_editable,
+    prepare_metadata_for_build_wheel,
+)
+from setuptools.build_meta import (
+    get_requires_for_build_editable as _get_requires_for_build_editable,
+)
+from setuptools.build_meta import (
+    get_requires_for_build_wheel as _get_requires_for_build_wheel,
+)
+
+__all__ = [
+    "build_editable",
+    "build_sdist",
+    "build_wheel",
+    "get_requires_for_build_editable",
+    "get_requires_for_build_sdist",
+    "get_requires_for_build_wheel",
+    "prepare_metadata_for_build_editable",
+    "prepare_metadata_for_build_wheel",
+]
+
+
+def _get_cmake_dep() -> list[str]:
+    if shutil.which("cmake3") or shutil.which("cmake"):
+        return []
+    return ["cmake>=3.18"]
+
+
+def get_requires_for_build_editable(*args, **kwargs) -> list[str]:
+    return _get_requires_for_build_editable(*args, **kwargs) + _get_cmake_dep()
+
+
+def get_requires_for_build_wheel(*args, **kwargs) -> list[str]:
+    return _get_requires_for_build_wheel(*args, **kwargs) + _get_cmake_dep()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
-requires = ["setuptools>=64", "protobuf>=3.20.2", "cmake>=3.18"]
-build-backend = "setuptools.build_meta"
+requires = ["setuptools>=64", "protobuf>=3.20.2"]
+backend-path = ["."]
+build-backend = "backend"
 
 [project]
 name = "onnx"

--- a/setup.py
+++ b/setup.py
@@ -56,12 +56,6 @@ COVERAGE = os.getenv("COVERAGE", "0") == "1"
 ONNX_WHEEL_PLATFORM_NAME = os.getenv("ONNX_WHEEL_PLATFORM_NAME")
 
 ################################################################################
-# Pre Check
-################################################################################
-
-assert CMAKE, "Could not find cmake in PATH"
-
-################################################################################
 # Version
 ################################################################################
 
@@ -171,6 +165,8 @@ class CmakeBuild(setuptools.Command):
             self.jobs = multiprocessing.cpu_count()
 
     def run(self):
+        assert CMAKE, "Could not find cmake in PATH"
+
         os.makedirs(CMAKE_BUILD_DIR, exist_ok=True)
 
         with cd(CMAKE_BUILD_DIR):


### PR DESCRIPTION
### Description
Instead of unconditionally pulling `cmake` PyPI package in, check whether `cmake` is available first and add the dependency only when it is not available.  This is the same approach as used by the `scikit-build-core` package, and it improves portability, especially given that CMake frequently requires downstream patching to work.

In this version of the patch, I've created a minimal PEP517 build backend that inherits the functions provided by setuptools, and adds the CMake dependency when necessary.  This avoids using deprecated setuptools `setup_requires` argument, and it avoids adding CMake dependency when building source distributions.

### Motivation and Context
Same as #6642, except using PEP517 backend instead of deprecated `setup_requires`.