### PR TITLE
Hardening of checkout

### DIFF
--- a/.github/workflows/auto_update_doc.yml
+++ b/.github/workflows/auto_update_doc.yml
@@ -24,6 +24,7 @@ jobs:
         # Checkout the branch made in the fork. Will automatically push changes
         # back to this branch.
         ref: ${{ github.head_ref }}
+        persist-credentials: false
     - name: Setup Python
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:

--- a/.github/workflows/check_urls.yml
+++ b/.github/workflows/check_urls.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
 
     - name: urls-checker-code
       uses: urlstechie/urlchecker-action@b643b43e2ac605e1475331c7b67247d242b7dce4 # v0.0.34

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,6 +46,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: misspell # Check spellings as well
         uses: reviewdog/action-misspell@18ffb61effb93b47e332f185216be7e49592e7e1 # v1.26.1
         with:
@@ -58,6 +60,8 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -25,6 +25,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:

--- a/.github/workflows/release_linux_aarch64.yml
+++ b/.github/workflows/release_linux_aarch64.yml
@@ -27,6 +27,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
     - name: Checkout submodules
       shell: bash
       run: |

--- a/.github/workflows/release_linux_aarch64.yml
+++ b/.github/workflows/release_linux_aarch64.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
-        persist-credentials: false
+        persist-credentials: true
     - name: Checkout submodules
       shell: bash
       run: |

--- a/.github/workflows/release_linux_aarch64.yml
+++ b/.github/workflows/release_linux_aarch64.yml
@@ -61,7 +61,7 @@ jobs:
           source .env/bin/activate && \
           yum install -y sudo && \
           sudo chmod +x .github/workflows/manylinux/entrypoint.sh && \
-          sudo .github/workflows/manylinux/entrypoint.sh ${{ env.py }} manylinux2014_aarch64 ${{ github.event_name }}
+          sudo bash -x .github/workflows/manylinux/entrypoint.sh ${{ env.py }} manylinux2014_aarch64 ${{ github.event_name }}
           deactivate'
 
       # using created virtual environment in new container and testing the wheel

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
-        persist-credentials: false
+        persist-credentials: true
     - name: Checkout submodules
       shell: bash
       run: |

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -25,6 +25,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
     - name: Checkout submodules
       shell: bash
       run: |

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -79,6 +79,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -29,6 +29,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+          persist-credentials: true
+    
     - name: Checkout submodules
       shell: bash
       run: |

--- a/.github/workflows/release_sdist.yml
+++ b/.github/workflows/release_sdist.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
-        persist-credentials: false
+        persist-credentials: true
     - name: Checkout submodules
       shell: bash
       run: |

--- a/.github/workflows/release_sdist.yml
+++ b/.github/workflows/release_sdist.yml
@@ -27,7 +27,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
+      with:
+        persist-credentials: false
     - name: Checkout submodules
       shell: bash
       run: |

--- a/.github/workflows/release_win.yml
+++ b/.github/workflows/release_win.yml
@@ -27,6 +27,7 @@ jobs:
       with:
          path: ./onnx
          submodules: 'recursive'
+         persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -14,5 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@bb774aa972c2a89ff34781233d275075cbddf542

--- a/.github/workflows/weekly_mac_ci.yml
+++ b/.github/workflows/weekly_mac_ci.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       name: Checkout repo
+      with:
+        persist-credentials: false
     - name: Checkout submodules
       shell: bash
       run: |

--- a/.github/workflows/win_no_exception_ci.yml
+++ b/.github/workflows/win_no_exception_ci.yml
@@ -30,6 +30,7 @@ jobs:
       with:
          path: ./onnx
          submodules: 'recursive'
+         persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0


### PR DESCRIPTION
### Description

- Hardening checkout
- when credential is needed, it should be made explicit

https://woodruffw.github.io/zizmor/audits/#remediation

```
By default, using [actions/checkout](https://github.com/actions/checkout) causes a credential to be persisted in the checked-out repo's .git/config, so that subsequent git operations can be authenticated.

Subsequent steps may accidentally publicly persist .git/config, e.g. by including it in a publicly accessible artifact via [actions/upload-artifact](https://github.com/actions/upload-artifact).

However, even without this, persisting the credential in the .git/config is non-ideal unless actually needed.

```