### PR TITLE
Fix a syntactic error in ONNXConfig.cmake.in

### DIFF
--- a/cmake/ONNXConfig.cmake.in
+++ b/cmake/ONNXConfig.cmake.in
@@ -4,7 +4,7 @@
 # library version information
 set(ONNX_VERSION "@ONNX_VERSION@")
 
-if((NOT @@ONNX_USE_PROTOBUF_SHARED_LIBS@@) AND @@Build_Protobuf@@)
+if((NOT @ONNX_USE_PROTOBUF_SHARED_LIBS@) AND @Build_Protobuf@)
   find_package(Protobuf REQUIRED CONFIG)
 endif()
 


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
There is a syntactic error in ``ONNXConfig.cmake.in`` introduced in #7385. This PR fixes it and #7378.
### Motivation and Context
Fix reported bugs
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
