### PR TITLE
Enable flake8-type-checking

### DIFF
--- a/onnx/backend/base.py
+++ b/onnx/backend/base.py
@@ -4,14 +4,16 @@
 from __future__ import annotations
 
 from collections import namedtuple
-from collections.abc import Sequence
-from typing import Any, NewType
-
-import numpy
+from typing import TYPE_CHECKING, Any, NewType
 
 import onnx.checker
 import onnx.onnx_cpp2py_export.checker as c_checker
 from onnx import IR_VERSION, ModelProto, NodeProto
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    import numpy
 
 
 class DeviceType:

--- a/onnx/backend/sample/ops/__init__.py
+++ b/onnx/backend/sample/ops/__init__.py
@@ -7,7 +7,10 @@ import importlib
 import inspect
 import pkgutil
 import sys
-from types import ModuleType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 
 def collect_sample_implementations() -> dict[str, str]:

--- a/onnx/backend/test/case/model/__init__.py
+++ b/onnx/backend/test/case/model/__init__.py
@@ -4,13 +4,17 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
-import numpy as np
-
-from onnx import ModelProto
 from onnx.backend.test.case.test_case import TestCase
 from onnx.backend.test.case.utils import import_recursive
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    import numpy as np
+
+    from onnx import ModelProto
 
 _SimpleModelTestCases = []
 

--- a/onnx/backend/test/case/model/expand.py
+++ b/onnx/backend/test/case/model/expand.py
@@ -3,13 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 import onnx
 from onnx.backend.test.case.base import Base
 from onnx.backend.test.case.model import expect
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class ExpandDynamicShape(Base):

--- a/onnx/backend/test/case/model/stringnormalizer.py
+++ b/onnx/backend/test/case/model/stringnormalizer.py
@@ -3,13 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 import onnx
 from onnx.backend.test.case.base import Base
 from onnx.backend.test.case.model import expect
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class NormalizeStrings(Base):

--- a/onnx/backend/test/case/node/__init__.py
+++ b/onnx/backend/test/case/node/__init__.py
@@ -5,12 +5,9 @@ from __future__ import annotations
 
 import subprocess
 import sys
-from collections.abc import Sequence
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Callable
-
-import numpy as np
+from typing import TYPE_CHECKING, Any, Callable
 
 import onnx
 from onnx.backend.test.case.test_case import TestCase
