### PR TITLE
Ignore .pb files from github language classification

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 # Set the default behavior
 * text=auto eol=auto
 *.bat text eol=crlf
+*.pb -linguist-detectable


### PR DESCRIPTION
The protobuf files where incorrectly classified as purebasic.



### Motivation and Context

Fixes #
