### PR TITLE
Make pyi stubs optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -227,8 +227,8 @@ class CmakeBuild(setuptools.Command):
                 # Accept all CMake boolean false values for disabling stubs
                 cmake_false_values = {"0", "off", "false", "no", "n"}
                 self.distribution.onnx_gen_stubs_disabled = any(
-                    arg.lower().startswith("-donnx_gen_pb_type_stubs=") and
-                    arg.split("=", 1)[1].strip().lower() in cmake_false_values
+                    arg.lower().startswith("-donnx_gen_pb_type_stubs=")
+                    and arg.split("=", 1)[1].strip().lower() in cmake_false_values
                     for arg in extra_cmake_args
                 )
 


### PR DESCRIPTION
Make Python stub files (.pyi) optional in build

  Remove hard assertion requiring .pyi stub files to exist, which breaks
  builds with protobuf < 21.0 or when ONNX_GEN_PB_TYPE_STUBS is disabled.

  Downstream build fails with:
    AssertionError: Bug: No generated python stubs found
  when `-DONNX_GEN_PB_TYPE_STUBS=OFF`.

  This affects:
  - RHEL 9 (protobuf 3.19.6)
  - Hermetic build environments with controlled dependencies
  - Minimal builds with stub generation disabled

  Python stub files (.pyi) are type hints for static analysis tools like
  mypy, not runtime requirements. They can safely be optional per PEP 561.

  Changes:
  - Remove assertion that .pyi files must exist
  - Add comment explaining why stubs are optional
  - Stub files still copied when generated (no behavior change)

  Fixes: Build failures with protobuf < 21.0
  Tested: RHEL 9 with protobuf 3.19.6

Signed-off-by: Anu Oguntayo <aoguntay@redhat.com>

Log:
```
copying /work/bootstrap-output/work-dir/onnx-1.20.0/onnx-1.20.0/.setuptools-cmake-build/onnx_cpp2py_export.abi3.so -> build/lib.linux-x86_64-cpython-312/onnx
Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.12/site-packages/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
    main()
  File "/opt/app-root/lib64/python3.12/site-packages/pyproject_hooks/_in_process/_in_process.py", line 373, in main
    json_out["return_val"] = hook(**hook_input["kwargs"])
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/pyproject_hooks/_in_process/_in_process.py", line 280, in build_wheel
    return _build_backend().build_wheel(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/bootstrap-output/work-dir/onnx-1.20.0/build-3.12.9/lib64/python3.12/site-packages/setuptools/build_meta.py", line 432, in build_wheel
    return _build(['bdist_wheel'])
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/bootstrap-output/work-dir/onnx-1.20.0/build-3.12.9/lib64/python3.12/site-packages/setuptools/build_meta.py", line 423, in _build
    return self._build_with_temp_dir(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/bootstrap-output/work-dir/onnx-1.20.0/build-3.12.9/lib64/python3.12/site-packages/setuptools/build_meta.py", line 404, in _build_with_temp_dir
    self.run_setup()
  File "/work/bootstrap-output/work-dir/onnx-1.20.0/build-3.12.9/lib64/python3.12/site-packages/setuptools/build_meta.py", line 317, in run_setup
    exec(code, locals())
  File "<string>", line 352, in <module>
  File "/work/bootstrap-output/work-dir/onnx-1.20.0/build-3.12.9/lib64/python3.12/site-packages/setuptools/__init__.py", line 115, in setup
    return distutils.core.setup(**attrs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/bootstrap-output/work-dir/onnx-1.20.0/build-3.12.9/lib64/python3.12/site-packages/setuptools/_distutils/core.py", line 186, in setup
    return run_commands(dist)
           ^^^^^^^^^^^^^^^^^^
  File "/work/bootstrap-output/work-dir/onnx-1.20.0/build-3.12.9/lib64/python3.12/site-packages/setuptools/_distutils/core.py", line 202, in run_commands
    dist.run_commands()
  File "/work/bootstrap-output/work-dir/onnx-1.20.0/build-3.12.9/lib64/python3.12/site-packages/setuptools/_distutils/dist.py", line 1002, in run_commands
    self.run_command(cmd)
  File "/work/bootstrap-output/work-dir/onnx-1.20.0/build-3.12.9/lib64/python3.12/site-packages/setuptools/dist.py", line 1102, in run_command
    super().run_command(command)
  File "/work/bootstrap-output/work-dir/onnx-1.20.0/build-3.12.9/lib64/python3.12/site-packages/setuptools/_distutils/dist.py", line 1021, in run_command
    cmd_obj.run()
  File "/work/bootstrap-output/work-dir/onnx-1.20.0/build-3.12.9/lib64/python3.12/site-packages/setuptools/command/bdist_wheel.py", line 370, in run
    self.run_command("build")
  File "/work/bootstrap-output/work-dir/onnx-1.20.0/build-3.12.9/lib64/python3.12/site-packages/setuptools/_distutils/cmd.py", line 357, in run_command
    self.distribution.run_command(command)
  File "/work/bootstrap-output/work-dir/onnx-1.20.0/build-3.12.9/lib64/python3.12/site-packages/setuptools/dist.py", line 1102, in run_command
    super().run_command(command)
  File "/work/bootstrap-output/work-dir/onnx-1.20.0/build-3.12.9/lib64/python3.12/site-packages/setuptools/_distutils/dist.py", line 1021, in run_command
    cmd_obj.run()
  File "/work/bootstrap-output/work-dir/onnx-1.20.0/build-3.12.9/lib64/python3.12/site-packages/setuptools/_distutils/command/build.py", line 135, in run
    self.run_command(cmd_name)
  File "/work/bootstrap-output/work-dir/onnx-1.20.0/build-3.12.9/lib64/python3.12/site-packages/setuptools/_distutils/cmd.py", line 357, in run_command
    self.distribution.run_command(command)
  File "/work/bootstrap-output/work-dir/onnx-1.20.0/build-3.12.9/lib64/python3.12/site-packages/setuptools/dist.py", line 1102, in run_command
    super().run_command(command)
  File "/work/bootstrap-output/work-dir/onnx-1.20.0/build-3.12.9/lib64/python3.12/site-packages/setuptools/_distutils/dist.py", line 1021, in run_command
    cmd_obj.run()
  File "<string>", line 261, in run
  File "/work/bootstrap-output/work-dir/onnx-1.20.0/build-3.12.9/lib64/python3.12/site-packages/setuptools/command/build_ext.py", line 96, in run
    _build_ext.run(self)
  File "/work/bootstrap-output/work-dir/onnx-1.20.0/build-3.12.9/lib64/python3.12/site-packages/setuptools/_distutils/command/build_ext.py", line 368, in run
    self.build_extensions()
  File "<string>", line 297, in build_extensions
AssertionError: Bug: No generated python stubs found
``` 