### PR TITLE
Export symbols used by PyTorch

### DIFF
--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -1156,7 +1156,7 @@ class OpSchemaRegistry final : public ISchemaRegistry {
     return nullptr;
   }
 
-  static OpSchemaRegistry* Instance();
+  ONNX_API static OpSchemaRegistry* Instance();
 
   const OpSchema* GetSchema(
       const std::string& key,

--- a/onnx/shape_inference/implementation.h
+++ b/onnx/shape_inference/implementation.h
@@ -477,20 +477,20 @@ void mergeShapesAndTypes(const TypeProto& inferredType, TypeProto* existingType)
 /// ModelLocalFunctionsMap is a map of function id -> model local function proto
 /// All the ONNX helper utilities expect the function id == <function_proto.domain>:<function_proto.name>
 ///
-void InferShapes(
+ONNX_API void InferShapes(
     GraphProto* g,
     const std::unordered_map<std::string, int>& opset_imports,
     const ISchemaRegistry* schema_registry = OpSchemaRegistry::Instance(),
     const ShapeInferenceOptions& options = ShapeInferenceOptions(),
     const ModelLocalFunctionsMap& in_model_functions = {});
 
-void InferShapes(
+ONNX_API void InferShapes(
     ModelProto& m,
     const ISchemaRegistry* schema_registry = OpSchemaRegistry::Instance(),
     const ShapeInferenceOptions& options = ShapeInferenceOptions(),
     DataValueMap* generated_shape_data_by_name = nullptr);
 
-void InferShapes(
+ONNX_API void InferShapes(
     const std::string& model_path,
     const std::string& save_path = "",
     const ISchemaRegistry* schema_registry = OpSchemaRegistry::Instance(),


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Cherry pick changes for 1.18.0. Private symbols were exposed before https://github.com/onnx/onnx/pull/6393. Although these symbols are now hidden, there are some of them already used in PyTorch. For backward compatibility, we have to expose them. 
### Motivation and Context
Better API compatibility.
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
