### PR TITLE
Fix return type of HardSigmoid in reference implementation

### DIFF
--- a/onnx/reference/ops/op_hard_sigmoid.py
+++ b/onnx/reference/ops/op_hard_sigmoid.py
@@ -12,5 +12,5 @@ class HardSigmoid(OpRunUnaryNum):
     def _run(self, x, alpha=None, beta=None):
         alpha = alpha or self.alpha
         beta = beta or self.beta
-        y = np.maximum(0, np.minimum(1, x * alpha + beta))
+        y = np.maximum(0, np.minimum(1, x * alpha + beta)).astype(x.dtype)
         return (y,)


### PR DESCRIPTION
### Description
added cast of result to ``x.dtype`` which is necessary since the result needs to be of the same type as ``x`` regardless of the types of``alpha`` and ``beta``.

### Motivation and Context
The problem arouse when testing onnx-reference via the https://github.com/cbourjau/onnx-tests tool.
