### PR TITLE
Update the saturating behavior for E4M3FNUZ/E5M2FNUZ in Cast and CastLike

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -29819,8 +29819,8 @@ This version of the operator has been available since version 23 of the default 
   | 0                 | 0        | 0        | 0        | 0        |
   | -0                | -0       | 0        | -0       | 0        |
   | NaN               | NaN      | NaN      | NaN      | NaN      |
-  | Inf               | FLT_MAX  | NaN      | FLT_MAX  | NaN      |
-  | -Inf              | -FLT_MAX | NaN      | -FLT_MAX | NaN      |
+  | Inf               | FLT_MAX  | FLT_MAX  | FLT_MAX  | FLT_MAX  |
+  | -Inf              | -FLT_MAX | -FLT_MAX | -FLT_MAX | -FLT_MAX |
   | \[x\] > FLT_MAX   | FLT_MAX  | FLT_MAX  | FLT_MAX  | FLT_MAX  |
   | \[x\] \< -FLT_MAX | -FLT_MAX | -FLT_MAX | -FLT_MAX | -FLT_MAX |
   | else              | RNE      | RNE      | RNE      | RNE      |

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -5588,8 +5588,8 @@ expect(
   | 0                 | 0        | 0        | 0        | 0        |
   | -0                | -0       | 0        | -0       | 0        |
   | NaN               | NaN      | NaN      | NaN      | NaN      |
-  | Inf               | FLT_MAX  | NaN      | FLT_MAX  | NaN      |
-  | -Inf              | -FLT_MAX | NaN      | -FLT_MAX | NaN      |
+  | Inf               | FLT_MAX  | FLT_MAX  | FLT_MAX  | FLT_MAX  |
+  | -Inf              | -FLT_MAX | -FLT_MAX | -FLT_MAX | -FLT_MAX |
   | \[x\] > FLT_MAX   | FLT_MAX  | FLT_MAX  | FLT_MAX  | FLT_MAX  |
   | \[x\] \< -FLT_MAX | -FLT_MAX | -FLT_MAX | -FLT_MAX | -FLT_MAX |
   | else              | RNE      | RNE      | RNE      | RNE      |

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -62,10 +62,10 @@ the target mantissa width.
 | 0                 | 0        | 0        | 0        | 0        |
 | -0                | -0       | 0        | -0       | 0        |
 | NaN               | NaN      | NaN      | NaN      | NaN      |
-| Inf               | FLT_MAX  | NaN      | FLT_MAX  | NaN      |
-| -Inf              | -FLT_MAX | NaN      | -FLT_MAX | NaN      |
+| Inf               | FLT_MAX  | FLT_MAX  | FLT_MAX  | FLT_MAX  |
+| -Inf              | FLT_MIN  | FLT_MIN  | FLT_MIN  | FLT_MIN  |
 | \[x\] > FLT_MAX   | FLT_MAX  | FLT_MAX  | FLT_MAX  | FLT_MAX  |
-| \[x\] \< -FLT_MAX | -FLT_MAX | -FLT_MAX | -FLT_MAX | -FLT_MAX |
+| \[x\] \< FLT_MIN  | FLT_MIN  | FLT_MIN  | FLT_MIN  | FLT_MIN  |
 | else              | RNE      | RNE      | RNE      | RNE      |
 
 The behavior changes if the parameter 'saturate' is set to False.

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -63,9 +63,9 @@ the target mantissa width.
 | -0                | -0       | 0        | -0       | 0        |
 | NaN               | NaN      | NaN      | NaN      | NaN      |
 | Inf               | FLT_MAX  | FLT_MAX  | FLT_MAX  | FLT_MAX  |
-| -Inf              | FLT_MIN  | FLT_MIN  | FLT_MIN  | FLT_MIN  |
+| -Inf              | -FLT_MAX | -FLT_MAX | -FLT_MAX | -FLT_MAX |
 | \[x\] > FLT_MAX   | FLT_MAX  | FLT_MAX  | FLT_MAX  | FLT_MAX  |
-| \[x\] \< FLT_MIN  | FLT_MIN  | FLT_MIN  | FLT_MIN  | FLT_MIN  |
+| \[x\] \< -FLT_MAX | -FLT_MAX | -FLT_MAX | -FLT_MAX | -FLT_MAX |
 | else              | RNE      | RNE      | RNE      | RNE      |
 
 The behavior changes if the parameter 'saturate' is set to False.


### PR DESCRIPTION
Fix https://github.com/onnx/onnx/issues/6220 by updating Cast-24 and CastLike-24. Saturating casts should yield Max/-Max values. This is consistent with the Graphcore paper.