### PR TITLE
Implement saturate_cast

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -6007,7 +6007,7 @@ for from_type, to_type in test_cases:
         input_shape = (3, 4)
 
     if from_type in F8_TYPES:
-        np_from = onnx.numpy_helper.saturating_cast(np_fp32, from_np_dtype)
+        np_from = onnx.numpy_helper.saturate_cast(np_fp32, from_np_dtype)
         input = make_tensor(
             "input",
             from_dtype,
@@ -6032,7 +6032,7 @@ for from_type, to_type in test_cases:
             "output",
             to_dtype,
             input_shape,
-            vals=onnx.numpy_helper.saturating_cast(np_from, to_np_dtype),
+            vals=onnx.numpy_helper.saturate_cast(np_from, to_np_dtype),
             raw=True,
         )
     elif to_type in FOUR_BIT_TYPES:
@@ -6422,7 +6422,7 @@ for from_type, to_type in test_cases:
         input_shape = (3, 4)
 
     if from_type in F8_TYPES:
-        np_from = onnx.numpy_helper.saturating_cast(np_fp32, from_np_dtype)
+        np_from = onnx.numpy_helper.saturate_cast(np_fp32, from_np_dtype)
         input = make_tensor(
             "input",
             from_dtype,
@@ -6447,7 +6447,7 @@ for from_type, to_type in test_cases:
             "output",
             to_dtype,
             input_shape,
-            vals=onnx.numpy_helper.saturating_cast(np_from, to_np_dtype),
+            vals=onnx.numpy_helper.saturate_cast(np_from, to_np_dtype),
             raw=True,
         )
     elif to_type in FOUR_BIT_TYPES:
