### PR TITLE
Use printer.to_text in tests

### DIFF
--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -27,6 +27,7 @@ from onnx import (
     defs,
     helper,
     numpy_helper,
+    printer,
 )
 
 
@@ -835,11 +836,9 @@ class TestPrintableGraph(unittest.TestCase):
             value_info=value_info,
         )
 
-        graph_str = helper.printable_graph(graph)
-        self.assertTrue(
-            """) optional inputs with matching initializers (
-  %Y_Initializer[FLOAT, 1]"""
-            in graph_str,
+        graph_str = printer.to_text(graph)
+        self.assertIn(
+            "test (float[1] X, float[1] Y_Initializer) => (float[1] Z)",
             graph_str,
         )
 
@@ -859,13 +858,8 @@ class TestPrintableGraph(unittest.TestCase):
             value_info=value_info,
         )
 
-        graph_str = helper.printable_graph(graph)
-        self.assertTrue(
-            """) initializers (
-  %Y_Initializer[FLOAT, 1]"""
-            in graph_str,
-            graph_str,
-        )
+        graph_str = printer.to_text(graph)
+        self.assertIn("test (float[1] X) => (float[1] Z)", graph_str)
 
     def test_unknown_dimensions(self) -> None:
         graph = helper.make_graph(
@@ -881,8 +875,8 @@ class TestPrintableGraph(unittest.TestCase):
         model = helper.make_model(graph)
         checker.check_model(model)
 
-        graph_str = helper.printable_graph(graph)
-        self.assertIn("X[FLOAT, ?]", graph_str)
+        graph_str = printer.to_text(graph)
+        self.assertIn("test (float[?] X) => (float[?] Z)", graph_str)
 
 
 @pytest.mark.parametrize(

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -27,7 +27,6 @@ from onnx import (
     defs,
     helper,
     numpy_helper,
-    printer,
 )
 
 
@@ -814,69 +813,6 @@ class TestHelperOptionalAndSequenceFunctions(unittest.TestCase):
         )
 
         self.assertEqual(sequence_val_info, sequence_val_info_prim)
-
-
-class TestPrintableGraph(unittest.TestCase):
-    def test_initializer_with_matching_graph_input(self) -> None:
-        add = helper.make_node("Add", ["X", "Y_Initializer"], ["Z"])
-        value_info = [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1])]
-
-        graph = helper.make_graph(
-            [add],
-            "test",
-            [
-                helper.make_tensor_value_info("X", TensorProto.FLOAT, [1]),
-                helper.make_tensor_value_info("Y_Initializer", TensorProto.FLOAT, [1]),
-            ],  # inputs
-            [helper.make_tensor_value_info("Z", TensorProto.FLOAT, [1])],  # outputs
-            [
-                helper.make_tensor("Y_Initializer", TensorProto.FLOAT, [1], [1])
-            ],  # initializers
-            doc_string=None,
-            value_info=value_info,
-        )
-
-        graph_str = printer.to_text(graph)
-        self.assertIn(
-            "test (float[1] X, float[1] Y_Initializer) => (float[1] Z)",
-            graph_str,
-        )
-
-    def test_initializer_no_matching_graph_input(self) -> None:
-        add = helper.make_node("Add", ["X", "Y_Initializer"], ["Z"])
-        value_info = [helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1])]
-
-        graph = helper.make_graph(
-            [add],
-            "test",
-            [helper.make_tensor_value_info("X", TensorProto.FLOAT, [1])],  # inputs
-            [helper.make_tensor_value_info("Z", TensorProto.FLOAT, [1])],  # outputs
-            [
-                helper.make_tensor("Y_Initializer", TensorProto.FLOAT, [1], [1])
-            ],  # initializers
-            doc_string=None,
-            value_info=value_info,
-        )
-
-        graph_str = printer.to_text(graph)
-        self.assertIn("test (float[1] X) => (float[1] Z)", graph_str)
-
-    def test_unknown_dimensions(self) -> None:
-        graph = helper.make_graph(
-            [helper.make_node("Add", ["X", "Y_Initializer"], ["Z"])],
-            "test",
-            [helper.make_tensor_value_info("X", TensorProto.FLOAT, [None])],  # inputs
-            [helper.make_tensor_value_info("Z", TensorProto.FLOAT, [None])],  # outputs
-            [
-                helper.make_tensor("Y_Initializer", TensorProto.FLOAT, [1], [1])
-            ],  # initializers
-            doc_string=None,
-        )
-        model = helper.make_model(graph)
-        checker.check_model(model)
-
-        graph_str = printer.to_text(graph)
-        self.assertIn("test (float[?] X) => (float[?] Z)", graph_str)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description
Don't use deprecated `helper.printable_graph` to avoid testing warnings.
<!-- - Describe your changes. -->

### Motivation and Context
Better code.
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
