### PR TITLE
Check the input of ConstantOfShape to be non-negative

### DIFF
--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -105,7 +105,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
 
           bool found = false;
-          TensorShapeProto output_shape = getShapeInput(ctx, 0, found, true);
+          TensorShapeProto output_shape = getShapeInput(ctx, 0, true, found);
           if (found) {
             *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape() = output_shape;
           }

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -105,7 +105,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
 
           bool found = false;
-          TensorShapeProto output_shape = getShapeInput(ctx, 0, found);
+          TensorShapeProto output_shape = getShapeInput(ctx, 0, found, true);
           if (found) {
             *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape() = output_shape;
           }

--- a/onnx/defs/generator/old.cc
+++ b/onnx/defs/generator/old.cc
@@ -744,7 +744,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
 
           bool found = false;
-          TensorShapeProto output_shape = getShapeInput(ctx, 0, found, true);
+          TensorShapeProto output_shape = getShapeInput(ctx, 0, true, found);
           if (found) {
             *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape() = output_shape;
           }
@@ -804,7 +804,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
 
           bool found = false;
-          TensorShapeProto output_shape = getShapeInput(ctx, 0, found, true);
+          TensorShapeProto output_shape = getShapeInput(ctx, 0, true, found);
           if (found) {
             *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape() = output_shape;
           }
@@ -863,7 +863,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
 
           bool found = false;
-          TensorShapeProto output_shape = getShapeInput(ctx, 0, found, true);
+          TensorShapeProto output_shape = getShapeInput(ctx, 0, true, found);
           if (found) {
             *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape() = output_shape;
           }

--- a/onnx/defs/generator/old.cc
+++ b/onnx/defs/generator/old.cc
@@ -744,7 +744,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
 
           bool found = false;
-          TensorShapeProto output_shape = getShapeInput(ctx, 0, found);
+          TensorShapeProto output_shape = getShapeInput(ctx, 0, found, true);
           if (found) {
             *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape() = output_shape;
           }
@@ -804,7 +804,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
 
           bool found = false;
-          TensorShapeProto output_shape = getShapeInput(ctx, 0, found);
+          TensorShapeProto output_shape = getShapeInput(ctx, 0, found, true);
           if (found) {
             *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape() = output_shape;
           }
@@ -863,7 +863,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
 
           bool found = false;
-          TensorShapeProto output_shape = getShapeInput(ctx, 0, found);
+          TensorShapeProto output_shape = getShapeInput(ctx, 0, found, true);
           if (found) {
             *ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape() = output_shape;
           }

--- a/onnx/defs/shape_inference.cc
+++ b/onnx/defs/shape_inference.cc
@@ -453,7 +453,8 @@ void propagateElemTypeWithValidation(const TypeProto* input_type, TypeProto* out
   }
 }
 
