### PR TITLE
Improve conditions in create_release.yml 

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -57,8 +57,6 @@ on:
           - 'preview'
         default: 'preview'
 
-
-
 permissions:
 
   contents: read
@@ -111,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
 
     needs: [call-linux, call-mac, call-win_x86, call-win_arm64, call-sdist]
-    if: (!contains(join(needs.*.result, ' '), 'skipped')) && (github.repository_owner == 'onnx') && startsWith(github.ref, 'refs/heads/rel-')
+    if: (!contains(join(needs.*.result, ' '), 'skipped')) && (github.repository_owner == 'onnx') && startsWith(github.ref, 'refs/heads/rel-') && (github.event_name == 'workflow_dispatch')
 
     steps:
 


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->

### Motivation and Context
A check or publishing to the official onnx-weekly should only be triggered by a manual "workflow dispatch" action.

Closes: https://github.com/onnx/onnx/issues/7185

@yuanyao-nv @justinchuby could be cherry picked for 1.19 (Functionally probably not necessary)
