### PR TITLE
Fix explanation code for ScatterND in  Operators.md

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -31040,7 +31040,7 @@ expect(
   output = np.copy(data)
   update_indices = indices.shape[:-1]
   for idx in np.ndindex(update_indices):
-      output[indices[idx]] = updates[idx]
+      output[tuple(indices[idx])] = updates[idx]
   ```
 
   The order of iteration in the above loop is not specified.
@@ -31057,7 +31057,7 @@ expect(
   output = np.copy(data)
   update_indices = indices.shape[:-1]
   for idx in np.ndindex(update_indices):
-      output[indices[idx]] = f(output[indices[idx]], updates[idx])
+      output[tuple(indices[idx])] = f(output[tuple(indices[idx])], updates[idx])
   ```
 
   where the `f` is `+`, `*`, `max` or `min` as specified.


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Fix explanation code for ScatterND in  Operators.md

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->

The explanation code is wrong when indices.shape[-1] > 1.