### PR TITLE
Fix a tensor type inaccuracy in the docs

### DIFF
--- a/docs/docsgen/source/intro/python.md
+++ b/docs/docsgen/source/intro/python.md
@@ -148,7 +148,7 @@ of each object of the graph.
             node.name, node.op_type, node.input, node.output))
 ```
 
-The tensor type is an integer (= 1). The helper function {func}`onnx.helper.tensor_dtype_to_np_dtype` gives the
+The tensor type is a float (= 1). The helper function {func}`onnx.helper.tensor_dtype_to_np_dtype` gives the
 corresponding type with numpy.
 
 ```{eval-rst}

--- a/docs/docsgen/source/intro/python.md
+++ b/docs/docsgen/source/intro/python.md
@@ -148,8 +148,8 @@ of each object of the graph.
             node.name, node.op_type, node.input, node.output))
 ```
 
-The tensor type is a float (= 1). The helper function {func}`onnx.helper.tensor_dtype_to_np_dtype` gives the
-corresponding type with numpy.
+The tensor type is an integer (= 1). The helper function {func}`onnx.helper.tensor_dtype_to_np_dtype` converts
+the integer to its corresponding numpy data type (float32 for 1).
 
 ```{eval-rst}
 .. exec_code::


### PR DESCRIPTION
### Description
Fix a tensor type inaccuracy in the docs

### Motivation and Context
It might be confusing to the reader why is suddenly an integer mention in the docs since it's not used in the example above. Furthermore, the float type has a value of 1.