### PR TITLE
Use CONFIG to find protobuf

### DIFF
--- a/cmake/ONNXConfig.cmake.in
+++ b/cmake/ONNXConfig.cmake.in
@@ -6,10 +6,7 @@
 # library version information
 set(ONNX_VERSION "@ONNX_VERSION@")
 
-if(@Protobuf_FOUND@)
-  list(APPEND CMAKE_MODULE_PATH "@PROTOBUF_DIR@")
-endif()
-find_package(Protobuf REQUIRED)
+find_package(Protobuf REQUIRED CONFIG)
 
 # import targets
 include ("${CMAKE_CURRENT_LIST_DIR}/ONNXTargets.cmake")


### PR DESCRIPTION
### Description
This uses the CMake configuration file mechanism to configure protobuf. 

### Motivation and Context
This is needed to correctly account for the dependency on abseil of the recent versions of protobuf.
Moreover this has the side effect that the generated file is actually relocatable fine if we happen to build in one folder and deploy in another.