### PR TITLE
Fix clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -30,14 +30,16 @@ Checks: >-
   -modernize-concat-nested-namespaces,
   -modernize-return-braced-init-list,
   -modernize-use-auto,
+  -modernize-use-integer-sign-comparison,
+  -modernize-use-ranges,
   -modernize-use-trailing-return-type,
   -modernize-use-nodiscard,
   readability-container-size-empty,
   readability-delete-null-pointer,
-  readability-duplicate-include
+  readability-duplicate-include,
   readability-misplaced-array-index,
   readability-non-const-parameter,
-  readability-redundant*
+  readability-redundant*,
   readability-simplify*,
   readability-static-accessed-through-instance,
   readability-static-definition-in-anonymous-namespace,

--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -839,7 +839,7 @@ class OpSetID final {
   explicit OpSetID(const OperatorSetIdProto& proto) : domain_(proto.domain()), version_(proto.version()) {}
 
   // Default Domain Constructor
-  explicit OpSetID(const int64_t version) : domain_(""), version_(version) {}
+  explicit OpSetID(const int64_t version) : version_(version) {}
 
   explicit OpSetID(std::string domain, int64_t version) : domain_(std::move(domain)), version_(version) {}
 

--- a/onnx/common/ir_pb_converter.cc
+++ b/onnx/common/ir_pb_converter.cc
@@ -112,7 +112,7 @@ static Tensor tensorProtoToTensor(const ONNX_NAMESPACE::TensorProto& tp) {
   }
 
   for (int i = 0; i < tp.external_data_size(); i++) {
-    ret.external_data().push_back(std::make_pair(tp.external_data(i).key(), tp.external_data(i).value()));
+    ret.external_data().emplace_back(tp.external_data(i).key(), tp.external_data(i).value());
   }
   if (tp.has_data_location()) {
     ret.data_location() = tp.data_location();

--- a/onnx/defs/controlflow/old.cc
+++ b/onnx/defs/controlflow/old.cc
@@ -3222,8 +3222,6 @@ values are computed in the outer graph, they need to be passed in as extra state
 
 )DOC";
 
-extern void ScanInferenceFunction(InferenceContext& ctx);
-
 ONNX_OPERATOR_SET_SCHEMA(
     Scan,
     11,

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -101,7 +101,7 @@ ONNX_API void convPoolShapeInference(
   }
 
   std::vector<int64_t> effective_kernel_shape = kernel_shape;
-  for (int i = 0; i < static_cast<int>(kernel_shape.size()); i++) {
+  for (size_t i = 0; i < kernel_shape.size(); i++) {
     // accounting for dilation, how big is the kernel in this dimension
     effective_kernel_shape[i] = (effective_kernel_shape[i] - 1) * dilations[i] + 1;
   }
@@ -427,8 +427,8 @@ static void maxUnpoolShapeInference(InferenceContext& ctx) {
       if (output_shape.dim_size() != 1) {
         fail_type_inference("'output_shape' must be rank 1 tensor.");
       }
-      if (output_shape.dim((int)0).has_dim_value() &&
-          static_cast<int>(output_shape.dim((int)0).dim_value()) != input_shape.dim_size()) {
+      if (output_shape.dim(0).has_dim_value() &&
+          static_cast<int>(output_shape.dim(0).dim_value()) != input_shape.dim_size()) {
         fail_shape_inference("'output_shape' must have same number of elements as the shape of input tensor X.");
       }
     }
@@ -1158,7 +1158,7 @@ ONNX_API void convTransposeShapeInference(InferenceContext& ctx) {
   }
 
   std::vector<int64_t> effective_kernel_shape = kernel_shape;
-  for (int i = 0; i < static_cast<int>(kernel_shape.size()); i++) {
+  for (size_t i = 0; i < kernel_shape.size(); i++) {
     // accounting for dilation, how big is the kernel in this dimension
     effective_kernel_shape[i] = (effective_kernel_shape[i] - 1) * dilations[i] + 1;
   }
@@ -2359,7 +2359,6 @@ static void col2imShapeInference(InferenceContext& ctx) {
     }
     *final_image_shape->add_dim() = image_dim_i;
   }
-  return;
 }
 
 static const char* Col2Im_ver18_doc = R"DOC(

--- a/onnx/defs/nn/old.cc
+++ b/onnx/defs/nn/old.cc
@@ -179,7 +179,7 @@ static void convPoolShapeInference_opset19(
   }
 
   std::vector<int64_t> effective_kernel_shape = kernel_shape;
-  for (int i = 0; i < static_cast<int>(kernel_shape.size()); i++) {
+  for (size_t i = 0; i < kernel_shape.size(); i++) {
     // accounting for dilation, how big is the kernel in this dimension
     effective_kernel_shape[i] = (effective_kernel_shape[i] - 1) * dilations[i] + 1;
   }
@@ -193,8 +193,8 @@ static void convPoolShapeInference_opset19(
     pads.assign(n_input_dims * 2, 0);
     const auto* auto_pad_attr = ctx.getAttribute("auto_pad");
     if ((nullptr != auto_pad_attr) && (auto_pad_attr->s() != "VALID")) {
-      int input_dims_size = static_cast<int>(n_input_dims);
-      for (int i = 0; i < input_dims_size; ++i) {
+      auto input_dims_size = n_input_dims;
+      for (size_t i = 0; i < input_dims_size; ++i) {
         int64_t residual = 0;
         int64_t stride = strides[i];
         if (stride > 1) {
@@ -206,7 +206,7 @@ static void convPoolShapeInference_opset19(
             residual -= stride;
           }
         }
-        if (i >= static_cast<int>(effective_kernel_shape.size())) {
+        if (i >= effective_kernel_shape.size()) {
           fail_shape_inference("kernel shape should have ", input_dims_size, " values in ", ctx.getDisplayName(), ".");
         }
         int64_t total_pad = residual == 0 ? effective_kernel_shape[i] - stride : effective_kernel_shape[i] - residual;
@@ -505,8 +505,8 @@ static void maxUnpoolShapeInference_opset11(InferenceContext& ctx) {
       if (output_shape.dim_size() != 1) {
         fail_type_inference("'output_shape' must be rank 1 tensor.");
       }
-      if (output_shape.dim(static_cast<int>(0)).has_dim_value() &&
-          static_cast<int>(output_shape.dim(static_cast<int>(0)).dim_value()) != input_shape.dim_size()) {
+      if (output_shape.dim(0).has_dim_value() &&
+          static_cast<int>(output_shape.dim(0).dim_value()) != input_shape.dim_size()) {
         fail_shape_inference("'output_shape' must have same number of elements as the shape of input tensor X.");
       }
     }
@@ -670,7 +670,7 @@ static void convTransposeShapeInference_opset11(InferenceContext& ctx) {
   }
 
   std::vector<int64_t> effective_kernel_shape = kernel_shape;
-  for (int i = 0; i < static_cast<int>(kernel_shape.size()); i++) {
+  for (size_t i = 0; i < kernel_shape.size(); i++) {
     // accounting for dilation, how big is the kernel in this dimension
     effective_kernel_shape[i] = (effective_kernel_shape[i] - 1) * dilations[i] + 1;
   }
@@ -2005,7 +2005,7 @@ static void convPoolShapeInference1(
   }
 
   std::vector<int64_t> effective_kernel_shape = kernel_shape;
-  for (int i = 0; i < static_cast<int>(kernel_shape.size()); i++) {
+  for (size_t i = 0; i < kernel_shape.size(); i++) {
     // accounting for dilation, how big is the kernel in this dimension
     effective_kernel_shape[i] = (effective_kernel_shape[i] - 1) * dilations[i] + 1;
   }
@@ -2606,8 +2606,8 @@ static void maxUnpoolShapeInference1(InferenceContext& ctx) {
       if (output_shape.dim_size() != 1) {
         fail_type_inference("'output_shape' must be rank 1 tensor.");
       }
-      if (output_shape.dim(static_cast<int>(0)).has_dim_value() &&
-          static_cast<int>(output_shape.dim(static_cast<int>(0)).dim_value()) != input_shape.dim_size()) {
+      if (output_shape.dim(0).has_dim_value() &&
+          static_cast<int>(output_shape.dim(0).dim_value()) != input_shape.dim_size()) {
         fail_shape_inference("'output_shape' must have same number of elements as the shape of input tensor X.");
       }
     }
@@ -3016,7 +3016,7 @@ static void convTransposeShapeInference1(InferenceContext& ctx) {
   }
 
   std::vector<int64_t> effective_kernel_shape = kernel_shape;
-  for (int i = 0; i < static_cast<int>(kernel_shape.size()); i++) {
+  for (size_t i = 0; i < kernel_shape.size(); i++) {
     // accounting for dilation, how big is the kernel in this dimension
     effective_kernel_shape[i] = (effective_kernel_shape[i] - 1) * dilations[i] + 1;
   }

--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -569,7 +569,7 @@ Status OnnxParser::ParseSingleAttributeValue(AttributeProto& attr, AttributeProt
         Literal literal;
         PARSE_TOKEN(literal);
         attr.set_type(AttributeProto_AttributeType_FLOAT);
-        attr.set_f(static_cast<float>(std::stof(literal.value)));
+        attr.set_f(std::stof(literal.value));
       } else {
         attr.set_type(AttributeProto_AttributeType_GRAPH);
         PARSE(*attr.mutable_g());
@@ -591,7 +591,7 @@ Status OnnxParser::ParseSingleAttributeValue(AttributeProto& attr, AttributeProt
         break;
       case LiteralType::FLOAT_LITERAL:
         attr.set_type(AttributeProto_AttributeType_FLOAT);
-        attr.set_f(static_cast<float>(std::stof(literal.value)));
+        attr.set_f(std::stof(literal.value));
         break;
       case LiteralType::STRING_LITERAL:
         attr.set_type(AttributeProto_AttributeType_STRING);

--- a/onnx/defs/printer.cc
+++ b/onnx/defs/printer.cc
@@ -89,7 +89,7 @@ class ProtoPrinter {
   }
 
   template <typename T>
-  inline void print(const T& prim) {
+  void print(const T& prim) {
     output_ << prim;
   }
 
@@ -104,21 +104,21 @@ class ProtoPrinter {
   }
 
   template <typename T>
-  inline void printKeyValuePair(KeyWordMap::KeyWord key, const T& val, bool addsep = true) {
+  void printKeyValuePair(KeyWordMap::KeyWord key, const T& val, bool addsep = true) {
     if (addsep)
       output_ << "," << '\n';
     output_ << std::setw(indent_level) << ' ' << KeyWordMap::ToString(key) << ": ";
     print(val);
   }
 
-  inline void printKeyValuePair(KeyWordMap::KeyWord key, const std::string& val) {
+  void printKeyValuePair(KeyWordMap::KeyWord key, const std::string& val) {
     output_ << "," << '\n';
     output_ << std::setw(indent_level) << ' ' << KeyWordMap::ToString(key) << ": ";
     printQuoted(val);
   }
 
   template <typename Collection>
-  inline void printSet(const char* open, const char* separator, const char* close, const Collection& coll) {
+  void printSet(const char* open, const char* separator, const char* close, const Collection& coll) {
     const char* sep = "";
     output_ << open;
     for (auto& elt : coll) {
@@ -130,7 +130,7 @@ class ProtoPrinter {
   }
 
   template <typename Collection>
-  inline void printIdSet(const char* open, const char* separator, const char* close, const Collection& coll) {
+  void printIdSet(const char* open, const char* separator, const char* close, const Collection& coll) {
     const char* sep = "";
     output_ << open;
     for (auto& elt : coll) {

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -28,8 +28,6 @@ namespace ONNX_NAMESPACE {
 // Other positive integer means the ONNX schemas for the specified version have been loaded
 int OpSchemaRegistry::loaded_schema_version = -1;
 
-constexpr int OpSchema::kUninitializedSinceVersion;
-
 // By default if opset_version_to_load=0, it registers all opset schema for all opset versions
 // Otherwise, it only registers the latest schema according to opset_version_to_load
 void RegisterSchema(

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -427,11 +427,7 @@ class OpSchema final {
 
   struct Attribute final {
     Attribute(std::string name_, std::string description_, AttributeProto::AttributeType type_, bool required_)
-        : name(std::move(name_)),
-          description(std::move(description_)),
-          type(type_),
-          required(required_),
-          default_value() {}
+        : name(std::move(name_)), description(std::move(description_)), type(type_), required(required_) {}
 
     Attribute(std::string name_, std::string description_, AttributeProto default_value_)
         : name(std::move(name_)),
@@ -729,11 +725,11 @@ class OpSchema final {
   }
 
   ONNX_API bool has_type_and_shape_inference_function() const {
-    return tensor_inference_function_ ? true : false;
+    return static_cast<bool>(tensor_inference_function_);
   }
 
   ONNX_API bool has_data_propagation_function() const {
-    return data_propagation_function_ ? true : false;
+    return static_cast<bool>(data_propagation_function_);
   }
 
   ONNX_API std::vector<int> function_opset_versions() const {
@@ -852,7 +848,7 @@ class OpSchema final {
   std::string doc_;
   // Default domain value ("") means it's ONNX domain.
   std::string domain_ = ONNX_DOMAIN;
-  std::unordered_map<std::string, Attribute> attributes_{};
+  std::unordered_map<std::string, Attribute> attributes_;
   bool allows_unchecked_attributes_ = false;
   std::vector<FormalParameter> inputs_;
   std::vector<FormalParameter> outputs_;
@@ -1091,7 +1087,7 @@ class OpSchemaRegistry final : public ISchemaRegistry {
       }
       auto lower_bound_incl = ver_range_it->second.first;
       auto upper_bound_incl = ver_range_it->second.second;
-      if (!(lower_bound_incl <= ver && upper_bound_incl >= ver)) {
+      if (lower_bound_incl > ver || upper_bound_incl < ver) {
         std::stringstream err;
         err << "Trying to register schema with name " << op_name << " (domain: " << op_domain << " version: " << ver
             << ") from file " << op_schema.file() << " line " << op_schema.line() << ", but its version is not "
@@ -1348,9 +1344,6 @@ size_t ReplaceAll(std::string& s, const char* from, const char* to);
 #define ONNX_OPERATOR_SCHEMA_UNIQ(Counter, name)                                                                      \
   static ONNX_NAMESPACE::OpSchemaRegistry::OpSchemaRegisterOnce(op_schema_register_once##name##Counter) ONNX_UNUSED = \
       OpSchema(#name, __FILE__, __LINE__)
-
-// Helper function
-size_t ReplaceAll(std::string& s, const char* from, const char* to);
 
 ONNX_API inline std::string GenerateOptionalArgumentsDoc() {
   return "This operator has **optional** inputs/outputs. "

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -326,7 +326,7 @@ inline bool hasShape(const TypeProto& type) {
 
 template <typename Context>
 inline bool hasInputShape(const Context& ctx, size_t n) {
-  return ctx.getNumInputs() > static_cast<size_t>(n) && ctx.getInputType(n) && hasShape(*ctx.getInputType(n));
+  return ctx.getNumInputs() > n && ctx.getInputType(n) && hasShape(*ctx.getInputType(n));
 }
 
 template <typename Context>

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -682,7 +682,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             false)
         .SetDoc(Split_ver18_doc)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-          for (int i = 0; i < static_cast<int>(ctx.getNumOutputs()); ++i) {
+          for (size_t i = 0; i < ctx.getNumOutputs(); ++i) {
             propagateElemTypeFromInputToOutput(ctx, 0, i);
           }
           if (!hasNInputShapes(ctx, 1)) {
@@ -928,7 +928,7 @@ ONNX_OPERATOR_SET_SCHEMA(
               (hasInputShape(ctx, 4) && !ctx.getInputData(4))) {
             const auto input_rank = ctx.getInputType(0)->tensor_type().shape().dim_size();
             // we can infer the output rank - it never changes
-            for (size_t i = 0; (int64_t)i < input_rank; ++i) {
+            for (int i = 0; i < input_rank; ++i) {
               ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim();
             }
             return;
@@ -984,7 +984,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
           }
 
-          for (size_t i = 0; (int64_t)i < input_rank; ++i) {
+          for (int i = 0; i < input_rank; ++i) {
             // first update rank of output dim
             auto* output_dim = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim();
             const auto& input_dim = input_shape.dim((int)i);
@@ -2126,7 +2126,7 @@ ONNX_OPERATOR_SET_SCHEMA(
                   "to the number of input dimensions.");
             }
 
-            for (size_t i = 0; (int64_t)i < input_rank; ++i) {
+            for (int i = 0; i < input_rank; ++i) {
               const auto& input_dim = input_shape.dim((int)i);
               auto* output_dim = output_shape->add_dim();
               if (input_dim.has_dim_value()) {
@@ -2137,7 +2137,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             // Infer output shape's rank in any case (if repeats data is not
             // available)
             auto* output_shape_0 = getOutputShape(ctx, 0);
-            for (size_t i = 0; (int64_t)i < input_rank; ++i) {
+            for (int i = 0; i < input_rank; ++i) {
               output_shape_0->add_dim();
             }
           }

--- a/onnx/defs/tensor/old.cc
+++ b/onnx/defs/tensor/old.cc
@@ -1552,7 +1552,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           const auto& dataInputTensorType = ctx.getInputType(0)->tensor_type();
           std::vector<bool> unresolvedZeros(targetShape.size(), false);
           int64_t outputProduct = 1;
-          for (int i = 0; i < static_cast<int>(targetShape.size()); ++i) {
+          for (size_t i = 0; i < targetShape.size(); ++i) {
             // Add a new dimension to outputShape
             auto* new_dim = outputShape->add_dim();
             if (targetShape[i] == -1) {
@@ -1569,7 +1569,7 @@ ONNX_OPERATOR_SET_SCHEMA(
               // inferred, set the corresponding  unresolvedZeros flag to true.
               unresolvedZeros[i] = true;
               if (dataInputTensorType.has_shape()) {
-                if (i >= dataInputTensorType.shape().dim_size()) {
+                if (i >= static_cast<size_t>(dataInputTensorType.shape().dim_size())) {
                   fail_shape_inference("Invalid position of 0");
                 }
                 if (dataInputTensorType.shape().dim(i).has_dim_value()) {
@@ -2324,7 +2324,7 @@ ONNX_OPERATOR_SET_SCHEMA(
               (hasInputShape(ctx, 4) && !ctx.getInputData(4))) {
             const auto input_rank = ctx.getInputType(0)->tensor_type().shape().dim_size();
             // we can infer the output rank - it never changes
-            for (size_t i = 0; (int64_t)i < input_rank; ++i) {
+            for (int i = 0; i < input_rank; ++i) {
               ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim();
             }
             return;
@@ -2386,7 +2386,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
           }
 
-          for (size_t i = 0; (int64_t)i < input_rank; ++i) {
+          for (int i = 0; i < input_rank; ++i) {
             // first update rank of output dim
             auto* output_dim = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim();
             const auto& input_dim = input_shape.dim((int)i);
@@ -4381,7 +4381,7 @@ ONNX_OPERATOR_SET_SCHEMA(
                   "to the number of input dimensions.");
             }
 
-            for (size_t i = 0; (int64_t)i < input_rank; ++i) {
+            for (int i = 0; i < input_rank; ++i) {
               const auto& input_dim = input_shape.dim((int)i);
               auto* output_dim = output_shape->add_dim();
               if (input_dim.has_dim_value()) {
@@ -4392,7 +4392,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             // Infer output shape's rank in any case (if repeats data is not
             // available)
             auto* output_shape_0 = getOutputShape(ctx, 0);
-            for (size_t i = 0; (int64_t)i < input_rank; ++i) {
+            for (int i = 0; i < input_rank; ++i) {
               output_shape_0->add_dim();
             }
           }
@@ -5456,7 +5456,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
 
             auto* output_shape = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
-            for (size_t i = 0; static_cast<int64_t>(i) < input_rank; ++i) {
+            for (int i = 0; i < input_rank; ++i) {
               const auto& input_dim = input_shape.dim((int)i);
               auto* output_dim = output_shape->add_dim();
               if (input_dim.has_dim_value()) {
@@ -5468,7 +5468,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           } else {
             // Infer output shapes' rank in any case
             auto* output_shape_0 = getOutputShape(ctx, 0);
-            for (size_t i = 0; static_cast<int64_t>(i) < input_rank; ++i) {
+            for (int i = 0; i < input_rank; ++i) {
               output_shape_0->add_dim();
             }
           }
@@ -6144,7 +6144,7 @@ ONNX_OPERATOR_SET_SCHEMA(
               (hasInputShape(ctx, 4) && !ctx.getInputData(4))) {
             const auto input_rank = ctx.getInputType(0)->tensor_type().shape().dim_size();
             // we can infer the output rank - it never changes
-            for (size_t i = 0; (int64_t)i < input_rank; ++i) {
+            for (int i = 0; i < input_rank; ++i) {
               ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim();
             }
             return;
@@ -6206,10 +6206,10 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
           }
 
-          for (size_t i = 0; (int64_t)i < input_rank; ++i) {
+          for (int i = 0; i < input_rank; ++i) {
             // first update rank of output dim
             auto* output_dim = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim();
-            const auto& input_dim = input_shape.dim((int)i);
+            const auto& input_dim = input_shape.dim(i);
             if (input_dim.has_dim_value()) {
               output_dim->set_dim_value(input_dim.dim_value());
             } else if (input_dim.has_dim_param()) {
@@ -6832,7 +6832,7 @@ ONNX_OPERATOR_SET_SCHEMA(
               fail_shape_inference("The input is not evenly splittable");
             }
             int chunk_size = split_dim_value / num_outputs;
-            for (int i = 0; i < static_cast<int>(ctx.getNumOutputs()); i++) {
+            for (size_t i = 0; i < ctx.getNumOutputs(); i++) {
               split.push_back(chunk_size);
             }
           }
@@ -6902,7 +6902,7 @@ ONNX_OPERATOR_SET_SCHEMA(
 
           ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
 
-          for (size_t i = 0; (int64_t)i < input_shape.dim_size(); ++i) {
+          for (int i = 0; i < input_shape.dim_size(); ++i) {
             auto* newdim = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape()->add_dim();
             if (ctx.getInputType(0)->tensor_type().shape().dim((int)i).has_dim_value()) {
               newdim->set_dim_value(
@@ -7260,7 +7260,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             }
 
             auto* output_shape = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
-            for (size_t i = 0; static_cast<int64_t>(i) < input_rank; ++i) {
+            for (int i = 0; i < input_rank; ++i) {
               const auto& input_dim = input_shape.dim((int)i);
               auto* output_dim = output_shape->add_dim();
               if (input_dim.has_dim_value()) {
@@ -7272,7 +7272,7 @@ ONNX_OPERATOR_SET_SCHEMA(
           } else {
             // Infer output shapes' rank in any case
             auto* output_shape_0 = getOutputShape(ctx, 0);
-            for (size_t i = 0; static_cast<int64_t>(i) < input_rank; ++i) {
+            for (int i = 0; i < input_rank; ++i) {
               output_shape_0->add_dim();
             }
           }

--- a/onnx/defs/tensor/utils.cc
+++ b/onnx/defs/tensor/utils.cc
@@ -149,7 +149,7 @@ void resizeShapeInferenceHelper(
               ").");
         }
       } else {
-        dim->set_dim_value(static_cast<int64_t>(dim_value));
+        dim->set_dim_value(dim_value);
       } // dim->has_dim_value()
     } // input_shape.dim(i).has_dim_value()
   }
@@ -348,7 +348,7 @@ void resizeShapeInferenceHelper_opset7_to_10(
               ").");
         }
       } else {
-        dim->set_dim_value(static_cast<int64_t>(dim_value));
+        dim->set_dim_value(dim_value);
       } // dim->has_dim_value()
     } // input_shape.dim(i).has_dim_value()
   }

--- a/onnx/inliner/inliner.cc
+++ b/onnx/inliner/inliner.cc
@@ -165,7 +165,7 @@ class InliningRenamer : public MutableVisitor {
   NameGenerator& generator;
 
  protected:
-  std::vector<std::unordered_map<std::string, std::string>> rename_scopes{};
+  std::vector<std::unordered_map<std::string, std::string>> rename_scopes;
 
  public:
   InliningRenamer(std::string suffix_, NameGenerator& generator_) : suffix(std::move(suffix_)), generator(generator_) {

--- a/onnx/shape_inference/implementation.h
+++ b/onnx/shape_inference/implementation.h
@@ -121,7 +121,7 @@ struct GraphInferenceContext {
 
 class GraphInferencerImpl : public GraphInferencer {
  public:
-  GraphInferencerImpl(GraphProto& g, GraphInferenceContext& context) : g_{&g}, context_{&context}, options_() {}
+  GraphInferencerImpl(GraphProto& g, GraphInferenceContext& context) : g_{&g}, context_{&context} {}
   GraphInferencerImpl(GraphProto& g, GraphInferenceContext& context, const ShapeInferenceOptions& options)
       : g_{&g}, context_{&context}, options_(options) {}
 

--- a/onnx/version_converter/adapters/axis_input_to_attribute.h
+++ b/onnx/version_converter/adapters/axis_input_to_attribute.h
@@ -87,7 +87,7 @@ class AxisInputToAttribute : public Adapter {
     }
   }
 
-  inline Node* EnsureAndReturnNode(Node* node) const {
+  Node* EnsureAndReturnNode(Node* node) const {
     ONNX_ASSERTM(node->hasAttribute(kaxis), "Axis attribute not created. This may be a bug.")
     return node;
   }

--- a/onnx/version_converter/helper.cc
+++ b/onnx/version_converter/helper.cc
@@ -19,7 +19,7 @@ int check_numpy_unibroadcastable_and_require_broadcast(
   // Check that axis is input1_sizes.size()-input2_sizes.size()
   bool broadcast = false;
   int axis = (int)(input1_sizes.size() - input2_sizes.size());
-  for (int i = 0; i < (int)input2_sizes.size(); i++) {
+  for (size_t i = 0; i < input2_sizes.size(); i++) {
     if (input2_sizes[i].dim != input1_sizes[axis + i].dim && input2_sizes[i].dim != 1)
       return -1;
     if (input2_sizes[i].dim != input1_sizes[axis + i].dim)
@@ -49,7 +49,7 @@ void assert_numpy_multibroadcastable(
   const std::vector<Dimension>& A_sizes = *A_ptr;
   const std::vector<Dimension>& B_sizes = *B_ptr;
   int axis = (int)(A_sizes.size() - B_sizes.size());
-  for (int i = 0; i < (int)B_sizes.size(); i++) {
+  for (size_t i = 0; i < B_sizes.size(); i++) {
     ONNX_ASSERTM(
         B_sizes[i].dim == A_sizes[axis + i].dim || B_sizes[i].dim == 1 || A_sizes[axis + i].dim == 1,
         "Dimension %d of input %d does not match "
@@ -74,7 +74,7 @@ void assertInputsAvailable(const ArrayRef<Value*>& inputs, const char* name, uin
       " between %d inputs",
       name,
       num_inputs)
-  for (int i = 0; i < (int)num_inputs; i++) {
+  for (size_t i = 0; i < num_inputs; i++) {
     ONNX_ASSERTM(inputs[i]->has_sizes(), "Shape of input %d is not available.", num_inputs)
     assertNotParams(inputs[i]->sizes());
   }


### PR DESCRIPTION
### Description
<!-- - Describe your changes. -->
This PR fixes several clang-tidy warnings. Some readability rules were not enabled due to a missing tailing comma, this PR fixes them. Two C++20 rules are also disabled. 
### Motivation and Context
Better code.
<!-- - Why is this change required? What problem does it solve? -->
<!-- - If it fixes an open issue, please link to the issue here. -->
