### PR TITLE
Unify minimum numpy version for py <=3.12

### DIFF
--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,7 +1,5 @@
 # Minimum package versions that ONNX supports
 # https://endoflife.date/numpy
 protobuf==4.25.1
-numpy==1.23.2; python_version=="3.10"
-numpy==1.23.2; python_version=="3.11"
-numpy==1.26.0; python_version=="3.12"
+numpy==1.26.0; python_version<="3.12"
 numpy==2.1.0; python_version>="3.13"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.22
+numpy>=1.26
 protobuf>=4.25.1
 typing_extensions>=4.7.1
 ml_dtypes


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Unify minimum numpy version for Python <=3.12

### Motivation and Context
Because older numpy versions have reached EOL. 
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
