### PR TITLE
Fix hardmax reference implementation

### DIFF
--- a/onnx/reference/ops/op_hardmax.py
+++ b/onnx/reference/ops/op_hardmax.py
@@ -11,6 +11,8 @@ from onnx.reference.ops._op import OpRunUnaryNum
 class Hardmax(OpRunUnaryNum):
     def _run(self, x, axis=None):
         axis = axis or self.axis
+        if x.size == 0:
+            return (x,)
         x_argmax = np.argmax(x, axis=axis)
         y = np.zeros_like(x)
         np.put_along_axis(


### PR DESCRIPTION
### Description
Hardmax threw an error when input had size 0, now it just returns the input if it has size 0.
