### PR TITLE
Create CPPLINT.cfg

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,1 @@
+filter=-whitespace


### PR DESCRIPTION
Create CPPLINT.cfg to ignore the whitespace lints. The googlestyle prefers 2 spaces before comments but clangformat prefers 1 space.
