### PR TITLE
Use DeprecationWarning

### DIFF
--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -366,7 +366,7 @@ def _split_complex_to_pairs(ca: Sequence[np.complex64]) -> Sequence[int]:
 
 @typing_extensions.deprecated(
     "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
-    category=FutureWarning,
+    category=DeprecationWarning,
 )
 def float32_to_bfloat16(*args, **kwargs) -> int:
     return _float32_to_bfloat16(*args, **kwargs)
@@ -393,7 +393,7 @@ def _float32_to_bfloat16(fval: float, truncate: bool = False) -> int:
 
 @typing_extensions.deprecated(
     "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
-    category=FutureWarning,
+    category=DeprecationWarning,
 )
 def float32_to_float8e4m3(*args, **kwargs) -> int:
     return _float32_to_float8e4m3(*args, **kwargs)
@@ -535,7 +535,7 @@ def _float32_to_float8e4m3(  # noqa: PLR0911
 
 @typing_extensions.deprecated(
     "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
-    category=FutureWarning,
+    category=DeprecationWarning,
 )
 def float32_to_float8e5m2(*args: Any, **kwargs: Any) -> int:
     return _float32_to_float8e5m2(*args, **kwargs)
@@ -669,7 +669,7 @@ def _float32_to_float8e5m2(  # noqa: PLR0911
 
 @typing_extensions.deprecated(
     "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
-    category=FutureWarning,
+    category=DeprecationWarning,
 )
 def pack_float32_to_4bit(array: np.ndarray | Sequence, signed: bool) -> np.ndarray:
     return _pack_float32_to_4bit(array, signed)
@@ -705,7 +705,7 @@ def _pack_float32_to_4bit(array: np.ndarray | Sequence, signed: bool) -> np.ndar
 
 @typing_extensions.deprecated(
     "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
-    category=FutureWarning,
+    category=DeprecationWarning,
 )
 def pack_float32_to_float4e2m1(array: np.ndarray | Sequence) -> np.ndarray:
     return _pack_float32_to_float4e2m1(array)

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -22,7 +22,7 @@ def _combine_pairs_to_complex(fa: Sequence[int]) -> list[complex]:
 
 @typing_extensions.deprecated(
     "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
-    category=FutureWarning,
+    category=DeprecationWarning,
 )
 def bfloat16_to_float32(
     data: np.int16 | np.int32 | np.ndarray,
@@ -96,7 +96,7 @@ _float8e4m3_to_float32 = np.vectorize(
 
 @typing_extensions.deprecated(
     "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
-    category=FutureWarning,
+    category=DeprecationWarning,
 )
 def float8e4m3_to_float32(
     data: np.int16 | np.int32 | np.ndarray,
@@ -175,7 +175,7 @@ _float8e5m2_to_float32 = np.vectorize(
 
 @typing_extensions.deprecated(
     "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
-    category=FutureWarning,
+    category=DeprecationWarning,
 )
 def float8e5m2_to_float32(
     data: np.int16 | np.int32 | np.ndarray,
@@ -205,7 +205,7 @@ def float8e5m2_to_float32(
 
 @typing_extensions.deprecated(
     "Deprecated since 1.18. Scheduled to remove in 1.20. Consider implementing your own unpack logic",
-    category=FutureWarning,
+    category=DeprecationWarning,
 )
 def unpack_int4(
     data: np.int32 | np.ndarray,

--- a/onnx/subbyte.py
+++ b/onnx/subbyte.py
@@ -17,7 +17,7 @@ UINT4_MAX = 15
 
 @typing_extensions.deprecated(
     "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
-    category=FutureWarning,
+    category=DeprecationWarning,
 )
 def float32_to_4bit_unpacked(*args, **kwargs):
     return _float32_to_4bit_unpacked(*args, **kwargs)
@@ -47,7 +47,7 @@ def _float32_to_4bit_unpacked(
 
 @typing_extensions.deprecated(
     "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
-    category=FutureWarning,
+    category=DeprecationWarning,
 )
 def float32x2_to_4bitx2(*args, **kwargs):
     return _float32x2_to_4bitx2(*args, **kwargs)
@@ -73,7 +73,7 @@ def _float32x2_to_4bitx2(
 
 @typing_extensions.deprecated(
     "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
-    category=FutureWarning,
+    category=DeprecationWarning,
 )
 def unpack_4bitx2(*args, **kwargs):
     return _unpack_4bitx2(*args, **kwargs)
@@ -108,7 +108,7 @@ def _unpack_4bitx2(
 
 @typing_extensions.deprecated(
     "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
-    category=FutureWarning,
+    category=DeprecationWarning,
 )
 def unpack_single_4bitx2(*args, **kwargs):
     return _unpack_single_4bitx2(*args, **kwargs)
@@ -139,7 +139,7 @@ def _unpack_single_4bitx2(
 
 @typing_extensions.deprecated(
     "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
-    category=FutureWarning,
+    category=DeprecationWarning,
 )
 def float32_to_float4e2m1_unpacked(*args, **kwargs):
     return _float32_to_float4e2m1_unpacked(*args, **kwargs)
@@ -171,7 +171,7 @@ def _float32_to_float4e2m1_unpacked(values: np.ndarray) -> np.ndarray:
 
 @typing_extensions.deprecated(
     "Deprecated since 1.18. Scheduled to remove in 1.20. Consider using libraries like ml_dtypes for dtype conversion",
-    category=FutureWarning,
+    category=DeprecationWarning,
 )
 def float32x2_to_float4e2m1x2(*args, **kwargs):
     return _float32x2_to_float4e2m1x2(*args, **kwargs)


### PR DESCRIPTION
Use DeprecationWarning instead of FutureWarning because it is more appropriate: https://docs.python.org/3/library/exceptions.html#DeprecationWarning
