### PR TITLE
fixed handling of empty inputs for the softmax operator

### DIFF
--- a/onnx/reference/ops/op_softmax.py
+++ b/onnx/reference/ops/op_softmax.py
@@ -10,6 +10,8 @@ from onnx.reference.ops._op import OpRunUnaryNum
 
 class Softmax(OpRunUnaryNum):
     def _run(self, X, axis=None):
+        if X.size == 0:
+            return (X,)
         axis = axis or self.axis
         tmp = X - X.max(axis=axis, keepdims=1)
         Y = np.exp(tmp)


### PR DESCRIPTION
### Description
When given an empty input, ``softmax`` should return an output of the same shape. Currently, an exception is raised by ``X.max`` in that case.

### Motivation and Context
We came across this problem when testing the onnxruntime via [onnx-tests](https://github.com/cbourjau/onnx-tests).
