### PR TITLE
Improve pyproject.toml and add py.typed

### DIFF
--- a/onnx/py.typed
+++ b/onnx/py.typed
@@ -1,1 +1,0 @@
-# Marker file for PEP-561 (inline types)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,14 +98,6 @@ module = [
 ]
 ignore_errors = true
 
-[tool.black]
-# NOTE: Do not create an exclude list. Edit .lintrunner.toml instead
-target-version = ["py39", "py310", "py311", "py312", "py313"]
-
-[tool.isort]
-# NOTE: Do not create an exclude list. Edit .lintrunner.toml instead
-profile = "black"
-
 [tool.pylint.message_control]
 # This list is for vscode. Add new disables in pyproject_pylint.toml for lintrunner and CI.
 # Exclude patterns should be modified in .lintrunner.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ ignore_errors = true
 
 [tool.black]
 # NOTE: Do not create an exclude list. Edit .lintrunner.toml instead
-target-version = ["py39", "py310", "py311"]
+target-version = ["py39", "py310", "py311", "py312"]
 
 [tool.isort]
 # NOTE: Do not create an exclude list. Edit .lintrunner.toml instead

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ ignore_errors = true
 
 [tool.black]
 # NOTE: Do not create an exclude list. Edit .lintrunner.toml instead
-target-version = ["py39", "py310", "py311", "py312"]
+target-version = ["py39", "py310", "py311", "py312", "py313"]
 
 [tool.isort]
 # NOTE: Do not create an exclude list. Edit .lintrunner.toml instead


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
py.typed is a marker file to support typing. See [pep 561](https://peps.python.org/pep-0561/). It's used to indicate that ONNX has typing support in the source code and tools such as mypy and pylint can take advantage of that. Therefore, we don't need an additional pyi file for typing.
### Motivation and Context
Better code.
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
