### PR TITLE
Switch order of steps in  release_win_x86_64.yml

### DIFF
--- a/.github/workflows/release_win_x86_64.yml
+++ b/.github/workflows/release_win_x86_64.yml
@@ -22,6 +22,7 @@ jobs:
     if: github.event_name != 'pull_request' || startsWith( github.base_ref, 'rel-') || contains( github.event.pull_request.labels.*.name, 'run release CIs')
     runs-on: windows-2022
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.13t']
         architecture: ['x64', 'x86']

--- a/.github/workflows/release_win_x86_64.yml
+++ b/.github/workflows/release_win_x86_64.yml
@@ -79,17 +79,17 @@ jobs:
         python -m build --wheel
         Get-ChildItem -Path dist/*.whl | foreach {python -m pip install --upgrade $_.fullname}
 
-    - name: Test the installed wheel
-      if: steps.build_wheel.outcome == 'success'
-      run: |
-        python -m pip install -q -r requirements-release_test.txt
-        pytest
-
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       if: steps.build_wheel.outcome == 'success'
       with:
         name: wheels-${{ inputs.os }}-${{ matrix.python-version }}-${{matrix.architecture}}
         path: ./dist
+    
+    - name: Test the installed wheel
+      if: steps.build_wheel.outcome == 'success'
+      run: |
+        python -m pip install -q -r requirements-release_test.txt
+        pytest
 
     - name: Verify ONNX with the latest numpy
       if: steps.build_wheel.outcome == 'success'


### PR DESCRIPTION
### Description
Switch pytest with upload artifact to the run


### Motivation and Context
This allows downloading the wheels and offline testing, also when pytest fails