### PR TITLE
use HEAD_SHA instead of HEAD_REF in auto_update_doc.yml

### DIFF
--- a/.github/workflows/auto_update_doc.yml
+++ b/.github/workflows/auto_update_doc.yml
@@ -27,7 +27,7 @@ jobs:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         # Checkout the branch made in the fork. Will automatically push changes
         # back to this branch.
-        ref: ${{ github.head_ref }}
+        ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: true # cmd_tools contains git commands
         
     - name: Setup Python


### PR DESCRIPTION
### Description
Pulling commit using HEAD_SHA instead of HEAD_REF. 

### Motivation and Context
This reduces the risk of Github Actions TOCTOU attack described here https://github.com/AdnaneKhan/ActionsTOCTOU
Ref #6736
