### PR TITLE
Clean up reference evaluator tests (#7098)

### DIFF
--- a/onnx/test/reference_evaluator_model_test.py
+++ b/onnx/test/reference_evaluator_model_test.py
@@ -19,8 +19,8 @@ def create_model():
 
     .. code-block:: python
 
-        from onnx importonnx.TensorProto
-        from onnx.helper import oh.make_tensor
+        from onnx import TensorProto
+        from onnx.helper import make_tensor
 
         from onnxscript import script
         from onnxscript.onnx_opset import opset15 as op

--- a/onnx/test/reference_evaluator_test.py
+++ b/onnx/test/reference_evaluator_test.py
@@ -2528,18 +2528,6 @@ class TestReferenceEvaluator(unittest.TestCase):
             c_out = complex_out[0:onesided_length]
             expected[0, i] = np.stack((c_out.real, c_out.imag), axis=1)
 
-        # import torch
-        # correspondence with torch
-        # hop_length = frame_step
-        # window = np.ones((frame_length,), dtype=np.float32)
-        # ex = torch.stft(
-        #      torch.Tensor(feeds["signal"][:, :, 0]),
-        #      n_fft=frame_length, window=torch.Tensor(window),
-        #      hop_length=hop_length, win_length=frame_length,
-        #      onesided=True, return_complex=True, center=False,
-        #      normalized=False)
-        # ex = np.transpose(ex.numpy(), [0, 2, 1])
-
         ref1 = ReferenceEvaluator(onnx_model)
         got1 = ref1.run(None, feeds)
         assert_allclose(got1[0], expected)
@@ -2582,16 +2570,6 @@ class TestReferenceEvaluator(unittest.TestCase):
             ]
             c_out = complex_out[0:onesided_length]
             expected[0, i] = np.stack((c_out.real, c_out.imag), axis=1)
-
-        # import torch
-        # hop_length = frame_step
-        # ex = torch.stft(
-        #      torch.Tensor(feeds["signal"][:, :, 0]),
-        #      n_fft=frame_length, window=torch.Tensor(window),
-        #      hop_length=hop_length, win_length=frame_length,
-        #      onesided=True, return_complex=True, center=False,
-        #      normalized=False)
-        # ex = np.transpose(ex.numpy(), [0, 2, 1])
 
         ref1 = ReferenceEvaluator(onnx_model)
         got1 = ref1.run(None, feeds)

--- a/onnx/test/test_backend_reference.py
+++ b/onnx/test/test_backend_reference.py
@@ -69,8 +69,6 @@ class ReferenceEvaluatorBackend(onnx.backend.base.Backend):
     def prepare(
         cls, model: Any, device: str = "CPU", **kwargs: Any
     ) -> ReferenceEvaluatorBackendRep:
-        # if isinstance(model, ReferenceEvaluatorBackendRep):
-        #    return model
         if isinstance(model, ReferenceEvaluator):
             return ReferenceEvaluatorBackendRep(model)
         if isinstance(model, (str, bytes, ModelProto)):


### PR DESCRIPTION
Remove dead code and fix docstrings in reference evaluator tests

- test_backend_reference.py: remove commented-out block in prepare()
- reference_evaluator_model_test.py: fix invalid Python in docstring (importonnx -> from onnx import TensorProto; oh.make_tensor -> make_tensor)
- reference_evaluator_test.py: remove commented-out torch.stft reference blocks in STFT tests

Fixes #7098

