### PR TITLE
Fix protobuf field checks and add GRAPHS attribute handling

### DIFF
--- a/onnx/compose.py
+++ b/onnx/compose.py
@@ -224,6 +224,9 @@ def merge_graphs(
             for attr in node.attribute:
                 if attr.type == AttributeProto.GRAPH:
                     connect_io(attr.g, 0, len(attr.g.node))
+                elif attr.type == AttributeProto.GRAPHS:
+                    for sub_g in attr.graphs:
+                        connect_io(sub_g, 0, len(sub_g.node))
 
             for index, name_ in enumerate(node.input):
                 if name_ in reversed_io_map:
@@ -510,10 +513,12 @@ def add_prefix_graph(
         for n in g.node:
             n.name = _prefixed(prefix, n.name)
             for attribute in n.attribute:
-                if attribute.g:
+                if attribute.HasField("g"):
                     add_prefix_graph(
                         attribute.g, prefix, inplace=True, name_map=name_map
                     )
+                for sub_g in attribute.graphs:
+                    add_prefix_graph(sub_g, prefix, inplace=True, name_map=name_map)
 
     if rename_initializers:
         for init in g.initializer:

--- a/onnx/external_data_helper.py
+++ b/onnx/external_data_helper.py
@@ -183,9 +183,7 @@ def set_external_data(
 ) -> None:
     if not tensor.HasField("raw_data"):
         raise ValueError(
-            "Tensor "
-            + tensor.name
-            + " does not have raw_data field. Cannot set external data for this tensor."
+            f"Tensor {tensor.name} does not have raw_data field. Cannot set external data for this tensor."
         )
 
     del tensor.external_data[:]

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -84,11 +84,12 @@ VersionMapType = dict[tuple[str, int], int]
 def _create_op_set_id_version_map(table: VersionTableType) -> VersionMapType:
     """Create a map from (opset-domain, opset-version) to ir-version from above table."""
     result: VersionMapType = {}
-
-    def process(release_version: str, ir_version: int, *args: Any) -> None:
-        del release_version  # Unused
+    for row in table:
+        ir_version = row[1]
         for pair in zip(
-            ["ai.onnx", "ai.onnx.ml", "ai.onnx.training"], args, strict=False
+            ["ai.onnx", "ai.onnx.ml", "ai.onnx.training"],
+            row[2:],
+            strict=False,
         ):
             if pair not in result:
                 result[pair] = ir_version
@@ -96,9 +97,6 @@ def _create_op_set_id_version_map(table: VersionTableType) -> VersionMapType:
                     result["ai.onnx.preview", pair[1]] = ir_version
                 if pair[0] == "ai.onnx.training":
                     result["ai.onnx.preview.training", pair[1]] = ir_version
-
-    for row in table:
-        process(*row)
     return result
 
 
@@ -1009,6 +1007,8 @@ def printable_attribute(
         graphs.append(attr.g)
     elif attr.HasField("tp"):
         content.append(f"<Type Proto {attr.tp}>")
+    elif attr.HasField("sparse_tensor"):
+        content.append("<Sparse Tensor>")
     elif attr.floats:
         content.append(str_list(str_float, attr.floats))
     elif attr.ints:
@@ -1018,6 +1018,8 @@ def printable_attribute(
         content.append(str(list(map(_sanitize_str, attr.strings))))
     elif attr.tensors:
         content.append("[<Tensor>, ...]")
+    elif attr.sparse_tensors:
+        content.append("[<Sparse Tensor>, ...]")
     elif attr.type_protos:
         content.append("[")
         for i, tp in enumerate(attr.type_protos):

--- a/onnx/model_container.py
+++ b/onnx/model_container.py
@@ -47,9 +47,12 @@ def _set_external_data(
 def _enumerate_subgraphs(graph):
     for node in graph.node:
         for att in node.attribute:
-            if att.g:
+            if att.HasField("g"):
                 yield att.g
                 yield from _enumerate_subgraphs(att.g)
+            for sub_g in att.graphs:
+                yield sub_g
+                yield from _enumerate_subgraphs(sub_g)
 
 
 def make_large_tensor_proto(

--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -336,8 +336,7 @@ def from_array(array: np.ndarray, /, name: str | None = None) -> onnx.TensorProt
                 tensor.string_data.append(e)
             else:
                 raise NotImplementedError(
-                    "Unrecognized object in the object array, expect a string, or array of bytes: ",
-                    str(type(e)),
+                    f"Unrecognized object in the object array, expect a string, or array of bytes: {type(e)}"
                 )
         return tensor
 
@@ -401,7 +400,7 @@ def from_list(
     if name:
         sequence.name = name
 
-    if dtype:
+    if dtype is not None:
         elem_type = dtype
     elif len(lst) > 0:
         first_elem = lst[0]
@@ -458,9 +457,7 @@ def to_dict(map_proto: onnx.MapProto) -> dict[Any, Any]:
     value_list = to_list(map_proto.values)
     if len(key_list) != len(value_list):
         raise IndexError(
-            "Length of keys and values for MapProto (map name: ",
-            map_proto.name,
-            ") are not the same.",
+            f"Length of keys and values for MapProto (map name: {map_proto.name}) are not the same."
         )
     return dict(zip(key_list, value_list, strict=False))
 
@@ -478,6 +475,8 @@ def from_dict(dict_: dict[Any, Any], name: str | None = None) -> onnx.MapProto:
     map_proto = onnx.MapProto()
     if name:
         map_proto.name = name
+    if not dict_:
+        raise ValueError("Cannot convert an empty dictionary to MapProto.")
     keys = list(dict_)
     raw_key_type = np.result_type(keys[0])
     key_type = helper.np_dtype_to_tensor_dtype(raw_key_type)
@@ -514,6 +513,8 @@ def from_dict(dict_: dict[Any, Any], name: str | None = None) -> onnx.MapProto:
         map_proto.string_keys.extend(keys)
     elif key_type in valid_key_int_types:
         map_proto.keys.extend(keys)
+    else:
+        raise TypeError(f"Unsupported map key type: {key_type}")
     map_proto.values.CopyFrom(value_seq)
     return map_proto
 

--- a/onnx/test/compose_test.py
+++ b/onnx/test/compose_test.py
@@ -662,6 +662,48 @@ class TestComposeFunctions(unittest.TestCase):
                         ):
                             self.assertEqual(_prefixed(prefix, output_n0), output_n1)
 
+    def test_add_prefix_attribute_multiple_subgraphs(self) -> None:
+        """Tests prefixing attribute's repeated graphs field."""
+        X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1])
+        Out = helper.make_tensor_value_info("Out", TensorProto.FLOAT, [1])
+
+        g1 = helper.make_graph(
+            [helper.make_node("Identity", ["X"], ["Out"], name="id1")],
+            "g1",
+            [X],
+            [Out],
+        )
+        g2 = helper.make_graph(
+            [helper.make_node("Identity", ["X"], ["Out"], name="id2")],
+            "g2",
+            [X],
+            [Out],
+        )
+        node = helper.make_node(
+            "CustomOp",
+            ["X"],
+            ["Out"],
+            name="custom",
+            bodies=[g1, g2],
+        )
+        graph = helper.make_graph([node], "graph", [X], [Out])
+
+        prefix = "pfx."
+        prefixed = compose.add_prefix_graph(graph, prefix)
+        self.assertEqual(prefixed.node[0].name, _prefixed(prefix, "custom"))
+
+        # Verify both subgraphs in the repeated graphs field are prefixed
+        pfx_graphs = prefixed.node[0].attribute[0].graphs
+        self.assertEqual(len(pfx_graphs), 2)
+        for name in ("id1", "id2"):
+            self.assertTrue(
+                any(
+                    n.name == _prefixed(prefix, name)
+                    for g in pfx_graphs
+                    for n in g.node
+                )
+            )
+
     def test_add_prefix_all(self) -> None:
         """Tests prefixing all names in the graph"""
         self._test_add_prefix(True, True, True, True, True, True)

--- a/onnx/test/helper_test.py
+++ b/onnx/test/helper_test.py
@@ -20,6 +20,7 @@ from onnx import (
     ModelProto,
     OptionalProto,
     SequenceProto,
+    SparseTensorProto,
     TensorProto,
     TypeProto,
     checker,
@@ -134,63 +135,50 @@ class TestHelperAttributeFunctions(unittest.TestCase):
         self.assertEqual(list(attr.tensors), tensors)
         checker.check_attribute(attr)
 
-    def test_attr_sparse_tensor_proto(self) -> None:
-        dense_shape = [3, 3]
-        sparse_values = [1.764052391052246, 0.40015721321105957, 0.978738009929657]
+    @staticmethod
+    def _make_sparse_tensor() -> SparseTensorProto:
         values_tensor = helper.make_tensor(
             name="sparse_values",
             data_type=TensorProto.FLOAT,
-            dims=[len(sparse_values)],
-            vals=np.array(sparse_values).astype(np.float32),
+            dims=[3],
+            vals=np.array(
+                [1.764052391052246, 0.40015721321105957, 0.978738009929657],
+                dtype=np.float32,
+            ),
             raw=False,
         )
-
-        linear_indices = [2, 3, 5]
         indices_tensor = helper.make_tensor(
             name="indices",
             data_type=TensorProto.INT64,
-            dims=[len(linear_indices)],
-            vals=np.array(linear_indices).astype(np.int64),
+            dims=[3],
+            vals=np.array([2, 3, 5], dtype=np.int64),
             raw=False,
         )
-        sparse_tensor = helper.make_sparse_tensor(
-            values_tensor, indices_tensor, dense_shape
-        )
+        return helper.make_sparse_tensor(values_tensor, indices_tensor, [3, 3])
 
+    def test_attr_sparse_tensor_proto(self) -> None:
+        sparse_tensor = self._make_sparse_tensor()
         attr = helper.make_attribute("sparse_attr", sparse_tensor)
         self.assertEqual(attr.name, "sparse_attr")
         checker.check_sparse_tensor(helper.get_attribute_value(attr))
         checker.check_attribute(attr)
 
     def test_attr_sparse_tensor_repeated_protos(self) -> None:
-        dense_shape = [3, 3]
-        sparse_values = [1.764052391052246, 0.40015721321105957, 0.978738009929657]
-        values_tensor = helper.make_tensor(
-            name="sparse_values",
-            data_type=TensorProto.FLOAT,
-            dims=[len(sparse_values)],
-            vals=np.array(sparse_values).astype(np.float32),
-            raw=False,
-        )
-
-        linear_indices = [2, 3, 5]
-        indices_tensor = helper.make_tensor(
-            name="indices",
-            data_type=TensorProto.INT64,
-            dims=[len(linear_indices)],
-            vals=np.array(linear_indices).astype(np.int64),
-            raw=False,
-        )
-        sparse_tensor = helper.make_sparse_tensor(
-            values_tensor, indices_tensor, dense_shape
-        )
-
-        repeated_sparse = [sparse_tensor, sparse_tensor]
-        attr = helper.make_attribute("sparse_attrs", repeated_sparse)
+        sparse_tensor = self._make_sparse_tensor()
+        attr = helper.make_attribute("sparse_attrs", [sparse_tensor, sparse_tensor])
         self.assertEqual(attr.name, "sparse_attrs")
         checker.check_attribute(attr)
         for s in helper.get_attribute_value(attr):
             checker.check_sparse_tensor(s)
+
+    def test_printable_attribute_sparse_tensor(self) -> None:
+        sparse_tensor = self._make_sparse_tensor()
+
+        attr = helper.make_attribute("st", sparse_tensor)
+        self.assertIn("<Sparse Tensor>", helper.printable_attribute(attr))
+
+        attr = helper.make_attribute("sts", [sparse_tensor, sparse_tensor])
+        self.assertIn("[<Sparse Tensor>, ...]", helper.printable_attribute(attr))
 
     def test_attr_repeated_graph_proto(self) -> None:
         graphs = [GraphProto(), GraphProto()]

--- a/onnx/test/numpy_helper_test.py
+++ b/onnx/test/numpy_helper_test.py
@@ -242,6 +242,37 @@ class TestNumpyHelper(unittest.TestCase):
             0xFF,
         )
 
+    def test_from_array_object_invalid_type(self) -> None:
+        a = np.array([42], dtype=object)
+        with self.assertRaises(NotImplementedError) as cm:
+            numpy_helper.from_array(a)
+        self.assertIn("int", str(cm.exception))
+
+    def test_from_list_explicit_dtype(self) -> None:
+        # Verify explicit dtype is honored, not auto-detected
+        seq = numpy_helper.from_list([], dtype=onnx.SequenceProto.MAP)
+        self.assertEqual(seq.elem_type, onnx.SequenceProto.MAP)
+        # Without dtype, empty list defaults to TENSOR
+        seq2 = numpy_helper.from_list([])
+        self.assertEqual(seq2.elem_type, onnx.SequenceProto.TENSOR)
+
+    def test_to_dict_mismatched_lengths(self) -> None:
+        # Build a valid map then add an extra key to create a mismatch
+        m = numpy_helper.from_dict({1: np.array(1.0), 2: np.array(2.0)})
+        m.keys.append(3)
+        with self.assertRaises(IndexError) as cm:
+            numpy_helper.to_dict(m)
+        self.assertIn("not the same", str(cm.exception))
+
+    def test_from_dict_empty(self) -> None:
+        with self.assertRaises(ValueError):
+            numpy_helper.from_dict({})
+
+    def test_from_dict_unsupported_key_type(self) -> None:
+        with self.assertRaises(TypeError) as cm:
+            numpy_helper.from_dict({1.5: np.array(1), 2.5: np.array(2)})
+        self.assertIn("Unsupported map key type", str(cm.exception))
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/onnx/tools/replace_constants.py
+++ b/onnx/tools/replace_constants.py
@@ -376,11 +376,7 @@ def replace_initializer_by_constant_of_shape(  # noqa: PLR0911
         modified = False
         atts = []
         for att in node.attribute:
-            if (
-                att.type == AttributeProto.GRAPH
-                and hasattr(att, "g")
-                and att.g is not None
-            ):
+            if att.type == AttributeProto.GRAPH and att.HasField("g"):
                 g = replace_initializer_by_constant_of_shape(
                     att.g,
                     threshold=threshold,
@@ -391,6 +387,21 @@ def replace_initializer_by_constant_of_shape(  # noqa: PLR0911
                 if id(g) != id(att.g):
                     modified = True
                     att = make_attribute(att.name, g)  # noqa: PLW2901
+            elif att.type == AttributeProto.GRAPHS:
+                new_graphs = []
+                for sub_g in att.graphs:
+                    new_g = replace_initializer_by_constant_of_shape(
+                        sub_g,
+                        threshold=threshold,
+                        ir_version=ir_version,
+                        use_range=use_range,
+                        value_constant_of_shape=value_constant_of_shape,
+                    )
+                    if id(new_g) != id(sub_g):
+                        modified = True
+                    new_graphs.append(new_g)
+                if modified:
+                    att = make_attribute(att.name, new_graphs)  # noqa: PLW2901
             atts.append(att)
         if modified:
             new_node = make_node(node.op_type, node.input, node.output)


### PR DESCRIPTION

### Motivation and Context

This PR improves and fixes some issues:
  - model_container.py: Replace ``if att.g:`` with ``HasField("g")`` for correct protobuf field presence check; add iteration over  att.graphs so GRAPHS-typed subgraphs are enumerated
  - replace_constants.py: Replace redundant ``hasattr/is not None`` with ``HasField("g")``; add GRAPHS branch to recursively process repeated graph attributes in replace_initializer_by_constant_of_shape
  - external_data_helper.py: Use f-string instead of string concatenation in set_external_data error message
