### PR TITLE
Export functions used in PyTorch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,7 +418,6 @@ add_onnx_global_defines(onnx_proto)
 add_library(onnx ${ONNX_SRCS} ${ONNX_PROTO_SRCS})
 add_dependencies(onnx onnx_proto)
 set_target_properties(onnx PROPERTIES CXX_VISIBILITY_PRESET hidden)
-set_target_properties(onnx PROPERTIES VISIBILITY_INLINES_HIDDEN ON)
 add_onnx_global_defines(onnx)
 
 if(ONNX_BUILD_PYTHON)

--- a/onnx/checker.h
+++ b/onnx/checker.h
@@ -158,24 +158,22 @@ void check_function(const FunctionProto& function, const CheckerContext&, const 
 // Check schema compatibility for 2 opset versions for a given node.
 // Checks whether the schema for 2 versions is same, this is true when the opschema
 // does not change between versions.
-void check_opset_compatibility(
+ONNX_API void check_opset_compatibility(
     const NodeProto& node,
     const CheckerContext& ctx,
     const std::unordered_map<std::string, int>& func_opset_imports,
     const std::unordered_map<std::string, int>& model_opset_imports);
 
 // Checks all model local functions present in ModelProto
-void check_model_local_functions(
-    const ModelProto& model,
-    const CheckerContext& ctx,
-    const LexicalScopeContext& parent_lex);
+ONNX_API void
+check_model_local_functions(const ModelProto& model, const CheckerContext& ctx, const LexicalScopeContext& parent_lex);
 
-void check_model(
+ONNX_API void check_model(
     const ModelProto& model,
     bool full_check = false,
     bool skip_opset_compatibility_check = false,
     bool check_custom_domain = false);
-void check_model(
+ONNX_API void check_model(
     const std::string& model_path,
     bool full_check = false,
     bool skip_opset_compatibility_check = false,
@@ -184,7 +182,7 @@ std::string resolve_external_data_location(
     const std::string& base_dir,
     const std::string& location,
     const std::string& tensor_name);
-bool check_is_experimental_op(const NodeProto& node);
+ONNX_API bool check_is_experimental_op(const NodeProto& node);
 
 } // namespace checker
 } // namespace ONNX_NAMESPACE

--- a/onnx/common/ir_pb_converter.h
+++ b/onnx/common/ir_pb_converter.h
@@ -43,7 +43,7 @@ void ExportModelProto(ModelProto* p_m, const std::shared_ptr<Graph>& g);
 
 std::unique_ptr<Graph> ImportModelProto(const ModelProto& mp);
 
-ModelProto PrepareOutput(const ModelProto& mp_in);
+ONNX_API ModelProto PrepareOutput(const ModelProto& mp_in);
 
 void assertNonNull(const std::shared_ptr<Graph>& g);
 } // namespace ONNX_NAMESPACE


### PR DESCRIPTION
### Motivation and Context

This PR exports more symbols which are used by PyTorch and other libraries. Specifically, header symbols are no longer hidden to export Protobuf symbols by removing 
```
set_target_properties(onnx PROPERTIES VISIBILITY_INLINES_HIDDEN ON)
```
 
This PR fixes #7377
