### PR TITLE
Update required Python version to 3.10 and related fixes

### DIFF
--- a/onnx/__init__.py
+++ b/onnx/__init__.py
@@ -76,7 +76,7 @@ __all__ = [
 
 import os
 import typing
-from typing import IO, Literal, Union
+from typing import IO, Literal
 
 
 from onnx import serialization
@@ -148,9 +148,7 @@ __version__ = onnx.version.version
 # Supported model formats that can be loaded from and saved to
 # The literals are formats with built-in support. But we also allow users to
 # register their own formats. So we allow str as well.
-_SupportedFormat = Union[
-    Literal["protobuf", "textproto", "onnxtxt", "json"], str  # noqa: PYI051
-]
+_SupportedFormat = Literal["protobuf", "textproto", "onnxtxt", "json"] | str  # noqa: PYI051
 # Default serialization format
 _DEFAULT_FORMAT = "protobuf"
 
@@ -159,7 +157,7 @@ def _load_bytes(f: IO[bytes] | str | os.PathLike) -> bytes:
     if hasattr(f, "read") and callable(typing.cast("IO[bytes]", f).read):
         content = typing.cast("IO[bytes]", f).read()
     else:
-        f = typing.cast("Union[str, os.PathLike]", f)
+        f = typing.cast("str | os.PathLike", f)
         with open(f, "rb") as readable:
             content = readable.read()
     return content
@@ -169,7 +167,7 @@ def _save_bytes(content: bytes, f: IO[bytes] | str | os.PathLike) -> None:
     if hasattr(f, "write") and callable(typing.cast("IO[bytes]", f).write):
         typing.cast("IO[bytes]", f).write(content)
     else:
-        f = typing.cast("Union[str, os.PathLike]", f)
+        f = typing.cast("str | os.PathLike", f)
         with open(f, "wb") as writable:
             writable.write(content)
 

--- a/onnx/backend/test/case/node/__init__.py
+++ b/onnx/backend/test/case/node/__init__.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 from copy import deepcopy
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 import onnx
 from onnx.backend.test.case.test_case import TestCase
@@ -23,7 +23,7 @@ from onnx.onnx_pb import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
     import numpy as np
 

--- a/onnx/backend/test/runner/__init__.py
+++ b/onnx/backend/test/runner/__init__.py
@@ -15,7 +15,7 @@ import time
 import unittest
 from collections import defaultdict
 from re import Pattern
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 from urllib.request import urlretrieve
 
 import numpy as np
@@ -27,7 +27,7 @@ from onnx.backend.test.loader import load_model_tests
 from onnx.backend.test.runner.item import TestItem
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Callable, Iterable, Sequence
 
     from onnx.backend.base import Backend
     from onnx.backend.test.case.test_case import TestCase

--- a/onnx/backend/test/runner/item.py
+++ b/onnx/backend/test/runner/item.py
@@ -4,9 +4,11 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from onnx import ModelProto, NodeProto
 
 # A container that hosts the test function and the associated

--- a/onnx/external_data_helper.py
+++ b/onnx/external_data_helper.py
@@ -8,7 +8,7 @@ import re
 import sys
 import uuid
 from itertools import chain
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 import onnx.onnx_cpp2py_export.checker as c_checker
 from onnx.onnx_pb import (
@@ -20,7 +20,7 @@ from onnx.onnx_pb import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
 
 
 class ExternalDataInfo:

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -8,7 +8,7 @@ import functools
 import math
 import numbers
 import typing
-from typing import TYPE_CHECKING, Any, Callable, TypeVar, Union
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import google.protobuf.message
 import numpy as np
@@ -33,11 +33,11 @@ from onnx.onnx_pb import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import KeysView, Sequence
+    from collections.abc import Callable, KeysView, Sequence
 
     from google.protobuf.internal.containers import RepeatedCompositeFieldContainer
 
-VersionRowType = Union[tuple[str, int, int, int], tuple[str, int, int, int, int]]
+VersionRowType = tuple[str, int, int, int] | tuple[str, int, int, int, int]
 VersionTableType = list[VersionRowType]
 AssignmentBindingType = list[tuple[str, str]]
 

--- a/onnx/onnx_cpp2py_export/defs.pyi
+++ b/onnx/onnx_cpp2py_export/defs.pyi
@@ -1,7 +1,7 @@
 """Submodule containing all the ONNX schema definitions."""
 
-from collections.abc import Sequence
-from typing import Callable, overload
+from collections.abc import Callable, Sequence
+from typing import overload
 
 from onnx import AttributeProto, FunctionProto
 from onnx.shape_inference import InferenceContext

--- a/onnx/reference/ops/aionnxml/op_tree_ensemble.py
+++ b/onnx/reference/ops/aionnxml/op_tree_ensemble.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from enum import IntEnum
-from typing import Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class AggregationFunction(IntEnum):

--- a/onnx/reference/ops/op_resize.py
+++ b/onnx/reference/ops/op_resize.py
@@ -3,12 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 import onnx
 from onnx.reference.op_run import OpRun
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def _cartesian(arrays: list[np.ndarray], out: np.ndarray | None = None) -> np.ndarray:

--- a/onnx/serialization.py
+++ b/onnx/serialization.py
@@ -11,7 +11,7 @@ __all__ = [
 ]
 
 import typing
-from typing import Any, Optional, Protocol, TypeVar
+from typing import Any, Protocol, TypeVar
 
 import google.protobuf.json_format
 import google.protobuf.message
@@ -118,7 +118,7 @@ class _ProtobufSerializer(ProtoSerializer):
             raise TypeError(
                 f"Parameter 'serialized' must be bytes, but got type: {type(serialized)}"
             )
-        decoded = typing.cast("Optional[int]", proto.ParseFromString(serialized))
+        decoded = typing.cast("int | None", proto.ParseFromString(serialized))
         if decoded is not None and decoded != len(serialized):
             raise google.protobuf.message.DecodeError(
                 f"Protobuf decoding consumed too few bytes: {decoded} out of {len(serialized)}"

--- a/onnx/test/compose_test.py
+++ b/onnx/test/compose_test.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import unittest
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -24,7 +24,7 @@ from onnx import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
 
 def _load_model(m_def: str) -> ModelProto:

--- a/onnx/test/test_backend_reference.py
+++ b/onnx/test/test_backend_reference.py
@@ -165,9 +165,6 @@ if sys.platform == "win32":
     backend_test.exclude("test_regex_full_match_empty_cpu")
     backend_test.exclude("test_image_decoder_decode_")
 
-if sys.version_info < (3, 10):
-    #  AttributeError: module 'numpy.typing' has no attribute 'NDArray'
-    backend_test.exclude("test_image_decoder_decode_")
 
 if sys.platform == "darwin":
     # FIXME: https://github.com/onnx/onnx/issues/5792

--- a/onnx/tools/net_drawer.py
+++ b/onnx/tools/net_drawer.py
@@ -18,7 +18,8 @@ from __future__ import annotations
 import argparse
 import json
 from collections import defaultdict
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import pydot
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 license = {text = "Apache License v2.0"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [project.urls]
 Homepage = "https://onnx.ai/"
@@ -113,7 +113,7 @@ disable = [
 
 [tool.ruff]
 # NOTE: Do not create an exclude list. Edit .lintrunner.toml instead
-target-version = "py39"
+target-version = "py310"
 unsafe-fixes = true
 lint.select = [
     "A", # flake8-builtins
@@ -149,6 +149,7 @@ lint.select = [
 # NOTE: Refrain from growing the ignore list unless for exceptional cases.
 # Always include a comment to explain why.
 lint.ignore = [
+    "B905", # We have many zip calls without an explicit strict parameter
     "D1", # D1 is for missing docstrings, which is not yet enforced.
     "D205", # D205 Too strict. "1 blank line required between summary line and description"
     "D400",
@@ -172,6 +173,7 @@ lint.ignore = [
     "SIM114", # Don't always combine if branches for debugability
     "SIM116", # Don't use dict lookup to replace if-else
     "TRY003", # Messages can be constructed in the exception
+    "UP038", # We don't want to update isinstance calls
 ]
 
 [tool.ruff.lint.flake8-builtins]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ lint.select = [
 # NOTE: Refrain from growing the ignore list unless for exceptional cases.
 # Always include a comment to explain why.
 lint.ignore = [
-    "B905", # We have many zip calls without an explicit strict parameter
+    "B905", # TODO: We have many zip calls without an explicit strict parameter
     "D1", # D1 is for missing docstrings, which is not yet enforced.
     "D205", # D205 Too strict. "1 blank line required between summary line and description"
     "D400",


### PR DESCRIPTION
### Description
Update target Python version to 3.10. The union typing has been simplified a lot.
<!-- - Describe your changes. -->

### Motivation and Context
Better typing
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
