### PR TITLE
Update test_backend_reference.py

### DIFF
--- a/onnx/test/test_backend_reference.py
+++ b/onnx/test/test_backend_reference.py
@@ -218,18 +218,6 @@ if sys.platform == "darwin":
     backend_test.exclude("test_qlinearmatmul_3D_int8_float16_cpu")
     backend_test.exclude("test_qlinearmatmul_3D_int8_float32_cpu")
 
-# op_dft and op_stft requires numpy >= 1.21.5
-if version_utils.numpy_older_than("1.21.5"):
-    backend_test.exclude("test_stft")
-    backend_test.exclude("test_stft_with_window")
-    backend_test.exclude("test_stft_cpu")
-    backend_test.exclude("test_dft")
-    backend_test.exclude("test_dft_axis")
-    backend_test.exclude("test_dft_inverse")
-    backend_test.exclude("test_dft_opset19")
-    backend_test.exclude("test_dft_axis_opset19")
-    backend_test.exclude("test_dft_inverse_opset19")
-
 if version_utils.pillow_older_than("10.0"):
     backend_test.exclude("test_image_decoder_decode_webp_rgb")
     backend_test.exclude("test_image_decoder_decode_jpeg2k_rgb")


### PR DESCRIPTION
### Description
Minimun required numpy version is 1.22 (https://github.com/onnx/onnx/blob/main/requirements-min.txt), which means we could adapt the test_backend_reference.py


### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
