### PR TITLE
Fix white space

### DIFF
--- a/docs/Broadcasting.md
+++ b/docs/Broadcasting.md
@@ -12,11 +12,11 @@ ONNX supports two types of broadcasting: multidirectional broadcasting and
 unidirectional broadcasting. We will introduce these two types of broadcasting
 respectively in the following sections.
 
-
 ## Multidirectional Broadcasting
 
 In ONNX, a set of tensors are multidirectional broadcastable to the same shape
 if one of the following is true:
+
 - The tensors all have exactly the same shape.
 - The tensors all have the same number of dimensions and the length of
 each dimensions is either a common length or 1.
@@ -34,6 +34,7 @@ For example, the following tensor shapes are supported by multidirectional broad
 Multidirectional broadcasting is the same as [Numpy's broadcasting](https://docs.scipy.org/doc/numpy/user/basics.broadcasting.html#general-broadcasting-rules).
 
 Multidirectional broadcasting is supported by the following operators in ONNX:
+
 - [Add](Operators.md#Add)
 - [And](Operators.md#And)
 - [Div](Operators.md#Div)
@@ -55,6 +56,7 @@ Multidirectional broadcasting is supported by the following operators in ONNX:
 
 In ONNX, tensor B is unidirectional broadcastable to tensor A
 if one of the following is true:
+
 - Tensor A and B both have exactly the same shape.
 - Tensor A and B all have the same number of dimensions and the length of
 each dimensions is either a common length or B's length is 1.
@@ -72,5 +74,6 @@ In the following examples, tensor B is unidirectional broadcastable to tensor A:
 - shape(A) = (2, 3, 4, 5), shape(B) = (1, 3, 1, 5), ==> shape(result) = (2, 3, 4, 5)
 
 Unidirectional broadcasting is supported by the following operators in ONNX:
+
 - [Gemm](Operators.md#Gemm)
 - [PRelu](Operators.md#PRelu)

--- a/docs/DefineDifferentiability.md
+++ b/docs/DefineDifferentiability.md
@@ -68,18 +68,23 @@ with open('model.onnx', 'wb') as f:
 The second way is formally proving the existence of the Jacobian matrix (or tensor) from outputs to inputs with at least two numerical examples. In this case, the reviewer should go through the math and confirm if the numerical result is correct. The author should add enough details so that any STEM graduated student can easily review it.
 
 For example, to show the differentiability of Add, the author may first write down its equation:
+
 ```
 C = A + B
 ```
+
 For the sake of simplicity, assume `A` and `B` are same-shape vector.
+
 ```
 A = [a1, a2]^T
 B = [b1, b2]^T
 C = [c1, c2]^T
 ```
+
 Here we use the symbol `^T` to denote transpose of the attached matrix or vector.
 Let `X = [a1, a2, b1, b2]^T` and `Y = [c1, c2]^T` and consider Add as a function which maps `X` to `Y`.
 Then, this function's Jacobian matrix is a 4-by-2 matrix,
+
 ```
 J = [[dc1/da1, dc2/da1],
      [dc1/da2, dc2/da2],
@@ -90,16 +95,21 @@ J = [[dc1/da1, dc2/da1],
      [1, 0],
      [0, 1]]
 ```
+
 If
+
 ```
 dL/dC = [dL/dc1, dL/dc2]^T,
 ```
+
 then `dL/dA = [dL/da1, dL/da2]^T` and `dL/dB = [dL/db1, dL/db2]^T` can be computed from elements in
+
 ```
   [[dL/da1], [dL/da2], [dL/db1], [dL/db2]]
 = J * dL/dC
 = [[dL/dc1], [dL/dc2], [dL/dc1], [dL/dc2]]
 ```
+
 where `*` is standard matrix multiplication.
 If `dL/dC = [0.2, 0.8]^T`, then `dL/dA = [0.2, 0.8]^T` and `dL/dB = [0.2, 0.8]^T`.
 Notice that the procedure to compute `dL/dA` and `dL/dB` from `dL/dC` is usually called backward of an operator.

--- a/docs/DimensionDenotation.md
+++ b/docs/DimensionDenotation.md
@@ -23,6 +23,7 @@ This proposal consists of three key components: Denotation Definition, Denotatio
 ## Denotation Definition
 
 To begin with, we define a set of types for tensor types. Such types are defined based on the following principles:
+
 1. Be fine grain enough to eliminate potential pitfalls. For instance, the above example illustrated in the motivation section mandates that we distinguish between a channel dimension and a spatial feature dimension to ensure the correctness of execution of the AveragePool op.
 2. Be coarse grain enough to alleviate the mental burden of users. For instance, in the above example, there is significantly less need to distinguish between a width dimension and a height dimension because operations like pooling and convolution often do not draw a distinction between various spatial dimensions. Thus, we summarize all the spatial dimensions as feature dimensions.
 3. As an important corollary of 2, be model agnostic. For instance, the semantics of feature dimensions in recurrent neural networks (RNN) and the semantics of spatial dimensions in convolutional neural network (CNN) are almost indistinguishable and therefore we permit users and developers to describe either as a feature dimension.

--- a/docs/ExternalData.md
+++ b/docs/ExternalData.md
@@ -28,6 +28,7 @@ load_external_data_for_model(onnx_model, "data/directory/path/")
 ```
 
 ## Converting an ONNX Model to External Data
+
 ```python
 import onnx
 from onnx.external_data_helper import convert_model_to_external_data
@@ -73,6 +74,7 @@ There are two fields related to the external data in TensorProto message type.
 ### data_location field
 
 `data_location` field stores the location of data for this tensor. Value MUST be one of:
+
 * `MESSAGE` - data stored in type-specific fields inside the protobuf message.
 * `RAW` - data stored in raw_data field.
 * `EXTERNAL` - data stored in an external location as described by external_data field.

--- a/docs/Hub.md
+++ b/docs/Hub.md
@@ -18,6 +18,7 @@ The ONNX Model Hub is capable of downloading, listing, and querying trained mode
  and defaults to the official [ONNX Model Zoo](https://github.com/onnx/models). In this section we demonstrate some of the basic functionality.
 
 First please import the hub using:
+
 ```python
 from onnx import hub
 ```
@@ -31,7 +32,6 @@ The `load` function will default to searching the model zoo for the latest model
 ```python
 model = hub.load("resnet50")
 ```
-
 
 #### Downloading from custom repositories:
 
@@ -63,7 +63,9 @@ One can also inspect the metadata of a model prior to download with the `get_mod
 ```python
 print(hub.get_model_info(model="mnist", opset=8))
 ```
+
 This will print something like:
+
 ```
 ModelInfo(
     model=MNIST,
@@ -81,7 +83,6 @@ ModelInfo(
      'model_with_data_bytes': 25962}
 )
 ```
-
 
 ## Local Caching
 
@@ -193,6 +194,7 @@ The ONNX Hub consists of two main components, the client and the server.
     }
 }
 ```
+
 These important fields are:
 
 - `model`: The name of the model used for querying
@@ -205,7 +207,6 @@ These important fields are:
 All other fields in the `metadata` field are optional for the client but provide important details for users.
 
 ## Adding to the ONNX Model Hub
-
 
 #### Contributing an official model
 
@@ -234,5 +235,6 @@ To host your own model hub, add an `ONNX_HUB_MANIFEST.json` to the top level of 
  using the "Downloading from custom repositories" section of this doc.
 
 ## Raise issue if any
+
 - For ONNX model problem or SHA mismatch issue, please raise issue in [Model Zoo]/(https://github.com/onnx/models/issues).
 - Other questions/issues regarding the usage of ONNX Model Hub, please raise issue in [this repo](https://github.com/onnx/onnx/issues).

--- a/docs/IR.md
+++ b/docs/IR.md
@@ -26,11 +26,11 @@ __Notes on language in this and all related documents__:
 
 ONNX is an open specification that consists of the following components:
 
-1)  A definition of an extensible computation graph model.
+1) A definition of an extensible computation graph model.
 
-2)  Definitions of standard data types.
+2) Definitions of standard data types.
 
-3)  Definitions of built-in operators.
+3) Definitions of built-in operators.
 
 #1 and #2 together make up the ONNX Intermediate Representation, or 'IR', specification which is covered herein; the built-in operators are covered in documents listed at the end. Specifically, built-in operators are divided into a set of primitive operators and functions. A function is an operator whose semantics is formally expressed via expansion into a sub-graph (called the function body) using other operators (and functions). Functionality-wise, an ONNX compatible framework or runtime may inline a function body to execute it if it does not have corresponding implementation of the function.
 
@@ -275,7 +275,6 @@ Graph|The names of graphs within a domain, unique within the model domain.
 Operator|The names of operators within a domain.
 Shape|The names of tensor shape variables – scoped to the value information records of a graph, which is where shape variables occur.
 
-
 ### Nodes
 
 Computation nodes are comprised of a name, the name of an operator that it invokes, a list of named inputs, a list of named outputs, and a list of attributes.
@@ -349,7 +348,6 @@ ref_attr_name|string|The name of a parent function's attribute.
 The properties ‘name’ and ‘type’ are required on all attributes, and ‘doc_string’ SHOULD be used on all attributes. An attribute MUST have only one of the value-carrying properties.
 
 In case ‘ref_attr_name’ is set, this attribute does not contain data, and instead it's a reference to the parent function's attribute of the given name. Can only be used within the function body.
-
 
 #### Variadic Inputs and Outputs
 
@@ -458,6 +456,7 @@ message TensorShapeProto {
   repeated Dimension dim = 1;
 }
 ```
+
 Which is referenced by the Tensor type message:
 
 ```
@@ -487,6 +486,7 @@ For example, a graph that performs matrix cross-product may be defined as taking
 Shapes MAY be defined using a combination of integers and variables.
 
 _Historical Notes_: The following extensions were considered early on, but were never implemented or supported.
+
 * The use of an empty string (as a dimension variable) to denote an unknown dimension not related to any other dimension. This was discarded in favor of using a Dimension with neither dim_value nor dim_param set.
 * The use of the string "\*" (as a dimension variable) to denote a sequence of zero or more dimensions of unknown cardinality. This is not supported. In the current implementation, the number of dimensions in a shape MUST represent the rank of the tensor. A tensor of unknown rank is represented using a TypeProto::Tensor object with no shape, which is legal.
 * A scoping mechanism to allow dimension variables that are local to a sub-graph (such as the body of a loop) may be useful, but is not currently supported.
@@ -585,6 +585,7 @@ The properties of a simple sharded dimension are:
 The multi-device annotations are hints to execution backends and do not affect the computational semantics of the model. Backends MAY ignore these annotations if the specified configurations are not supported or available. All communication operations required for multi-device execution (such as data transfers between devices) are implicit and handled by the runtime.
 
 For tensor parallelism, tensors can be:
+
 - **Split** across devices along specified axes, distributing different portions of the data to different devices
 - **Replicated** across devices, where the same tensor data is duplicated on multiple devices
 

--- a/docs/ManagingExperimentalOps.md
+++ b/docs/ManagingExperimentalOps.md
@@ -29,9 +29,11 @@ Old operator        |New Operator
 The experimental flag in ONNX operator definitions indicates that a customer of ONNX may not be able to take a long term dependency on that op. Ops in the ONNX namespace (ai.onnx) in the _main_ branch, whether experimental or not, go through the regular review process.
 
 Experimental ops that are being worked on that do not have consensus yet can be managed in one of 2 ways:
+
 1. Use a fork or branch – what you do in the fork or branch is entirely up to you. When you are ready, you can submit a PR using the normal process. This is the recommended way.
 2. If a fork/branch is not workable (for example due to complexity of mapping different branches between multiple repos), put the experimental ops in a custom namespace in the main branch.
 The specific process for this is:
+
  * Submit an Issue with a proposal explaining the motivation and plan. It does not need to include detailed technical design. Issues will be tagged as "experimental op".
  * Reviewers will generally approve by default unless the proposal directly conflicts with existing ops or somehow goes against general ONNX strategy. Approval is indicated by adding the "experiment approved" tag.
  * The approval is good for 3 months, but can be renewed if needed.

--- a/docs/MetadataProps.md
+++ b/docs/MetadataProps.md
@@ -33,6 +33,3 @@ Specifically, we define here the following set image metadata:
 |`Image.BitmapPixelFormat`|__string__|Specifies the format of pixel data. Each enumeration value defines a channel ordering and bit depth. Possible values: <ul><li>`Gray8`: 1 channel image, the pixel data is 8 bpp grayscale.</li><li>`Rgb8`: 3 channel image, channel order is RGB, pixel data is 8bpp (No alpha)</li><li>`Bgr8`: 3 channel image, channel order is BGR, pixel data is 8bpp (No alpha)</li><li>`Rgba8`: 4 channel image, channel order is RGBA, pixel data is 8bpp (Straight alpha)</li><li>`Bgra8`: 4 channel image, channel order is BGRA, pixel data is 8bpp (Straight alpha)</li></ul>|
 |`Image.ColorSpaceGamma`|__string__|Specifies the gamma color space used. Possible values:<ul><li>`Linear`: Linear color space, gamma == 1.0</li><li>`SRGB`: sRGB color space, gamma == 2.2</li></ul>|
 |`Image.NominalPixelRange`|__string__|Specifies the range that pixel values are stored. Possible values: <ul><li>`NominalRange_0_255`:  [0...255] for 8bpp samples</li><li>`Normalized_0_1`: [0...1] pixel data is stored normalized</li><li>`Normalized_1_1`: [-1...1] pixel data is stored normalized</li><li>`NominalRange_16_235`: [16...235] for 8bpp samples</li></ul>|
-
-
-

--- a/docs/OnnxReleases.md
+++ b/docs/OnnxReleases.md
@@ -9,6 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 The ONNX project, going forward, will plan to release roughly on a four month cadence. We follow the [Semver](https://semver.org/) versioning approach and will make decisions as a community on a release by release basis on whether to do a major or minor release.
 
 ## Preparation
+
 * Reach out to the SIG Arch/Infra leads to confirm whether the required status checks for the release branches are still valid and up to date, and whether any rely on outdated hardcoded runner image versions that may need updatingCheck whether the 'required checks' for the release branches are still up to date or need to be adjusted: 'Branches' -> 'Branch protection rules'
 * Determine version (X.Y.Z) for the new release
     * Discuss in Slack channel for Releases (https://lfaifoundation.slack.com/archives/C018VGGJUGK)
@@ -19,16 +20,17 @@ The ONNX project, going forward, will plan to release roughly on a four month ca
         * The new tag will be `v1.16.0`
 * Create new page for the release in [Release logistics wiki](https://github.com/onnx/onnx/wiki)
 * Before creating a release branch, it is highly recommended to have in mind to compile **preliminary release notes** — ideally maintained in a shared location such as the **release wiki page**. These notes should include a clear summary of the **new features**, a list of **bug fixes**, any **known issues**, and especially any **deprecations or removals**, with links to relevant tickets or documentation where applicable. Having this information ready ensures that the team can confidently and promptly create a `rc1` (release candidate 1) immediately after the branch is cut, without delays. Acting quickly at this stage also helps to **reduce the need for parallel work on both the main and release branches**, minimizing merge conflicts, duplicated effort, and coordination overhead. This practice supports a smoother, more transparent release process.
-   *   To generate good release notes, it is helpful if pull requests have meaningful names and corresponding labels. Labels can also be added retrospectively to PRs that have already been merged.
-   *   The labels used can be found [here](https://github.com/onnx/onnx/blob/main/.github/release.yml)
-   *   The preliminary release notes one gets if one drafts a release on GitHub.
+   * To generate good release notes, it is helpful if pull requests have meaningful names and corresponding labels. Labels can also be added retrospectively to PRs that have already been merged.
+   * The labels used can be found [here](https://github.com/onnx/onnx/blob/main/.github/release.yml)
+   * The preliminary release notes one gets if one drafts a release on GitHub.
 
 ## Create Release Branch
+
 * In `main` branch, before creating the release branch:
-    1.  Bump the `LAST_RELEASE_VERSION` in [version.h](/onnx/common/version.h).
+    1. Bump the `LAST_RELEASE_VERSION` in [version.h](/onnx/common/version.h).
         * Set to X.Y.Z, which is same as the release branch you are currently creating.
         * After the release branch is cut, `VERSION_NUMBER` in `main` will be increased to the next future version.
-    1.  Make sure the release version, IR version, ai.onnx opset version, ai.onnx.ml opset version, and ai.onnx.training opset version are correct for the new release in [ONNX proto files](/onnx/onnx.in.proto), [Versioning.md](Versioning.md), [schema.h](/onnx/defs/schema.h), [helper.py](/onnx/helper.py), and [helper_test.py](/onnx/test/helper_test.py).
+    1. Make sure the release version, IR version, ai.onnx opset version, ai.onnx.ml opset version, and ai.onnx.training opset version are correct for the new release in [ONNX proto files](/onnx/onnx.in.proto), [Versioning.md](Versioning.md), [schema.h](/onnx/defs/schema.h), [helper.py](/onnx/helper.py), and [helper_test.py](/onnx/test/helper_test.py).
 
 * Create a release branch
     1. Click "New branch" from [branches](https://github.com/onnx/onnx/branches) and choose `main` as Source.
@@ -48,6 +50,7 @@ The ONNX project, going forward, will plan to release roughly on a four month ca
 <img width="1078" height="1584" alt="RunWorkflow" src="https://github.com/user-attachments/assets/59c89418-395e-4c52-b0c6-a75ed4a6333b" />
 
 RC-Candidates
+
 * Published to https://test.pypi.org/
 * Build-mode: Release
 
@@ -61,10 +64,9 @@ RC-Candidates
 
 * Before the final merge, it must be confirmed manually via the set up deployment environments.
 
-
-
 ## Upload release candidate to TestPyPI (valid for releases up to and including 1.18 / fallback for 1.19)
 **Important**
+
 * **WAIT** for PR to set the release branch's `VERSION_NUMBER` to merge and build before continuing.
 * To push files to TestPyPI or PyPI, install `twine` if you don't already have it: `pip install twine`
     * When prompted for a password by `twine` commands, use an API token. Your password will not work.
@@ -84,10 +86,11 @@ RC-Candidates
             * `pip uninstall -y onnx && pip install --index-url http://127.0.0.1:80/simple/ --pre onnx`
 
 **Push Wheels**
+
 1. Gather the wheel files from the ONNX Github Actions for the release candidate.
    * ONNX GitHub Action
      * [Create_release](https://github.com/onnx/onnx/blob/main/.github/workflows/create_release.yml)
-      
+
    * Find the run for the release branch
      * Or start a run by clicking "Run workflow", pick the release branch, Click "Run Workflow"
       * Click the completed run, scroll to the "Artifacts" section (bottom), and click "wheels" to download the files
@@ -98,6 +101,7 @@ RC-Candidates
     * The project name and version built into the files.
 
 **Source Distribution**
+
 1. Make sure all the git submodules are updated
     * ``git submodule update --init``
 1. Make sure the git checkout is clean –
@@ -122,6 +126,7 @@ RC-Candidates
 ## Package verification
 
 **Partner Validation**
+
  * User should install the rc-packages with *pip install --no-deps -i https://test.pypi.org/simple/ onnx* (and manually install its dependencies so they are not obtained from test-pypi)
  * Test with onnxruntime package:
      * Run the test script from [test_with_ort.py](/onnx/test/test_with_ort.py) with installed onnxruntime package.
@@ -158,9 +163,11 @@ Validation steps must be completed before this point! This is the point of new r
 * Once pushed to PyPI there is no way to update the release. A new release must be made instead
 
 ## Set final version number
+
 * Create PR to remove "`rcX`" suffix from `VERSION_NUMBER` file in the new release's branch.
 
 ## Create release tag
+
 * [Draft a release](https://github.com/onnx/onnx/releases/new) based on the release branch:
     * DO NOT click `Publish release` until you are sure no more changes are needed.
         * Use `Save Draft` if need to save and update more later.
@@ -175,18 +182,20 @@ Validation steps must be completed before this point! This is the point of new r
     * .tar.gz and .zip will be auto-generated after publishing the release.
 
 ## Upload to Official PyPI
+
 * Starting with the release of 1.19, the final release will also be pushed to pypi via Github “Action" -> "Create releases" (see above). Use the following config for official release:
 
 <img width="548" height="749" alt="RunWorkflow_Final" src="https://github.com/user-attachments/assets/d836d0b8-b033-4317-aa21-2aeed3c74d05" />
 
-
 ### NOTES:
+
 * Once the packages are uploaded to PyPI, **you cannot overwrite it on the same PyPI instance**.
   * Please make sure everything is good on TestPyPI before uploading to PyPI**
 * PyPI has separate logins, passwords, and API tokens from TestPyPI but the process is the same. An ONNX PyPI owner will need to grant access, etc.
 
 ### old notes (with twine) ##
 Follow the **Wheels** and **Source Distribution** steps in [Upload release candidate toTestPyPI](#Upload-release-candidate-to-TestPyPI) above with the following changes:
+
 * Create a new API token of onnx scope for uploading onnx wheel in your [PyPI account](https://pypi.org/manage/account) (**API tokens** section).
     * Remove the created token after pushing the wheels and source for the release.
 * When uploading, remove `--repository testpypi` from twine commands.
@@ -195,6 +204,7 @@ Follow the **Wheels** and **Source Distribution** steps in [Upload release candi
 ## After PyPI Release
 
 **Announce**
+
 * Slack:
     * Post in the [onnx-release](https://lfaifoundation.slack.com/archives/C018VGGJUGK) and [onnx-general](https://lfaifoundation.slack.com/archives/C016UBNDBL2) channels.
 * Notify ONNX partners via email lists:
@@ -223,11 +233,13 @@ Conda builds of ONNX are done via [conda-forge/onnx-feedstock](https://github.co
     * Note: Use the sha256 hash (`sha256sum onnx-X.Y.Z.tar.gz`) of the release's tar.gz file from https://github.com/onnx/onnx/releases.
 
 **Merge into main branch**
+
 * Check which changes to the release branch are also relevant for main:
    * If urgent changes were made directly into the release branch, merge the release branch back into main branch.
    * If all PRs merged into the release branch (after it was cut) were cherry-picks from main, the merge PR will show as empty and this step is not needed.
 
 **Remove old onnx-weekly packages on PyPI**
+
 * Remove all [onnx-weekly packages](https://pypi.org/project/onnx-weekly/#history) from PyPI for the just released version to save space.
 * Steps:
     * Go to [PyPI onnx-weekly/releases](https://pypi.org/manage/project/onnx-weekly/releases/)
@@ -235,6 +247,7 @@ Conda builds of ONNX are done via [conda-forge/onnx-feedstock](https://github.co
     * Click target package -> Options -> Delete.
 
 **Remove old release-candidate packages on PyPI**
+
 * Remove [onnx-release-candidate packages](https://test.pypi.org/project/onnx/#history) from PyPI up to at least the time specified by the previous release version to save space.
 * Steps:
     * Go to [PyPI onnx-weekly/releases](https://test.pypi.org/manage/project/onnx/releases/)

--- a/docs/OpConventions.md
+++ b/docs/OpConventions.md
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 # Operator Conventions
 
 To maintain consistency in operator signatures, we use the following principles:
+
 - All attribute names should be lower case and use underscores when it helps with readability
 - Any input/output represented by a single letter is capitalized (i.e. X)
 - Any input/output represented by a full word or multiple words is all lower case and uses underscores when it helps with readability

--- a/docs/PythonAPIOverview.md
+++ b/docs/PythonAPIOverview.md
@@ -16,13 +16,15 @@ import onnx
 # onnx_model is an in-memory ModelProto
 onnx_model = onnx.load("path/to/the/model.onnx")
 ```
+
 Runnable IPython notebooks:
+
 - [load_model.ipynb](/examples/load_model.ipynb)
 
 ## Loading an ONNX Model with External Data
 
-
 * [Default] If the external data is under the same directory of the model, simply use `onnx.load()`
+
 ```python
 import onnx
 
@@ -41,6 +43,7 @@ load_external_data_for_model(onnx_model, "data/directory/path/")
 ```
 
 ## Converting an ONNX Model to External Data
+
 ```python
 from onnx.external_data_helper import convert_model_to_external_data
 
@@ -52,6 +55,7 @@ convert_model_to_external_data(onnx_model, all_tensors_to_one_file=True, locatio
 ```
 
 ## Saving an ONNX Model
+
 ```python
 import onnx
 
@@ -61,11 +65,13 @@ onnx_model = ...
 # Save the ONNX model
 onnx.save(onnx_model, "path/to/the/model.onnx")
 ```
+
 Runnable IPython notebooks:
+
 - [save_model.ipynb](/examples/save_model.ipynb)
 
-
 ## Converting and Saving an ONNX Model to External Data
+
 ```python
 import onnx
 
@@ -75,8 +81,8 @@ onnx.save_model(onnx_model, "path/to/save/the/model.onnx", save_as_external_data
 # Then the onnx_model has converted raw data as external data and saved to specific directory
 ```
 
-
 ## Manipulating TensorProto and Numpy Array
+
 ```python
 import numpy
 import onnx
@@ -121,10 +127,13 @@ for tensor_dtype in helper.get_all_tensor_dtypes():
     print(helper.tensor_dtype_to_string(tensor_dtype))
 
 ```
+
 Runnable IPython notebooks:
+
 - [np_array_tensorproto.ipynb](/examples/np_array_tensorproto.ipynb)
 
 ## Creating an ONNX Model Using Helper Functions
+
 ```python
 import onnx
 from onnx import helper, AttributeProto, TensorProto, GraphProto
@@ -162,11 +171,14 @@ print("Model is valid!")
 
 
 ```
+
 Runnable IPython notebooks:
+
 - [make_model.ipynb](/examples/make_model.ipynb)
 - [Protobufs.ipynb](/examples/Protobufs.ipynb)
 
 ## Conversion utilities for mapping attributes in ONNX IR
+
 ```python
 from onnx import TensorProto, helper
 
@@ -180,6 +192,7 @@ print(f"The field name for {helper.tensor_dtype_to_string(TensorProto.FLOAT)} is
 ```
 
 ## Checking an ONNX Model
+
 ```python
 import onnx
 
@@ -197,7 +210,9 @@ except onnx.checker.ValidationError as e:
 else:
     print("The model is valid!")
 ```
+
 Runnable IPython notebooks:
+
 - [check_model.ipynb](/examples/check_model.ipynb)
 
 ### Checking a Large ONNX Model >2GB
@@ -211,6 +226,7 @@ onnx.checker.check_model("path/to/the/model.onnx")
 ```
 
 ## Running Shape Inference on an ONNX Model
+
 ```python
 import onnx
 from onnx import helper, shape_inference
@@ -241,7 +257,9 @@ inferred_model = shape_inference.infer_shapes(original_model)
 onnx.checker.check_model(inferred_model)
 print(f"After shape inference, the shape info of Y is:\n{inferred_model.graph.value_info}")
 ```
+
 Runnable IPython notebooks:
+
 - [shape_inference.ipynb](/examples/shape_inference.ipynb)
 
 ### Shape inference a Large ONNX Model >2GB
@@ -288,6 +306,7 @@ print(result) # a list containing the (single) output type
 ```
 
 ## Converting Version of an ONNX Model within Default Domain (""/"ai.onnx")
+
 ```python
 import onnx
 from onnx import version_converter, helper
@@ -336,6 +355,7 @@ from the first model with inputs from the second model. By default, inputs/outpu
 `io_map` argument will remain as inputs/outputs of the combined model.
 
 In this example we merge two models by connecting each output of the first model to an input in the second. The resulting model will have the same inputs as the first model and the same outputs as the second:
+
 ```python
 import onnx
 
@@ -362,6 +382,7 @@ Additionally, a user can specify a list of `inputs`/`outputs` to be included in 
 effectively dropping the part of the graph that does't contribute to the combined model outputs.
 In the following example, we are connecting only one of the two outputs in the first model
 to both inputs in the second. By specifying the outputs of the combined model explicitly, we are dropping the output not consumed from the first model, and the relevant part of the graph:
+
 ```python
 import onnx
 
@@ -428,6 +449,7 @@ to the provided values in the parameter. You could provide both static and dynam
 by using dim_param. For more information on static and dynamic dimension size, checkout [Tensor Shapes](IR.md#tensor-shapes).
 
 The function runs model checker after the input/output sizes are updated.
+
 ```python
 import onnx
 from onnx.tools import update_model_dims

--- a/docs/ShapeInference.md
+++ b/docs/ShapeInference.md
@@ -14,8 +14,8 @@ or to define shape inference implementations to go along with your
 custom operators (or both!). Shape inference functions are stored as a
 member of the OpSchema objects.
 
-In ONNX 1.10 release, symbol generation and propagation along with shape 
-data propagation was added to ONNX graph level shape inference. 
+In ONNX 1.10 release, symbol generation and propagation along with shape
+data propagation was added to ONNX graph level shape inference.
 Detailed proposal is [here](proposals/SymbolicShapeInfProposal.md)
 
 ## Background
@@ -125,6 +125,7 @@ These utilities handle missing shapes and dimensions safely.
 _Example_: Consider a simple matrix-multiplication op that expects inputs of shape
 `[M,K]` and `[K,N]` and returns an output of shape `[M,N]`. This can be coded
 up as below:
+
 ```cpp
    // Check that input 0 has rank 2 (if its rank is known).
    checkInputRank(ctx, 0, 2);
@@ -138,4 +139,3 @@ up as below:
    unifyInputDim(ctx, 1, 1, N);
    updateOutputShape(ctx, 0, {M. N});
 ```
-

--- a/docs/TypeDenotation.md
+++ b/docs/TypeDenotation.md
@@ -17,6 +17,7 @@ input_in_NCHW -> data_0 -> SqueezeNet() -> output_softmaxout_1
 ```
 
 In order to run this model the user needs a lot of information.    In this case the user needs to know:
+
 * the input is an image
 * the image is in the format of NCHW
 * the color channels are in the order of bgr
@@ -24,6 +25,7 @@ In order to run this model the user needs a lot of information.    In this case 
 * the pixel data is normalized as values 0-255
 
 This proposal consists of three key components to provide all of this information:
+
 * Type Denotation,
 * [Dimension Denotation](DimensionDenotation.md),
 * [Model Metadata](MetadataProps.md).

--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -134,6 +134,7 @@ B|-     |**2**  |2      |2
 C|-     |-      |**3**  |**4**
 
 Notes:
+
 - Values that are new or updated from a previous OpSet version are in **bold**.
 
 ## Model versioning

--- a/docs/docsgen/source/api/model_container.md
+++ b/docs/docsgen/source/api/model_container.md
@@ -1,6 +1,5 @@
 # onnx.model_container
 
-
 ## ModelContainer
 
 ```{eval-rst}

--- a/docs/docsgen/source/technical/float4.md
+++ b/docs/docsgen/source/technical/float4.md
@@ -65,6 +65,7 @@ The float value is defined by the following expressions:
 ```
 
 The following table lists all the representable values by float4 E2M1, ignoring the sign bit:
+
 ```{eval-rst}
 .. list-table:: Float4 type values
    :widths: 10 10
@@ -110,9 +111,11 @@ The behavior for downcasting to float 4 is summarized below
 Float4 is stored as 2x4bit in a single byte.
 The first element is stored in the 4 LSB and the second element is stored in the 4 MSB,
 i.e. for elements `x` and `y` that are consecutive elements in the array:
+
 ```
 pack(x,y): y << 4 | x & 0x0F
 unpack(z): x = z & 0x0F, y = z >> 4
 ```
+
 In case the total number of elements is odd, padding of 4 bits will be appended.
 The storage size of a 4 bit tensor of size `N` is `ceil(N/2)`.

--- a/docs/docsgen/source/technical/float8.md
+++ b/docs/docsgen/source/technical/float8.md
@@ -198,7 +198,6 @@ The conversion may also be defined without any saturation.
 | \[x\] \< -FLT_MAX | NaN    | NaN      | -Inf | NaN      |
 | else              | RNE    | RNE      | RNE  | RNE      |
 
-
 ## E8M0
 
 The E8M0 data type serves as the common scale type for all [OCP Microscaling (MX) Formats](https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf). It has eight bits for the exponent, and no sign or mantissa bits.
@@ -225,6 +224,7 @@ The E8M0 data type serves as the common scale type for all [OCP Microscaling (MX
 ```
 
 When computing scale factors in MX formats, there are different casting choices one can make. For this reason, the ONNX spec for the Cast operator has introduced an additional "round_mode" attribute, which accepts the following:
+
 - "up": round to nearest value away from zero
 - "down": round to nearest value towards zero
 - "nearest": round to nearest value and ties round up

--- a/docs/docsgen/source/technical/int4.md
+++ b/docs/docsgen/source/technical/int4.md
@@ -33,6 +33,7 @@ a highly optimized end-to-end W4A4 encoder inference pipeline that supports vari
 
 As a result, two new types were introduced in `onnx==1.17.0` supporting a limited set of operators to enable compression using
 4 bit data-types:
+
 - `UINT4`: 4 bit unsigned integer, values in range [0, 15]
 - `INT4`: 4 bit signed integer, using two's complement representation. Values in range [-8, 7].
 
@@ -47,9 +48,11 @@ nearest-even integer and truncating.
 All 4 bit types are stored as 2x4bit in a single byte.
 The first element is stored in the 4 LSB and the second element is stored in the 4 MSB.
 i.e. for elements x, y, that are consecutive elements in the array:
+
 ```
 pack(x,y): y << 4 | x & 0x0F
 unpack(z): x = z & 0x0F, y = z >> 4
 ```
+
 In case the total number of elements is odd, padding of 4 bits will be appended.
 The storage size of a 4 bit tensor of size `N` is `ceil(N/2)`.

--- a/docs/proposals/ArchiveFileFormatProposal.md
+++ b/docs/proposals/ArchiveFileFormatProposal.md
@@ -14,21 +14,16 @@ We propose a new file format for ONNX models that is a specific application of t
 
 We propose to treat a .zip file as a key-value store, mapping string keys (filenames) to binary data files. For ONNX model serialization, we will have the following entries:
 
-
 * Data files - Files mapping a unique string identifier to a raw binary data file. These files shall be referenced from the appropriate fields within the base `ModelProto`
 * `__MODEL_PROTO` - File that contains the `ModelProto` describing the file
-
 
 Note that the order is significant here. We place the model definition file at the end of the archive to allow for the common case of net manipulations while keeping the weights invariant. This way, tools that manipulate the archive do not need to repack or realign all weights when only touching the model file.
 
 Within the ONNX protobuf definition, we propose the following changes:
 
-
 * Add `optional string external_data` to `TensorProto`. This can be treated as a data field similar to `float_data`, `int_data`, etc in that there must be exactly one of those fields specified. If a `TensorProto` specifies `external_data`, the implementation shall resolve this reference by string key in the containing zip archive. All values of `external_data` must be unique (under down-casing) and conform to the C identifier specification.
 
-
 Raw data files referenced by `TensorProto`s shall conform to the following specification:
-
 
 * The data shall be equivalent to that stored within the `raw_data` field in `TensorProto`.
 * Raw data files within the zip archive shall reside on an alignment boundary of 64 bytes. That is, the byte offset within the file of the first byte of a raw data tensor must be divisible by 64. This requirement can be fulfilled by packing bytes into the `extra` field of each local file record in the zip archive. (example: [2]). This constraint facilitates the direct memory-mapping of data files within the archive, and allows for architectures with both strict alignment requirements (e.g. SIMD instructions on aligned data) to operate and give architectures that operate more efficiently on cache line-aligned data to take full advantage.
@@ -37,12 +32,9 @@ Raw data files referenced by `TensorProto`s shall conform to the following speci
 
 In keeping with other domain-specific zip applications, we propose to use a custom file extension rather than the `.zip` extension. A custom file extension makes it clear to the user that this is not a general zip file, but rather a file that should be emitted by ONNX tools to conform to the spec.
 
-
 ## Future-Proofing Considerations
 
 This file format represents a generic key-value store that is scalable to many entries as well as large values. Further improvements to the format may come in the form of supporting different or multiple model definitions within the same model, or modifying the way in which weight files are stored. Building off of a proven archival format allows us the reliability as well as flexibility of zip.
-
-
 
 [0] https://github.com/onnx/onnx/issues/251
 [1] https://stackoverflow.com/questions/34128872/google-protobuf-maximum-size

--- a/docs/proposals/FunctionsProposal.md
+++ b/docs/proposals/FunctionsProposal.md
@@ -7,7 +7,8 @@ Copyright (c) ONNX Project Contributors
 ## Proposal Adding Function into ONNX
 
 Motivation:
-1.  Reduce number of primitive operators in ONNX
+
+1. Reduce number of primitive operators in ONNX
 To make it easier for hardware vendors to follow ONNX, we want to make it possible to define composite operators in terms of more primitive operators, reducing the number of kernels which must be directly implemented. For example, FC should be declared to be a composition MatMul and Add.
 
 2. Expose customize function capability for graph optimization.
@@ -17,6 +18,7 @@ To provide a mechanism of doing graph optimization, say, kernel fusion (merge a 
 To define a library of RNN cells and allow the user to write a custom one.
 
 MAJOR CHANGES:
+
 1.	FunctionProto added to represent a function.
 2.	FunctionSetProto added to represent a function set.
 3.	AttributeProto updated to support function attribute type and allow attribute reference.

--- a/docs/proposals/NLPinONNXproposal.md
+++ b/docs/proposals/NLPinONNXproposal.md
@@ -36,7 +36,6 @@ seq2seq with attention can roughly be broken down into these constituent parts:
     * This network weights the Encoder contexts based on the Decoder's generation state, and provides a focused Encoder context to the decoder. The Decoder “focuses” on a certain part of the input sequence at each timestep via this mechanism.
     * Many classes of attention mechanism: some examples are here https://arxiv.org/pdf/1508.04025.pdf
 
-
 Vanilla seq2seq with attention and non-backtracking beam search does NOT include things such as auxiliary data-structures (e.g. stacks), thus it does not require us to implement the full semantics of a programming language. It is an architecture that we can break down into incremental improvements to ONNX without compromising ONNX's fundamental goal.
 
 [1] https://arxiv.org/abs/1409.0473
@@ -56,7 +55,6 @@ Once we move beyond the domain of standard LSTM and GRU operations, we need a mo
 Of course, the dynamic control flow constructs can be used for more general use cases. For example, consider the [beam search](https://en.wikipedia.org/wiki/Beam_search) used often in NLP for sequence generation. This algorithm has several tricky aspects: a (potentially) dynamic stopping condition, a desired maximum trip count (so we don't fall into an infinite loop), loop-carried dependencies, and the desire to preserve the outputs at every time-step, not just the final time-step. Inherently, this is an imperative algorithm that operates on mutable state. The proposed control flow operators in ONNX, however, fulfill all of these requirements, and thus we can represent many instances of sequence generation in ONNX graphs.
 
 Note that there are more general forms of beam search, such as those including backtracking, but we are not considering these forms for this focused proposal.
-
 
 ## End-to-end Example : seq2seq with attention
 

--- a/docs/proposals/ONNXIFIproposal.md
+++ b/docs/proposals/ONNXIFIproposal.md
@@ -17,6 +17,7 @@ So far, ONNX format targets the problem of offline conversion of neural network 
 We should strive for consensus on a library API to interface with optimized backends and offload parts of ONNX graphs to these high-performance hardware and software implementation. The API should enable wide interoperability between high-level deep learning frameworks, software implementations of optimized graph runtimes, and existing and upcoming neural network acceleration hardware.
 
 The standardized API should reduce friction in deploying neural network models for all involved parties:
+
 - Applications would be able to ship only one version of a neural network model (either in ONNX format, or in the format of their deep learning framework, and convert it on the fly to ONNX).
 - Deep learning frameworks would be able to integrate with many hardware vendors by using only a single interface.
 - Hardware vendors would be able to implement only one interface and get integration with many deep learning frameworks.
@@ -56,7 +57,6 @@ We propose a small C-based API, which includes the following functionality:
     c. The user additionally estimates time to transfer subgraph inputs to the backend using `ONNX_BACKEND_CPU_MEMORY_READ_BANDWIDTH` information query and to transfer subgraph outputs from the backend using `ONNX_BACKEND_CPU_MEMORY_WRITE_BANDWIDTH`.
 
     d. If predicted time to transfer inputs to the backend, do inference, and transfer outputs from the backend exceeds predicted time to do the inference on default engine (e.g. CPU), the user falls back to a different ONNX backend, or to the default engine.
-
 
 4. The user initialized the backend, and offloads the subgraph execution to the ONNX backend by calling `onnxInitGraph`, `onnxSetGraphIO` and `onnxRunGraph`
 
@@ -103,6 +103,7 @@ Magic is an arbitrary 32-bit integer unique for a library implementing the API. 
 ### Library initialization
 
 During one-time library initialization, the implementation of the API would detect `n` supported devices and map them to backend indices in `0...(n-1)` range. The implementation of device discovery and checking required device characteristics is highly vendor- and platform-specific, e.g.:
+
 - A CPU implementation may always expose 1 device.
 - A CUDA-based implementation may call `cudaGetDeviceCount` to get the number of CUDA-enabled devices, then
  call `cudaGetDeviceProperties` for each device, and map CUDA devices which satisfy the minimum required functionality, such as compute capability, to backend indices.

--- a/docs/proposals/ONNXMultiDeviceProposal.md
+++ b/docs/proposals/ONNXMultiDeviceProposal.md
@@ -12,12 +12,12 @@ The recent trend in increasingly larger models has spurred an interest in distri
 
 Our goal is to extend ONNX so that it can serve as a representation of a parallelized model. This is driven by the current state-of-the-art techniques used for distributed inference (eg., see [GSPMD: General and Scalable Parallelization for ML Computation Graphs](https://arxiv.org/pdf/2105.04663.pdf)). In particular, two techniques of interest are tensor parallelism and pipelining. In tensor parallelism (also known as horizontal parallelism or operator parallelism), the computation of a single operator (node) in the graph is parallelized across multiple devices by sharding its inputs, In pipeline parallelism, different subgraphs are assigned to different devices.
 
-
 ## Design
 
 See [this commit](https://github.com/kevinch-nv/onnx/commit/07e97452096b28ba7c46fec6927d195907431e07) for the proposed additions to the ONNX spec.
 
 The key point of this design is that all multi-device specific annotations are at the node level, and do not affect the main computational graph. This means:
+
  - All communication operations required for multi-device execution are implicit
  - A backend may choose to ignore the annotations if the provided configurations are either not supported or not available
 
@@ -34,10 +34,12 @@ For example, consider the following 2x2 tensor:
 `[[1, 2], [3, 4]]`
 
 If a sharding across axis 0 is specified over two devices, then:
+
 - Device 0 will receive a tensor of shape 1x2 with data `[[1, 2]]`
 - Device 1 will receive a tensor of shape 1x2 with data `[[3, 4]]`
 
 The corresponding ShardingSpecProto for the above will look like:
+
 ```
 {
     device = [0, 1]
@@ -56,10 +58,12 @@ The corresponding ShardingSpecProto for the above will look like:
 ```
 
 If a sharding across axis 1 is specified over two devices, then:
+
 - Device 0 will receive a tensor of shape 2x1 with data `[[1], [3]]`
 - Device 1 will receive a tensor of shape 2x1 with data `[[2], [4]]`
 
 The corresponding ShardingSpecProto for the above will look like:
+
 ```
 {
     device = [0, 1]
@@ -78,12 +82,14 @@ The corresponding ShardingSpecProto for the above will look like:
 ```
 
 If a sharding across axis 0 and axis 1 is specified over four devices, then:
+
 - Device 0 will receive a tensor of shape 1x1 with data `[[1]]`
 - Device 1 will receive a tensor of shape 1x1 with data `[[2]]`
 - Device 2 will receive a tensor of shape 1x1 with data `[[3]]`
 - Device 3 will receive a tensor of shape 1x1 with data `[[4]]`
 
 The corresponding ShardingSpecProto for the above will look like:
+
 ```
 {
     device = [0, 1, 2, 3]
@@ -125,7 +131,6 @@ for a in range(num_shards_a):
 ```
 
 Note that the above examples assume that the num_shards are evenly divisible into the axis that's being sharded. While this is not a hard restriction, it is up to the backend on how to handle non-evenly divisble cases.
-
 
 #### Sharding as a Broadcast
 
@@ -178,4 +183,3 @@ A -> B -> C -> D -> E
 ```
 
 It is possible to have both pipeline and tensor parallel annotations in the same ONNX graph.
-

--- a/docs/proposals/ShardingFormalism.md
+++ b/docs/proposals/ShardingFormalism.md
@@ -28,7 +28,7 @@ For example, consider the addition operator `Add(A,B)`, where both inputs are
 two dimensional tensors of shapes `[32, 1024]`. Sharding the first input between
 two devices along axis 0 and the second input between the same two devices
 along axis 1 does not make sense. In fact, we typically expect both inputs to be
-sharded the same way. 
+sharded the same way.
 
 A sharding-checker to check if a given input sharding spec makes sense would be
 useful and we recommend building one. The correctness requirements, however, vary from
@@ -82,9 +82,11 @@ List of operations:
 _Abs, Acos, Acosh, Asin, Asinh, Atan, Atanh, Cast, Ceil, Cos, Cosh, Dropout, Erf, Exp, Floor, Identity, IsInf, IsNaN, Log, Max, Min, Neg, Not, Reciprocal, Round, Sigmoid, Sign, Sin, Sinh, Tan, Tanh, ConstantOfShape_.
 
 **Constraints on input sharding**
+
 * No constraints on input sharding.
 
 **Inference of output sharding**
+
 * If not specified, the output sharding is the same as input sharding
 
 ### Broadcast n-ary elementwise ops
@@ -93,6 +95,7 @@ List of operations:
 _Add, And, BitShift, BitwiseAnd, BitwiseNot, BitwiseOr, BitwiseXor, Equal, Greater, Less, Mod, Mul, Or, Pow, Sub, Sum, Where, Xor_.
 
 **Constraints on input sharding**
+
 * For any non-broadcast axis, the sharding spec of the two (or more) inputs must be identical
 * Any broadcast axis of size 1 (in the unsharded original tensor) must be replicated across all devices
 that participate in the parallel computation (that is, all devices identified in the node's sharding spec).
@@ -102,6 +105,7 @@ The constraint is that the sharding specs of the multiple broadcast axes must be
 which is illustrated down below.
 
 **Inference of output sharding**
+
 * The sharding spec for any axis of the output is the same as the sharding spec for the corresponding
 input axes in the case of non-broadcast.
 * In the case of a single broadcast axis, the output axis derives the sharding spec from the corresponding
@@ -127,6 +131,7 @@ Note that in this example, both the `M` and `N` axes are split into two shards e
 This means that the output itself has 4 shards, as shown in the figure.
 In this example, we want each output-shard to be on one device, as described by
 the sharding spec
+
 ```
 {
     device = [0, 1, 2, 3]
@@ -152,6 +157,7 @@ the sharding spec
     ]
 }
 ```
+
 To produce this output, however, we need to ensure that the input-shards are
 each available in two devices each, as shown in the figure above. In particular,
 the first shard of `Input1` is needed by both devices 0 and 1, as it is used
@@ -177,19 +183,22 @@ Thus, the sharding spec for `Input1` is as below:
     ]
 }
 ```
+
 The sharding spec for `Input2` is analogous, as explained and shown in figure above.
 
 This leads to the following constraint for input-sharding and inference rule
 for output-sharding in the presence of two broadcast axes:
+
 * The (inferred) devices for `output-shard[i,j]` is the intersection of the set of devices
 for `input-1-shard[i]` and `input-2-shard[j]`. If this set is empty, then the input
 sharding specs are not compatible (for broadcast composition).
 
-This rule is extended to the case of more than two broadcast axes accordingly. 
+This rule is extended to the case of more than two broadcast axes accordingly.
 
 ### Reduction ops
 
 **Constraints on input sharding**
+
 * No constraints on input sharding.
 * Sharding along non-reduction axes is straightforward. It indicates
 parallelization of the iteration over the non-reduction axes.
@@ -199,6 +208,7 @@ reduction is done locally on the shard, and in the second step the reduction is 
 across the different shards. This can be typically mapped to a collective-reduce operation.
 
 **Inference of output sharding**
+
 * Non-reduction axes inherit the sharding of the corresponding axes of the input.
 * Since the size of the reduction axis is one after the reduction, it can't be used
 for any meaningful sharding. The axis may even be omitted from the output shape,

--- a/docs/proposals/SymbolicShapeInfProposal.md
+++ b/docs/proposals/SymbolicShapeInfProposal.md
@@ -8,87 +8,83 @@ SPDX-License-Identifier: Apache-2.0
 
 *Note: This proposal was accepted and implemented in ONNX 1.10. Following PRs implemented this proposal: 3518, 3551, 3593, 3580*
 
-## Introduction 
-ONNX provides an implementation of shape inference on ONNX graphs. Shape inference is computed using the operator level shape inference functions. The inferred shape of an operator is used to get the shape information without having to launch the model in a session. Such static shape inference can be used to catch obvious errors before runtime, eliminate run-time checks which are otherwise guaranteed to pass, improve static memory planning and improve model visualization experience. For pytorch exporter and compiler-based execution providers like Nuphar, shape inference is required (rank inference is minimum requirement), and they cannot work with unknown shapes. 
+## Introduction
+ONNX provides an implementation of shape inference on ONNX graphs. Shape inference is computed using the operator level shape inference functions. The inferred shape of an operator is used to get the shape information without having to launch the model in a session. Such static shape inference can be used to catch obvious errors before runtime, eliminate run-time checks which are otherwise guaranteed to pass, improve static memory planning and improve model visualization experience. For pytorch exporter and compiler-based execution providers like Nuphar, shape inference is required (rank inference is minimum requirement), and they cannot work with unknown shapes.
 
 This document explains the limitations of shape inference and lays out a proposal for addressing these limitations.  
 
-## Current onnx shape inference limitations (Pre ONNX 1.10) 
-Today, ONNX shape inference is not guaranteed to be complete. Wherever possible we fall back to rank inference however, there are scenarios when rank inference is not possible either. Here are the various limitations which block the completion of shape inference: 
+## Current onnx shape inference limitations (Pre ONNX 1.10)
+Today, ONNX shape inference is not guaranteed to be complete. Wherever possible we fall back to rank inference however, there are scenarios when rank inference is not possible either. Here are the various limitations which block the completion of shape inference:
 
 1. Some dynamic behaviors block the flow of shape inference, and the shape inference stops. For example, reshape to a dynamically computed shape.
 
-2. Shape inference works only with constants and simple variables. It does not support arithmetic expressions containing variables nor does it support symbol generation. For example, concatenation on tensors of shapes (5, 2) and (7, 2) can be inferred to produce a result of shape (12, 2), but concatenation on tensors of shapes (5, 2) and (N, 2) will simply produce (?, 2), where “?” represents a dimension with neither dim value nor dim param, rather than containing a representation of N+5 or generating a new symbol (M, 2). In such scenarios shape propagation stops. 
+2. Shape inference works only with constants and simple variables. It does not support arithmetic expressions containing variables nor does it support symbol generation. For example, concatenation on tensors of shapes (5, 2) and (7, 2) can be inferred to produce a result of shape (12, 2), but concatenation on tensors of shapes (5, 2) and (N, 2) will simply produce (?, 2), where “?” represents a dimension with neither dim value nor dim param, rather than containing a representation of N+5 or generating a new symbol (M, 2). In such scenarios shape propagation stops.
 
 3. All operators are not required to have a shape inference implementation. When such an op is encountered the shape inference stops. There are also cases when rank inference is not done as a fallback mechanism. (Note: We are working on an ongoing basis to identify and fix such issues. The current document does not focus on this limitation)  
   
+## Goals and Non-Goals
+Our **goal** is to fix the shape inference gap in scenarios where:
 
-## Goals and Non-Goals 
-Our **goal** is to fix the shape inference gap in scenarios where: 
+* Shape computations are done in branches (refer to limitation 1)
 
-* Shape computations are done in branches (refer to limitation 1) 
+* Symbolic dimensions are present (refer to limitation 2)
 
-* Symbolic dimensions are present (refer to limitation 2) 
-
-By fixing these gaps we aim to:   
+By fixing these gaps we aim to:
 
 * Unblock pytorch exporter from exporting models when exporting stops because of absence of shape information.  
 
-* Improve static memory planning in the runtimes. 
+* Improve static memory planning in the runtimes.
 
 * Enable pre-allocating output buffers outside of the runtimes so that its lifetime can be managed by the caller itself.  
   
-
 ### Non-goals  
-* Add symbolic expressions to ONNX standard: This is not necessary for accomplishing our goals. There are advantages to having this capability, for example this can significantly reduce the number of symbols introduced and it can also provide more deterministic shape calculations in certain special cases. However, the tradeoff is the added complexity. So, at this point we are not considering it. This can be considered in future iterations. 
 
-* Enable data computation and propagation for older operator sets. (details in the proposal section) 
+* Add symbolic expressions to ONNX standard: This is not necessary for accomplishing our goals. There are advantages to having this capability, for example this can significantly reduce the number of symbols introduced and it can also provide more deterministic shape calculations in certain special cases. However, the tradeoff is the added complexity. So, at this point we are not considering it. This can be considered in future iterations.
+
+* Enable data computation and propagation for older operator sets. (details in the proposal section)
 
 Note: This work will benefit Nuphar as well but right now there is no plan to move Nuphar to use this solution.  
   
-
-## Terminology 
+## Terminology
 Shape inference can be broken into 2 parts:  
 
 * Node level shape inference: This refers to operator specific shape inference functions. They are defined with the operator schema itself.  
 
 * Graph-level shape inference: This refers to the higher-level logic which walks through the entire graph, gets the inferred shape from node level shape inference functions and then makes decisions on merging these inferred shapes with existing shapes so that they are available for downstream nodes.  
- 
 
-## Proposal 
+## Proposal
 Extend current shape inference to allow:  
-* Symbol generation and propagation 
 
-* Partial data computation and propagation 
+* Symbol generation and propagation
+
+* Partial data computation and propagation
 
 * Extend shape op to generate slice of the shape to facilitate simplifying shape computations.  
 
-
 ## Extend shape inference  
 
-### Symbol generation and propagation 
-Extend graph level shape inference to maintain a graph level view of symbols and generate new symbols where necessary. This will enable us to continue the shape inference of the downstream nodes. 
+### Symbol generation and propagation
+Extend graph level shape inference to maintain a graph level view of symbols and generate new symbols where necessary. This will enable us to continue the shape inference of the downstream nodes.
 
-Example: 
+Example:
 
 For an op like “Concat” if its inputs have shapes “[M]” and “[N]” current shape-inference returns “[?]” where “?” is to indicate a dimension with neither dim-value nor dim-param set. Now, suppose the output X of “Concat” is input to a unary-op Op1() whose output Y is then input to another unary-op Op2() whose output is Z, etc. The shape “[?]” is propagated further. We infer that Y and Z have shape “[?]”. However, we do not infer that X, Y, and Z have the same shape because two “?” cannot be considered equal.  
 
 Per the current proposal, “[?]” in inferred shapes will be replaced by a new unique symbol by the graph level shape inference so the downstream nodes can use the symbolic shapes to carry out shape inference. In the current example, “Concat” will produce “[?]” as the shape which will then be replaced by “[K]”, then subsequent shape inference will infer that X, Y, and Z all have the same shape “[K]”. Runtimes can use this information to reuse memory for these tensors.  
 
+### Partial data computation and propagation
+When shape inputs are computed dynamically, shape inference post a reshape node stops. This can be prevented by making this data available to the reshape node during shape inference. We propose computation and propagation of data for operators which are used in shape computation.
 
-### Partial data computation and propagation 
-When shape inputs are computed dynamically, shape inference post a reshape node stops. This can be prevented by making this data available to the reshape node during shape inference. We propose computation and propagation of data for operators which are used in shape computation. 
+It is called “partial” data computation and propagation because this will only be done for shape computations. It is not meant to be a full-fledged kernel for the operator. For the same reasons data computations will be implemented for a limited set of operators. While we will increase the coverage in the future iterations it is important to note that for some operators like LSTM, convolution ops, pooling ops etc. data propagation function will never be added because such ops are not used in shape computations.
 
-It is called “partial” data computation and propagation because this will only be done for shape computations. It is not meant to be a full-fledged kernel for the operator. For the same reasons data computations will be implemented for a limited set of operators. While we will increase the coverage in the future iterations it is important to note that for some operators like LSTM, convolution ops, pooling ops etc. data propagation function will never be added because such ops are not used in shape computations. 
+The following operators will be picked in the first phase. (These operators are generally used for shape computations.)
 
-The following operators will be picked in the first phase. (These operators are generally used for shape computations.) 
-
-| Ops     | 
-| --------| 
-| Add     | 
+| Ops     |
+| --------|
+| Add     |
 | Sub     |
 | Mul     |
-| Cast    | 
+| Cast    |
 | Concat  |
 | Gather  |
 | Reshape |
@@ -100,9 +96,9 @@ The following operators will be picked in the first phase. (These operators are 
 
 The OpSchema class will be extended to include an optional “PartialDataPropagationFunction” like the existing TypeAndShapeInferenceFunction. This function will provide data computation for the operators which will then be propagated to the downstream operators by the graph level shape inference. PartialDataPropagationFunction will be called by the graph level shape inference after TypeAndShapeInference runs for the node because the output shape is required for partial data computation.  
 
-A new interface "DataPropagationContext” will be added to allow  PartialDataPropagationFunction to access all the information required to propagate shape data for the given node and allow writing of the computed data. 
+A new interface "DataPropagationContext” will be added to allow  PartialDataPropagationFunction to access all the information required to propagate shape data for the given node and allow writing of the computed data.
 
-Example: 
+Example:
 
 ```
 using DataPropagationFunction = std::function<void(DataPropagationContext&)>  
@@ -148,22 +144,17 @@ ONNX_OPERATOR_SET_SCHEMA(
 
 The symbol generation will happen at the graph level shape inference, therefore all the models (older opsets as well as the latest opset versions) can benefit from this enhancement. However, the data computation and propagation are tied to the OpScehma and will happen at node level. To begin with these functions will only be added to the latest op schemas. Older schemas can be extended to support data computation later, on a case by case basis to support some high priority scenarios. What this means is that older opset models will not benefit from shape inference improvements because of this enhancement.  
   
-
-## Special Cases 
+## Special Cases
 This section considers some edge cases and proposes a solution to handle them.  
 
-
-### Broadcasting with symbolic dims 
+### Broadcasting with symbolic dims
 If we have a broadcast between two unknown dimensions “M” and “N” we cannot infer that both M and N should have the same value. The runtime semantics allows for one of the two symbols to have the value 1 and the other to have a value different from 1. So, merging M and N and treating them as the same value is potentially unsound. In this case, a new symbol will be generated for the output shape and the shape inference will continue.  
 
-
-### Inferred shape does not match output shape 
+### Inferred shape does not match output shape
 Inferred and existing shapes can be mismatched. Although failing shape inference in such cases seems like the correct approach it may not always be practical. By default, shape inference will fail when such a case is encountered however callers will have an option to override existing types with inferred types. When this option is enabled, shape inference will continue with the inferred type.  
 
+### Handling symbolic dimensions with data propagation
+When the shape contains symbolic dimensions, we try and propagate them downstream, however in cases where some arithmetic operations are performed on these symbolic dims we create new symbols and propagate them instead.
 
-### Handling symbolic dimensions with data propagation 
-When the shape contains symbolic dimensions, we try and propagate them downstream, however in cases where some arithmetic operations are performed on these symbolic dims we create new symbols and propagate them instead.   
-
-
-### Output shape is dependent on input data 
+### Output shape is dependent on input data
 There are certain nodes like NonZero where the output shape depends on the input data. In this case it is not possible to infer the shape completely hence a new symbolic shape will be created using the inferred rank and shape inference will continue.  


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
Format and remove white space in the docs by markdownlint-cli2. The aim is enable the tool in CI.
### Motivation and Context
Better docs
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
