### PR TITLE
Require ml_dtypes>=0.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.23.2
 protobuf>=4.25.1
 typing_extensions>=4.7.1
-ml_dtypes
+ml_dtypes>=0.5.0


### PR DESCRIPTION
Require ml_dtypes>=0.5.0 due to issues reported from https://github.com/onnx/onnx/issues/7249