### PR TITLE
Fix symbol refinition in unity builds

### DIFF
--- a/onnx/defs/controlflow/defs.cc
+++ b/onnx/defs/controlflow/defs.cc
@@ -68,7 +68,7 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint("B", {"tensor(bool)"}, "Only bool")
         .TypeAndShapeInferenceFunction(IfInferenceFunction));
 
-static const char* Loop_ver16_doc = R"DOC(
+static const char* Loop_ver23_doc = R"DOC(
 Generic Looping construct. This loop has multiple termination conditions:
 
 1) Trip count. Iteration count specified at runtime. Set by
@@ -210,7 +210,7 @@ ONNX_OPERATOR_SET_SCHEMA(
     Loop,
     23,
     OpSchema()
-        .SetDoc(Loop_ver16_doc)
+        .SetDoc(Loop_ver23_doc)
         .Input(
             0,
             "M",
@@ -259,7 +259,7 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint("B", {"tensor(bool)"}, "tensor of bool, which should be a scalar.")
         .TypeAndShapeInferenceFunction(LoopInferenceFunction));
 
-static const char* scan_16_doc = R"DOC(
+static const char* scan_23_doc = R"DOC(
 Scan can be used to iterate over one or more scan_input tensors,
 constructing zero or more scan_output tensors. It combines ideas from general recurrences,
 functional programming constructs such as scan, fold, map, and zip, and is intended to enable
@@ -387,7 +387,7 @@ ONNX_OPERATOR_SET_SCHEMA(
     Scan,
     23,
     OpSchema()
-        .SetDoc(scan_16_doc)
+        .SetDoc(scan_23_doc)
         .Input(
             0,
             "initial_state_and_scan_inputs",

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -9,7 +9,7 @@
 #include "onnx/defs/schema.h"
 
 namespace ONNX_NAMESPACE {
-static const char* Constant_ver19_doc = R"DOC(
+static const char* Constant_ver23_doc = R"DOC(
 This operator produces a constant tensor. Exactly one of the provided attributes, either value, sparse_value,
 or value_* must be specified.
 )DOC";
@@ -18,7 +18,7 @@ ONNX_OPERATOR_SET_SCHEMA(
     Constant,
     23,
     OpSchema()
-        .SetDoc(Constant_ver19_doc)
+        .SetDoc(Constant_ver23_doc)
         .Attr("value", "The value for the elements of the output tensor.", AttributeProto::TENSOR, false)
         .Attr(
             "sparse_value",
@@ -59,7 +59,7 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint("T", OpSchema::all_tensor_types_ir11(), "Constrain input and output types to all tensor types.")
         .TypeAndShapeInferenceFunction(ConstantOpInference));
 
-static const char* ConstantOfShape_ver20_doc = R"DOC(
+static const char* ConstantOfShape_ver23_doc = R"DOC(
 Generate a tensor with given value and shape.
 )DOC";
 
@@ -67,7 +67,7 @@ ONNX_OPERATOR_SET_SCHEMA(
     ConstantOfShape,
     23,
     OpSchema()
-        .SetDoc(ConstantOfShape_ver20_doc)
+        .SetDoc(ConstantOfShape_ver23_doc)
         .Attr(
             "value",
             "(Optional) The value of the output elements."

--- a/onnx/defs/nn/old.cc
+++ b/onnx/defs/nn/old.cc
@@ -1633,7 +1633,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
         }));
 
-static const char* Flatten_ver11_doc = R"DOC(
+static const char* Flatten_ver21_doc = R"DOC(
 Flattens the input tensor into a 2D matrix. If input tensor has shape
 (d_0, d_1, ... d_n) then the output will have shape
 (d_0 X d_1 ... d_(axis-1), d_axis X d_(axis+1) ... X dn).
@@ -1643,7 +1643,7 @@ ONNX_OPERATOR_SET_SCHEMA(
     Flatten,
     21,
     OpSchema()
-        .SetDoc(Flatten_ver11_doc)
+        .SetDoc(Flatten_ver21_doc)
         .Input(0, "input", "A tensor of rank >= axis.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Output(
             0,
@@ -1692,7 +1692,7 @@ ONNX_OPERATOR_SET_SCHEMA(
     Flatten,
     13,
     OpSchema()
-        .SetDoc(Flatten_ver11_doc)
+        .SetDoc(Flatten_ver21_doc)
         .Input(0, "input", "A tensor of rank >= axis.", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Output(
             0,
@@ -1738,7 +1738,7 @@ ONNX_OPERATOR_SET_SCHEMA(
     Flatten,
     11,
     OpSchema()
-        .SetDoc(Flatten_ver11_doc)
+        .SetDoc(Flatten_ver21_doc)
         .Input(0, "input", "A tensor of rank >= axis.", "T")
         .Output(
             0,

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -14,7 +14,7 @@
 
 namespace ONNX_NAMESPACE {
 
-static const char* Cast_ver19_doc = R"DOC(
+static const char* Cast_ver23_doc = R"DOC(
 The operator casts the elements of a given input tensor to a data type
 specified by the 'to' argument and returns an output tensor of the same size in
 the converted type. The 'to' argument must be one of the data types specified
@@ -85,7 +85,7 @@ ONNX_OPERATOR_SET_SCHEMA(
     Cast,
     23,
     OpSchema()
-        .SetDoc(Cast_ver19_doc)
+        .SetDoc(Cast_ver23_doc)
         .Attr(
             "to",
             "The data type to which the elements of the input tensor are cast. "
@@ -128,7 +128,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           PropagateShapeDataFromInputToOutput(ctx, 0);
         }));
 
-static const char* CastLike_ver21_doc = R"DOC(
+static const char* CastLike_ver23_doc = R"DOC(
 The operator casts the elements of a given input tensor (the first input) to
 the same data type as the elements of the second input tensor.
 See documentation of the Cast operator for further details.
@@ -138,7 +138,7 @@ ONNX_OPERATOR_SET_SCHEMA(
     CastLike,
     23,
     OpSchema()
-        .SetDoc(CastLike_ver21_doc)
+        .SetDoc(CastLike_ver23_doc)
         .Attr(
             "saturate",
             "The parameter defines how the conversion behaves if an input value is out of "
@@ -196,7 +196,7 @@ ONNX_OPERATOR_SET_SCHEMA(
               return true;
             }));
 
-static const char* Reshape_ver19_doc = R"DOC(
+static const char* Reshape_ver23_doc = R"DOC(
 Reshape the input tensor similar to numpy.reshape.
 First input is the data tensor, second input is a shape tensor which specifies the output shape. It outputs the reshaped tensor.
 At most one dimension of the new shape can be -1. In this case, the value is
@@ -216,7 +216,7 @@ ONNX_OPERATOR_SET_SCHEMA(
     Reshape,
     23,
     OpSchema()
-        .SetDoc(Reshape_ver19_doc)
+        .SetDoc(Reshape_ver23_doc)
         .Attr(
             "allowzero",
             "(Optional) By default, when any value in the 'shape' input is equal to zero "
@@ -360,7 +360,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
         }));
 
-static const char* Shape_ver19_doc = R"DOC(
+static const char* Shape_ver23_doc = R"DOC(
 Takes a tensor as input and outputs an 1D int64 tensor containing the shape of the input tensor.
 Optional attributes start and end can be used to compute a slice of the input tensor's shape.
 If start axis is omitted, the slice starts from axis 0.
@@ -405,7 +405,7 @@ ONNX_OPERATOR_SET_SCHEMA(
     Shape,
     23,
     OpSchema()
-        .SetDoc(Shape_ver19_doc)
+        .SetDoc(Shape_ver23_doc)
         .Input(0, "data", "An input tensor.", "T", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
         .Output(0, "shape", "Shape of the input tensor", "T1", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
         .Attr(
@@ -463,7 +463,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
         }));
 
-static const char* Size_ver19_doc = R"DOC(
+static const char* Size_ver23_doc = R"DOC(
 Takes a tensor as input and outputs a int64 scalar that equals to the total number of elements of the input tensor.
 )DOC";
 
@@ -471,7 +471,7 @@ ONNX_OPERATOR_SET_SCHEMA(
     Size,
     23,
     OpSchema()
-        .SetDoc(Size_ver19_doc)
+        .SetDoc(Size_ver23_doc)
         .Input(0, "data", "An input tensor.", "T", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
         .Output(
             0,
@@ -1058,7 +1058,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
         }));
 
-static const char* Transpose_ver13_doc = R"DOC(
+static const char* Transpose_ver23_doc = R"DOC(
 Transpose the input tensor similar to numpy.transpose. For example, when
 perm=(1, 0, 2), given an input tensor of shape (1, 2, 3), the output shape
 will be (2, 1, 3).
@@ -1068,7 +1068,7 @@ ONNX_OPERATOR_SET_SCHEMA(
     Transpose,
     23,
     OpSchema()
-        .SetDoc(Transpose_ver13_doc)
+        .SetDoc(Transpose_ver23_doc)
         .Attr(
             "perm",
             "A list of integers. By default, reverse the dimensions, "
@@ -1700,7 +1700,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
         }));
 
-static const char* Squeeze_ver13_doc = R"DOC(
+static const char* Squeeze_ver23_doc = R"DOC(
 Remove single-dimensional entries from the shape of a tensor.
 Takes an input `axes` with a list of axes to squeeze.
 If `axes` is not provided, all the single dimensions will be removed from
@@ -1711,7 +1711,7 @@ ONNX_OPERATOR_SET_SCHEMA(
     Squeeze,
     23,
     OpSchema()
-        .SetDoc(Squeeze_ver13_doc)
+        .SetDoc(Squeeze_ver23_doc)
         .Input(
             0,
             "data",
@@ -1803,7 +1803,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           PropagateShapeDataFromInputToOutput(ctx, 0);
         }));
 
-static const char* Unsqueeze_ver13_doc = R"DOC(
+static const char* Unsqueeze_ver23_doc = R"DOC(
 Insert single-dimensional entries to the shape of an input tensor (`data`).
 Takes one required input `axes` - which contains a list of dimension indices and this operator will insert a dimension of value `1` into the corresponding index of the output tensor (`expanded`).
 
@@ -1820,7 +1820,7 @@ ONNX_OPERATOR_SET_SCHEMA(
     Unsqueeze,
     23,
     OpSchema()
-        .SetDoc(Unsqueeze_ver13_doc)
+        .SetDoc(Unsqueeze_ver23_doc)
         .Input(0, "data", "Original tensor", "T", OpSchema::Single, true, 1, OpSchema::Differentiable)
         .Input(
             1,
@@ -3570,7 +3570,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           }
         }));
 
-static const char* Pad_ver19_doc = R"DOC(
+static const char* Pad_ver23_doc = R"DOC(
 Given a tensor containing the data to be padded (`data`), a tensor containing the number of start and end pad values for axis (`pads`), (optionally) a `mode`, and (optionally) `constant_value`,
 a padded tensor (`output`) is generated.
 
@@ -3677,7 +3677,7 @@ ONNX_OPERATOR_SET_SCHEMA(
     Pad,
     23,
     OpSchema().FillUsing(PadDocGenerator(
-        Pad_ver19_doc,
+        Pad_ver23_doc,
         "Supported modes: `constant`(default), `reflect`, `edge`, `wrap`",
         OpSchema::all_tensor_types_ir11(),
         "Constrain input and output types to all tensor types up to IRv11.")));


### PR DESCRIPTION
### Description
Some static variables have the same name, fix them to enable unity builds by renaming.
<!-- - Describe your changes. -->

### Motivation and Context
Better code.
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
