### PR TITLE
Add SkipLayerNormalization and RMSNormalization to ONNX Opset 23

### DIFF
--- a/onnx/defs/operator_sets.h
+++ b/onnx/defs/operator_sets.h
@@ -1306,6 +1306,8 @@ class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 23, Reshape);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 23, Scan);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 23, Shape);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 23, Size);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 23, SkipLayerNormalization);
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 23, SkipRMSNormalization);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 23, Squeeze);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 23, Transpose);
 class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 23, Unsqueeze);
@@ -1329,6 +1331,8 @@ class OpSet_Onnx_ver23 {
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 23, Scan)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 23, Shape)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 23, Size)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 23, SkipLayerNormalization)>());
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 23, SkipRMSNormalization)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 23, Squeeze)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 23, Transpose)>());
     fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 23, Unsqueeze)>());

--- a/onnx/reference/ops/_op_list.py
+++ b/onnx/reference/ops/_op_list.py
@@ -209,6 +209,8 @@ from onnx.reference.ops.op_sign import Sign
 from onnx.reference.ops.op_sin import Sin
 from onnx.reference.ops.op_sinh import Sinh
 from onnx.reference.ops.op_size import Size
+from onnx.reference.ops.op_skip_layer_normalization import SkipLayerNormalization
+from onnx.reference.ops.op_skip_rms_normalization import SkipRMSNormalization
 from onnx.reference.ops.op_slice import Slice_1, Slice_10
 from onnx.reference.ops.op_softmax import Softmax
 from onnx.reference.ops.op_softmax_cross_entropy_loss import SoftmaxCrossEntropyLoss

--- a/onnx/reference/ops/op_skip_layer_normalization.py
+++ b/onnx/reference/ops/op_skip_layer_normalization.py
@@ -1,0 +1,55 @@
+# Copyright (c) ONNX Project Contributors
+
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import numpy as np
+
+from onnx.reference.op_run import OpRun
+from onnx.reference.ops.op_layer_normalization import _layer_normalization
+
+
+def _skip_layer_normalization(
+    X: np.ndarray,
+    S: np.ndarray,
+    gamma: np.ndarray,
+    beta: None | np.ndarray,
+    B: None | np.ndarray,
+    axis: int = -1,
+    epsilon: float = 1e-5,
+    scaling_factor: int = 1,
+) -> tuple[np.ndarray, np.ndarray]:
+    input_skip_sum = X + (S * scaling_factor)
+    if B is not None:
+        input_skip_bias_sum = input_skip_sum + B
+    else:
+        input_skip_bias_sum = input_skip_sum
+    output, _, _ = _layer_normalization(
+        input_skip_bias_sum, gamma, beta, epsilon=epsilon, axis=axis
+    )
+    return output, input_skip_bias_sum
+
+
+class SkipLayerNormalization(OpRun):
+    def _run(
+        self,
+        X,
+        S,
+        Scale,
+        beta=None,
+        B=None,
+        axis=None,
+        epsilon=None,
+        scaling_factor=None,
+    ):  # type: ignore
+        res = _skip_layer_normalization(
+            X,
+            S,
+            Scale,
+            beta,
+            B,
+            axis=axis,
+            epsilon=epsilon,
+            scaling_factor=scaling_factor,
+        )
+        return res  # type: ignore

--- a/onnx/reference/ops/op_skip_rms_normalization.py
+++ b/onnx/reference/ops/op_skip_rms_normalization.py
@@ -1,0 +1,35 @@
+# Copyright (c) ONNX Project Contributors
+
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import numpy as np
+
+from onnx.reference.op_run import OpRun
+from onnx.reference.ops.op_rms_normalization import _rms_normalization
+
+
+def _skip_rms_normalization(
+    X: np.ndarray,
+    S: np.ndarray,
+    gamma: np.ndarray,
+    B: None | np.ndarray,
+    axis: int = -1,
+    epsilon: float = 1e-5,
+    scaling_factor: int = 1,
+) -> tuple[np.ndarray, np.ndarray]:
+    input_skip_sum = X + (S * scaling_factor)
+    if B is not None:
+        input_skip_bias_sum = input_skip_sum + B
+    else:
+        input_skip_bias_sum = input_skip_sum
+    output = _rms_normalization(input_skip_bias_sum, gamma, epsilon=epsilon, axis=axis)
+    return output, input_skip_bias_sum
+
+
+class SkipRMSNormalization(OpRun):
+    def _run(self, X, S, Scale, B=None, axis=None, epsilon=None, scaling_factor=None):  # type: ignore
+        res = _skip_rms_normalization(
+            X, S, Scale, B, axis=axis, epsilon=epsilon, scaling_factor=scaling_factor
+        )
+        return res  # type: ignore

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -1381,6 +1381,27 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
+    @parameterized.expand(all_versions_for("SkipLayerNormalization"))
+    def test_skip_layer_normalization(self) -> None:
+        graph = self._make_graph(
+            [
+                ("X", TensorProto.FLOAT, ("N", "C", "H", "W")),
+                ("S", TensorProto.FLOAT, ("N", "C", "H", "W")),
+                ("gamma", TensorProto.FLOAT, ("H", "W")),
+                ("beta", TensorProto.FLOAT, ("H", "W")),
+            ],
+            [
+                make_node(
+                    "SkipLayerNormalization", ["X", "S", "gamma", "beta"], ["y"], axis=2
+                )
+            ],
+            [],
+        )
+        self._assert_inferred(
+            graph,
+            [make_tensor_value_info("y", TensorProto.FLOAT, ("N", "C", "H", "W"))],
+        )  # type: ignore
+
     @parameterized.expand(all_versions_for("Gather"))
     def test_gather(self, _, version) -> None:
         graph = self._make_graph(

--- a/onnx/test/test_backend_onnxruntime.py
+++ b/onnx/test/test_backend_onnxruntime.py
@@ -455,6 +455,29 @@ if ort is not None:
         ")"
     )
 
