### PR TITLE
Simplify proto source file generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,6 +316,7 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP SRCS)
   set(${SRCS})
 
   set(GEN_PROTO_PY "${ONNX_ROOT}/onnx/gen_proto.py")
+  set(GENERATED_FILE_TARGETS)
   foreach(INFILE ${ARGN})
     message(WARNING "${INFILE}")
     set(ABS_FILE "${ONNX_ROOT}/${INFILE}")
@@ -386,10 +387,11 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP SRCS)
         list(APPEND PROTOC_ARGS ${CMAKE_CURRENT_BINARY_DIR})
       endif()
     endif()
+    list(APPEND GENERATED_FILE_TARGETS ${GENERATED_FILE_WE}_proto_file)
     add_custom_target(${GENERATED_FILE_WE}_src
         COMMAND "${ONNX_PROTOC_EXECUTABLE}" ${PROTOC_ARGS}
         BYPRODUCTS "${OUTPUT_PB_SRC}"
-        DEPENDS ${GENERATED_FILE_WE}_proto_file
+        DEPENDS ${GENERATED_FILE_TARGETS}
         COMMENT "Running C++ protocol buffer compiler on ${GENERATED_PROTO}")
   endforeach()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,7 +304,7 @@ message(STATUS "ONNX_PROTOC_EXECUTABLE: ${ONNX_PROTOC_EXECUTABLE}")
 # b.com/tensorflow/tensorflow/blob/d2c3b873c6f8ff999a2e4ee707a84ff00d9c15a5/tens
 # orflow/contrib/cmake/tf_core_framework.cmake to solve the problem that
 # customized dir can't be specified when calling PROTOBUF_GENERATE_CPP.
-function(RELATIVE_PROTOBUF_GENERATE_CPP NAME SRCS HDRS ROOT_DIR DEPEND)
+function(RELATIVE_PROTOBUF_GENERATE_CPP NAME SRCS DEPEND)
   if(NOT ARGN)
     message(
       SEND_ERROR
@@ -317,11 +317,10 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP NAME SRCS HDRS ROOT_DIR DEPEND)
   set(ONNX_DLLEXPORT_STR "dllexport_decl=ONNX_API:")
 
   set(${SRCS})
-  set(${HDRS})
 
-  set(GEN_PROTO_PY "${ROOT_DIR}/onnx/gen_proto.py")
+  set(GEN_PROTO_PY "${ONNX_ROOT}/onnx/gen_proto.py")
   foreach(INFILE ${ARGN})
-    set(ABS_FILE "${ROOT_DIR}/${INFILE}")
+    set(ABS_FILE "${ONNX_ROOT}/${INFILE}")
     get_filename_component(FILE_DIR ${ABS_FILE} DIRECTORY)
     get_filename_component(FILE_WE ${INFILE} NAME_WE)
     # "onnx-data" check is because we do not want to create/compile an "onnx-data-ml.proto" file
@@ -338,7 +337,7 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP NAME SRCS HDRS ROOT_DIR DEPEND)
         set(GENERATED_FILE_WE "${FILE_WE}_${ONNX_NAMESPACE}")
       endif()
     endif()
-    file(RELATIVE_PATH REL_DIR "${ROOT_DIR}" "${FILE_DIR}")
+    file(RELATIVE_PATH REL_DIR "${ONNX_ROOT}" "${FILE_DIR}")
     set(OUTPUT_PROTO_DIR "${CMAKE_CURRENT_BINARY_DIR}/${REL_DIR}")
 
     set(OUTPUT_PB_HEADER "${OUTPUT_PROTO_DIR}/${GENERATED_FILE_WE}.pb.h")
@@ -350,7 +349,6 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP NAME SRCS HDRS ROOT_DIR DEPEND)
       list(APPEND ${HDRS} "${OUTPUT_PROTO_DIR}/${GENERATED_FILE_WE}.pb.h")
     endif()
     list(APPEND ${SRCS} "${OUTPUT_PB_SRC}")
-    list(APPEND ${HDRS} "${OUTPUT_PB_HEADER}")
 
     if(NOT EXISTS "${OUTPUT_PROTO_DIR}")
       file(MAKE_DIRECTORY "${OUTPUT_PROTO_DIR}")
