### PR TITLE
Bump versions for 1.20.0

### DIFF
--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -197,6 +197,7 @@ ONNX version|IR version|Opset version ai.onnx|Opset version ai.onnx.ml|Opset ver
 1.18.0|11|23|5|1
 1.19.0|12|24|5|1
 1.19.1|12|24|5|1
+1.20.0|12|24|5|1
 
 A programmatically accessible version of the above table is available [here](../onnx/helper.py). Limited version number
 information is also maintained in [version.h](../onnx/common/version.h) and [schema.h](../onnx/defs/schema.h).

--- a/onnx/common/version.h
+++ b/onnx/common/version.h
@@ -9,6 +9,6 @@
 namespace ONNX_NAMESPACE {
 
 // Represents the most recent release version. Updated with every release.
-constexpr const char* LAST_RELEASE_VERSION = "1.19.1";
+constexpr const char* LAST_RELEASE_VERSION = "1.20.0";
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -74,6 +74,7 @@ VERSION_TABLE: VersionTableType = [
     ("1.18.0", 11, 23, 5, 1),
     ("1.19.0", 12, 24, 5, 1),
     ("1.19.1", 12, 24, 5, 1),
+    ("1.20.0", 12, 24, 5, 1),
 ]
 
 VersionMapType = dict[tuple[str, int], int]


### PR DESCRIPTION
> [!NOTE]
> There is no opset version bump in 1.20.0

Following the instructions in https://github.com/onnx/onnx/blob/main/docs/OnnxReleases.md#create-release-branch, these documentations need to be updated before the branch cut.


