### PR TITLE
Fix testsuite fails on s390x (big-endian)

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -6135,6 +6135,8 @@ for from_type, to_type in test_cases:
     elif from_type in FOUR_BIT_TYPES:
         np_from = np_fp32.astype(from_np_dtype)
         packed = onnx.numpy_helper._pack_4bitx2(np_from)
+        # No byteswap needed on big-endian machines as _pack_4bitx2()
+        # returns a numpy array with uint8 datatype.
         input = make_tensor(
             "input", from_dtype, input_shape, vals=packed.tobytes(), raw=True
         )
@@ -6154,6 +6156,8 @@ for from_type, to_type in test_cases:
         )
     elif to_type in FOUR_BIT_TYPES:
         packed = onnx.numpy_helper._pack_4bitx2(np_from.astype(to_np_dtype))
+        # No byteswap needed on big-endian machines as _pack_4bitx2()
+        # returns a numpy array with uint8 datatype.
         output = make_tensor(
             "output", to_dtype, input_shape, vals=packed.tobytes(), raw=True
         )
@@ -6231,14 +6235,14 @@ for from_type, to_type in test_cases:
         "input",
         getattr(TensorProto, from_type),
         [2, 4],
-        input_np.tobytes(),
+        input_np,
         raw=True,
     )
     output = make_tensor(
         "output",
         getattr(TensorProto, to_type),
         [2, 4],
-        output_np.tobytes(),
+        output_np,
         raw=True,
     )
     if to_type == "FLOAT8E8M0":
@@ -6550,6 +6554,8 @@ for from_type, to_type in test_cases:
     elif from_type in FOUR_BIT_TYPES:
         np_from = np_fp32.astype(from_np_dtype)
         packed = onnx.numpy_helper._pack_4bitx2(np_from)
+        # No byteswap needed on big-endian machines as _pack_4bitx2()
+        # returns a numpy array with uint8 datatype.
         input = make_tensor(
             "input", from_dtype, input_shape, vals=packed.tobytes(), raw=True
         )
@@ -6569,6 +6575,8 @@ for from_type, to_type in test_cases:
         )
     elif to_type in FOUR_BIT_TYPES:
         packed = onnx.numpy_helper._pack_4bitx2(np_from.astype(to_np_dtype))
+        # No byteswap needed on big-endian machines as _pack_4bitx2()
+        # returns a numpy array with uint8 datatype.
         output = make_tensor(
             "output", to_dtype, input_shape, vals=packed.tobytes(), raw=True
         )

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -4730,6 +4730,8 @@ for from_type, to_type in test_cases:
     elif from_type in FOUR_BIT_TYPES:
         np_from = np_fp32.astype(from_np_dtype)
         packed = onnx.numpy_helper._pack_4bitx2(np_from)
+        # No byteswap needed on big-endian machines as _pack_4bitx2()
+        # returns a numpy array with uint8 datatype.
         input = make_tensor(
             "input", from_dtype, input_shape, vals=packed.tobytes(), raw=True
         )
@@ -4749,6 +4751,8 @@ for from_type, to_type in test_cases:
         )
     elif to_type in FOUR_BIT_TYPES:
         packed = onnx.numpy_helper._pack_4bitx2(np_from.astype(to_np_dtype))
+        # No byteswap needed on big-endian machines as _pack_4bitx2()
+        # returns a numpy array with uint8 datatype.
         output = make_tensor(
             "output", to_dtype, input_shape, vals=packed.tobytes(), raw=True
         )
@@ -4824,14 +4828,14 @@ for from_type, to_type in test_cases:
         "input",
         getattr(TensorProto, from_type),
         [2, 4],
-        input_np.tobytes(),
+        input_np,
         raw=True,
     )
     output = make_tensor(
         "output",
         getattr(TensorProto, to_type),
         [2, 4],
-        output_np.tobytes(),
+        output_np,
         raw=True,
     )
     if to_type == "FLOAT8E8M0":
@@ -5094,6 +5098,8 @@ for from_type, to_type in test_cases:
     elif from_type in FOUR_BIT_TYPES:
         np_from = np_fp32.astype(from_np_dtype)
         packed = onnx.numpy_helper._pack_4bitx2(np_from)
