### PR TITLE
Define PYBIND11_DETAILED_ERROR_MESSAGES

### DIFF
--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -26,6 +26,10 @@
 #pragma error "Pybind11 must be >= 2.12 to be compatible with numpy 2.0."
 #endif
 
+#ifndef PYBIND11_DETAILED_ERROR_MESSAGES
+#define PYBIND11_DETAILED_ERROR_MESSAGES
+#endif
+
 namespace ONNX_NAMESPACE {
 namespace py = pybind11;
 using namespace pybind11::literals;


### PR DESCRIPTION
Define PYBIND11_DETAILED_ERROR_MESSAGES for better error messages. I expect a small binary size increase, but for the python package it should be marginal and will improve user experiences when they hit any pybind method errors.