@@ -24,6 +21,11 @@ from onnx.onnx_pb import (
     TensorProto,
     TypeProto,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    import numpy as np
 
 _NodeTestCases = []
 _TargetOpType = None

--- a/onnx/backend/test/case/node/concat.py
+++ b/onnx/backend/test/case/node/concat.py
@@ -3,14 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 import onnx
 from onnx.backend.test.case.base import Base
 from onnx.backend.test.case.node import expect
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class Concat(Base):

--- a/onnx/backend/test/case/test_case.py
+++ b/onnx/backend/test/case/test_case.py
@@ -3,12 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-import numpy as np
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
-import onnx
+    import numpy as np
+
+    import onnx
 
 
 @dataclass

--- a/onnx/backend/test/case/utils.py
+++ b/onnx/backend/test/case/utils.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 
 import importlib
 import pkgutil
-from types import ModuleType
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from onnx import ONNX_ML
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 all_numeric_dtypes = [
     np.int8,

--- a/onnx/backend/test/report/__init__.py
+++ b/onnx/backend/test/report/__init__.py
@@ -3,13 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import _pytest
 import pytest
 
 from onnx.backend.test.report.coverage import Coverage
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    import _pytest
 
 _coverage = Coverage()
 _marks: dict[str, Sequence[Any]] = {}

--- a/onnx/backend/test/runner/__init__.py
+++ b/onnx/backend/test/runner/__init__.py
@@ -14,9 +14,8 @@ import tempfile
 import time
 import unittest
 from collections import defaultdict
-from collections.abc import Iterable, Sequence
 from re import Pattern
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 from urllib.request import urlretrieve
 
 import numpy as np
@@ -24,10 +23,14 @@ import numpy as np
 import onnx
 import onnx.reference
 from onnx import ONNX_ML, ModelProto, NodeProto, TypeProto, ValueInfoProto, numpy_helper
-from onnx.backend.base import Backend
-from onnx.backend.test.case.test_case import TestCase
 from onnx.backend.test.loader import load_model_tests
 from onnx.backend.test.runner.item import TestItem
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from onnx.backend.base import Backend
+    from onnx.backend.test.case.test_case import TestCase
 
 
 class BackendIsNotSupposedToImplementIt(unittest.SkipTest):

--- a/onnx/backend/test/runner/item.py
+++ b/onnx/backend/test/runner/item.py
@@ -4,9 +4,10 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
-from onnx import ModelProto, NodeProto
+if TYPE_CHECKING:
+    from onnx import ModelProto, NodeProto
 
 # A container that hosts the test function and the associated
 # test item (ModelProto)

--- a/onnx/backend/test/stat_coverage.py
+++ b/onnx/backend/test/stat_coverage.py
@@ -6,13 +6,15 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Sequence
-from typing import IO, Any
+from typing import IO, TYPE_CHECKING, Any
 
 from onnx import AttributeProto, defs, load
 from onnx.backend.test.case import collect_snippets
 from onnx.backend.test.loader import load_model_tests
 from onnx.backend.test.runner import Runner
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def is_ml(schemas: Sequence[defs.OpSchema]) -> bool:

--- a/onnx/defs/gen_doc.py
+++ b/onnx/defs/gen_doc.py
@@ -7,8 +7,7 @@ from __future__ import annotations
 
 import os
 from collections import defaultdict
-from collections.abc import Sequence
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import numpy as np
 
@@ -16,6 +15,9 @@ from onnx import defs, helper
 from onnx.backend.sample.ops import collect_sample_implementations
 from onnx.backend.test.case import collect_snippets
 from onnx.defs import ONNX_ML_DOMAIN, OpSchema
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 SNIPPETS = collect_snippets()
 SAMPLE_IMPLEMENTATIONS = collect_sample_implementations()

--- a/onnx/reference/custom_element_types.py
+++ b/onnx/reference/custom_element_types.py
@@ -3,12 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import numpy as np
-
 try:
     import ml_dtypes
 except ImportError:
     ml_dtypes = None  # type: ignore[assignment]
+
+from typing import TYPE_CHECKING
 
 from onnx._custom_element_types import (
     bfloat16,
@@ -20,6 +20,9 @@ from onnx._custom_element_types import (
     int4,
     uint4,
 )
+
+if TYPE_CHECKING:
+    import numpy as np
 
 _supported_types = [
     (bfloat16, "bfloat16", "bfloat16"),

--- a/onnx/reference/op_run.py
+++ b/onnx/reference/op_run.py
@@ -4,8 +4,7 @@
 from __future__ import annotations
 
 import abc
-from collections.abc import Iterable
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
 
@@ -24,6 +23,9 @@ from onnx.defs import get_all_schemas_with_history, get_schema, onnx_opset_versi
 from onnx.helper import make_node, make_tensor_type_proto, np_dtype_to_tensor_dtype
 from onnx.numpy_helper import to_array
 from onnx.onnx_pb import AttributeProto, GraphProto, NodeProto, TypeProto
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 def _split_class_name(name):  # type: ignore

--- a/onnx/reference/ops/_op.py
+++ b/onnx/reference/ops/_op.py
@@ -3,16 +3,18 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from onnx.onnx_pb import NodeProto
 from onnx.reference.custom_element_types import (
     convert_from_ml_dtypes,
     convert_to_ml_dtypes,
 )
 from onnx.reference.op_run import OpRun, RuntimeTypeError
+
+if TYPE_CHECKING:
+    from onnx.onnx_pb import NodeProto
 
 
 class OpRunUnary(OpRun):

--- a/onnx/reference/ops/op_if.py
+++ b/onnx/reference/ops/op_if.py
@@ -4,9 +4,12 @@
 
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 from onnx.reference.op_run import OpRun
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class If(OpRun):

--- a/onnx/reference/ops/op_leaky_relu.py
+++ b/onnx/reference/ops/op_leaky_relu.py
@@ -3,9 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 from onnx.reference.ops._op import OpRunUnaryNum
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 def _leaky_relu(x: np.ndarray, alpha: float) -> np.ndarray:

--- a/onnx/reference/ops/op_pool_common.py
+++ b/onnx/reference/ops/op_pool_common.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 
 import itertools
 import math
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from onnx.reference.op_run import OpRun
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def get_pad_shape(

--- a/onnx/reference/ops/op_split_to_sequence.py
+++ b/onnx/reference/ops/op_split_to_sequence.py
@@ -3,9 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 from onnx.reference.op_run import OpRun
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class SplitToSequence(OpRun):

--- a/onnx/test/checker_test.py
+++ b/onnx/test/checker_test.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import os
 import tempfile
 import unittest
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -21,6 +21,9 @@ from onnx import (
     numpy_helper,
     shape_inference,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class TestChecker(unittest.TestCase):

--- a/onnx/test/compose_test.py
+++ b/onnx/test/compose_test.py
@@ -4,8 +4,7 @@
 from __future__ import annotations
 
 import unittest
-from collections.abc import Sequence
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 import numpy as np
 
@@ -23,6 +22,9 @@ from onnx import (
     parser,
     version_converter,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def _load_model(m_def: str) -> ModelProto:

--- a/onnx/test/function_inference_test.py
+++ b/onnx/test/function_inference_test.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import unittest
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from shape_inference_test import TestShapeInferenceHelper
 
@@ -13,6 +13,9 @@ import onnx.helper
 import onnx.parser
 import onnx.shape_inference
 from onnx import AttributeProto, TypeProto
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 float_type_ = onnx.helper.make_tensor_type_proto(1, None)
 uint8_type_ = onnx.helper.make_tensor_type_proto(2, None)

--- a/onnx/test/reference_evaluator_test.py
+++ b/onnx/test/reference_evaluator_test.py
@@ -16,12 +16,12 @@ import importlib
 import itertools
 import math
 import unittest
-from collections.abc import Sequence
 from contextlib import redirect_stdout
 from functools import wraps
 from io import StringIO
 from os import getenv
 from textwrap import dedent
+from typing import TYPE_CHECKING
 
 import numpy as np
 import parameterized
@@ -73,6 +73,9 @@ from onnx.reference.ops.op_col2im import (
 from onnx.reference.ops.op_conv import Conv, _conv_implementation
 from onnx.reference.ops_optimized import Conv as ConvOptimized
 from onnx.reference.ops_optimized.op_conv_optimized import _conv_implementation_im2col
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 # TODO (https://github.com/microsoft/onnxruntime/issues/14932): Get max supported version from onnxruntime directly
 # For now, bump the version in CIs whenever there is a new onnxruntime release

--- a/onnx/test/schema_test.py
+++ b/onnx/test/schema_test.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 
 import contextlib
 import unittest
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import parameterized
 
 import onnx
 from onnx import defs
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class TestSchema(unittest.TestCase):

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -6,8 +6,7 @@ from __future__ import annotations
 
 import itertools
 import unittest
-from collections.abc import Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pytest
@@ -45,6 +44,9 @@ from onnx.helper import (
     make_tensor_value_info,
 )
 from onnx.parser import parse_graph
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def get_available_versions(schema: OpSchema) -> set[int]:

--- a/onnx/test/test_backend_test.py
+++ b/onnx/test/test_backend_test.py
@@ -7,10 +7,7 @@ import itertools
 import os
 import platform
 import unittest
-from collections.abc import Sequence
-from typing import Any
-
-import numpy
+from typing import TYPE_CHECKING, Any
 
 import onnx.backend.base
 import onnx.backend.test
@@ -19,6 +16,11 @@ import onnx.version_converter
 from onnx import ModelProto, NodeProto, TensorProto
 from onnx.backend.base import Device, DeviceType
 from onnx.backend.test.runner import BackendIsNotSupposedToImplementIt
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    import numpy
 
 # The following just executes the fake backend through the backend test
 # infrastructure. Since we don't have full reference implementation of all ops

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -9,8 +9,7 @@ import pathlib
 import tempfile
 import unittest
 import uuid
-from collections.abc import Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import parameterized
@@ -33,6 +32,9 @@ from onnx.external_data_helper import (
     set_external_data,
 )
 from onnx.numpy_helper import from_array, to_array
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class TestLoadExternalDataBase(unittest.TestCase):

--- a/onnx/test/version_converter/automatic_conversion_test_base.py
+++ b/onnx/test/version_converter/automatic_conversion_test_base.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 
 import string
 import unittest
-from collections.abc import Sequence
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import onnx
 from onnx import TensorProto, ValueInfoProto, helper, shape_inference, version_converter
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 LATEST_OPSET = onnx.defs.onnx_opset_version()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ lint.select = [
     "SIM", # flake8-simplify
     "SLOT", # flake8-slot
     "T10", # flake8-debugger
+    "TC", # flake8-type-checking
     "TID", # Disallow relative imports
     "TRY", # flake8-try-except-raise
     "UP", # pyupgrade

--- a/tools/protoc-gen-mypy.py
+++ b/tools/protoc-gen-mypy.py
@@ -26,9 +26,11 @@ from __future__ import annotations
 
 import sys
 from collections import defaultdict
-from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Any, Callable, cast
+from typing import TYPE_CHECKING, Any, Callable, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 try:
     import google.protobuf.descriptor_pb2 as d_typed


### PR DESCRIPTION
### Description
Enables TYPE_CHECKING, which has the advantage that types used for annotation are imported only when needed.
<!-- - Describe your changes. -->

### Motivation and Context
Better code.
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