@@ -368,21 +366,15 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP NAME SRCS HDRS ROOT_DIR DEPEND)
     if(ONNX_USE_LITE_PROTO)
       list(APPEND GEN_PROTO_ARGS -l)
     endif()
-    if(ONNX_VERIFY_PROTO3)
-        if(NOT ONNX_PROTOC_EXECUTABLE)
-          message(FATAL_ERROR "Protobuf compiler not found")
-        endif()
-        list(APPEND GEN_PROTO_ARGS --protoc_path)
-        list(APPEND GEN_PROTO_ARGS "${ONNX_PROTOC_EXECUTABLE}")
-    endif()
 
-    add_custom_command(OUTPUT "${GENERATED_PROTO}"
-                       COMMAND Python3::Interpreter "${GEN_PROTO_PY}"
-                               ARGS ${GEN_PROTO_ARGS}
+    add_custom_target("${GENERATED_FILE_WE}_proto_file"
+                       COMMAND Python3::Interpreter "${GEN_PROTO_PY}" ${GEN_PROTO_ARGS}
+                       BYPRODUCTS "${GENERATED_PROTO}"
                        DEPENDS ${INFILE}
                        COMMENT "Running gen_proto.py on ${INFILE}"
-                       VERBATIM)
+                       )
     message("Generated: ${GENERATED_PROTO}")
+
     set(PROTOC_ARGS
         ${GENERATED_PROTO}
         -I
@@ -400,61 +392,34 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP NAME SRCS HDRS ROOT_DIR DEPEND)
     if(NOT ONNX_PROTOC_EXECUTABLE)
       message(FATAL_ERROR "Protobuf compiler not found")
     endif()
-    if(ONNX_PROTO_POST_BUILD_SCRIPT)
-      add_custom_command(
-        OUTPUT "${OUTPUT_PB_SRC}" "${OUTPUT_PB_HEADER}"
-        COMMAND "${ONNX_PROTOC_EXECUTABLE}" ARGS ${PROTOC_ARGS}
-        COMMAND "${CMAKE_COMMAND}" -DFILENAME=${OUTPUT_PB_HEADER}
-                -DNAMESPACES=${ONNX_NAMESPACE} -P
-                ${ONNX_PROTO_POST_BUILD_SCRIPT}
-        COMMAND "${CMAKE_COMMAND}" -DFILENAME=${OUTPUT_PB_SRC}
-                -DNAMESPACES=${ONNX_NAMESPACE} -P
-                ${ONNX_PROTO_POST_BUILD_SCRIPT}
-        DEPENDS ${GENERATED_PROTO} ${DEPEND}
-        COMMENT "Running C++ protocol buffer compiler on ${GENERATED_PROTO}"
-        VERBATIM)
-    else()
-      add_custom_command(
-        OUTPUT "${OUTPUT_PB_SRC}" "${OUTPUT_PB_HEADER}"
-        COMMAND "${ONNX_PROTOC_EXECUTABLE}" ARGS ${PROTOC_ARGS}
-        DEPENDS ${GENERATED_PROTO} ${DEPEND}
-        COMMENT "Running C++ protocol buffer compiler on ${GENERATED_PROTO}"
-        VERBATIM)
-    endif()
-    add_custom_target(${NAME} DEPENDS ${OUTPUT_PB_SRC} ${OUTPUT_PB_HEADER})
+    add_custom_target(${NAME}
+        COMMAND "${ONNX_PROTOC_EXECUTABLE}" ${PROTOC_ARGS}
+        BYPRODUCTS "${OUTPUT_PB_SRC}" "${OUTPUT_PB_HEADER}"
+        DEPENDS ${GENERATED_FILE_WE}_proto_file ${DEPEND}
+        COMMENT "Running C++ protocol buffer compiler on ${GENERATED_PROTO}")
   endforeach()
 
-  set_source_files_properties(${${SRCS}} ${${HDRS}} PROPERTIES GENERATED TRUE)
   set(${SRCS} ${${SRCS}} PARENT_SCOPE)
-  set(${HDRS} ${${HDRS}} PARENT_SCOPE)
 endfunction()
 
 relative_protobuf_generate_cpp(gen_onnx_proto
                                __tmp_srcs
-                               __tmp_hdrs
-                               ${ONNX_ROOT}
                                ""
                                onnx/onnx.in.proto)
 list(APPEND ONNX_PROTO_SRCS ${__tmp_srcs})
