### PR TITLE
Explicitly specify the Google Python Style Guide in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ python onnx/defs/gen_doc.py
 
 ### Coding style
 
-We adopted the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html) for this project.
+We adopted the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html) and [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) for this project.
 
 We use `lintrunner` to drive multiple linters defined in `.lintrunner.toml` to lint the codebase.
 


### PR DESCRIPTION
Added a note about adopting the Google Python Style Guide for coding standards. Previously the adoption has been implicit. This change makes it explicitly stated.
