### PR TITLE
fixed erf for empty inputs

### DIFF
--- a/onnx/reference/ops/op_erf.py
+++ b/onnx/reference/ops/op_erf.py
@@ -13,7 +13,7 @@ from onnx.reference.ops._op import OpRunUnaryNum
 class Erf(OpRunUnaryNum):
     def __init__(self, onnx_node, run_params):
         OpRunUnaryNum.__init__(self, onnx_node, run_params)
-        self._erf = np.vectorize(erf)
+        self._erf = np.vectorize(erf, otypes=["f"])
 
     def _run(self, x):
         return (self._erf(x).astype(x.dtype),)


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->

``np.vectorize`` needs to be told the outputs type via the ``otypes`` argument. Otherwise, applying the vectorized function to an empty array will result in an error.

### Motivation and Context
The problem arouse when testing onnx-reference via the https://github.com/cbourjau/onnx-tests tool.