+        # No byteswap needed on big-endian machines as _pack_4bitx2()
+        # returns a numpy array with uint8 datatype.
         input = make_tensor(
             "input", from_dtype, input_shape, vals=packed.tobytes(), raw=True
         )
@@ -5113,6 +5119,8 @@ for from_type, to_type in test_cases:
         )
     elif to_type in FOUR_BIT_TYPES:
         packed = onnx.numpy_helper._pack_4bitx2(np_from.astype(to_np_dtype))
+        # No byteswap needed on big-endian machines as _pack_4bitx2()
+        # returns a numpy array with uint8 datatype.
         output = make_tensor(
             "output", to_dtype, input_shape, vals=packed.tobytes(), raw=True
         )

--- a/onnx/backend/test/case/node/cast.py
+++ b/onnx/backend/test/case/node/cast.py
@@ -174,6 +174,8 @@ class Cast(Base):
             elif from_type in FOUR_BIT_TYPES:
                 np_from = np_fp32.astype(from_np_dtype)
                 packed = onnx.numpy_helper._pack_4bitx2(np_from)
+                # No byteswap needed on big-endian machines as _pack_4bitx2()
+                # returns a numpy array with uint8 datatype.
                 input = make_tensor(
                     "input", from_dtype, input_shape, vals=packed.tobytes(), raw=True
                 )
@@ -193,6 +195,8 @@ class Cast(Base):
                 )
             elif to_type in FOUR_BIT_TYPES:
                 packed = onnx.numpy_helper._pack_4bitx2(np_from.astype(to_np_dtype))
+                # No byteswap needed on big-endian machines as _pack_4bitx2()
+                # returns a numpy array with uint8 datatype.
                 output = make_tensor(
                     "output", to_dtype, input_shape, vals=packed.tobytes(), raw=True
                 )
@@ -334,14 +338,14 @@ class Cast(Base):
                 "input",
                 getattr(TensorProto, from_type),
                 [2, 4],
-                input_np.tobytes(),
+                input_np,
                 raw=True,
             )
             output = make_tensor(
                 "output",
                 getattr(TensorProto, to_type),
                 [2, 4],
-                output_np.tobytes(),
+                output_np,
                 raw=True,
             )
             if to_type == "FLOAT8E8M0":

--- a/onnx/backend/test/case/node/castlike.py
+++ b/onnx/backend/test/case/node/castlike.py
@@ -172,6 +172,8 @@ class CastLike(Base):
             elif from_type in FOUR_BIT_TYPES:
                 np_from = np_fp32.astype(from_np_dtype)
                 packed = onnx.numpy_helper._pack_4bitx2(np_from)
+                # No byteswap needed on big-endian machines as _pack_4bitx2()
+                # returns a numpy array with uint8 datatype.
                 input = make_tensor(
                     "input", from_dtype, input_shape, vals=packed.tobytes(), raw=True
                 )
@@ -191,6 +193,8 @@ class CastLike(Base):
                 )
             elif to_type in FOUR_BIT_TYPES:
                 packed = onnx.numpy_helper._pack_4bitx2(np_from.astype(to_np_dtype))
+                # No byteswap needed on big-endian machines as _pack_4bitx2()
+                # returns a numpy array with uint8 datatype.
                 output = make_tensor(
                     "output", to_dtype, input_shape, vals=packed.tobytes(), raw=True
                 )

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -7,6 +7,7 @@ import collections.abc
 import functools
 import math
 import numbers
