### PR TITLE
Fix wrong mantissa mask in to_float8e8m0 round-up mode

### DIFF
--- a/onnx/numpy_helper.py
+++ b/onnx/numpy_helper.py
@@ -69,7 +69,7 @@ def to_float8e8m0(
         exponent += increment
 
     elif round_mode == "up":
-        has_fraction = (f_bits & 0x4FFFFF) > 0
+        has_fraction = (f_bits & 0x7FFFFF) > 0
         round_up = has_fraction & normal_mask
 
         if saturate:

--- a/onnx/test/numpy_helper_test.py
+++ b/onnx/test/numpy_helper_test.py
@@ -183,6 +183,65 @@ class TestNumpyHelper(unittest.TestCase):
     def test_to_array_from_array_string(self):
         self._to_array_from_array(onnx.TensorProto.STRING, False)
 
+    def test_to_float8e8m0_round_modes(self) -> None:
+        # Inputs in [1.0, 2.0): 1.125 has only mantissa bit 20 set, 1.25 only
+        # bit 21, 1.375 bits 20+21, 1.5 bit 22, 1.75 bits 21+22.
+        x = np.array([1.0, 1.125, 1.25, 1.375, 1.5, 1.75], dtype=np.float32)
+
+        # "up": any non-zero mantissa rounds up to the next power of 2.
+        # Regression: a previous mask of 0x4FFFFF missed bits 20 and 21,
+        # so 1.125 / 1.25 / 1.375 were not rounded up.
+        np.testing.assert_array_equal(
+            numpy_helper.to_float8e8m0(x, round_mode="up").view(np.uint8),
+            [127, 128, 128, 128, 128, 128],
+        )
+        # "down" truncates: every value in [1.0, 2.0) keeps exponent 127.
+        np.testing.assert_array_equal(
+            numpy_helper.to_float8e8m0(x, round_mode="down").view(np.uint8),
+            [127, 127, 127, 127, 127, 127],
+        )
+        # "nearest" rounds at bit 22 (i.e., at 1.5), independent of bits 0-21.
+        np.testing.assert_array_equal(
+            numpy_helper.to_float8e8m0(x, round_mode="nearest").view(np.uint8),
+            [127, 127, 127, 127, 128, 128],
+        )
+        # Unknown round_mode is a programming error.
+        with self.assertRaises(ValueError):
+            numpy_helper.to_float8e8m0(
+                np.array([1.0], dtype=np.float32), round_mode="bogus"
+            )
+
+    def test_to_float8e8m0_extreme_values(self) -> None:
+        # NaN/Inf inputs (exponent byte 0xFF) survive every mode/saturate combo.
+        special = np.array([np.nan, np.inf, -np.inf], dtype=np.float32)
+        for mode in ("up", "down", "nearest"):
+            for saturate in (True, False):
+                out = numpy_helper.to_float8e8m0(
+                    special, saturate=saturate, round_mode=mode
+                )
+                np.testing.assert_array_equal(
+                    out.view(np.uint8),
+                    [0xFF, 0xFF, 0xFF],
+                    err_msg=f"mode={mode}, saturate={saturate}",
+                )
+
+        # 1.5 * 2**127 has exponent 0xFE with a non-zero mantissa. Under
+        # round_mode="up", saturate=True caps at 0xFE; saturate=False lets
+        # the exponent roll into 0xFF (the NaN slot).
+        near_max = np.array([1.5 * 2.0**127], dtype=np.float32)
+        self.assertEqual(
+            numpy_helper.to_float8e8m0(near_max, saturate=True, round_mode="up").view(
+                np.uint8
+            )[0],
+            0xFE,
+        )
+        self.assertEqual(
+            numpy_helper.to_float8e8m0(near_max, saturate=False, round_mode="up").view(
+                np.uint8
+            )[0],
+            0xFF,
+        )
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION

### Motivation and Context

This is detected by Claude.

```
  ## Reproduction

  from onnx.numpy_helper import to_float8e8m0
  import numpy as np

  result = to_float8e8m0(np.float32([1.125, 1.25, 5.0]), round_mode="up")
  # Before:  [1.0, 1.0, 4.0]  (wrong)
  # After:   [2.0, 2.0, 8.0]  (correct)

```