@@ -40111,5 +40111,3 @@ expect(
 ```
 
 </details>
-
-

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -40111,3 +40111,5 @@ expect(
 ```
 
 </details>
+
+

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -4624,7 +4624,7 @@ for from_type, to_type in test_cases:
         input_shape = (3, 4)
 
     if from_type in F8_TYPES:
-        np_from = onnx.numpy_helper.saturating_cast(np_fp32, from_np_dtype)
+        np_from = onnx.numpy_helper.saturate_cast(np_fp32, from_np_dtype)
         input = make_tensor(
             "input",
             from_dtype,
@@ -4649,7 +4649,7 @@ for from_type, to_type in test_cases:
             "output",
             to_dtype,
             input_shape,
-            vals=onnx.numpy_helper.saturating_cast(np_from, to_np_dtype),
+            vals=onnx.numpy_helper.saturate_cast(np_from, to_np_dtype),
             raw=True,
         )
     elif to_type in FOUR_BIT_TYPES:
@@ -4988,7 +4988,7 @@ for from_type, to_type in test_cases:
         input_shape = (3, 4)
 
     if from_type in F8_TYPES:
-        np_from = onnx.numpy_helper.saturating_cast(np_fp32, from_np_dtype)
+        np_from = onnx.numpy_helper.saturate_cast(np_fp32, from_np_dtype)
         input = make_tensor(
             "input",
             from_dtype,
@@ -5013,7 +5013,7 @@ for from_type, to_type in test_cases:
             "output",
             to_dtype,
             input_shape,
-            vals=onnx.numpy_helper.saturating_cast(np_from, to_np_dtype),
+            vals=onnx.numpy_helper.saturate_cast(np_from, to_np_dtype),
             raw=True,
         )
     elif to_type in FOUR_BIT_TYPES:

--- a/onnx/backend/test/case/node/cast.py
+++ b/onnx/backend/test/case/node/cast.py
@@ -163,7 +163,7 @@ class Cast(Base):
                 input_shape = (3, 4)
 
             if from_type in F8_TYPES:
-                np_from = onnx.numpy_helper.saturating_cast(np_fp32, from_np_dtype)
+                np_from = onnx.numpy_helper.saturate_cast(np_fp32, from_np_dtype)
                 input = make_tensor(
                     "input",
                     from_dtype,
@@ -188,7 +188,7 @@ class Cast(Base):
                     "output",
                     to_dtype,
                     input_shape,
-                    vals=onnx.numpy_helper.saturating_cast(np_from, to_np_dtype),
+                    vals=onnx.numpy_helper.saturate_cast(np_from, to_np_dtype),
                     raw=True,
                 )
             elif to_type in FOUR_BIT_TYPES:

--- a/onnx/backend/test/case/node/castlike.py
+++ b/onnx/backend/test/case/node/castlike.py
@@ -161,7 +161,7 @@ class CastLike(Base):
                 input_shape = (3, 4)
 
             if from_type in F8_TYPES:
-                np_from = onnx.numpy_helper.saturating_cast(np_fp32, from_np_dtype)
+                np_from = onnx.numpy_helper.saturate_cast(np_fp32, from_np_dtype)
                 input = make_tensor(
                     "input",
                     from_dtype,
@@ -186,7 +186,7 @@ class CastLike(Base):
                     "output",
                     to_dtype,
                     input_shape,
-                    vals=onnx.numpy_helper.saturating_cast(np_from, to_np_dtype),
+                    vals=onnx.numpy_helper.saturate_cast(np_from, to_np_dtype),
                     raw=True,
                 )
             elif to_type in FOUR_BIT_TYPES:

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -781,7 +781,7 @@ def make_tensor(
         TensorProto.FLOAT8E5M2FNUZ,
     }:
         # Float8 values are by default casted using saturating cast.
-        vals = onnx.numpy_helper.saturating_cast(np.asarray(vals), np_dtype).flatten()
+        vals = onnx.numpy_helper.saturate_cast(np.asarray(vals), np_dtype).flatten()
     elif data_type == TensorProto.FLOAT8E8M0:
         vals = onnx.numpy_helper.to_float8e8m0(
             np.asarray(vals), saturate=True, round_mode="up"

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -796,12 +796,17 @@ def create_random_int(
         raise TypeError(f"{dtype} is not supported by create_random_int.")
 
 
-def saturating_cast(x: np.ndarray, dtype: np.dtype) -> np.ndarray:
-    """Saturating cast for float8 and float4 types.
+def saturate_cast(x: np.ndarray, dtype: np.dtype) -> np.ndarray:
+    """Saturate cast for numeric types.
 
     This function ensures that values outside the representable range
     of the target dtype are clamped to the maximum or minimum representable
     value of that dtype.
     """
-    finfo = ml_dtypes.finfo(dtype)
-    return np.clip(x, finfo.min, finfo.max).astype(dtype)
+    if np.issubdtype(dtype, np.integer) or dtype in (ml_dtypes.int4, ml_dtypes.uint4):
+        info = ml_dtypes.iinfo(dtype)
+        x = np.round(x)
+    else:
+        info = ml_dtypes.finfo(dtype)
+
+    return np.clip(x, info.min, info.max).astype(dtype)

--- a/onnx/reference/ops/op_cast.py
+++ b/onnx/reference/ops/op_cast.py
@@ -26,7 +26,7 @@ def cast_to(
         }
         and saturate
     ):
-        return onnx.numpy_helper.saturating_cast(x, dtype)
+        return onnx.numpy_helper.saturate_cast(x, dtype)
 
     if to == onnx.TensorProto.FLOAT8E8M0:
         return onnx.numpy_helper.to_float8e8m0(x, saturate, round_mode).astype(dtype)

--- a/onnx/reference/ops/op_quantize_linear.py
+++ b/onnx/reference/ops/op_quantize_linear.py
@@ -146,7 +146,7 @@ class _CommonQuantizeLinear(OpRun):
         }:
             if saturate:
                 return (
-                    onnx.numpy_helper.saturating_cast(
+                    onnx.numpy_helper.saturate_cast(
                         x, dtype=tensor_dtype_to_np_dtype(tensor_type)
                     ),
                 )

--- a/onnx/test/reference_evaluator_test.py
+++ b/onnx/test/reference_evaluator_test.py
@@ -3358,9 +3358,9 @@ class TestReferenceEvaluator(unittest.TestCase):
         expected1 = onnx.numpy_helper.saturate_cast(
             data, ml_dtypes.float8_e4m3fn
         ).astype(np.float32)
-        expected2 = onnx.numpy_helper.saturate_cast(
-            data, ml_dtypes.float8_e5m2
-        ).astype(np.float32)
+        expected2 = onnx.numpy_helper.saturate_cast(data, ml_dtypes.float8_e5m2).astype(
+            np.float32
+        )
         got = ref.run(None, {"X": data})
         assert_allclose(got[0], expected1)
         assert_allclose(got[1], expected2)

--- a/onnx/test/reference_evaluator_test.py
+++ b/onnx/test/reference_evaluator_test.py
@@ -3355,10 +3355,10 @@ class TestReferenceEvaluator(unittest.TestCase):
         )
         ref = ReferenceEvaluator(model)
         data = np.array([0, 1, 2, 5e-2, 200], dtype=np.float32)
-        expected1 = onnx.numpy_helper.saturating_cast(
+        expected1 = onnx.numpy_helper.saturate_cast(
             data, ml_dtypes.float8_e4m3fn
         ).astype(np.float32)
-        expected2 = onnx.numpy_helper.saturating_cast(
+        expected2 = onnx.numpy_helper.saturate_cast(
             data, ml_dtypes.float8_e5m2
         ).astype(np.float32)
         got = ref.run(None, {"X": data})
@@ -3418,8 +3418,8 @@ class TestReferenceEvaluator(unittest.TestCase):
         )
         ref = ReferenceEvaluator(model)
         data = np.array([0, 1, 2, 5e-2, 200], dtype=np.float32)
-        expected1 = onnx.numpy_helper.saturating_cast(data, ml_dtypes.float8_e4m3fn)
-        expected2 = onnx.numpy_helper.saturating_cast(data, ml_dtypes.float8_e5m2)
+        expected1 = onnx.numpy_helper.saturate_cast(data, ml_dtypes.float8_e4m3fn)
+        expected2 = onnx.numpy_helper.saturate_cast(data, ml_dtypes.float8_e5m2)
         got = ref.run(None, {"X": data})
         self.assertEqual(got[0].tolist(), expected1.tolist())
         self.assertEqual(got[1].tolist(), expected2.tolist())


### PR DESCRIPTION
- Rename saturating_cast to saturate_cast to match conventions in other frameworks.
- Make the function work on all onnx supported dtypes.