+import sys
 import typing
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -409,6 +410,17 @@ def make_tensor(
         expected_size_bytes *= math.prod(dims)
         expected_size_bytes = math.ceil(expected_size_bytes)
         if isinstance(vals, np.ndarray):
+            if data_type in {
+                TensorProto.INT4,
+                TensorProto.UINT4,
+                TensorProto.FLOAT4E2M1,
+            }:
+                vals = onnx.numpy_helper._pack_4bitx2(vals)
+
+            if sys.byteorder == "big":
+                # Convert endian from big to little
+                vals = vals.byteswap()
+
             raw_data = vals.tobytes()
         elif isinstance(vals, bytes):
             raw_data = vals

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -7,7 +7,6 @@ import collections.abc
 import functools
 import math
 import numbers
-import sys
 import typing
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -417,11 +416,7 @@ def make_tensor(
             }:
                 vals = onnx.numpy_helper._pack_4bitx2(vals)
 
-            if sys.byteorder == "big":
-                # Convert endian from big to little
-                vals = vals.byteswap()
-
-            raw_data = vals.tobytes()
+            raw_data = onnx.numpy_helper.tobytes_little_endian(vals)
         elif isinstance(vals, bytes):
             raw_data = vals
         else:

--- a/onnx/model_container.py
+++ b/onnx/model_container.py
@@ -214,11 +214,8 @@ class ModelContainer:
                 )
             np_tensor = self.large_initializers[prop.value]
 
-            if sys.byteorder == "big":
-                # Convert endian from little to big
-                tensor_bytes = np_tensor.byteswap().tobytes()
-            else:
-                tensor_bytes = np_tensor.tobytes()
+            tensor_bytes = onnx.numpy_helper.tobytes_little_endian(np_tensor)
+
             if all_tensors_to_one_file:
                 _set_external_data(
                     tensor,

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -229,6 +229,16 @@ def to_array(tensor: onnx.TensorProto, base_dir: str = "") -> np.ndarray:  # noq
 
 
 def tobytes_little_endian(array: np.ndarray) -> bytes:
+    """Converts an array into bytes in little endian byte order.
+
+    Args:
+        array: a numpy array.
+
+    Returns:
+        bytes: Byte representation of passed array in little endian byte order.
+
+    .. versionadded:: 1.20
+    """
     if sys.byteorder == "big":
         # Convert endian from big to little
         array = array.byteswap()

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -16,9 +16,6 @@ from onnx import helper
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-# System is little endian
-_IS_LITTLE_ENDIAN = sys.byteorder == "little"
-
 
 def to_float8e8m0(
     x: np.ndarray,
@@ -277,8 +274,10 @@ def from_array(array: np.ndarray, /, name: str | None = None) -> onnx.TensorProt
     }:
         # Pack the array into int4
         array = _pack_4bitx2(array)
-    if not _IS_LITTLE_ENDIAN:
-        array = array.view(array.dtype.newbyteorder("<"))
+
+    if sys.byteorder == "big":
+        # Convert endian from big to little
+        array = array.byteswap()
 
     tensor.raw_data = array.tobytes()
     tensor.data_type = dtype

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -239,9 +239,11 @@ def tobytes_little_endian(array: np.ndarray) -> bytes:
 
     .. versionadded:: 1.20
     """
-    if sys.byteorder == "big":
-        # Convert endian from big to little
-        array = array.byteswap()
+    if array.dtype.byteorder == ">" or (
+        sys.byteorder == "big" and array.dtype.byteorder == "="
+    ):
+        # Ensure that the bytes will be in little-endian byte-order.
+        array = array.astype(array.dtype.newbyteorder("<"))
 
     return array.tobytes()
 

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -228,6 +228,14 @@ def to_array(tensor: onnx.TensorProto, base_dir: str = "") -> np.ndarray:  # noq
     return np.asarray(data, dtype=storage_np_dtype).astype(np_dtype).reshape(dims)
 
 
+def tobytes_little_endian(array: np.ndarray) -> bytes:
+    if sys.byteorder == "big":
+        # Convert endian from big to little
+        array = array.byteswap()
+
+    return array.tobytes()
+
+
 def from_array(array: np.ndarray, /, name: str | None = None) -> onnx.TensorProto:
     """Converts an array into a TensorProto including
 
@@ -275,11 +283,7 @@ def from_array(array: np.ndarray, /, name: str | None = None) -> onnx.TensorProt
         # Pack the array into int4
         array = _pack_4bitx2(array)
 
-    if sys.byteorder == "big":
-        # Convert endian from big to little
-        array = array.byteswap()
-
-    tensor.raw_data = array.tobytes()
+    tensor.raw_data = tobytes_little_endian(array)
     tensor.data_type = dtype
     return tensor
 

--- a/onnx/test/checker_test.py
+++ b/onnx/test/checker_test.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
 import unittest
 from typing import TYPE_CHECKING
@@ -319,7 +320,11 @@ class TestChecker(unittest.TestCase):
         tensor = self._sample_float_tensor
         checker.check_tensor(tensor)
 
-        tensor.raw_data = np.random.randn(2, 3).astype(np.float32).tobytes()
+        input_np = np.random.randn(2, 3).astype(np.float32)
+        if sys.byteorder == "big":
+            # Convert endian from big to little
+            input_np = input_np.byteswap()
+        tensor.raw_data = input_np.tobytes()
         self.assertRaises(checker.ValidationError, checker.check_tensor, tensor)
 
     def test_check_string_tensor(self) -> None:

--- a/onnx/test/checker_test.py
+++ b/onnx/test/checker_test.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import os
-import sys
 import tempfile
 import unittest
 from typing import TYPE_CHECKING
@@ -321,10 +320,8 @@ class TestChecker(unittest.TestCase):
         checker.check_tensor(tensor)
 
         input_np = np.random.randn(2, 3).astype(np.float32)
-        if sys.byteorder == "big":
-            # Convert endian from big to little
-            input_np = input_np.byteswap()
-        tensor.raw_data = input_np.tobytes()
+
+        tensor.raw_data = onnx.numpy_helper.tobytes_little_endian(input_np)
         self.assertRaises(checker.ValidationError, checker.check_tensor, tensor)
 
     def test_check_string_tensor(self) -> None:

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import itertools
 import math
 import random
-import sys
 import unittest
 from typing import Any
 
@@ -525,19 +524,11 @@ class TestHelperTensorFunctions(unittest.TestCase):
             dtype=ml_dtypes.bfloat16,
         ).view(np.uint16)
 
