### PR TITLE
fix: dont' push wheels with the same filename to pypi twice

### DIFF
--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        target-architecture: ['x86_64', 'arm64']
+        target-architecture: ['x86_64'] # we build universal build => no 'arm64' needed here
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -71,7 +71,7 @@ jobs:
     runs-on: ${{ (matrix.target-architecture == 'x86_64') && 'macos-15' || 'macos-14' }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         target-architecture: ['x86_64', 'arm64']
 
     steps:

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -24,8 +24,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        target-architecture: ['x86_64'] # we build universal build => no 'arm64' needed here
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']       
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -63,7 +62,7 @@ jobs:
     - name: Upload wheel artifacts
       uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
       with:
-        name: wheels-${{ inputs.os }}-${{ matrix.python-version }}-${{ matrix.target-architecture }}
+        name: wheels-${{ inputs.os }}-${{ matrix.python-version }}
         path: dist/*.whl
 
   test:
@@ -90,7 +89,7 @@ jobs:
 
     - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806
       with:
-        name: wheels-${{ inputs.os }}-${{ matrix.python-version }}-${{ matrix.target-architecture }}
+        name: wheels-${{ inputs.os }}-${{ matrix.python-version }}
         path: dist
 
     - name: Test the wheel

--- a/.github/workflows/release_mac.yml
+++ b/.github/workflows/release_mac.yml
@@ -114,7 +114,7 @@ jobs:
         arch -${{ matrix.target-architecture }} pytest
 
     - name: Verify ONNX with the minimumly supported packages
-      if: always() && (matrix.target-architecture == 'x86_64' || (matrix.python-version != '3.9'))
+      if: (matrix.target-architecture == 'x86_64' || (matrix.python-version != '3.9'))
       run: |
         arch -${{ matrix.target-architecture }} python -m pip uninstall -y numpy protobuf onnx
         arch -${{ matrix.target-architecture }} python -m pip install -r requirements-min.txt


### PR DESCRIPTION
### Description
remove unnecesssary builds (we build universal2 whl)

### Motivation and Context 

```
         ('onnx_weekly-1.18.0.dev20250310-cp310-cp310-macosx_12_0_universal2.whl
         ', with blake2_256 hash                                                
         '9ec8a1663ea77a15b4094e62644795ebb7e75b9adc04df731782128c59302022').   
         See https://pypi.org/help/#file-name-reuse for more                    
         information.</title>                                                   
          </head>                                                               
          <body>                                                                
           <h1>400 File already exists                                          
         ('onnx_weekly-1.18.0.dev20250310-cp310-cp310-macosx_12_0_universal2.whl
         ', with blake2_256 hash                                                
         '9ec8a1663ea77a15b4094e62644795ebb7e75b9adc04df731782128c59302022').   
         See https://pypi.org/help/#file-name-reuse for more information.</h1>  
           The server could not comply with the request since it is either      
         malformed or otherwise incorrect.<br/><br/>                            
         File already exists                                                    
         (&#x27;onnx_weekly-1.18.0.dev20250310-cp310-cp310-macosx_12_0_universal
         2.whl&#x27;, with blake2_256 hash                                      
         &#x27;9ec8a1663ea77a15b4094e62644795ebb7e75b9adc04df731782128c59302022&
         #x27;). See https://pypi.org/help/#file-name-reuse for more            
         information.      
```