### PR TITLE
Use a valid SPDX identifier as license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ authors = [
 classifiers = [
     "Programming Language :: Python :: 3",
 ]
-license = {text = "Apache License v2.0"}
+license = {text = "Apache-2.0"}
 requires-python = ">=3.10"
 
 [project.urls]


### PR DESCRIPTION
This helps automatic license checkers like pip-licenses to identify the right license for this project

This is also the recommendation at https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license