-        if sys.byteorder == "big":
-            # Convert endian from big to little as numpy_helper.to_array()
-            # assumes that the raw bytes within the tensor are in little endian
-            # order and performs a byteswap on big-endian machines.
-            np_array_intermediate = array.byteswap()
-        else:
-            np_array_intermediate = array
-
         tensor = helper.make_tensor(
             name="test",
             data_type=TensorProto.BFLOAT16,
             dims=array.shape,
-            vals=np_array_intermediate.tobytes(),
+            vals=numpy_helper.tobytes_little_endian(array),
             raw=True,
         )
         np.testing.assert_allclose(numpy_helper.to_array(tensor).view(np.uint16), array)
@@ -969,13 +960,7 @@ def test_make_tensor_raw(tensor_dtype: int, vals_as_bytes: bool) -> None:
         }:
             np_array_intermediate = _pack_4bit(np_array)
 
-        if sys.byteorder == "big":
-            # Convert endian from big to little as numpy_helper.to_array() assumes
-            # that the raw bytes within the tensor are in little endian order and
-            # performs a byteswap on big-endian machines.
-            np_array_intermediate = np_array_intermediate.byteswap()
-
-        vals = np_array_intermediate.tobytes()
+        vals = numpy_helper.tobytes_little_endian(np_array_intermediate)
     else:
         vals = np_array
 

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -900,9 +900,19 @@ class TestPrintableGraph(unittest.TestCase):
     ids=lambda tensor_dtype: helper.tensor_dtype_to_string(tensor_dtype),
 )
 def test_make_tensor_vals(tensor_dtype: int) -> None:
-    np_array = np.random.randn(2, 3).astype(
-        helper.tensor_dtype_to_np_dtype(tensor_dtype)
-    )
+    np_type = helper.tensor_dtype_to_np_dtype(tensor_dtype)
+    if tensor_dtype in {
+        TensorProto.UINT8,
+        TensorProto.UINT16,
+        TensorProto.UINT32,
+        TensorProto.UINT64,
+    }:
+        # Avoid "RuntimeWarning: invalid value encountered in cast" when using
+        # astype() for negative floats.
+        np_array = numpy_helper.create_random_int((2, 3), np_type)
+    else:
+        np_array = np.random.randn(2, 3)
+    np_array = np_array.astype(np_type)
     tensor = helper.make_tensor(
         name="test", data_type=tensor_dtype, dims=np_array.shape, vals=np_array
     )