-list(APPEND ONNX_PROTO_HDRS ${__tmp_hdrs})
 
 relative_protobuf_generate_cpp(gen_onnx_operators_proto
                                __tmp_srcs
-                               __tmp_hdrs
-                               ${ONNX_ROOT}
                                gen_onnx_proto
                                onnx/onnx-operators.in.proto)
 list(APPEND ONNX_PROTO_SRCS ${__tmp_srcs})
-list(APPEND ONNX_PROTO_HDRS ${__tmp_hdrs})
 
 relative_protobuf_generate_cpp(gen_onnx_data_proto
                                __tmp_srcs
-                               __tmp_hdrs
-                               ${ONNX_ROOT}
                                gen_onnx_proto
                                onnx/onnx-data.in.proto)
 list(APPEND ONNX_PROTO_SRCS ${__tmp_srcs})
-list(APPEND ONNX_PROTO_HDRS ${__tmp_hdrs})
+add_library(onnx_proto ${ONNX_PROTO_SRCS})
 
 file(GLOB_RECURSE __tmp_srcs "${ONNX_ROOT}/onnx/*.h" "${ONNX_ROOT}/onnx/*.cc")
 file(GLOB_RECURSE onnx_gtests_src "${ONNX_ROOT}/onnx/test/cpp/*.h"
@@ -465,7 +430,6 @@ list(REMOVE_ITEM __tmp_srcs "${ONNX_ROOT}/onnx/cpp2py_export.cc")
 list(REMOVE_ITEM __tmp_srcs ${onnx_gtests_src})
 list(APPEND ONNX_SRCS ${__tmp_srcs})
 
-add_library(onnx_proto ${ONNX_PROTO_SRCS} ${ONNX_PROTO_HDRS})
 add_dependencies(onnx_proto gen_onnx_operators_proto gen_onnx_data_proto)
 
 set(ONNX_API_DEFINE "-DONNX_API=")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,7 +304,7 @@ message(STATUS "ONNX_PROTOC_EXECUTABLE: ${ONNX_PROTOC_EXECUTABLE}")
 # b.com/tensorflow/tensorflow/blob/d2c3b873c6f8ff999a2e4ee707a84ff00d9c15a5/tens
 # orflow/contrib/cmake/tf_core_framework.cmake to solve the problem that
 # customized dir can't be specified when calling PROTOBUF_GENERATE_CPP.
-function(RELATIVE_PROTOBUF_GENERATE_CPP NAME SRCS DEPEND)
+function(RELATIVE_PROTOBUF_GENERATE_CPP SRCS)
   if(NOT ARGN)
     message(
       SEND_ERROR
@@ -317,6 +317,7 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP NAME SRCS DEPEND)
 
   set(GEN_PROTO_PY "${ONNX_ROOT}/onnx/gen_proto.py")
   foreach(INFILE ${ARGN})
+    message(WARNING "${INFILE}")
     set(ABS_FILE "${ONNX_ROOT}/${INFILE}")
     get_filename_component(FILE_DIR ${ABS_FILE} DIRECTORY)
     get_filename_component(FILE_WE ${INFILE} NAME_WE)
@@ -337,7 +338,6 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP NAME SRCS DEPEND)
     file(RELATIVE_PATH REL_DIR "${ONNX_ROOT}" "${FILE_DIR}")
     set(OUTPUT_PROTO_DIR "${CMAKE_CURRENT_BINARY_DIR}/${REL_DIR}")
 
-    set(OUTPUT_PB_HEADER "${OUTPUT_PROTO_DIR}/${GENERATED_FILE_WE}.pb.h")
     set(OUTPUT_PB_SRC "${OUTPUT_PROTO_DIR}/${GENERATED_FILE_WE}.pb.cc")
     set(GENERATED_PROTO "${OUTPUT_PROTO_DIR}/${GENERATED_FILE_WE}.proto")
     if(NOT (ONNX_NAMESPACE STREQUAL "onnx"))
@@ -386,33 +386,21 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP NAME SRCS DEPEND)
         list(APPEND PROTOC_ARGS ${CMAKE_CURRENT_BINARY_DIR})
       endif()
     endif()
