### PR TITLE
reduce length of names in create_release.yml

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -58,49 +58,49 @@ concurrency:
 
 jobs:
 
-  call-workflow-ubuntu_x86:
+  call-ubuntu_x86:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run release CIs')
     uses: ./.github/workflows/release_linux_x86_64.yml
     with:
       os: "linux_x86_64"
       build_mode: ${{ github.event.inputs.build_mode || 'preview' }}
 
-  call-workflow-ubuntu_aarch64:
+  call-ubuntu_aarch64:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run release CIs')
     uses: ./.github/workflows/release_linux_aarch64.yml
     with:
       os: "linux_aarch64"
       build_mode: ${{ github.event.inputs.build_mode || 'preview' }}
 
-  call-workflow-win_x86:
+  call-win_x86:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run release CIs')
     uses: ./.github/workflows/release_win_x86_64.yml
     with:
       os: "win"
       build_mode: ${{ github.event.inputs.build_mode || 'preview' }}
 
-  call-workflow-win_arm64:
+  call-win_arm64:
       if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run release CIs')
       uses: ./.github/workflows/release_win_aarch64.yml
       with:
         os: "win_arm64"
         build_mode: ${{ github.event.inputs.build_mode || 'preview' }}
 
-  call-workflow-win-freethreading: # experimental
+  call-win-freethreading: # experimental
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run release CIs')
     uses: ./.github/workflows/release_win_freethreading.yml
     with:
       os: "win_free"
       build_mode: ${{ github.event.inputs.build_mode || 'preview' }}
 
-  call-workflow-mac:
+  call-mac:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run release CIs')
     uses: ./.github/workflows/release_mac.yml
     with:
       os: "macos"   
       build_mode: ${{ github.event.inputs.build_mode || 'preview' }}
   
-  call-workflow-sdist:
+  call-sdist:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run release CIs')
     uses: ./.github/workflows/release_sdist.yml
     with:
@@ -112,7 +112,7 @@ jobs:
     name: Check for Publish preview build to test.pypi-weekly
     runs-on: ubuntu-latest
 
-    needs: [call-workflow-ubuntu_x86, call-workflow-ubuntu_aarch64, call-workflow-mac, call-workflow-win_x86, call-workflow-win_arm64, call-workflow-win-freethreading, call-workflow-sdist]
+    needs: [call-ubuntu_x86, call-ubuntu_aarch64, call-mac, call-win_x86, call-win_arm64, call-win-freethreading, call-sdist]
     if: (!contains(join(needs.*.result, ' '), 'skipped')) && (github.event.inputs.publish_testpypi_weekly   == 'yes' ) && (github.ref == 'refs/heads/main') && (github.repository_owner == 'onnx') && (github.event_name == 'workflow_dispatch')
 
     steps:
@@ -164,7 +164,7 @@ jobs:
     name: Check for Publish release build to test.pypi
     runs-on: ubuntu-latest
 
-    needs: [call-workflow-ubuntu_x86, call-workflow-ubuntu_aarch64, call-workflow-mac, call-workflow-win_x86, call-workflow-win_arm64, call-workflow-win-freethreading, call-workflow-sdist]
+    needs: [call-ubuntu_x86, call-ubuntu_aarch64, call-mac, call-win_x86, call-win_arm64, call-win-freethreading, call-sdist]
     if: (!contains(join(needs.*.result, ' '), 'skipped')) && (github.event.inputs.publish_testpypi_release == 'yes' ) && startsWith(github.ref, 'refs/heads/rel') && (github.repository_owner == 'onnx') && (github.event_name == 'workflow_dispatch')
 
     steps:
@@ -216,7 +216,7 @@ jobs:
     name: Check for Publish preview build to pypi-weekly
     runs-on: ubuntu-latest
 
-    needs: [call-workflow-ubuntu_x86, call-workflow-ubuntu_aarch64, call-workflow-mac, call-workflow-win_x86, call-workflow-win_arm64, call-workflow-win-freethreading, call-workflow-sdist]
+    needs: [call-ubuntu_x86, call-ubuntu_aarch64, call-mac, call-win_x86, call-win_arm64, call-win-freethreading, call-sdist]
     if: (!contains(join(needs.*.result, ' '), 'skipped')) && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
 
     steps:


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->

### Motivation and Context
When the display is small, e.g. on a smartphone, the full name cannot be read in the actions overview => therefore reducing the length of the names
