### PR TITLE
Fix ReduceLogSumExp reference implementation for integer input

### DIFF
--- a/onnx/reference/ops/op_reduce_log_sum_exp.py
+++ b/onnx/reference/ops/op_reduce_log_sum_exp.py
@@ -9,6 +9,10 @@ from onnx.reference.ops._op import OpRunReduceNumpy
 
 
 def compute_log_sum_exp(data, axes, keepdims):
+    # Cast integer types to float64 since log/exp operations produce floats
+    # and we need to handle -inf assignments
+    if np.issubdtype(data.dtype, np.integer):
+        data = data.astype(np.float64)
     data_max = data.copy()
     ind = np.isinf(data_max)
     data_max[ind] = -np.inf


### PR DESCRIPTION
## Summary

Fixes #7141

The reference implementation of `ReduceLogSumExp` crashes when given integer input because it tries to assign `-np.inf` to an integer array.

## Problem

```python
node = oh.make_node("ReduceLogSumExp", inputs=["data"], outputs=["res"])
sess = ReferenceEvaluator(node, optimized=False)
data = np.asarray([1], np.int64)
sess.run(None, {"data": data})  # Crashes with OverflowError
```

Error:
```
OverflowError: cannot convert float infinity to integer
```

This occurs at line 14 in `op_reduce_log_sum_exp.py`:
```python
data_max[ind] = -np.inf
```

## Solution

Cast integer input types to `float64` before processing. This is appropriate because:
1. `log` and `exp` operations inherently produce floating-point results
2. The ONNX specification lists integer types as supported inputs for `ReduceLogSumExp`
3. The mathematical operation requires floating-point arithmetic for correctness

## Changes

Added a check at the start of `compute_log_sum_exp()` to convert integer dtypes to float64.

## Test plan

```python
import numpy as np
import onnx.helper as oh
from onnx.reference import ReferenceEvaluator

node = oh.make_node("ReduceLogSumExp", inputs=["data"], outputs=["res"])
sess = ReferenceEvaluator(node, optimized=False)
data = np.asarray([1], np.int64)
result = sess.run(None, {"data": data})
print(result)  # Should work without error
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)