### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,25 +4,18 @@
 
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  // Package-specific rules for grouping and enabling updates
-  "packageRules": [
-    {
-      // Group manylinux Docker images together in a single PR
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["quay.io/pypa/manylinux_2_28_x86_64", "quay.io/pypa/manylinux_2_28_aarch64"],
-      "enabled": true,
-      "groupName": "manylinux docker images"
-    }
-  ],
+  // Only enable custom regex manager to avoid overlap with dependabot
+  // Dependabot handles: pip (Python), github-actions
+  // Renovate handles: Docker images (manylinux), CMake dependencies (nanobind)
+  "enabledManagers": ["custom.regex"],
+  // Disable the Dependency Dashboard issue
+  "dependencyDashboard": false,
   // Custom managers for dependencies not auto-detected by Renovate
   "customManagers": [
     {
       // Detect manylinux Docker images in GitHub Actions workflows
       // Example: uses: docker://quay.io/pypa/manylinux_2_28_x86_64:2025.10.10-1
-      "customType": "regex",      
+      "customType": "regex",
       "fileMatch": ["^\\.github/workflows/release_linux\\.yml$"],
       "matchStrings": [
         "uses:\\s*docker://quay\\.io/pypa/(?<depName>manylinux_[^:]+):(?<currentValue>[0-9]{4}\\.[0-9]{2}\\.[0-9]{2}-[0-9]+)"
@@ -30,6 +23,27 @@
       "datasourceTemplate": "docker",
       "depNameTemplate": "quay.io/pypa/{{{depName}}}",
       "versioningTemplate": "loose"
+    },
+    {
+      // Detect nanobind version in CMakeLists.txt
+      // Example: set(NANOBIND_VERSION "v2.4.0")
+      "customType": "regex",
+      "fileMatch": ["^CMakeLists\\.txt$"],
+      "matchStrings": [
+        "set\\(NANOBIND_VERSION\\s+\"v(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\"\\)"
+      ],
+      "depNameTemplate": "wjakob/nanobind",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }
+  ],
+  // Package-specific rules for grouping
+  "packageRules": [
+    {
+      // Group manylinux Docker images together in a single PR
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["quay.io/pypa/manylinux_**"],
+      "groupName": "manylinux docker images"
     }
   ]
 }


### PR DESCRIPTION
### Motivation and Context

* Only enable custom regex manager to avoid overlap with dependabot, 
  * Dependabot handles: pip (Python), github-actions
  * Renovate handles: Docker images (manylinux), CMake dependencies (nanobind)
* turn off renovate dashboard
