### PR TITLE
Clarify Mod operator

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -16744,7 +16744,7 @@ This version of the operator has been available since version 13 of the default 
   The following special cases apply when `fmod` is set to `1`:
   - If `x` is `-0` and `y` is greater than zero, either `+0` or `-0` may be returned.
   - If `x` is `±∞` and `y` is not `NaN`, `NaN` is returned.
-  - If `y` is `±0` and `x` is not `NaN`, `NaN` is returned.
+  - If `y` is `±0` and `x` is not `NaN`, `NaN` should be returned.
   - If `y` is `±∞` and `x` is finite, `x` is returned.
   - If either argument is `NaN`, `NaN` is returned.
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -16732,19 +16732,23 @@ This version of the operator has been available since version 13 of the default 
 
 ### <a name="Mod-13"></a>**Mod-13**</a>
 
-  Performs element-wise binary modulus (with Numpy-style broadcasting support).
-    The sign of the remainder is the same as that of the Divisor.
+  Performs an element-wise binary modulo operation.
+  The semantics and supported data types depend on the value of the `fmod` attribute which must be `0` (default), or `1`.
 
-    Mod operator can also behave like C fmod() or numpy.fmod. In this case, the sign of the remainder however, will be the same as the Dividend
-    (in contrast to integer mod). To force a behavior like numpy.fmod() an 'fmod' Attribute is provided.
-    This attribute is set to 0 by default causing the behavior to be like integer mod.
-    Setting this attribute to 1 causes the remainder to be calculated similar to that of numpy.fmod().
+  If the `fmod` attribute is set to `0`, `T` is constrained to integer data types and the semantics follow that of the Python `%`-operator.
+  The sign of the result is that of the divisor.
 
-    If the input type is floating point, then `fmod` attribute must be set to 1.
+  If `fmod` is set to `1`, the behavior of this operator follows that of the `fmod` function in C and `T` is constrained to floating point data types.
+  The result of this operator is the remainder of the division operation `x / y` where `x` and `y` are respective elements of `A` and `B`. The result is exactly the value `x - n * y`, where `n` is `x / y` with its fractional part truncated.
+  The returned value has the same sign as `x` (except if `x` is `-0`) and is less or equal to `|y|` in magnitude.
+  The following special cases apply when `fmod` is set to `1`:
+  - If `x` is `-0` and `y` is greater than zero, either `+0` or `-0` may be returned.
+  - If `x` is `±∞` and `y` is not `NaN`, `NaN` is returned.
+  - If `y` is `±0` and `x` is not `NaN`, `NaN` is returned.
+  - If `y` is `±∞` and `x` is finite, `x` is returned.
+  - If either argument is `NaN`, `NaN` is returned.
 
