### PR TITLE
Add ml_dtypes as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy>=1.22
 protobuf>=4.25.1
 typing_extensions>=4.7.1
+ml_dtypes


### PR DESCRIPTION
According to https://github.com/onnx/onnx/issues/6605, we are adding ml_dtypes as a python dependency for this package.

Closes https://github.com/onnx/onnx/issues/6605