### PR TITLE
Rename pr_checks_comment.yml to pr_checks_post.yml

### DIFF
--- a/.github/workflows/pr_checks_post.yml
+++ b/.github/workflows/pr_checks_post.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: PR Checks Comment
+name: PR Checks Post
 
 on:
   workflow_run:


### PR DESCRIPTION
Adapt to naming convention for "split-workflows" in the same folder



### Motivation and Context

Fixes #
