### PR TITLE
TypoFix in float8.md

### DIFF
--- a/docs/docsgen/source/technical/float8.md
+++ b/docs/docsgen/source/technical/float8.md
@@ -17,7 +17,7 @@ does not suffer too much.
 
 [FP8 Formats for Deep Learning](https://arxiv.org/abs/2209.05433)
 from NVIDIA, Intel and ARM introduces two types following
-[IEEE specifciations](https://en.wikipedia.org/wiki/IEEE_754).
+[IEEE specification](https://en.wikipedia.org/wiki/IEEE_754).
 First one is E4M3, 1 bit for the sign, 4 bits for the exponents and 3
 bits for the mantissa. Second one is E5M2, 1 bit for the sign,
 5 bits for the exponents and 2 for the mantissa. The first types


### PR DESCRIPTION
There was a typo in the doc. 'specifciations'-> specification

### Description
Typo is fixed

### Motivation and Context
There was a slight typo in the docs/docsgen/source/technical/float8.md file
