### PR TITLE
Update stale workflow to not close issues that should stay open

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -31,3 +31,8 @@ jobs:
         days-before-stale: 365
         days-before-close: 21
         ascending: true
+        exempt-issue-labels: bug,no-stale
+        exempt-pr-labels: no-stale
+        remove-issue-stale-when-updated: true
+        remove-pr-stale-when-updated: true
+        exempt-all-milestones: true


### PR DESCRIPTION
Update the workflow so that we can use `no-stale` to keep an issue or PR open. Additionally it will not close any bugs or milestone issues.