### PR TITLE
Fix Transpose documentation example to disambiguate permutation

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -32616,8 +32616,8 @@ This version of the operator has been available since version 25 of the default 
   The optional attribute `perm` must be a permutation of the dimensions of
   the input tensor. Axis `i` of the output tensor corresponds to the axis
   `perm[i]` of the input tensor.
-  For example, when perm=(1, 0, 2), given an input tensor of shape (1, 2, 3),
-  the output shape will be (2, 1, 3).
+  For example, when perm=(2, 0, 1), given an input tensor of shape (1, 2, 3),
+  the output shape will be (3, 1, 2).
   When perm=(1, 2, 0), given an input tensor of shape (1, 2, 3),
   the output shape will be (2, 3, 1).
   If the attribute `perm` is omitted, its default value is `(n-1, ..., 0)`,

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -38980,8 +38980,8 @@ expect(
   The optional attribute `perm` must be a permutation of the dimensions of
   the input tensor. Axis `i` of the output tensor corresponds to the axis
   `perm[i]` of the input tensor.
-  For example, when perm=(1, 0, 2), given an input tensor of shape (1, 2, 3),
-  the output shape will be (2, 1, 3).
+  For example, when perm=(2, 0, 1), given an input tensor of shape (1, 2, 3),
+  the output shape will be (3, 1, 2).
   When perm=(1, 2, 0), given an input tensor of shape (1, 2, 3),
   the output shape will be (2, 3, 1).
   If the attribute `perm` is omitted, its default value is `(n-1, ..., 0)`,

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -1063,8 +1063,8 @@ Returns a transpose of the input tensor. (Similar to `numpy.transpose`).
 The optional attribute `perm` must be a permutation of the dimensions of
 the input tensor. Axis `i` of the output tensor corresponds to the axis
 `perm[i]` of the input tensor.
-For example, when perm=(1, 0, 2), given an input tensor of shape (1, 2, 3),
-the output shape will be (2, 1, 3).
+For example, when perm=(2, 0, 1), given an input tensor of shape (1, 2, 3),
+the output shape will be (3, 1, 2).
 When perm=(1, 2, 0), given an input tensor of shape (1, 2, 3),
 the output shape will be (2, 3, 1).
 If the attribute `perm` is omitted, its default value is `(n-1, ..., 0)`,


### PR DESCRIPTION
### Motivation and Context

Fixes #6329

The first example in the Transpose operator documentation uses `perm=(1, 0, 2)`, which is its own inverse permutation. This means both possible interpretations of `perm` produce the same result, so the example does not clarify the semantics.

This PR replaces the first example with `perm=(2, 0, 1)`, which produces shape `(3, 1, 2)` under the correct interpretation (`d'i = d(perm[i])`) but would produce `(2, 3, 1)` under the incorrect one. The second example (`perm=(1, 2, 0)`) is kept as-is.

The same change is applied to the latest Changelog entry (Transpose-25) and `docs/Operators.md`.