### PR TITLE
Lift min numpy version to 1.25.2

### DIFF
--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,8 +1,6 @@
 # Minimum package versions that ONNX supports
 # https://endoflife.date/numpy
 protobuf==4.25.1
-numpy==1.22.0; python_version<"3.10"
-numpy==1.23.2; python_version=="3.10"
-numpy==1.23.2; python_version=="3.11"
-numpy==1.26.0; python_version=="3.12"
+numpy==1.25.2; python_version<="3.11"
+numpy==1.26.4; python_version=="3.12"
 numpy==2.1.0; python_version>="3.13"

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -2,7 +2,6 @@ build
 ipython
 ml_dtypes
 nbval
-numpy==1.24.3; python_version<"3.9"
 numpy==2.0.0; python_version >= "3.9" and python_version <= "3.12"
 numpy==2.2.0; python_version>="3.13"
 parameterized


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Because lower versions have reached EOL.
### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
Better dependencies.
