### PR TITLE
Fix external data bug in version converter

### DIFF
--- a/onnx/common/ir_pb_converter.cc
+++ b/onnx/common/ir_pb_converter.cc
@@ -109,6 +109,13 @@ static Tensor tensorProtoToTensor(const ONNX_NAMESPACE::TensorProto& tp) {
   if (tp.has_segment()) {
     ret.set_segment_begin_and_end(tp.segment().begin(), tp.segment().end());
   }
+
+  for (int i = 0; i < tp.external_data_size(); i++) {
+    ret.external_data().push_back(std::make_pair(tp.external_data(i).key(), tp.external_data(i).value()));
+  }
+  if (tp.has_data_location()) {
+    ret.data_location() = tp.data_location();
+  }
   return ret;
 }
 
@@ -492,6 +499,16 @@ static void encodeTensor(ONNX_NAMESPACE::TensorProto* p, const Tensor& tensor) {
   }
   if (tensor.is_raw_data()) {
     p->set_raw_data(tensor.raw());
+  }
+  if (!tensor.external_data().empty()) {
+    for (const auto& entry : tensor.external_data()) {
+      auto* external_data = p->add_external_data();
+      external_data->set_key(entry.first);
+      external_data->set_value(entry.second);
+    }
+  }
+  if (tensor.has_data_location()) {
+    p->set_data_location(tensor.data_location());
   }
 }
 

