### PR TITLE
Reference evaluator: treat empty axes as empty

### DIFF
--- a/onnx/reference/ops/_op.py
+++ b/onnx/reference/ops/_op.py
@@ -149,7 +149,7 @@ class OpRunReduceNumpy(OpRun):
                 self.axes = tuple(self.axes)
 
     def is_axes_empty(self, axes):
-        return axes is None
+        return axes is None or axes.shape == (0,)
 
     def handle_axes(self, axes):  # noqa: PLR0911
         if isinstance(axes, tuple):

--- a/onnx/reference/ops/op_reduce_sum.py
+++ b/onnx/reference/ops/op_reduce_sum.py
@@ -20,7 +20,7 @@ class ReduceSum_1(OpRunReduceNumpy):
 
 class ReduceSum_13(OpRunReduceNumpy):
     def _run(self, x, axes=None, keepdims=None, noop_with_empty_axes=None):
-        if (axes is None or axes.shape == (0,)) and noop_with_empty_axes:
+        if self.is_axes_empty(axes) and noop_with_empty_axes:
             return (x,)
         axes = self.handle_axes(axes)
         try:


### PR DESCRIPTION
### Description

Fix the `is_axes_empty` method to treat empty axis empty.
And as refactor, use this method in `ReduceSum_13`.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->

https://github.com/onnx/onnx/issues/7140