### PR TITLE
Display types on cast node test errors

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -5490,7 +5490,7 @@ for from_type, to_type in test_cases:
             )
         else:
             raise ValueError(
-                "Conversion from {from_type} to {to_type} is not tested."
+                f"Conversion from {from_type} to {to_type} is not tested."
             )
 
         if to_type == "FLOAT8E4M3FN":
@@ -5517,7 +5517,7 @@ for from_type, to_type in test_cases:
             expected = input_values
         else:
             raise ValueError(
-                "Conversion from {from_type} to {to_type} is not tested."
+                f"Conversion from {from_type} to {to_type} is not tested."
             )
         expected_tensor = make_tensor(
             "x", getattr(TensorProto, to_type), [3, 5], expected.tolist()
@@ -5548,7 +5548,7 @@ for from_type, to_type in test_cases:
             )
         else:
             raise ValueError(
-                "Conversion from {from_type} to {to_type} is not tested."
+                f"Conversion from {from_type} to {to_type} is not tested."
             )
         if to_type == "UINT4":
             expected = vect_float32_to_uint4(input_values).astype(custom.uint4)
@@ -5564,7 +5564,7 @@ for from_type, to_type in test_cases:
             expected = input_values.astype(np.int8)
         else:
             raise ValueError(
-                "Conversion from {from_type} to {to_type} is not tested."
+                f"Conversion from {from_type} to {to_type} is not tested."
             )
         expected_tensor = make_tensor(
             "y", getattr(TensorProto, to_type), input_shape, expected.tolist()
@@ -5741,7 +5741,7 @@ for from_type, to_type in test_cases:
         )
     else:
         raise ValueError(
-            "Conversion from {from_type} to {to_type} is not tested."
+            f"Conversion from {from_type} to {to_type} is not tested."
         )
 
     if to_type == "FLOAT8E4M3FN":
@@ -5758,7 +5758,7 @@ for from_type, to_type in test_cases:
         )
     else:
         raise ValueError(
-            "Conversion from {from_type} to {to_type} is not tested."
+            f"Conversion from {from_type} to {to_type} is not tested."
         )
 
     ivals = bytes([int(i) for i in expected])

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -4155,7 +4155,7 @@ for from_type, to_type in test_cases:
             )
         else:
             raise ValueError(
-                "Conversion from {from_type} to {to_type} is not tested."
+                f"Conversion from {from_type} to {to_type} is not tested."
             )
 
         if to_type == "FLOAT8E4M3FN":
@@ -4182,7 +4182,7 @@ for from_type, to_type in test_cases:
             expected = input_values
         else:
             raise ValueError(
-                "Conversion from {from_type} to {to_type} is not tested."
+                f"Conversion from {from_type} to {to_type} is not tested."
             )
         expected_tensor = make_tensor(
             "x", getattr(TensorProto, to_type), [3, 5], expected.tolist()
@@ -4213,7 +4213,7 @@ for from_type, to_type in test_cases:
             )
         else:
             raise ValueError(
-                "Conversion from {from_type} to {to_type} is not tested."
+                f"Conversion from {from_type} to {to_type} is not tested."
             )
         if to_type == "UINT4":
             expected = vect_float32_to_uint4(input_values).astype(custom.uint4)
@@ -4229,7 +4229,7 @@ for from_type, to_type in test_cases:
             expected = input_values.astype(np.int8)
         else:
             raise ValueError(
-                "Conversion from {from_type} to {to_type} is not tested."
+                f"Conversion from {from_type} to {to_type} is not tested."
             )
         expected_tensor = make_tensor(
             "y", getattr(TensorProto, to_type), input_shape, expected.tolist()
@@ -4404,7 +4404,7 @@ for from_type, to_type in test_cases:
         )
     else:
         raise ValueError(
-            "Conversion from {from_type} to {to_type} is not tested."
+            f"Conversion from {from_type} to {to_type} is not tested."
         )
 
     if to_type == "FLOAT8E4M3FN":
@@ -4421,7 +4421,7 @@ for from_type, to_type in test_cases:
         )
     else:
         raise ValueError(
-            "Conversion from {from_type} to {to_type} is not tested."
+            f"Conversion from {from_type} to {to_type} is not tested."
         )
 
     ivals = bytes([int(i) for i in expected])

--- a/onnx/backend/test/case/node/cast.py
+++ b/onnx/backend/test/case/node/cast.py
@@ -200,7 +200,7 @@ class Cast(Base):
                     )
                 else:
                     raise ValueError(
-                        "Conversion from {from_type} to {to_type} is not tested."
+                        f"Conversion from {from_type} to {to_type} is not tested."
                     )
 
                 if to_type == "FLOAT8E4M3FN":
@@ -227,7 +227,7 @@ class Cast(Base):
                     expected = input_values
                 else:
                     raise ValueError(
-                        "Conversion from {from_type} to {to_type} is not tested."
+                        f"Conversion from {from_type} to {to_type} is not tested."
                     )
                 expected_tensor = make_tensor(
                     "x", getattr(TensorProto, to_type), [3, 5], expected.tolist()
@@ -258,7 +258,7 @@ class Cast(Base):
                     )
                 else:
                     raise ValueError(
-                        "Conversion from {from_type} to {to_type} is not tested."
+                        f"Conversion from {from_type} to {to_type} is not tested."
                     )
                 if to_type == "UINT4":
                     expected = vect_float32_to_uint4(input_values).astype(custom.uint4)
@@ -274,7 +274,7 @@ class Cast(Base):
                     expected = input_values.astype(np.int8)
                 else:
                     raise ValueError(
-                        "Conversion from {from_type} to {to_type} is not tested."
+                        f"Conversion from {from_type} to {to_type} is not tested."
                     )
                 expected_tensor = make_tensor(
                     "y", getattr(TensorProto, to_type), input_shape, expected.tolist()
@@ -445,7 +445,7 @@ class Cast(Base):
                 )
             else:
                 raise ValueError(
-                    "Conversion from {from_type} to {to_type} is not tested."
+                    f"Conversion from {from_type} to {to_type} is not tested."
                 )
 
             if to_type == "FLOAT8E4M3FN":
@@ -462,7 +462,7 @@ class Cast(Base):
                 )
             else:
                 raise ValueError(
-                    "Conversion from {from_type} to {to_type} is not tested."
+                    f"Conversion from {from_type} to {to_type} is not tested."
                 )
 
             ivals = bytes([int(i) for i in expected])


### PR DESCRIPTION
### Description
This small PR evaluates and displays the `from` and `to` types in the error messages.

### Motivation and Context

