### PR TITLE
Make destructor inline

### DIFF
--- a/onnx/inliner/inliner.cc
+++ b/onnx/inliner/inliner.cc
@@ -788,8 +788,6 @@ Renamer::Renamer(const std::string& prefix, const GraphProto& graph) : pImpl_(st
 Renamer::Renamer(const std::string& prefix, const FunctionProto& function)
     : pImpl_(std::make_unique<Impl>(prefix, function)) {}
 
-Renamer::~Renamer() = default;
-
 void Renamer::BindName(const std::string& formal_name, const std::string& actual_name) {
   pImpl_->BindName(formal_name, actual_name);
 }

--- a/onnx/inliner/inliner.h
+++ b/onnx/inliner/inliner.h
@@ -107,7 +107,7 @@ class Renamer {
   /**
    * @brief Destructor.
    */
-  ~Renamer();
+  ~Renamer() = default;
 
   /**
    * @brief Binds a formal parameter name to an actual parameter name.


### PR DESCRIPTION
### Description
`Renamer::~Renamer()` is defaulted and could be move to the class declaration.
 
### Motivation and Context
A PyTorch Bazel build fails with undefined `Renamer::~Renamer()`. 
