### PR TITLE
Fix scatternd defs

### DIFF
--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -1280,7 +1280,7 @@ When `reduction` is set to some reduction function `f`, `output` is calculated a
 output = np.copy(data)
 update_indices = indices.shape[:-1]
 for idx in np.ndindex(update_indices):
-    output[indices[idx]] = f(output[indices[idx]], updates[idx])
+    output[*indices[idx]] = f(output[*indices[idx]], updates[idx])
 ```
 
 where the `f` is `+`, `*`, `max` or `min` as specified.


### PR DESCRIPTION
### Description
As far as I understand, the original description does not work correctly for the case where indices.shape[-1] > 1. This fix is intended to resolve the issue.

### Motivation and Context
Here is a code snippet for showing

```python
import numpy as np


data = np.array(
    [
        [[1, 2, 3, 4], [5, 6, 7, 8], [8, 7, 6, 5], [4, 3, 2, 1]],
        [[1, 2, 3, 4], [5, 6, 7, 8], [8, 7, 6, 5], [4, 3, 2, 1]],
        [[8, 7, 6, 5], [4, 3, 2, 1], [1, 2, 3, 4], [5, 6, 7, 8]],
        [[8, 7, 6, 5], [4, 3, 2, 1], [1, 2, 3, 4], [5, 6, 7, 8]],
    ]
)
indices = np.array([[0, 0], [2, 2]])
updates = np.array(
    [
        [500, 500, 500, 500],
        [100, 100, 100, 100],
    ]
)
output = np.array(
    [
        [[500, 500, 500, 500], [5, 6, 7, 8], [8, 7, 6, 5], [4, 3, 2, 1]],
        [[1, 2, 3, 4], [5, 6, 7, 8], [8, 7, 6, 5], [4, 3, 2, 1]],
        [[8, 7, 6, 5], [4, 3, 2, 1], [100, 100, 100, 100], [5, 6, 7, 8]],
        [[8, 7, 6, 5], [4, 3, 2, 1], [1, 2, 3, 4], [5, 6, 7, 8]],
    ]
)


def expected_scatternd(data, indices, updates):
    assert (
        len(updates.shape)
        == len(data.shape) + len(indices.shape) - indices.shape[-1] - 1
    )

    output = np.copy(data)
    update_indices = indices.shape[:-1]
    for idx in np.ndindex(update_indices):
        output[*indices[idx]] = updates[idx]

    return output


def defs_scatternd(data, indices, updates):
    assert (
        len(updates.shape)
        == len(data.shape) + len(indices.shape) - indices.shape[-1] - 1
    )

    output = np.copy(data)
    update_indices = indices.shape[:-1]
    for idx in np.ndindex(update_indices):
        output[indices[idx]] = updates[idx]

    return output


assert (output == expected_scatternd(data, indices, updates)).all()  # passed
assert (output == defs_scatternd(data, indices, updates)).all()  # failed
```