+    # Exclude all tests that require IR11 until onnxruntime aligns
+    # TODO: Unwaive tests once onnxruntime supports Opset23/IR11
+    backend_test.exclude(
+        "("
+        "test_skip_layer_normalization_2d_example"
+        "|test_skip_layer_normalization_2d_example_expanded"
+        "|test_skip_layer_normalization_3d_example"
+        "|test_skip_layer_normalization_3d_example_expanded"
+        "|test_skip_layer_normalization_epsilon_example"
+        "|test_skip_layer_normalization_epsilon_example_expanded"
+        "|test_skip_layer_normalization_scaling_factor_example"
+        "|test_skip_layer_normalization_scaling_factor_example_expanded"
+        "|test_skip_rms_normalization_2d_example"
+        "|test_skip_rms_normalization_2d_example_expanded"
+        "|test_skip_rms_normalization_3d_example"
+        "|test_skip_rms_normalization_3d_example_expanded"
+        "|test_skip_rms_normalization_epsilon_example"
+        "|test_skip_rms_normalization_epsilon_example_expanded"
+        "|test_skip_rms_normalization_scaling_factor_example"
+        "|test_skip_rms_normalization_scaling_factor_example_expanded"
+        ")"
+    )
+
     # TODO(titaiwang): Re-enable this tests once ORT is fixed.
     # https://github.com/microsoft/onnxruntime/pull/16752
     backend_test.exclude("test_averagepool_2d_ceil_last_window_starts_on_pad")

--- a/onnx/test/version_converter/automatic_upgrade_test.py
+++ b/onnx/test/version_converter/automatic_upgrade_test.py
@@ -1209,6 +1209,33 @@ class TestAutomaticUpgrade(automatic_conversion_test_base.TestAutomaticConversio
             "Size", 1, [[3, 4, 5]], [[]], output_types=[TensorProto.INT64]
         )
 
+    def test_SkipLayerNormalization(self) -> None:
+        self._test_op_upgrade(
+            "SkipLayerNormalization",
+            23,
+            [[2, 3, 4, 5], [2, 3, 4, 5], [4, 5], [4, 5]],
+            [[2, 3, 4, 5]],
+            input_types=[
+                TensorProto.FLOAT,
+                TensorProto.FLOAT,
+                TensorProto.FLOAT,
+                TensorProto.FLOAT,
+            ],
+            output_types=[TensorProto.FLOAT],
+            attrs={"axis": 2},
+        )
+
+    def test_SkipRMSNormalization(self) -> None:
+        self._test_op_upgrade(
+            "SkipRMSNormalization",
+            23,
+            [[2, 3, 4, 5], [2, 3, 4, 5], [4, 5]],
+            [[2, 3, 4, 5]],
+            input_types=[TensorProto.FLOAT, TensorProto.FLOAT, TensorProto.FLOAT],
+            output_types=[TensorProto.FLOAT],
+            attrs={"axis": 2},
+        )
+
     def test_Slice(self) -> None:
         self._test_op_upgrade(
             "Slice",


### PR DESCRIPTION
This is a draft PR adding the following ops to ONNX Opset 23
- SkipLayerNormalization
- SkipRMSNormalization

Will continue following up on this PR when consensus is reached on whether we need to add these ops to the standard.

Dependent on the merging of 
https://github.com/onnx/onnx/pull/6443