@@ -930,10 +940,19 @@ def test_make_tensor_vals(tensor_dtype: int) -> None:
     ids=lambda tensor_dtype: helper.tensor_dtype_to_string(tensor_dtype),
 )
 def test_make_tensor_raw(tensor_dtype: int) -> None:
-    np_array = np.random.randn(2, 3).astype(
-        helper.tensor_dtype_to_np_dtype(tensor_dtype)
-    )
-
+    np_type = helper.tensor_dtype_to_np_dtype(tensor_dtype)
+    if tensor_dtype in {
+        TensorProto.UINT8,
+        TensorProto.UINT16,
+        TensorProto.UINT32,
+        TensorProto.UINT64,
+    }:
+        # Avoid "RuntimeWarning: invalid value encountered in cast" when using
+        # astype() for negative floats.
+        np_array = numpy_helper.create_random_int((2, 3), np_type)
+    else:
+        np_array = np.random.randn(2, 3)
+    np_array = np_array.astype(np_type)
     np_array_intermediate = np_array
 
     if tensor_dtype in {

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import itertools
 import os
 import pathlib
-import sys
 import tempfile
 import unittest
 import uuid
@@ -593,19 +592,13 @@ class TestExternalDataToArray(unittest.TestCase):
     def tearDown(self) -> None:
         self._temp_dir_obj.cleanup()
 
-    def convert_ndarray_to_bytes(self, array: np.ndarray) -> bytes:
-        if sys.byteorder == "big":
-            # Convert endian from bit to little
-            array = array.byteswap()
-        return array.tobytes()
-
     def create_test_model(self) -> ModelProto:
         X = helper.make_tensor_value_info("X", TensorProto.FLOAT, self.large_data.shape)
         input_init = helper.make_tensor(
             name="X",
             data_type=TensorProto.FLOAT,
             dims=self.large_data.shape,
-            vals=self.convert_ndarray_to_bytes(self.large_data),
+            vals=onnx.numpy_helper.tobytes_little_endian(self.large_data),
             raw=True,
         )
 
@@ -614,7 +607,7 @@ class TestExternalDataToArray(unittest.TestCase):
             name="Shape",
             data_type=TensorProto.INT64,
             dims=shape_data.shape,
-            vals=self.convert_ndarray_to_bytes(shape_data),
+            vals=onnx.numpy_helper.tobytes_little_endian(shape_data),
             raw=True,
         )
         C = helper.make_tensor_value_info("C", TensorProto.INT64, self.small_data)

--- a/onnx/test/version_converter/automatic_upgrade_test.py
+++ b/onnx/test/version_converter/automatic_upgrade_test.py
@@ -293,7 +293,7 @@ class TestAutomaticUpgrade(automatic_conversion_test_base.TestAutomaticConversio
             "Value",
             TensorProto.FLOAT,
             dims=[3, 4, 5],
-            vals=np.random.rand(3, 4, 5).astype(np.float32).tobytes(),
+            vals=np.random.rand(3, 4, 5).astype(np.float32),
             raw=True,
         )
         self._test_op_upgrade("Constant", 1, [], attrs={"value": value})
@@ -577,7 +577,7 @@ class TestAutomaticUpgrade(automatic_conversion_test_base.TestAutomaticConversio
             "Value",
             TensorProto.FLOAT,
             dims=[3, 4, 5],
-            vals=np.random.rand(3, 4, 5).astype(np.float32).tobytes(),
+            vals=np.random.rand(3, 4, 5).astype(np.float32),
             raw=True,
         )
         then_node = helper.make_node("Constant", [], ["out"], value=then_tensor)