-TensorShapeProto getShapeInput(const InferenceContext& ctx, size_t input_index, bool& found, bool xneg) {
+TensorShapeProto
+getShapeInput(const InferenceContext& ctx, size_t input_index, bool& found, bool fail_if_negative_value) {
   TensorShapeProto shape_input;
 
   found = false;
@@ -491,7 +492,7 @@ TensorShapeProto getShapeInput(const InferenceContext& ctx, size_t input_index, 
     }
   }
 
-  if (found && xneg) {
+  if (found && fail_if_negative_value) {
     int dims_size = shape_input.dim_size();
     for (int i = 0; i < dims_size; ++i) {
       const auto& dim = shape_input.dim(i);

--- a/onnx/defs/shape_inference.cc
+++ b/onnx/defs/shape_inference.cc
@@ -453,8 +453,10 @@ void propagateElemTypeWithValidation(const TypeProto* input_type, TypeProto* out
   }
 }
 
-TensorShapeProto getShapeInput(const InferenceContext& ctx, size_t input_index, bool& found) {
+TensorShapeProto getShapeInput(const InferenceContext& ctx, size_t input_index, bool& found, bool xneg) {
   TensorShapeProto shape_input;
+
+  found = false;
 
   // First, check initializer.
   const TensorProto* shape_initializer = ctx.getInputData(input_index);
@@ -464,19 +466,17 @@ TensorShapeProto getShapeInput(const InferenceContext& ctx, size_t input_index, 
       shape_input.add_dim()->set_dim_value(e);
     }
     found = true;
-    return shape_input;
   }
 
   // Then, check symbolic input.
   const TensorShapeProto* symbolic_input = ctx.getSymbolicInput(input_index);
-  if (symbolic_input) {
+  if (!found && symbolic_input) {
     shape_input.CopyFrom(*symbolic_input);
     found = true;
-    return shape_input;
   }
 
   // Try rank inference.
-  if (hasInputShape(ctx, input_index)) {
+  if (!found && hasInputShape(ctx, input_index)) {
     const TensorShapeProto& shape_input_shape = getInputShape(ctx, input_index);
     if (shape_input_shape.dim_size() != 1) {
       fail_shape_inference("shape input must be 1D tensor");
@@ -488,12 +488,19 @@ TensorShapeProto getShapeInput(const InferenceContext& ctx, size_t input_index, 
         shape_input.add_dim();
       }
       found = true;
-      return shape_input;
     }
   }
 
-  // Shape input was not found.
-  found = false;
+  if (found && xneg) {
+    int dims_size = shape_input.dim_size();
+    for (int i = 0; i < dims_size; ++i) {
+      const auto& dim = shape_input.dim(i);
+      if (dim.has_dim_value() && dim.dim_value() < 0) {
+        fail_shape_inference("shape input tensor must have non-negative elements");
+      }
+    }
+  }
+
   return shape_input;
 }
 

--- a/onnx/defs/shape_inference.cc
+++ b/onnx/defs/shape_inference.cc
@@ -453,8 +453,12 @@ void propagateElemTypeWithValidation(const TypeProto* input_type, TypeProto* out
   }
 }
 
+TensorShapeProto getShapeInput(const InferenceContext& ctx, size_t input_index, bool& found) {
+  return getShapeInput(ctx, input_index, false, found);
+}
+
 TensorShapeProto
-getShapeInput(const InferenceContext& ctx, size_t input_index, bool& found, bool fail_if_negative_value) {
+getShapeInput(const InferenceContext& ctx, size_t input_index, bool fail_if_negative_value, bool& found) {
   TensorShapeProto shape_input;
 
   found = false;

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -592,7 +592,8 @@ inline void updateOutputShape(
 // If neither is available, try rank inference.
 // When one of above succeeds, `true` is stored in `found`.
 // Otherwise, `false` is stored, which means that returned TensorShapeProto does not make sense.
-TensorShapeProto getShapeInput(const InferenceContext& ctx, size_t input_index, bool& found, bool xneg = false);
+TensorShapeProto
+getShapeInput(const InferenceContext& ctx, size_t input_index, bool& found, bool fail_if_negative_value = false);
 
 // Infer shape of an output from the value of a specified attribute, which is
 // expected to be a list of integers specifying a valid shape.

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -594,6 +594,8 @@ inline void updateOutputShape(
 // Otherwise, `false` is stored, which means that returned TensorShapeProto does not make sense.
 TensorShapeProto getShapeInput(const InferenceContext& ctx, size_t input_index, bool& found);
 
+// Argument `fail_if_negative_value` is used to control whether negative values are allowed in the shape. The shape
+// check would fail if not.
 TensorShapeProto
 getShapeInput(const InferenceContext& ctx, size_t input_index, bool fail_if_negative_value, bool& found);
 

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -592,8 +592,10 @@ inline void updateOutputShape(
 // If neither is available, try rank inference.
 // When one of above succeeds, `true` is stored in `found`.
 // Otherwise, `false` is stored, which means that returned TensorShapeProto does not make sense.
+TensorShapeProto getShapeInput(const InferenceContext& ctx, size_t input_index, bool& found);
+
 TensorShapeProto
-getShapeInput(const InferenceContext& ctx, size_t input_index, bool& found, bool fail_if_negative_value = false);
+getShapeInput(const InferenceContext& ctx, size_t input_index, bool fail_if_negative_value, bool& found);
 
 // Infer shape of an output from the value of a specified attribute, which is
 // expected to be a list of integers specifying a valid shape.

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -592,7 +592,7 @@ inline void updateOutputShape(
 // If neither is available, try rank inference.
 // When one of above succeeds, `true` is stored in `found`.
 // Otherwise, `false` is stored, which means that returned TensorShapeProto does not make sense.
-TensorShapeProto getShapeInput(const InferenceContext& ctx, size_t input_index, bool& found);
+TensorShapeProto getShapeInput(const InferenceContext& ctx, size_t input_index, bool& found, bool xneg = false);
 
 // Infer shape of an output from the value of a specified attribute, which is
 // expected to be a list of integers specifying a valid shape.

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -10530,6 +10530,28 @@ class TestShapeInference(TestShapeInferenceHelper):
             onnx.checker.check_model(model, full_check=True)
             onnx.shape_inference.infer_shapes(model)
 
+    @parameterized.expand(all_versions_for("ConstantOfShape"))
+    def test_issue_constantofshape_6135(self, _, version):
+        graph = self._make_graph(
+            [("std.constant", TensorProto.INT64, (1,)), "output"],
+            [
+                make_node(
+                    "ConstantOfShape",
+                    inputs=["std.constant"],
+                    outputs=["output"],
+                    name="invalid_node",
+                )
+            ],
+            [],
+            initializer=[make_tensor("std.constant", TensorProto.FLOAT, (1,), (-10,))],
+        )
+        self.assertRaises(
+            onnx.shape_inference.InferenceError,
+            self._inferred,
+            graph,
+            opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
+        )
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
### Description
I added a flag parameter in the `getShapeInput` function to check shape dims non-negative in some cases.

### Motivation and Context
This PR is to solve the issue #6135. It proposes that the operator `ConstantOfShape` doesn't check input validation and may produce negative output.

I added a flag to the `getShapeInput` function. When it's true, the function will check the shape returned and fail if any aim is negative. This flag is enabled on `ConstantOfShape` operator.

(By the way, it's my first time contributing a PR to the open-source community. Please let me know if there is anything wrong with it. Thank you for your attention and review🙂
