### PR TITLE
Revise security vulnerability reporting guidelines

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,13 +7,21 @@ SPDX-License-Identifier: Apache-2.0
 # Security Policy
 
 ## Reporting a Vulnerability
-If you think you have found a security vulnerability, please send a report to onnx-security@lists.lfaidata.foundation. Please do not post security vulnerabilities on Slack.
+If you believe you have discovered a security vulnerability in ONNX, please report it privately using GitHub Security Advisories.
 
-We don't currently have a PGP key, unfortunately.
+👉 Open a private report: https://github.com/onnx/onnx/security/advisories/new
 
-An ONNX committer will send you a response indicating the next steps in handling your report. After the initial reply to your report, the committer will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+This allows maintainers to triage the issue, collaborate on a fix, and coordinate disclosure.
 
-Important: Please don't disclose the vulnerability before it has been fixed and announced, to protect our users.
+If you are unable to use GitHub for reporting, you may contact the maintainers at onnx-security@lists.lfaidata.foundation as a fallback.
+
+After your report is received, a maintainer will acknowledge it, work with you to understand impact and remediation, and keep you informed about progress toward a fix and public disclosure.
+
+Please do not disclose the vulnerability publicly until a fix and advisory have been released.
 
 ## Security announcements
 Please subscribe to the [announcements mailing list](https://lists.lfaidata.foundation/g/onnx-announce), where we post notifications and remediation details for security vulnerabilities.
+
+## Security Requirements
+
+Open Neural Network Exchange (ONNX) manages reported vulnerabilities according to its documented security policy and delivers remediations in maintained releases. The project employs established secure development practices such as automated testing, continuous integration, and tooling intended to identify defects during development. Third-party dependencies and build components are periodically reviewed and updated to address known issues and to mitigate supply-chain risk. ONNX does not guarantee that models or inputs are trustworthy, and operators are responsible for validating provenance and applying appropriate isolation, resource limits, and runtime safeguards when executing untrusted workloads.


### PR DESCRIPTION
### Motivation and Context

* Updated the vulnerability reporting process to use GitHub Security Advisories and clarified communication with maintainers.
* Explain "security requirements" for openssf silver badge
