### PR TITLE
Require ml_dtypes>=0.5.4 on s390x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy>=1.23.2
 protobuf>=4.25.1
 typing_extensions>=4.7.1
-ml_dtypes>=0.5.0
+ml_dtypes>=0.5.0; platform_machine != "s390x"
+ml_dtypes>=0.5.4; platform_machine == "s390x"


### PR DESCRIPTION
In order to get the testsuite clean on s390x (big-endian), we need the already committed onnx-commit:
"Fix testsuite fails on s390x (big-endian) (#7309)" https://github.com/onnx/onnx/commit/f307a8d6b32d7ff6935af45a872caf3ece2e79ea

AND the ml_dtypes-commit:
"Fix bfloat16 byteswap not working"
https://github.com/jax-ml/ml_dtypes/commit/fd7fa4a62e7664856aa98a278fff88cfe9247f5f

The ml_dtypes one has now landed in ml_dtypes v0.5.4 release:
https://github.com/jax-ml/ml_dtypes/releases/tag/v0.5.4 
"Fixed bug in byte-swap operation for custom floats (#311)"


This patch bumps the requirement for ml_dtypes to v0.5.4 only on s390x as discussed in the original pull-request:
https://github.com/onnx/onnx/pull/7309#issuecomment-3309556772 All other architectures, still require for ml_dtypes v0.5.0 as before.