### PR TITLE
Simplify Protobuf detection logic for cross compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,107 +147,95 @@ if(ONNX_BUILD_TESTS)
 endif()
 
 if(NOT ONNX_BUILD_CUSTOM_PROTOBUF)
-  if((ONNX_USE_LITE_PROTO AND TARGET protobuf::libprotobuf-lite) OR ((NOT ONNX_USE_LITE_PROTO) AND TARGET protobuf::libprotobuf))
-    # Sometimes we need to use protoc compiled for host architecture while linking
-    # libprotobuf against target architecture. See https://github.com/caffe2/caffe
-    # 2/blob/96f35ad75480b25c1a23d6e9e97bccae9f7a7f9c/cmake/ProtoBuf.cmake#L92-L99
-    if(EXISTS "${ONNX_CUSTOM_PROTOC_EXECUTABLE}")
-      message(STATUS "Using custom protoc executable")
-      set(ONNX_PROTOC_EXECUTABLE ${ONNX_CUSTOM_PROTOC_EXECUTABLE})
-    else()
-      if(TARGET protobuf::protoc)
-        set(ONNX_PROTOC_EXECUTABLE $<TARGET_FILE:protobuf::protoc>)
-      endif()
-    endif()
-  else()
-    # Customized version of find Protobuf. We need to avoid situations mentioned
-    # in https://github.com/caffe2/caffe2/blob/b7d983f255ef5496474f1ea188edb5e0ac4
-    # 42761/cmake/ProtoBuf.cmake#L82-L92 The following section is stolen from
-    # cmake/ProtoBuf.cmake in Caffe2
-    find_program(Protobuf_PROTOC_EXECUTABLE
-                NAMES protoc
-                DOC "The Google Protocol Buffers Compiler")
+  # Customized version of find Protobuf. We need to avoid situations mentioned
+  # in https://github.com/caffe2/caffe2/blob/b7d983f255ef5496474f1ea188edb5e0ac4
+  # 42761/cmake/ProtoBuf.cmake#L82-L92 The following section is stolen from
+  # cmake/ProtoBuf.cmake in Caffe2
+  find_program(Protobuf_PROTOC_EXECUTABLE
+              NAMES protoc
+              DOC "The Google Protocol Buffers Compiler")
 
