### PR TITLE
Clean up shape inference imports

### DIFF
--- a/onnx/shape_inference.py
+++ b/onnx/shape_inference.py
@@ -14,7 +14,13 @@ from typing import TYPE_CHECKING
 
 import onnx
 import onnx.onnx_cpp2py_export.shape_inference as C  # noqa: N812
-from onnx.onnx_pb import AttributeProto, FunctionProto, ModelProto, TypeProto
+from onnx.onnx_pb import (
+    IR_VERSION,
+    AttributeProto,
+    FunctionProto,
+    ModelProto,
+    TypeProto,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -109,7 +115,7 @@ def infer_node_outputs(
     input_data: dict[str, onnx.TensorProto] | None = None,
     input_sparse_data: dict[str, onnx.SparseTensorProto] | None = None,
     opset_imports: list[onnx.OperatorSetIdProto] | None = None,
-    ir_version: int = onnx.IR_VERSION,
+    ir_version: int = IR_VERSION,
 ) -> dict[str, onnx.TypeProto]:
     if not schema.has_type_and_shape_inference_function:
         return {}


### PR DESCRIPTION
Import IR_VERSION separately (not from onnx) to avoid potential circular import situations.