-    In case of dividend being zero, the results will be platform dependent.
-
-    This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+  This operator supports **multidirectional (i.e., NumPy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
 #### Version
 

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -19365,19 +19365,23 @@ expect(node, inputs=[input_data], outputs=[expected_output], name="test_mish")
 
 ### <a name="Mod"></a><a name="mod">**Mod**</a>
 
-  Performs element-wise binary modulus (with Numpy-style broadcasting support).
-    The sign of the remainder is the same as that of the Divisor.
+  Performs an element-wise binary modulo operation.
+  The semantics and supported data types depend on the value of the `fmod` attribute which must be `0` (default), or `1`.
 
-    Mod operator can also behave like C fmod() or numpy.fmod. In this case, the sign of the remainder however, will be the same as the Dividend
-    (in contrast to integer mod). To force a behavior like numpy.fmod() an 'fmod' Attribute is provided.
-    This attribute is set to 0 by default causing the behavior to be like integer mod.
-    Setting this attribute to 1 causes the remainder to be calculated similar to that of numpy.fmod().
+  If the `fmod` attribute is set to `0`, `T` is constrained to integer data types and the semantics follow that of the Python `%`-operator.
+  The sign of the result is that of the divisor.
 
-    If the input type is floating point, then `fmod` attribute must be set to 1.
+  If `fmod` is set to `1`, the behavior of this operator follows that of the `fmod` function in C and `T` is constrained to floating point data types.
+  The result of this operator is the remainder of the division operation `x / y` where `x` and `y` are respective elements of `A` and `B`. The result is exactly the value `x - n * y`, where `n` is `x / y` with its fractional part truncated.
+  The returned value has the same sign as `x` (except if `x` is `-0`) and is less or equal to `|y|` in magnitude.
+  The following special cases apply when `fmod` is set to `1`:
+  - If `x` is `-0` and `y` is greater than zero, either `+0` or `-0` may be returned.
+  - If `x` is `±∞` and `y` is not `NaN`, `NaN` is returned.
+  - If `y` is `±0` and `x` is not `NaN`, `NaN` is returned.
+  - If `y` is `±∞` and `x` is finite, `x` is returned.
+  - If either argument is `NaN`, `NaN` is returned.
 
-    In case of dividend being zero, the results will be platform dependent.
-
-    This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+  This operator supports **multidirectional (i.e., NumPy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 
 #### Version
 

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -19377,7 +19377,7 @@ expect(node, inputs=[input_data], outputs=[expected_output], name="test_mish")
   The following special cases apply when `fmod` is set to `1`:
   - If `x` is `-0` and `y` is greater than zero, either `+0` or `-0` may be returned.
   - If `x` is `±∞` and `y` is not `NaN`, `NaN` is returned.
-  - If `y` is `±0` and `x` is not `NaN`, `NaN` is returned.
+  - If `y` is `±0` and `x` is not `NaN`, `NaN` should be returned.
   - If `y` is `±∞` and `x` is finite, `x` is returned.
   - If either argument is `NaN`, `NaN` is returned.
 

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -94,19 +94,23 @@ ONNX_OPERATOR_SET_SCHEMA(
         .PartialDataPropagationFunction([](DataPropagationContext& ctx) { MathOpDataPropagator(ctx, "Sub"); }));
 
 static const char* Mod_doc = R"DOC(
-  Performs element-wise binary modulus (with Numpy-style broadcasting support).
-  The sign of the remainder is the same as that of the Divisor.
+Performs an element-wise binary modulo operation.
+The semantics and supported data types depend on the value of the `fmod` attribute which must be `0` (default), or `1`.
 
-  Mod operator can also behave like C fmod() or numpy.fmod. In this case, the sign of the remainder however, will be the same as the Dividend
-  (in contrast to integer mod). To force a behavior like numpy.fmod() an 'fmod' Attribute is provided.
-  This attribute is set to 0 by default causing the behavior to be like integer mod.
-  Setting this attribute to 1 causes the remainder to be calculated similar to that of numpy.fmod().
+If the `fmod` attribute is set to `0`, `T` is constrained to integer data types and the semantics follow that of the Python `%`-operator.
+The sign of the result is that of the divisor.
 
-  If the input type is floating point, then `fmod` attribute must be set to 1.
+If `fmod` is set to `1`, the behavior of this operator follows that of the `fmod` function in C and `T` is constrained to floating point data types.
+The result of this operator is the remainder of the division operation `x / y` where `x` and `y` are respective elements of `A` and `B`. The result is exactly the value `x - n * y`, where `n` is `x / y` with its fractional part truncated.
+The returned value has the same sign as `x` (except if `x` is `-0`) and is less or equal to `|y|` in magnitude.
+The following special cases apply when `fmod` is set to `1`:
+- If `x` is `-0` and `y` is greater than zero, either `+0` or `-0` may be returned.
+- If `x` is `±∞` and `y` is not `NaN`, `NaN` is returned.
+- If `y` is `±0` and `x` is not `NaN`, `NaN` is returned.
+- If `y` is `±∞` and `x` is finite, `x` is returned.
+- If either argument is `NaN`, `NaN` is returned.
 
-  In case of dividend being zero, the results will be platform dependent.
-
-  This operator supports **multidirectional (i.e., Numpy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
+This operator supports **multidirectional (i.e., NumPy-style) broadcasting**; for more details please check [the doc](Broadcasting.md).
 )DOC";
 
 ONNX_OPERATOR_SET_SCHEMA(

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -106,7 +106,7 @@ The returned value has the same sign as `x` (except if `x` is `-0`) and is less 
 The following special cases apply when `fmod` is set to `1`:
 - If `x` is `-0` and `y` is greater than zero, either `+0` or `-0` may be returned.
 - If `x` is `±∞` and `y` is not `NaN`, `NaN` is returned.
-- If `y` is `±0` and `x` is not `NaN`, `NaN` is returned.
+- If `y` is `±0` and `x` is not `NaN`, `NaN` should be returned.
 - If `y` is `±∞` and `x` is finite, `x` is returned.
 - If either argument is `NaN`, `NaN` is returned.
 


### PR DESCRIPTION
### Description
Improve description of the `Mod` operator. Closes #5564

### Motivation and Context
The description of the `Mod` operator has been very vague. The proposed change aligns with the behavior of onnxruntime and the onnx reference implementation.

<details>
<summary>Test against onnxruntime and onnx reference implementation</summary>
The following code snippet checks the existing behavior of onnxruntime and the onnx reference implementation. This is not a stable feature of spox, yet, thus the private imports.

Execute using pixi
```
pixi exec -s onnxruntime -s onnx -s spox -s numpy python mod.py 
```

or in any Python environment with onnx, onnxruntime and spox installed.

```python
import math

import spox
import spox._future
import spox.opset.ai.onnx.v21 as op
import numpy as np

BACKENDS = [spox._value_prop.ValuePropBackend.ONNXRUNTIME, spox._value_prop.ValuePropBackend.REFERENCE]

def check_mod_impl(x, y, expected, fmod):
    for backend in BACKENDS:
        spox._future.set_value_prop_backend(backend)
        a = op.const(x)
        b = op.const(y)
        res = op.mod(a, b, fmod=fmod)._value.value

        np.testing.assert_equal(expected, res)

cases = [
    (3.0, 2.0),
    (3.0, -2.0),
    (-3.0, 2.0),
    (-3.0, -2.0),
]
for (x, y) in cases:
    expected = x - math.trunc(x/y) * y
    check_mod_impl(x, y, expected, fmod=1)

special_cases = [
    (-0.0, -1.0, -0.0),
    (-0.0, 1.0, -0.0),
    (float("inf"), 2.0, float("nan")),
    (3.0, float("inf"), 3.0),
    (float("nan"), 2.0, float("nan")),
    (2.0, float("nan"), float("nan")),
]
for (x, y, expected) in special_cases:
    check_mod_impl(x, y, expected, fmod=1)


cases = [
    (5, 3),
    (5, -3),
    (-5, 3),
    (-5, -3),
]
for (x, y) in cases:
    expected = x % y
    check_mod_impl(x, y, expected, fmod=0)
```

</details>
