### PR TITLE
Remove nbval dependency, replaces #6896

### DIFF
--- a/.github/workflows/preview_source_dist_test.yml
+++ b/.github/workflows/preview_source_dist_test.yml
@@ -47,7 +47,7 @@ jobs:
             python -m pip install --upgrade pip
             python -m pip install setuptools
             python -m pip install --use-deprecated=legacy-resolver --no-binary onnx-weekly onnx-weekly
-            python -m pip install pytest nbval ml_dtypes pillow parameterized google-re2
+            python -m pip install pytest ml_dtypes pillow parameterized google-re2
             pytest
             
         - name: Test preview build source distribution from test.PyPI
@@ -56,5 +56,5 @@ jobs:
             python -m pip uninstall -y onnx-weekly
             python -m pip install setuptools
             python -m pip install -i https://test.pypi.org/pypi/ --use-deprecated=legacy-resolver --no-binary onnx-weekly onnx-weekly
-            python -m pip install pytest nbval ml_dtypes pillow parameterized google-re2
+            python -m pip install pytest ml_dtypes pillow parameterized google-re2
             pytest

--- a/.github/workflows/release_win_freethreading.yml
+++ b/.github/workflows/release_win_freethreading.yml
@@ -71,12 +71,6 @@ jobs:
     - name: Test the installed wheel
       run: |
 
-        # 2025.03.09 jupyter_client and ipython have conflicting dependencies
-        # therefore [tool.pytest.ini_options] in pyproject.toml is overwritten
-        # because it contains nbval which cannot be installed
-        # TODO: this section should be revised either a) by direct integration into pyproject,
-        # or b) by revising the dependencies in the original projects."
-
         echo "[pytest]" > pytest.ini
         echo "addopts = --tb=short --color=yes" >> pytest.ini
         echo "testpaths =" >> pytest.ini

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ Run `lintrunner --help` and see the `.lintrunner.toml` file for more usage examp
 ONNX uses [pytest](https://docs.pytest.org) as a test driver. To run tests, you'll first need to install pytest:
 
 ```sh
-pip install pytest nbval
+pip install pytest
 ```
 
 After installing pytest, run from the root of the repo:

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Detailed install instructions, including Common Build Options and Common Errors 
 ONNX uses [pytest](https://docs.pytest.org) as test driver. In order to run tests, you will first need to install `pytest`:
 
 ```sh
-pip install pytest nbval
+pip install pytest
 ```
 
 After installing pytest, use the following command to run tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ onnx = [
 
 [tool.pytest.ini_options]
 
-addopts = "--nbval --nbval-current-env --tb=short --color=yes"
+addopts = "--tb=short --color=yes"
 testpaths = [
     "onnx/test",
     "onnx/examples",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 build
-nbval
 numpy
 parameterized
 protobuf

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,6 +1,5 @@
 build
 ml_dtypes
-nbval
 numpy==2.0.0; python_version >= "3.9" and python_version <= "3.12"
 numpy==2.2.0; python_version>="3.13"
 parameterized

--- a/requirements-release_test.txt
+++ b/requirements-release_test.txt
@@ -1,6 +1,4 @@
-ipython
 ml_dtypes
-nbval
 parameterized
 pytest
 pytest-cov


### PR DESCRIPTION
### Description
Replaces #6896. onnx should not need nbval, jupyter... notebook should be turned into examples.
