### PR TITLE
Include `backend.py` in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,4 @@ include VERSION_NUMBER
 include CMakeLists.txt
 include requirements.txt
 include requirements-reference.txt
+include backend.py


### PR DESCRIPTION
### Description
Add `backend.py` to `MANIFEST.in`, so that it is included in source distribution archives.

### Motivation and Context
Fixes #6751
