### PR TITLE
Fix NaN values in float8 quantization by handling them in saturate_cast

### DIFF
--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -555,8 +555,18 @@ def saturate_cast(x: np.ndarray, dtype: np.dtype) -> np.ndarray:
 
     This function ensures that values outside the representable range
     of the target dtype are clamped to the maximum or minimum representable
-    value of that dtype.
+    value of that dtype. For float8 types, it also handles NaN values properly.
     """
+    # Handle NaN values explicitly for float8 types to prevent them from becoming NaN in the result
+    if dtype in {
+        ml_dtypes.float8_e4m3fn,
+        ml_dtypes.float8_e4m3fnuz,
+        ml_dtypes.float8_e5m2,
+        ml_dtypes.float8_e5m2fnuz,
+    }:
+        # Replace NaN values with 0 before clipping
+        x = np.where(np.isnan(x), 0, x)
+    
     if np.issubdtype(dtype, np.integer) or dtype in (ml_dtypes.int4, ml_dtypes.uint4):
         info = ml_dtypes.iinfo(dtype)
         x = np.round(x)


### PR DESCRIPTION


### Description
When converting to float8 types, NaN values were not properly handled and would remain as NaN in the quantized tensors. This caused model validation to fail. The fix explicitly replaces NaN values with 0 before clipping in the saturate_cast function for float8 types.

### Motivation and Context
https://github.com/onnx/onnx/issues/7222
