### PR TITLE
chore(config): set persist credentials to false

### DIFF
--- a/.github/workflows/release_linux_aarch64.yml
+++ b/.github/workflows/release_linux_aarch64.yml
@@ -29,7 +29,7 @@ jobs:
       
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
-        persist-credentials: true
+        persist-credentials: false
         submodules: true
 
       # setting up qemu for enabling aarch64 binary execution on x86 machine

--- a/.github/workflows/release_linux_x86_64.yml
+++ b/.github/workflows/release_linux_x86_64.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
-        persist-credentials: true
+        persist-credentials: false
         submodules: true
 
     - name: Build manylinux2014_x86_64

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
-          persist-credentials: true
+          persist-credentials: false
           submodules: true
     
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/release_mac_freethreading.yml
+++ b/.github/workflows/release_mac_freethreading.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
-        persist-credentials: true
+        persist-credentials: false
         submodules: true
     
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/release_sdist.yml
+++ b/.github/workflows/release_sdist.yml
@@ -28,14 +28,9 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
-        persist-credentials: true
-    - name: Checkout submodules
-      shell: bash
-      run: |
-        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
-        git submodule sync --recursive
-        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-
+        persist-credentials: false
+        submodules: true
+    
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:


### PR DESCRIPTION
Since we do the checkout of the git submodules directly at the checkout without a separate step, it is no longer necessary to keep the credentials. 