### PR TITLE
Add `.txtpb` as a support text proto format in serialization

### DIFF
--- a/onnx/serialization.py
+++ b/onnx/serialization.py
@@ -130,7 +130,7 @@ class _TextProtoSerializer(ProtoSerializer):
     """Serialize and deserialize text proto."""
 
     supported_format = "textproto"
-    file_extensions = frozenset({".textproto", ".prototxt", ".pbtxt"})
+    file_extensions = frozenset({".txtpb", ".textproto", ".prototxt", ".pbtxt"})
 
     def serialize_proto(self, proto: _Proto) -> bytes:
         textproto = google.protobuf.text_format.MessageToString(proto)


### PR DESCRIPTION
It is the official file extension: https://protobuf.dev/reference/protobuf/textformat-spec/#:~:text=%7D-,Text%20Format%20Files,-A%20text%20format, although https://github.com/protocolbuffers/txtpbfmt#which-file-extension-should-i-use-for-my-text-proto-files states `.textproto` is the most widely used.