### PR TITLE
Remove dependabot configs for dockerfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,16 +28,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 15
+    open-pull-requests-limit: 20
     labels:      
       - "github_actions"
       - "run release CIs"      
 
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 10
-    labels:      
-      - "docker"
-      - "run release CIs"


### PR DESCRIPTION
### Description
we don't have dockerfiles

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
