### PR TITLE
Disable nanobind leak warnings in cpp2py_export

### DIFF
--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -188,6 +188,10 @@ static std::tuple<std::vector<T>, std::vector<const T*>> ConvertPyObjToPtr(const
 }
 
 NB_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
+  // Disabling nanobind leak warnings
+  // TODO(#7283): Avoid leaks if possible
+  nb::set_leak_warnings(false);
+
   onnx_cpp2py_export.doc() = "Python interface to ONNX";
 
   onnx_cpp2py_export.attr("ONNX_ML") = nb::bool_(


### PR DESCRIPTION
Added comments to disable nanobind leak warnings and noted a TODO for future improvements. https://github.com/onnx/onnx/issues/7283