### PR TITLE
Clarify the `axes` input of [un]Squeeze to be 1D tensors

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -29661,7 +29661,7 @@ This version of the operator has been available since version 23 of the default 
 <dt><tt>data</tt> (differentiable) : T</dt>
 <dd>Tensors with at least max(dims) dimensions.</dd>
 <dt><tt>axes</tt> (optional, non-differentiable) : tensor(int64)</dt>
-<dd>List of integers indicating the dimensions to squeeze. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(data).</dd>
+<dd>1D tensor of integers indicating the dimensions to squeeze. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(data).</dd>
 </dl>
 
 #### Outputs
@@ -29739,7 +29739,7 @@ This version of the operator has been available since version 23 of the default 
 <dt><tt>data</tt> (differentiable) : T</dt>
 <dd>Original tensor</dd>
 <dt><tt>axes</tt> (non-differentiable) : tensor(int64)</dt>
-<dd>List of integers indicating the dimensions to be inserted. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(expanded).</dd>
+<dd>1D tensor of integers indicating the dimensions to be inserted. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(expanded).</dd>
 </dl>
 
 #### Outputs

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -35314,7 +35314,7 @@ Other versions of this operator: <a href="Changelog.md#Squeeze-1">1</a>, <a href
 <dt><tt>data</tt> (differentiable) : T</dt>
 <dd>Tensors with at least max(dims) dimensions.</dd>
 <dt><tt>axes</tt> (optional, non-differentiable) : tensor(int64)</dt>
-<dd>List of integers indicating the dimensions to squeeze. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(data).</dd>
+<dd>1D tensor of integers indicating the dimensions to squeeze. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(data).</dd>
 </dl>
 
 #### Outputs
@@ -38137,7 +38137,7 @@ Other versions of this operator: <a href="Changelog.md#Unsqueeze-1">1</a>, <a hr
 <dt><tt>data</tt> (differentiable) : T</dt>
 <dd>Original tensor</dd>
 <dt><tt>axes</tt> (non-differentiable) : tensor(int64)</dt>
-<dd>List of integers indicating the dimensions to be inserted. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(expanded).</dd>
+<dd>1D tensor of integers indicating the dimensions to be inserted. Negative value means counting dimensions from the back. Accepted range is [-r, r-1] where r = rank(expanded).</dd>
 </dl>
 
 #### Outputs

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -1724,7 +1724,7 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Input(
             1,
             "axes",
-            "List of integers indicating the dimensions to squeeze. Negative value means counting dimensions "
+            "1D tensor of integers indicating the dimensions to squeeze. Negative value means counting dimensions "
             "from the back. Accepted range is [-r, r-1] where r = rank(data).",
             "tensor(int64)",
             OpSchema::Optional,
@@ -1825,7 +1825,7 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Input(
             1,
             "axes",
-            "List of integers indicating the dimensions to be inserted. Negative value means counting dimensions "
+            "1D tensor of integers indicating the dimensions to be inserted. Negative value means counting dimensions "
             "from the back. Accepted range is [-r, r-1] where r = rank(expanded).",
             "tensor(int64)",
             OpSchema::Single,


### PR DESCRIPTION
### Description

Clarify the `axes` input of [un]Squeeze to be 1D tensors.

### Motivation and Context

Reduce ambiguity of the op spec.

Fixes https://github.com/onnx/onnx/issues/6886
