### PR TITLE
Override __repr__ for some proto classes (#7259)

### DIFF
--- a/onnx/__init__.py
+++ b/onnx/__init__.py
@@ -368,3 +368,9 @@ def save_tensor(
 load = load_model
 load_from_string = load_model_from_string
 save = save_model
+
+
+# Override __repr__ for some proto classes to make it more efficient
+ModelProto.__repr__ = object.__repr__  # type: ignore[method-assign]
+GraphProto.__repr__ = object.__repr__  # type: ignore[method-assign]
+FunctionProto.__repr__ = object.__repr__  # type: ignore[method-assign]


### PR DESCRIPTION
Override __repr__ for some proto classes to make it more efficient
because. Prior to this change, calling repr on a big model proto would
cause a costly serialization to run which dumps a lot of text. This
change makes `repr(model_proto)` to return
`'<onnx.onnx_ml_pb2.ModelProto object at 0x7572f254ada0>'`.

Users can still call `str()` model proto classes to obtain a prototext
representation.

This also does not affect `print()` because print calls `str()`.

Fix https://github.com/onnx/onnx/issues/4738

---------

Signed-off-by: Justin Chu <justinchuby@users.noreply.github.com>