### PR TITLE
WIP: Allow .whl Publishing Even If Certain Build Jobs Fail

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
 
     needs: [call-linux, call-mac, call-win_x86, call-sdist]
-    if: (!contains(join(needs.*.result, ' '), 'skipped')) && (!contains(join(needs.*.result, ' '), 'failure')) && (github.event.inputs.publish_pypi_release == 'yes') && startsWith(github.ref, 'refs/heads/rel-') && (github.repository_owner == 'onnx') && startsWith(github.ref, 'refs/heads/rel-')
+    if: (!contains(join(needs.*.result, ' '), 'skipped')) && (!contains(join(needs.*.result, ' '), 'failure')) && (github.event.inputs.publish_pypi_release == 'yes') && (github.repository_owner == 'onnx') && startsWith(github.ref, 'refs/heads/rel-')
 
     steps:
 

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
 
     needs: [call-linux, call-mac, call-win_x86, call-sdist]
-    if: (!contains(join(needs.*.result, ' '), 'skipped')) && (github.repository_owner == 'onnx') && startsWith(github.ref, 'refs/heads/rel-')
+    if: (!contains(join(needs.*.result, ' '), 'skipped')) && (!contains(join(needs.*.result, ' '), 'failure')) && (github.event.inputs.publish_pypi_release == 'yes') && startsWith(github.ref, 'refs/heads/rel-') && (github.repository_owner == 'onnx') && startsWith(github.ref, 'refs/heads/rel-')
 
     steps:
 
@@ -139,7 +139,7 @@ jobs:
     runs-on: ubuntu-latest
 
     needs: [call-linux, call-mac, call-win_x86, call-win_arm64, call-sdist]
-    if: (!contains(join(needs.*.result, ' '), 'skipped')) && (github.event.inputs.publish_testpypi_weekly == 'yes') && (github.ref == 'refs/heads/main') && (github.repository_owner == 'onnx') && (github.event_name == 'workflow_dispatch')
+    if: (!contains(join(needs.*.result, ' '), 'skipped')) && (!contains(join(needs.*.result, ' '), 'failure')) && (github.event.inputs.publish_testpypi_weekly == 'yes') && (github.ref == 'refs/heads/main') && (github.repository_owner == 'onnx') && (github.event_name == 'workflow_dispatch')
 
     steps:
       - name: print debug vars
@@ -192,7 +192,7 @@ jobs:
     runs-on: ubuntu-latest
 
     needs: [call-linux, call-mac, call-win_x86, call-win_arm64, call-sdist]
-    if: (!contains(join(needs.*.result, ' '), 'skipped')) && (github.event.inputs.publish_testpypi_release == 'yes') && startsWith(github.ref, 'refs/heads/rel') && (github.repository_owner == 'onnx') && (github.event_name == 'workflow_dispatch')
+    if: (!contains(join(needs.*.result, ' '), 'skipped')) && (!contains(join(needs.*.result, ' '), 'failure')) && (github.event.inputs.publish_testpypi_release == 'yes') && startsWith(github.ref, 'refs/heads/rel') && (github.repository_owner == 'onnx') && (github.event_name == 'workflow_dispatch')
 
     steps:
       - name: print debug vars
@@ -244,7 +244,7 @@ jobs:
     runs-on: ubuntu-latest
 
     needs: [call-linux, call-mac, call-win_x86, call-win_arm64, call-sdist]
-    if: (!contains(join(needs.*.result, ' '), 'skipped')) && (github.event_name == 'schedule' || github.event.inputs.publish_pypi_weekly == 'yes') && (github.repository_owner == 'onnx')
+    if: (!contains(join(needs.*.result, ' '), 'skipped')) && (!contains(join(needs.*.result, ' '), 'failure')) && (github.event_name == 'schedule' || github.event.inputs.publish_pypi_weekly == 'yes') && (github.repository_owner == 'onnx')
 
     steps:
       - name: placeholder for debug vars


### PR DESCRIPTION
### Description
"also allow failure" for builds

### Motivation and Context
With the addition of python 3.14-dev for Windows, the Windows job always failed, which meant that check_for_publish did not become true. It was added that it could be faulty, so perhaps skipped should be added as well.

Before pushing towards release, we still have to perform a manual check anyway.
