### PR TITLE
Silently drop 32bit support on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -184,16 +184,10 @@ class CmakeBuild(setuptools.Command):
             if WINDOWS:
                 if USE_MSVC_STATIC_RUNTIME:
                     cmake_args.append("-DONNX_USE_MSVC_STATIC_RUNTIME=ON")
-                if platform.architecture()[0] == "64bit":
-                    if "arm" in platform.machine().lower():
-                        cmake_args.extend(["-A", "ARM64"])
-                    else:
-                        cmake_args.extend(["-A", "x64", "-T", "host=x64"])
-                else:  # noqa: PLR5501
-                    if "arm" in platform.machine().lower():
-                        cmake_args.extend(["-A", "ARM"])
-                    else:
-                        cmake_args.extend(["-A", "Win32", "-T", "host=x86"])
+                if "arm" in platform.machine().lower():
+                    cmake_args.extend(["-A", "ARM64"])
+                else:
+                    cmake_args.extend(["-A", "x64", "-T", "host=x64"])
             if ONNX_ML:
                 cmake_args.append("-DONNX_ML=1")
             if ONNX_VERIFY_PROTO3:


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
There is no sense to support 32bit builds on Windows in 2025.
### Motivation and Context
Better tooling.
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
