### PR TITLE
Fix target_link_option on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -549,7 +549,7 @@ if(ONNX_BUILD_PYTHON)
   target_link_libraries(onnx_cpp2py_export PRIVATE pybind11::headers)
 
   if(APPLE)
-    target_link_options(onnx_cpp2py_export PRIVATE "-undefined dynamic_lookup")
+    target_link_options(onnx_cpp2py_export PRIVATE -undefined dynamic_lookup)
     target_link_libraries(onnx_cpp2py_export PRIVATE $<LINK_LIBRARY:WHOLE_ARCHIVE,onnx>)
   elseif(MSVC)
     # In MSVC, we will add whole archive in default
@@ -624,7 +624,7 @@ if(ONNX_USE_ASAN AND NOT MSVC)
 endif()
 
 if(APPLE)
-  target_link_options(onnx PRIVATE "-undefined dynamic_lookup")
+  target_link_options(onnx PRIVATE -undefined dynamic_lookup)
 endif()
 
 install(DIRECTORY ${ONNX_ROOT}/onnx


### PR DESCRIPTION
### Description

At least in my conda-based setup, I ran into the following link-time [error](https://github.com/cbourjau/onnx/actions/runs/15083156389/job/42402396988#step:4:17846):
```
[ 82%] Linking CXX shared library libonnx.dylib
  ld: invalid option to -undefined [ warning | error | suppress | dynamic_lookup ]
```
The error arises due to the linker seeing the following argument `-undefined " dynamic_lookup"`. The proposed change [fixes](https://github.com/cbourjau/onnx/actions/runs/15131514625) the issue.

### Motivation and Context

Linking error on MacOS.
