### PR TITLE
Bump minimum numpy to 1.22

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy>=1.20
+numpy>=1.22
 protobuf>=4.25.1
 typing_extensions>=4.7.1


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
