### PR TITLE
remove twine from requirements-dev-file

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,6 @@ pytest
 pytest-cov
 pytest-xdist
 setuptools
-twine
 wheel
 ml_dtypes
 # Dependencies for linting. Versions match those in setup.py.


### PR DESCRIPTION
### Description
remove twine from requirements dev list

### Motivation and Context
Reduce number of dependency. We use the trusted publishing github action. Twine is no longer necessary for our CI.