@@ -586,7 +586,7 @@ class TestAutomaticUpgrade(automatic_conversion_test_base.TestAutomaticConversio
             "Value",
             TensorProto.FLOAT,
             dims=[3, 4, 5],
-            vals=np.random.rand(3, 4, 5).astype(np.float32).tobytes(),
+            vals=np.random.rand(3, 4, 5).astype(np.float32),
             raw=True,
         )
         else_node = helper.make_node("Constant", [], ["out"], value=else_tensor)
@@ -1038,7 +1038,7 @@ class TestAutomaticUpgrade(automatic_conversion_test_base.TestAutomaticConversio
             "a",
             TensorProto.FLOAT,
             dims=[3, 4, 5],
-            vals=np.random.rand(3, 4, 5).astype(np.float32).tobytes(),
+            vals=np.random.rand(3, 4, 5).astype(np.float32),
             raw=True,
         )
         self._test_op_upgrade(
@@ -1055,7 +1055,7 @@ class TestAutomaticUpgrade(automatic_conversion_test_base.TestAutomaticConversio
             "a",
             TensorProto.FLOAT,
             dims=[3, 4, 5],
-            vals=np.random.rand(3, 4, 5).astype(np.float32).tobytes(),
+            vals=np.random.rand(3, 4, 5).astype(np.float32),
             raw=True,
         )
         self._test_op_upgrade(

--- a/onnx/test/version_converter_test.py
+++ b/onnx/test/version_converter_test.py
@@ -2196,7 +2196,7 @@ class TestVersionConverter(unittest.TestCase):
                 name="initializer_tensor",
                 data_type=onnx.TensorProto.FLOAT,
                 dims=list(shape),
-                vals=random_data.tobytes(),
+                vals=random_data,
                 raw=True,
             )
             initializer_scalar = onnx.helper.make_tensor(


### PR DESCRIPTION
On big-endian machines, there are plenty of test fails due to missing/wrong byteswaps. I've created a couple of patches to fix those fails, in numpy_helper.py::from_array() and helper.py::make_tensor() and in various testcases.

Some of the fixed Testcases test_make_tensor_raw are also mentioned in the issue from 2024-07-14 created by tehbone:
[s390x test failures - test_make_tensor_raw #6181](https://github.com/onnx/onnx/issues/6181)

Especially the last commit "Adjust remaining tests which are using tobytes()." is not really required as all corresponding tests did not fail before. But it makes the tests more consistent as before.

In the end I'm down to 7 remaining fails:
```
7 failed, 5314 passed, 3660 skipped, 31 warnings
FAILED onnx/test/helper_test.py::TestHelperTensorFunctions::test_make_bfloat16_tensor_raw
FAILED onnx/test/test_backend_reference.py::OnnxBackendNodeModelTest::test_cast_BFLOAT16_to_FLOAT_cpu
FAILED onnx/test/test_backend_reference.py::OnnxBackendNodeModelTest::test_cast_FLOAT_to_BFLOAT16_cpu
FAILED onnx/test/test_backend_reference.py::OnnxBackendNodeModelTest::test_castlike_BFLOAT16_to_FLOAT_cpu
FAILED onnx/test/test_backend_reference.py::OnnxBackendNodeModelTest::test_castlike_BFLOAT16_to_FLOAT_expanded_cpu
FAILED onnx/test/test_backend_reference.py::OnnxBackendNodeModelTest::test_castlike_FLOAT_to_BFLOAT16_cpu
FAILED onnx/test/test_backend_reference.py::OnnxBackendNodeModelTest::test_castlike_FLOAT_to_BFLOAT16_expanded_cpu
```

Those fails happen as the ml_dtypes-bfloat16 datatype does not byteswap. I've already filed an issue:
["bfloat16: byteswap does not swap bytes #308"](https://github.com/jax-ml/ml_dtypes/issues/308)
There is already a pull-request fixing this issue, but the assigned reviewer has not yet responded:
["Fix bfloat16 byteswap #311"](https://github.com/jax-ml/ml_dtypes/pull/311)
With a locally fixed ml_dtypes, the remaining tests are also passing.

How are those dependency issues solved in onnx?
Is the required version bumped as soon as fixed and released in ml_dtypes?
Or shall we implement a workaround with a different approach to swap bytes for bfloat16 datatype in onnx-sources?