-    # Only if protoc was found, seed the include directories and libraries. We
-    # assume that protoc is installed at PREFIX/bin. We use get_filename_component
-    # to resolve PREFIX.
-    if(Protobuf_PROTOC_EXECUTABLE)
-      set(ONNX_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE})
-      get_filename_component(_PROTOBUF_INSTALL_PREFIX
-                            ${Protobuf_PROTOC_EXECUTABLE} DIRECTORY)
-      get_filename_component(_PROTOBUF_INSTALL_PREFIX
-                            ${_PROTOBUF_INSTALL_PREFIX}/.. REALPATH)
-      find_library(Protobuf_PROTOC_LIBRARY
-                  NAMES protoc
-                  PATHS ${_PROTOBUF_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
-                  NO_DEFAULT_PATH)
-      if(ONNX_USE_LITE_PROTO)
-        find_library(Protobuf_LITE_LIBRARY
-          NAMES protobuf-lite
-          PATHS ${_PROTOBUF_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
-          NO_DEFAULT_PATH)
-      else()
-        find_library(Protobuf_LIBRARY
-          NAMES protobuf
-          PATHS ${_PROTOBUF_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
-          NO_DEFAULT_PATH)
-      endif(ONNX_USE_LITE_PROTO)
-      find_path(Protobuf_INCLUDE_DIR google/protobuf/service.h
-                PATHS ${_PROTOBUF_INSTALL_PREFIX}/include
+  # Only if protoc was found, seed the include directories and libraries. We
+  # assume that protoc is installed at PREFIX/bin. We use get_filename_component
+  # to resolve PREFIX.
+  if(Protobuf_PROTOC_EXECUTABLE)
+    set(ONNX_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE})
+    get_filename_component(_PROTOBUF_INSTALL_PREFIX
+                          ${Protobuf_PROTOC_EXECUTABLE} DIRECTORY)
+    get_filename_component(_PROTOBUF_INSTALL_PREFIX
+                          ${_PROTOBUF_INSTALL_PREFIX}/.. REALPATH)
+    find_library(Protobuf_PROTOC_LIBRARY
+                NAMES protoc
+                PATHS ${_PROTOBUF_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
                 NO_DEFAULT_PATH)
-      if(ONNX_USE_PROTOBUF_SHARED_LIBS)
-        set(Protobuf_USE_STATIC_LIBS OFF)
-      else()
-        set(Protobuf_USE_STATIC_LIBS ON)
-      endif()
-      find_package(Protobuf)
-      if(Protobuf_FOUND)
-        set(PROTOBUF_DIR "${_PROTOBUF_INSTALL_PREFIX}")
-        set(Build_Protobuf OFF)
-        if("${Protobuf_VERSION}" VERSION_GREATER_EQUAL "4.22.0")
-          # There are extra dependencies for protobuf.
-          find_package(absl REQUIRED)
-          find_package(utf8_range)
+    if(ONNX_USE_LITE_PROTO)
+      find_library(Protobuf_LITE_LIBRARY
+        NAMES protobuf-lite
+        PATHS ${_PROTOBUF_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
+        NO_DEFAULT_PATH)
+    else()
+      find_library(Protobuf_LIBRARY
+        NAMES protobuf
+        PATHS ${_PROTOBUF_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
+        NO_DEFAULT_PATH)
+    endif(ONNX_USE_LITE_PROTO)
+    find_path(Protobuf_INCLUDE_DIR google/protobuf/service.h
+              PATHS ${_PROTOBUF_INSTALL_PREFIX}/include
+              NO_DEFAULT_PATH)
+    if(ONNX_USE_PROTOBUF_SHARED_LIBS)
+      set(Protobuf_USE_STATIC_LIBS OFF)
+    else()
+      set(Protobuf_USE_STATIC_LIBS ON)
+    endif()
+    find_package(Protobuf)
+    if(Protobuf_FOUND)
+      set(PROTOBUF_DIR "${_PROTOBUF_INSTALL_PREFIX}")
+      set(Build_Protobuf OFF)
+      if("${Protobuf_VERSION}" VERSION_GREATER_EQUAL "4.22.0")
+        # There are extra dependencies for protobuf.
+        find_package(absl)
+        if(absl_VERSION)
           message(STATUS "absl_VERSION: ${absl_VERSION}")
-          set(protobuf_ABSL_USED_TARGETS
-            absl::absl_check
-            absl::absl_log
-            absl::algorithm
-            absl::base
-            absl::bind_front
-            absl::bits
-            absl::btree
-            absl::cleanup
-            absl::cord
-            absl::core_headers
-            absl::debugging
-            absl::die_if_null
-            absl::dynamic_annotations
-            absl::flags
-            absl::flat_hash_map
-            absl::flat_hash_set
-            absl::function_ref
-            absl::hash
-            absl::layout
-            absl::log_initialize
-            absl::log_severity
-            absl::memory
-            absl::node_hash_map
-            absl::node_hash_set
-            absl::optional
-            absl::span
-            absl::status
-            absl::statusor
-            absl::strings
-            absl::synchronization
-            absl::time
-            absl::type_traits
-            absl::utility
-            absl::variant
-            utf8_range::utf8_range
-            utf8_range::utf8_validity
-          )
         endif()
+        find_package(utf8_range)
+        set(protobuf_ABSL_USED_TARGETS
+          absl::absl_check
+          absl::absl_log
+          absl::algorithm
+          absl::base
+          absl::bind_front
+          absl::bits
+          absl::btree
+          absl::cleanup
+          absl::cord
+          absl::core_headers
+          absl::debugging
+          absl::die_if_null
+          absl::dynamic_annotations
+          absl::flags
+          absl::flat_hash_map
+          absl::flat_hash_set
+          absl::function_ref
+          absl::hash
+          absl::layout
+          absl::log_initialize
+          absl::log_severity
+          absl::memory
+          absl::node_hash_map
+          absl::node_hash_set
+          absl::optional
+          absl::span
+          absl::status
+          absl::statusor
+          absl::strings
+          absl::synchronization
+          absl::time
+          absl::type_traits
+          absl::utility
+          absl::variant
+          utf8_range::utf8_range
+          utf8_range::utf8_validity
+        )
       endif()
     endif()
   endif()


### PR DESCRIPTION
### Description
The old branch complicates the logic of Protobuf detection.
Fixes #6901.
I'm familiar with PyTorch build system enough that I will deal with the potential integration issues once this PR is used together with PyTorch.
### Motivation and Context
Better code.
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
