### PR TITLE
Fix division for integer dtype in reference implementation

### DIFF
--- a/onnx/reference/ops/op_div.py
+++ b/onnx/reference/ops/op_div.py
@@ -10,7 +10,14 @@ from onnx.reference.ops._op import OpRunBinaryNumpy
 
 class Div(OpRunBinaryNumpy):
     def __init__(self, onnx_node, run_params):
-        OpRunBinaryNumpy.__init__(self, np.divide, onnx_node, run_params)
+        def func(x, y):
+            if np.issubdtype(x.dtype, np.integer) and np.issubdtype(
+                y.dtype, np.integer
+            ):
+                return x // y
+            return np.divide / x, y
+
+        OpRunBinaryNumpy.__init__(self, func, onnx_node, run_params)
 
     def _run(self, a, b):
         res = OpRunBinaryNumpy._run(self, a, b)

--- a/onnx/reference/ops/op_div.py
+++ b/onnx/reference/ops/op_div.py
@@ -11,9 +11,8 @@ from onnx.reference.ops._op import OpRunBinaryNumpy
 class Div(OpRunBinaryNumpy):
     def __init__(self, onnx_node, run_params):
         def func(x, y):
-            if np.issubdtype(x.dtype, np.integer) and np.issubdtype(
-                y.dtype, np.integer
-            ):
+            if np.issubdtype(x.dtype, np.integer):
+                assert np.issubtype(y.dtype, np.integer)
                 return x // y
             return np.divide(x, y)
 

--- a/onnx/reference/ops/op_div.py
+++ b/onnx/reference/ops/op_div.py
@@ -11,8 +11,8 @@ from onnx.reference.ops._op import OpRunBinaryNumpy
 class Div(OpRunBinaryNumpy):
     def __init__(self, onnx_node, run_params):
         def func(x, y):
-            if np.issubdtype(x.dtype, np.integer):
-                assert np.issubtype(y.dtype, np.integer)
+            if issubclass(x.dtype.type, np.integer):
+                assert issubclass(y.dtype.type, np.integer)
                 return x // y
             return np.divide(x, y)
 

--- a/onnx/reference/ops/op_div.py
+++ b/onnx/reference/ops/op_div.py
@@ -15,7 +15,7 @@ class Div(OpRunBinaryNumpy):
                 y.dtype, np.integer
             ):
                 return x // y
-            return np.divide / x, y
+            return np.divide(x, y)
 
         OpRunBinaryNumpy.__init__(self, func, onnx_node, run_params)
 


### PR DESCRIPTION
### Description
So far, the division operator in the reference implementation worked via ``np.divide``, which produces a float dtype when both inputs have an integer input dtype. the result was then cast back to integer dtype.
Now, integer division is put in place when both inputs are integers.

### Motivation and Context
We came over this bug when testing the reference implementation vs. the onnxruntime in https://github.com/cbourjau/onnx-tests.
