### PR TITLE
Fix Softmax reference for inputs of length 1

### DIFF
--- a/onnx/reference/ops/op_softplus.py
+++ b/onnx/reference/ops/op_softplus.py
@@ -10,7 +10,7 @@ from onnx.reference.ops._op import OpRunUnaryNum
 
 class Softplus(OpRunUnaryNum):
     def _run(self, X):
-        tmp = np.exp(X).astype(X.dtype)
+        tmp = np.asarray(np.exp(X), dtype=X.dtype)
         tmp += 1
         np.log(tmp, out=tmp)
         return (tmp,)


### PR DESCRIPTION
### Description
``np.asarray`` ensures that an array is returned. This is necessary since ``np.exp`` returns a scalar when the input has length 1.

### Motivation and Context
The problem arouse when testing onnx-reference via the https://github.com/cbourjau/onnx-tests tool.
