### PR TITLE
Relax naming requirements in IR spec

### DIFF
--- a/docs/IR.md
+++ b/docs/IR.md
@@ -259,7 +259,7 @@ Graphs SHOULD be populated with documentation strings, which MAY be interpreted 
 
 ### Names Within a Graph
 
-All names MUST adhere to [C90 identifier syntax rules](https://en.cppreference.com/w/c/language/identifier).
+All names SHOULD adhere to [C90 identifier syntax rules](https://en.cppreference.com/w/c/language/identifier).
 
 Names of nodes, inputs, outputs, initializers, and attributes are organized into several namespaces. Within a namespace, each name MUST be unique for each given graph. Please see below for further clarification in the case where a graph contains nested subgraphs (as attribute values).
 
@@ -474,7 +474,7 @@ Each size in the list MAY be expressed as an integral value or as a "dimension v
 
 For example, a NxM matrix would have the shape list [N,M].
 
-The name of each dimension variable MUST adhere to [C90 identifier syntax rules](https://en.cppreference.com/w/c/language/identifier).
+The name of each dimension variable SHOULD adhere to [C90 identifier syntax rules](https://en.cppreference.com/w/c/language/identifier).
 
 Currently, dimension variables are not scoped. A dimension variable "N" represents the same value across the entire graph in a model. For example, if the graph has two inputs X and Y each with shape ["N"], then at runtime the values passed in for X and Y MUST be tensors of rank 1 with the same dimension. Nested sub-graphs currently share the same scope for dimension variables as the main-graph. This allows a model to relate the dimensions of tensors inside the subgraph to the dimensions of tensors in the outer graph.
 


### PR DESCRIPTION
### Description

This pull request includes changes to the `docs/IR.md` file to relax the strictness of identifier syntax rules. 

* Changed the requirement for names within a graph to adhere to C90 identifier syntax rules from "MUST" to "SHOULD". (`docs/IR.md`, [docs/IR.mdL262-R262](diffhunk://#diff-abcfc88a55144836fff2a055d73bc894201789bda5c0de98594e931037b5ec21L262-R262))
* Updated the requirement for dimension variable names to adhere to C90 identifier syntax rules from "MUST" to "SHOULD". (`docs/IR.md`, [docs/IR.mdL477-R477](diffhunk://#diff-abcfc88a55144836fff2a055d73bc894201789bda5c0de98594e931037b5ec21L477-R477))

### Motivation and Context

The change was motivated by practicality.

1. Currently tools in the ecosystem does not assume adherence, and popular source of ONNX models like the PyTorch exporter does not produce models that adheres to the requirements. Relaxing the spec makes it easier for tools in the ecosystem to be conformant.
2. The onnx checker does not enforce this aspect of naming

It further promotes interoperability with other ML frameworks. For example, model weights in a PyTorch model is named in the format `a.b.c`. By relaxing the spec, we are able to directly map PyTorch model weights to ONNX initializers without any name transformation rules.

Fixes https://github.com/onnx/onnx/issues/6219