--- a/onnx/common/tensor.h
+++ b/onnx/common/tensor.h
@@ -41,6 +41,9 @@ struct Tensor final {
   bool is_raw_data_{false};
   std::string raw_data_;
 
+  std::vector<std::pair<std::string, std::string>> external_data_;
+  ONNX_NAMESPACE::TensorProto_DataLocation data_location_{ONNX_NAMESPACE::TensorProto_DataLocation_DEFAULT};
+
  public:
   const std::vector<int64_t>& sizes() const {
     return sizes_;
@@ -165,6 +168,26 @@ struct Tensor final {
 
   bool is_raw_data() const {
     return is_raw_data_;
+  }
+
+  const std::vector<std::pair<std::string, std::string>>& external_data() const {
+    return external_data_;
+  }
+
+  std::vector<std::pair<std::string, std::string>>& external_data() {
+    return external_data_;
+  }
+
+  bool has_data_location() const {
+    return data_location_ != ONNX_NAMESPACE::TensorProto_DataLocation_DEFAULT;
+  }
+
+  const ONNX_NAMESPACE::TensorProto_DataLocation& data_location() const {
+    return data_location_;
+  }
+
+  ONNX_NAMESPACE::TensorProto_DataLocation& data_location() {
+    return data_location_;
   }
 };
 

--- a/onnx/test/version_converter_test.py
+++ b/onnx/test/version_converter_test.py
@@ -2184,6 +2184,90 @@ class TestVersionConverter(unittest.TestCase):
         with context_manager:
             test(y_shape, scale_shape, axis, block_size)
 
+    def test_external_data_version_conversion(self) -> None:
+        # Create a model with external data
+        shape = (200, 300)
+        random_data = np.random.rand(*shape).astype(np.float32)
+
+        initializer_tensor = onnx.helper.make_tensor(
+            name="initializer_tensor",
+            data_type=onnx.TensorProto.FLOAT,
+            dims=list(shape),
+            vals=random_data.tobytes(),
+            raw=True,
+        )
+        initializer_scalar = onnx.helper.make_tensor(
+            name="initializer_scalar",
+            data_type=onnx.TensorProto.FLOAT,
+            dims=[],
+            vals=[1.0],
+        )
+
+        add_node = onnx.helper.make_node(
+            "Add",
+            inputs=["initializer_tensor", "initializer_scalar"],
+            outputs=["sum_output"],
+        )
+
+        graph_def = onnx.helper.make_graph(
+            name="SimpleAddition",
+            nodes=[add_node],
+            inputs=[],
+            outputs=[
+                onnx.helper.make_tensor_value_info(
+                    "sum_output", onnx.TensorProto.FLOAT, list(shape)
+                )
+            ],
+            initializer=[initializer_tensor, initializer_scalar],
+        )
+
+        # Save model to file with external data
+        model_filename = "test_simple_add.onnx"
+        data_filename = model_filename + ".data"
+        opset_imports = [onnx.helper.make_opsetid("", 20)]
+        model_def = onnx.helper.make_model(graph_def, opset_imports=opset_imports)
+        model_def.ir_version = 10
+        onnx.save_model(
+            model_def,
+            model_filename,
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location=data_filename,
+            size_threshold=0,
+            convert_attribute=False,
+        )
+
+        # Load the model and verify external data
+        converted_model = onnx.version_converter.convert_version(
+            onnx.load(model_filename, load_external_data=False), 21
+        )
+        self.assertEqual(len(converted_model.graph.initializer), 2)
+
+        # Verify the large tensor has external data
+        large_tensor = converted_model.graph.initializer[0]
+        self.assertEqual(large_tensor.name, "initializer_tensor")
+
+        self.assertEqual(len(large_tensor.external_data), 3)
+        self.assertEqual(large_tensor.external_data[0].key, "location")
+        self.assertEqual(large_tensor.external_data[0].value, data_filename)
+        self.assertEqual(large_tensor.external_data[1].key, "offset")
+        self.assertEqual(large_tensor.external_data[1].value, "0")
+        self.assertEqual(large_tensor.external_data[2].key, "length")
+        self.assertEqual(large_tensor.external_data[2].value, "240000")
+
+        # Verify the scalar tensor has no external data
+        scalar_tensor = converted_model.graph.initializer[1]
+        self.assertEqual(scalar_tensor.name, "initializer_scalar")
+        self.assertEqual(len(scalar_tensor.external_data), 0)
+
+        # Clean up
+        import os
+
+        if os.path.exists(model_filename):
+            os.remove(model_filename)
+        if os.path.exists(data_filename):
+            os.remove(data_filename)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/onnx/test/version_converter_test.py
+++ b/onnx/test/version_converter_test.py
@@ -2247,24 +2247,17 @@ class TestVersionConverter(unittest.TestCase):
             self.assertEqual(len(converted_model.graph.initializer), 2)
 
             # Verify the large tensor has external data
-            found_large_tensor = False
-            for i in range(2):
-                if converted_model.graph.initializer[i].name == "initializer_tensor":
-                    found_large_tensor = True
-                    large_tensor = converted_model.graph.initializer[i]
-                    self.assertEqual(large_tensor.data_location, TensorProto.EXTERNAL)
-                    self.assertEqual(len(large_tensor.external_data), 3)
+            tensors = {init.name: init for init in converted_model.graph.initializer}
+            self.assertIn("initializer_tensor", tensors)
+            large_tensor = tensors["initializer_tensor"]
+            self.assertEqual(large_tensor.data_location, TensorProto.EXTERNAL)
+            self.assertEqual(len(large_tensor.external_data), 3)
 
-                    # Convert external_data to dictionary for order-independent checking
-                    external_data_dict = {
-                        entry.key: entry.value for entry in large_tensor.external_data
-                    }
-                    self.assertEqual(external_data_dict["location"], data_filename)
-                    self.assertEqual(external_data_dict["offset"], "0")
-                    self.assertEqual(external_data_dict["length"], "24")
-            self.assertTrue(
-                found_large_tensor, "initializer_tensor not found in initializers"
-            )
+            # Convert external_data to dictionary for order-independent checking
+            external_data_dict = {ed.key: ed.value for ed in large_tensor.external_data}
+            self.assertEqual(external_data_dict["location"], data_filename)
+            self.assertEqual(external_data_dict["offset"], "0")
+            self.assertEqual(external_data_dict["length"], "24")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description
There is currently a bug in the convert.cc::conver_version() function for models with external data. This function calls ir_pb_converter.cc::ImportModelProto(), which calls ir_pb_converter.cc::graphProtoToGraph(), which calls ir_pb_converter.cc::tensorProtoToTensor(). But tensorProtoToTensor() doesn't handle external data. While TensorProto has external data support, the struct in tensor.h::Tensor does not. The version converter works on a Graph and not a GraphProto, so the conversion to Tensor struct destroys the external data references. This PR adds the missing logic for external data.

The change can be verified on a simple model with external data:
```
import onnx_graphsurgeon as gs
import onnx
import numpy as np

dtype = np.float32
X = gs.Variable(name="X", dtype=dtype, shape=(1,1))

Y = gs.Constant(name="Y", values=np.zeros((20000,30000), dtype=dtype))
Add_out = gs.Variable(name="Add_out", dtype=dtype)

node_identity = gs.Node(op="Add", inputs=[X, Y], outputs=[Add_out])

graph = gs.Graph(nodes=[node_identity], inputs=[X, Y], outputs=[Add_out], opset=20)

model = gs.export_onnx(graph)
onnx.save(model, "test.onnx", save_as_external_data=True)
```

### Motivation and Context
https://github.com/onnx/onnx/issues/6529
