### PR TITLE
add windows 3.13t build to main_freethreading.yml (Updates of external dependencies now enable this)

### DIFF
--- a/.github/workflows/main_freethreading.yml
+++ b/.github/workflows/main_freethreading.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-latest] # windows-latest not working yet
+        os: [ubuntu-24.04, macos-latest, windows-latest]
         python_version: ['3.13t']
         include:        
           - python_version: '3.13t'


### PR DESCRIPTION
### Description
add windows 3.13t build to main_freethreading.yml
