### PR TITLE
Make stale bot ignore "contributions welcome" issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -32,7 +32,7 @@ jobs:
         days-before-close: 21
         ascending: true
         exempt-issue-labels: bug,no-stale
-        exempt-pr-labels: no-stale
+        exempt-pr-labels: no-stale,contributions welcome
         remove-issue-stale-when-updated: true
         remove-pr-stale-when-updated: true
         exempt-all-milestones: true


### PR DESCRIPTION
"contributions welcome" issues should be kept open because they are expecting contributions.