### PR TITLE
Add update into main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,6 +108,7 @@ jobs:
       - name: Install external protobuf - Linux
         if: matrix.protobuf_type == 'External' && startsWith(matrix.os,'ubuntu')
         run: |
+          sudo apt-get update
           sudo apt-get install libprotobuf-dev protobuf-compiler
 
       - name: Install external protobuf - MacOS


### PR DESCRIPTION
This pull request makes a small improvement to the GitHub Actions workflow by ensuring package lists are up to date before installing dependencies.

* Added `sudo apt-get update` before installing `libprotobuf-dev` and `protobuf-compiler` on Ubuntu in `.github/workflows/main.yml` to prevent package installation failures.


Fix https://github.com/onnx/onnx/actions/runs/22463106838/job/65066352993?pr=7686