### PR TITLE
Add backend node testing for Lpnormalization op

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -17142,6 +17142,144 @@ Other versions of this operator: <a href="Changelog.md#LpNormalization-1">1</a>
 <dd>Constrain input and output types to float tensors.</dd>
 </dl>
 
+#### Examples
+
+<details>
+<summary>lpnormalization_default</summary>
+
+```python
+"""
+input_shape: [3, 4, 5]
+output_shape: [3, 4, 5]
+"""
+node = onnx.helper.make_node(
+    'LpNormalization',
+    inputs=['x'],
+    outputs=['y']
+)
+x = np.random.rand(3, 4, 5).astype(np.float32)
+lp_norm_default = np.sqrt(np.sum(x**2, axis=-1, keepdims=True))
+y = x / lp_norm_default
+expect(node, inputs=[x], outputs=[y], name='test_lpnormalization_default')
+```
+
+</details>
+
+<details>
+<summary>l2normalization_axis_0</summary>
+
+```python
+"""
+input_shape: [3, 4, 5]
+output_shape: [3, 4, 5]
+"""
+node = onnx.helper.make_node(
+    'LpNormalization',
+    inputs=['x'],
+    outputs=['y'],
+    axis=0,
+    p=2
+)
+x = np.random.randn(3, 4, 5).astype(np.float32)
+l2_norm_axis_0 = np.sqrt(np.sum(x**2, axis=0, keepdims=True))
+y = x / l2_norm_axis_0
+expect(node, inputs=[x], outputs=[y], name='test_l2normalization_axis_0')
+```
+
+</details>
+
+<details>
+<summary>l2normalization_axis_1</summary>
+
+```python
+"""
+input_shape: [3, 4, 5]
+output_shape: [3, 4, 5]
+"""
+node = onnx.helper.make_node(
+    'LpNormalization',
+    inputs=['x'],
+    outputs=['y'],
+    axis=0,
+    p=2
+)
+x = np.random.randn(3, 4, 5).astype(np.float32)
+l2_norm_axis_0 = np.sqrt(np.sum(x**2, axis=1, keepdims=True))
+y = x / l2_norm_axis_0
+expect(node, inputs=[x], outputs=[y], name='test_l2normalization_axis_1')
+```
+
+</details>
+
+<details>
+<summary>l1normalization_axis_0</summary>
+
+```python
+"""
+input_shape: [3, 4, 5]
+output_shape: [3, 4, 5]
+"""
+node = onnx.helper.make_node(
+    'LpNormalization',
+    inputs=['x'],
+    outputs=['y'],
+    axis=0,
+    p=1
+)
+x = np.random.rand(3, 4, 5).astype(np.float32)
+l1_norm_axis_0 = np.sum(abs(x), axis=0, keepdims=True)
+y = x / l1_norm_axis_0
+expect(node, inputs=[x], outputs=[y], name='test_l1normalization_axis_0')
+```
+
+</details>
+
+<details>
+<summary>l1normalization_axis_1</summary>
+
+```python
+"""
+input_shape: [3, 4, 5]
+output_shape: [3, 4, 5]
+"""
+node = onnx.helper.make_node(
+    'LpNormalization',
+    inputs=['x'],
+    outputs=['y'],
+    axis=0,
+    p=1
+)
+x = np.random.rand(3, 4, 5).astype(np.float32)
+l1_norm_axis_0 = np.sum(abs(x), axis=1, keepdims=True)
+y = x / l1_norm_axis_0
+expect(node, inputs=[x], outputs=[y], name='test_l1normalization_axis_1')
+```
+
+</details>
+
+<details>
+<summary>l1normalization_axis_last</summary>
+
+```python
+"""
+input_shape: [3, 4, 5]
+output_shape: [3, 4, 5]
+"""
+node = onnx.helper.make_node(
+    'LpNormalization',
+    inputs=['x'],
+    outputs=['y'],
+    axis=-1,
+    p=1
+)
+x = np.random.rand(3, 4, 5).astype(np.float32)
+l1_norm_axis_last = np.sum(abs(x), axis=-1, keepdims=True)
+y = x / l1_norm_axis_last
+expect(node, inputs=[x], outputs=[y], name='test_l2normalization_axis_last')
+```
+
+</details>
+
 
 ### <a name="LpPool"></a><a name="lppool">**LpPool**</a>
 

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -12009,6 +12009,143 @@ expect(
 
 </details>
 
+### LpNormalization
+There are 6 test cases, listed as following:
+<details>
+<summary>lpnormalization_default</summary>
+
+```python
+"""
+input_shape: [3, 4, 5]
+output_shape: [3, 4, 5]
+"""
+node = onnx.helper.make_node(
+    'LpNormalization',
+    inputs=['x'],
+    outputs=['y']
+)
+x = np.random.rand(3, 4, 5).astype(np.float32)
+lp_norm_default = np.sqrt(np.sum(x**2, axis=-1, keepdims=True))
+y = x / lp_norm_default
+expect(node, inputs=[x], outputs=[y], name='test_lpnormalization_default')
+```
+
+</details>
+
+<details>
+<summary>l2normalization_axis_0</summary>
+
+```python
+"""
+input_shape: [3, 4, 5]
+output_shape: [3, 4, 5]
+"""
+node = onnx.helper.make_node(
+    'LpNormalization',
+    inputs=['x'],
+    outputs=['y'],
+    axis=0,
+    p=2
+)
+x = np.random.randn(3, 4, 5).astype(np.float32)
+l2_norm_axis_0 = np.sqrt(np.sum(x**2, axis=0, keepdims=True))
+y = x / l2_norm_axis_0
+expect(node, inputs=[x], outputs=[y], name='test_l2normalization_axis_0')
+```
+
+</details>
+
+<details>
+<summary>l2normalization_axis_1</summary>
+
+```python
+"""
+input_shape: [3, 4, 5]
+output_shape: [3, 4, 5]
+"""
+node = onnx.helper.make_node(
+    'LpNormalization',
+    inputs=['x'],
+    outputs=['y'],
+    axis=0,
+    p=2
+)
+x = np.random.randn(3, 4, 5).astype(np.float32)
+l2_norm_axis_0 = np.sqrt(np.sum(x**2, axis=1, keepdims=True))
+y = x / l2_norm_axis_0
+expect(node, inputs=[x], outputs=[y], name='test_l2normalization_axis_1')
+```
+
+</details>
+
+<details>
+<summary>l1normalization_axis_0</summary>
+
+```python
+"""
+input_shape: [3, 4, 5]
+output_shape: [3, 4, 5]
+"""
+node = onnx.helper.make_node(
+    'LpNormalization',
+    inputs=['x'],
+    outputs=['y'],
+    axis=0,
+    p=1
+)
+x = np.random.rand(3, 4, 5).astype(np.float32)
+l1_norm_axis_0 = np.sum(abs(x), axis=0, keepdims=True)
+y = x / l1_norm_axis_0
+expect(node, inputs=[x], outputs=[y], name='test_l1normalization_axis_0')
+```
+
+</details>
+
+<details>
+<summary>l1normalization_axis_1</summary>
+
+```python
+"""
+input_shape: [3, 4, 5]
+output_shape: [3, 4, 5]
+"""
+node = onnx.helper.make_node(
+    'LpNormalization',
+    inputs=['x'],
+    outputs=['y'],
+    axis=0,
+    p=1
+)
+x = np.random.rand(3, 4, 5).astype(np.float32)
+l1_norm_axis_0 = np.sum(abs(x), axis=1, keepdims=True)
+y = x / l1_norm_axis_0
+expect(node, inputs=[x], outputs=[y], name='test_l1normalization_axis_1')
+```
+
+</details>
+
+<details>
+<summary>l1normalization_axis_last</summary>
+
+```python
+"""
+input_shape: [3, 4, 5]
+output_shape: [3, 4, 5]
+"""
+node = onnx.helper.make_node(
+    'LpNormalization',
+    inputs=['x'],
+    outputs=['y'],
+    axis=-1,
+    p=1
+)
+x = np.random.rand(3, 4, 5).astype(np.float32)
+l1_norm_axis_last = np.sum(abs(x), axis=-1, keepdims=True)
+y = x / l1_norm_axis_last
+expect(node, inputs=[x], outputs=[y], name='test_l2normalization_axis_last')
+```
+
+</details>
 
 ### LpPool
 There are 8 test cases, listed as following:
@@ -27222,9 +27359,6 @@ expect(node, inputs=[x, y], outputs=[z], name="test_xor_bcast4v4d")
 
 
 ### LessOrEqual (call for test cases)
-
-
-### LpNormalization (call for test cases)
 
 
 ### MaxRoiPool (call for test cases)

--- a/onnx/backend/test/case/node/lpnormalization.py
+++ b/onnx/backend/test/case/node/lpnormalization.py
@@ -1,0 +1,100 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import numpy as np
+
+import onnx
+from onnx.backend.test.case.base import Base
+from onnx.backend.test.case.node import expect
+
+class LpNormalization(Base):
+
+    @staticmethod
+    def export_l2normalization_axis_0() -> None:
+        node = onnx.helper.make_node(
+            'LpNormalization',
+            inputs=['x'],
+            outputs=['y'],
+            axis=0,
+            p=2
+        )
+        x = np.random.randn(3, 4, 5).astype(np.float32)
+        l2_norm_axis_0 = np.sqrt(np.sum(x**2, axis=0, keepdims=True))
+        y = x / l2_norm_axis_0
+        expect(node, inputs=[x], outputs=[y],
+               name='test_l2normalization_axis_0')
+
+    @staticmethod
+    def export_l2normalization_axis_1() -> None:
+        node = onnx.helper.make_node(
+            'LpNormalization',
+            inputs=['x'],
+            outputs=['y'],
+            axis=1,
+            p=2
+        )
+        x = np.random.randn(3, 4, 5).astype(np.float32)
+        l2_norm_axis_1 = np.sqrt(np.sum(x**2, axis=1, keepdims=True))
+        y = x / l2_norm_axis_1
+        expect(node, inputs=[x], outputs=[y],
+               name='test_l2normalization_axis_1')
+
+    @staticmethod
+    def export_l1normalization_axis_0() -> None:
+        node = onnx.helper.make_node(
+            'LpNormalization',
+            inputs=['x'],
+            outputs=['y'],
+            axis=0,
+            p=1
+        )
+        x = np.random.rand(3, 4, 5).astype(np.float32)
+        l1_norm_axis_0 = np.sum(abs(x), axis=0, keepdims=True)
+        y = x / l1_norm_axis_0
+        expect(node, inputs=[x], outputs=[y],
+               name='test_l1normalization_axis_0')
+
+    @staticmethod
+    def export_l1normalization_axis_1() -> None:
+        node = onnx.helper.make_node(
+            'LpNormalization',
+            inputs=['x'],
+            outputs=['y'],
+            axis=1,
+            p=1
+        )
+        x = np.random.rand(3, 4, 5).astype(np.float32)
+        l1_norm_axis_1 = np.sum(abs(x), axis=1, keepdims=True)
+        y = x / l1_norm_axis_1
+        expect(node, inputs=[x], outputs=[y],
+               name='test_l1normalization_axis_1')
+
+    @staticmethod
+    def export_l1normalization_axis_last() -> None:
+        node = onnx.helper.make_node(
+            'LpNormalization',
+            inputs=['x'],
+            outputs=['y'],
+            axis=-1,
+            p=1
+        )
+        x = np.random.rand(3, 4, 5).astype(np.float32)
+        l1_norm_axis_last = np.sum(abs(x), axis=-1, keepdims=True)
+        y = x / l1_norm_axis_last
+        expect(node, inputs=[x], outputs=[y],
+               name='test_l2normalization_axis_last')
+
+    @staticmethod
+    def export_default() -> None:
+        node = onnx.helper.make_node(
+            'LpNormalization',
+            inputs=['x'],
+            outputs=['y']
+        )
+        x = np.random.rand(3, 4, 5).astype(np.float32)
+        lp_norm_default = np.sqrt(np.sum(x**2, axis=-1, keepdims=True))
+        y = x / lp_norm_default
+        expect(node, inputs=[x], outputs=[y],
+               name='test_lpnormalization_default')


### PR DESCRIPTION
This PR adds the backend node testing for LpNormalization op and updates the documentation as well, addressing Issue: https://github.com/onnx/onnx/issues/6996

This PR is ready for review. Please let me know if there are any additional improvements or adjustments needed.

Closes https://github.com/onnx/onnx/issues/6996.