-    add_custom_target(${NAME}
+    add_custom_target(${GENERATED_FILE_WE}_src
         COMMAND "${ONNX_PROTOC_EXECUTABLE}" ${PROTOC_ARGS}
         BYPRODUCTS "${OUTPUT_PB_SRC}"
-        DEPENDS ${GENERATED_FILE_WE}_proto_file ${DEPEND}
+        DEPENDS ${GENERATED_FILE_WE}_proto_file
         COMMENT "Running C++ protocol buffer compiler on ${GENERATED_PROTO}")
   endforeach()
 
   set(${SRCS} ${${SRCS}} PARENT_SCOPE)
 endfunction()
 
-relative_protobuf_generate_cpp(gen_onnx_proto
-                               __tmp_srcs
-                               ""
-                               onnx/onnx.in.proto)
-list(APPEND ONNX_PROTO_SRCS ${__tmp_srcs})
-
-relative_protobuf_generate_cpp(gen_onnx_operators_proto
-                               __tmp_srcs
-                               gen_onnx_proto
-                               onnx/onnx-operators.in.proto)
-list(APPEND ONNX_PROTO_SRCS ${__tmp_srcs})
-
-relative_protobuf_generate_cpp(gen_onnx_data_proto
-                               __tmp_srcs
-                               gen_onnx_proto
+relative_protobuf_generate_cpp(ONNX_PROTO_SRCS
+                               onnx/onnx.in.proto
+                               onnx/onnx-operators.in.proto
                                onnx/onnx-data.in.proto)
-list(APPEND ONNX_PROTO_SRCS ${__tmp_srcs})
+
 add_library(onnx_proto ${ONNX_PROTO_SRCS})
 
 file(GLOB_RECURSE __tmp_srcs "${ONNX_ROOT}/onnx/*.h" "${ONNX_ROOT}/onnx/*.cc")
@@ -423,8 +411,6 @@ file(GLOB_RECURSE onnx_gtests_src "${ONNX_ROOT}/onnx/test/cpp/*.h"
 list(REMOVE_ITEM __tmp_srcs "${ONNX_ROOT}/onnx/cpp2py_export.cc")
 list(REMOVE_ITEM __tmp_srcs ${onnx_gtests_src})
 list(APPEND ONNX_SRCS ${__tmp_srcs})
-
-add_dependencies(onnx_proto gen_onnx_operators_proto gen_onnx_data_proto)
 
 set(ONNX_API_DEFINE "-DONNX_API=")
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,9 +313,6 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP NAME SRCS DEPEND)
     return()
   endif()
 
-  # Add ONNX_API prefix to protobuf classes and methods in all cases
-  set(ONNX_DLLEXPORT_STR "dllexport_decl=ONNX_API:")
-
   set(${SRCS})
 
   set(GEN_PROTO_PY "${ONNX_ROOT}/onnx/gen_proto.py")
@@ -380,7 +377,7 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP NAME SRCS DEPEND)
         -I
         ${CMAKE_CURRENT_BINARY_DIR}
         --cpp_out
-        ${ONNX_DLLEXPORT_STR}${CMAKE_CURRENT_BINARY_DIR})
+        ${CMAKE_CURRENT_BINARY_DIR})
     if(ONNX_BUILD_PYTHON)
       list(APPEND PROTOC_ARGS --python_out)
       if(ONNX_GEN_PB_TYPE_STUBS)
@@ -389,12 +386,9 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP NAME SRCS DEPEND)
         list(APPEND PROTOC_ARGS ${CMAKE_CURRENT_BINARY_DIR})
       endif()
     endif()
-    if(NOT ONNX_PROTOC_EXECUTABLE)
-      message(FATAL_ERROR "Protobuf compiler not found")
-    endif()
     add_custom_target(${NAME}
         COMMAND "${ONNX_PROTOC_EXECUTABLE}" ${PROTOC_ARGS}
-        BYPRODUCTS "${OUTPUT_PB_SRC}" "${OUTPUT_PB_HEADER}"
+        BYPRODUCTS "${OUTPUT_PB_SRC}"
         DEPENDS ${GENERATED_FILE_WE}_proto_file ${DEPEND}
         COMMENT "Running C++ protocol buffer compiler on ${GENERATED_PROTO}")
   endforeach()


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Reduce the amount of CMake code. Generated headers are not required for added to ``onnx_proto`` because proper include directories have been set. `add_custom_target` is used for more explicit dependency specification. Other unnecessary code has been removed due to improvements in the overall code quality.
### Motivation and Context
Better tooling.
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
