### PR TITLE
Clean up tests

### DIFF
--- a/onnx/test/test_backend_reference.py
+++ b/onnx/test/test_backend_reference.py
@@ -14,8 +14,6 @@ import version_utils
 
 import onnx.backend.base
 import onnx.backend.test
-import onnx.shape_inference
-import onnx.version_converter
 from onnx import ModelProto
 from onnx.backend.base import Device, DeviceType
 from onnx.reference import ReferenceEvaluator
@@ -139,21 +137,6 @@ backend_test.exclude(
 
 # The following tests cannot pass because they consists in generating random number.
 backend_test.exclude("(test_bernoulli)")
-
-# The following tests fail due to a bug in the backend test comparison.
-backend_test.exclude(
-    "(test_cast_FLOAT_to_STRING|test_castlike_FLOAT_to_STRING|test_strnorm)"
-)
-
-# The following tests fail due to a shape mismatch.
-backend_test.exclude(
-    "(test_center_crop_pad_crop_axes_hwc_expanded"
-    "|test_lppool_2d_dilations"
-    "|test_averagepool_2d_dilations)"
-)
-
-# The following tests fail due to a type mismatch.
-backend_test.exclude("(test_eyelike_without_dtype)")
 
 # The following tests fail due to discrepancies (small but still higher than 1e-7).
 backend_test.exclude("test_adam_multiple")  # 1e-2

--- a/onnx/test/test_backend_test.py
+++ b/onnx/test/test_backend_test.py
@@ -120,9 +120,6 @@ if os.getenv("APPVEYOR"):
 if platform.architecture()[0] == "32bit":
     backend_test.exclude(r"(test_vgg19|test_zfnet|test_bvlc_alexnet)")
 
-# Needs investigation on onnxruntime.
-backend_test.exclude("test_dequantizelinear_e4m3fn_float16")
-
 # import all test cases at global scope to make them visible to python.unittest
 globals().update(backend_test.test_cases)
 


### PR DESCRIPTION
### Description
Clean up tests. Remove unnecessary skips and imports.

### Motivation and Context
As per issue #7098 there are unnecessary skips and imports in some tests. I found 17 tests that were marked as skipped a couple of years ago, now they pass without warnings. 
