### PR TITLE
Fix TOCTOU race in external data file open

### DIFF
--- a/docs/Security.md
+++ b/docs/Security.md
@@ -19,73 +19,65 @@ When an ONNX model references external data files via relative paths, an attacke
 
 ## Defense Layers
 
-We use a 4-layer defense-in-depth approach. Each layer is applied at every entry point that opens external data files.
+We use a 4-layer defense-in-depth approach. Each entry point applies the layers appropriate to its context (see the table below).
 
 ### Layer 1: Canonical Path Containment
 
 - **C++**: `std::filesystem::weakly_canonical()` resolves the path, then verifies it starts with the canonical base directory.
-- **Python**: `os.path.realpath()` resolves all symlinks in the full path, then verifies the result is within the model base directory.
 
 This catches `..` traversal and symlinks in any path component (not just the final one).
 
 ### Layer 2: Symlink Detection
 
 - **C++**: `std::filesystem::is_symlink(data_path)` rejects the final-component symlink.
-- **Python**: `os.path.islink(path)` rejects the final-component symlink.
 
 This is a belt-and-suspenders check alongside containment. It provides a clear, specific error message when the final path component is a symlink.
 
-### Layer 3: O_NOFOLLOW on File Open (Python only)
+### Layer 3: Secure File Open with Post-Open Verification
 
-- **Python**: `os.O_NOFOLLOW` added to `os.open()` flags where available (`hasattr(os, "O_NOFOLLOW")`).
+Three platform-specific strategies, in order of preference:
 
-The C++ checker validates paths but does not open files, so `O_NOFOLLOW` is not applicable there. In Python, this is the last-resort defense: even if a symlink is created between the check and the open (TOCTOU race), the kernel rejects the open with `ELOOP` on Linux/macOS.
+- **Linux 5.6+**: `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)` — atomic kernel-level containment and symlink rejection. No TOCTOU possible. Falls back at runtime if the kernel is too old (`ENOSYS`).
+- **FreeBSD 13+ / macOS 15+**: `openat(O_RESOLVE_BENEATH | O_NOFOLLOW)` — equivalent kernel-level containment via BSD-style flags.
+- **POSIX fallback**: `open(O_NOFOLLOW)` followed by inode comparison (`stat` canonical path vs `fstat` fd) to verify the opened fd matches the validated path. This narrows the TOCTOU window to a race between `open()` and `stat()`.
+- **Windows**: `CreateFileW(FILE_FLAG_OPEN_REPARSE_POINT)` opens without following symlinks/junctions, then checks `dwFileAttributes` for reparse points and verifies via inode comparison (`dwVolumeSerialNumber` + `nFileIndexHigh/Low` from `GetFileInformationByHandle()`). Returns a raw OS HANDLE (not a CRT fd) to avoid fd table mismatch across DLL boundaries; Python converts via `msvcrt.open_osfhandle()`.
 
-### Layer 4: Hardlink Count Check
+Hardlinks are detected via `fstat()` link count (POSIX) or `GetFileInformationByHandle()` (Windows), always fail closed.
 
-- **C++**: `std::filesystem::hard_link_count(data_path) > 1` rejects files with multiple hardlinks.
-- **Python**: `os.stat(path).st_nlink > 1` rejects files with multiple hardlinks.
+### Layer 4: Pre-Open Hardlink Count Check
 
-This prevents an attacker from using a hardlink (which is not a symlink) to point external data at a sensitive file. Note that `O_NOFOLLOW` does **not** protect against hardlinks — only this explicit check does.
+- **C++**: `std::filesystem::hard_link_count(data_path) > 1` rejects files with multiple hardlinks before opening.
+
+This is defense-in-depth alongside Layer 3's post-open hardlink check. It provides a clear error message at the path level before any file I/O occurs.
 
 ## Protected Entry Points
 
-Not all layers apply at every entry point. The C++ checker validates paths but does not open files, so Layer 3 (O_NOFOLLOW) is Python-only.
+All Python entry points that open external data files use the C++ `open_external_data()` function, which applies Layers 1-4 in a single call. The C++ checker (`resolve_external_data_location`) validates paths without opening files, so Layer 3 does not apply there.
 
 | Entry Point | File | Layers |
 |---|---|---|
-| `_resolve_external_data_location` | `onnx/checker.cc` | 1, 2, 4 |
-| `load_external_data_for_tensor` | `onnx/external_data_helper.py` | 1, 2, 3, 4 |
-| `save_external_data` | `onnx/external_data_helper.py` | 1, 2, 3, 4 |
-| `ModelContainer._load_large_initializers` | `onnx/model_container.py` | 1, 2, 3, 4 |
-
-The C++ checker runs first for all Python load paths (via `c_checker._resolve_external_data_location`). The Python checks serve as defense-in-depth.
+| `resolve_external_data_location` | `onnx/checker.cc` | 1, 2, 4 |
+| `open_external_data` | `onnx/checker.cc` | 1, 2, 3, 4 |
+| `load_external_data_for_tensor` | `onnx/external_data_helper.py` | 1, 2, 3, 4 (via `open_external_data`) |
+| `save_external_data` | `onnx/external_data_helper.py` | 1, 3 (via `open_external_data`) |
+| `ModelContainer._load_large_initializers` | `onnx/model_container.py` | 1, 2, 3, 4 (via `open_external_data`) |
 
 ## Known Limitations
 
-### TOCTOU (Time-of-Check-to-Time-of-Use)
-
-There is an inherent race window between the security checks (Layers 1-2, 4) and the file open (Layer 3). An attacker with write access to the model directory could:
-
-1. Place a legitimate file to pass checks.
-2. Replace it with a symlink or hardlink between the check and the open.
-
-**Mitigation**: `O_NOFOLLOW` (Layer 3) catches late symlink replacement on Linux/macOS at the kernel level. However, `O_NOFOLLOW` does **not** protect against hardlink replacement — this TOCTOU gap cannot be fully closed at the application level.
-
 ### Windows
 
-- `O_NOFOLLOW` is **not available** on Windows (`hasattr(os, "O_NOFOLLOW")` returns `False`). The TOCTOU window for symlink attacks is fully open on Windows, relying solely on Layers 1-2.
+- Reparse points (symlinks, junctions) are rejected via `FILE_FLAG_OPEN_REPARSE_POINT` + attribute check.
 - Symlink and hardlink tests are skipped on Windows in the test suite.
 
 ### Case-Insensitive Filesystems
 
-The canonical path containment check uses string comparison. On case-insensitive filesystems (Windows NTFS, macOS HFS+), paths with different casing may incorrectly fail containment. This fails closed (false rejection, not a bypass).
+The canonical path containment checks (Layers 1 and 3) use string comparison. On case-insensitive filesystems (Windows NTFS, macOS HFS+), paths with different casing may incorrectly fail containment. This fails closed (false rejection, not a bypass).
 
 ## Testing
 
 Test coverage is in:
 
-- **C++**: `onnx/test/cpp/checker_test.cc` — `SymLink*` tests for symlink detection and containment.
+- **C++**: `onnx/test/cpp/checker_test.cc` — `*SymLink*` tests for symlink detection and containment, `OpenExternalData*` for secure open and verification.
 - **Python**: `onnx/test/test_external_data.py`:
   - `TestSaveExternalDataSymlinkProtection` — save-side symlink rejection.
   - `TestLoadExternalDataSymlinkProtection` — load-side symlink rejection, parent-directory symlink, `load_external_data_for_model` rejection.

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -37,10 +37,12 @@ This is a belt-and-suspenders check alongside containment. It provides a clear, 
 
 Three platform-specific strategies, in order of preference:
 
-- **Linux 5.6+**: `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)` — atomic kernel-level containment and symlink rejection. No TOCTOU possible. Falls back at runtime if the kernel is too old (`ENOSYS`).
-- **FreeBSD 13+ / macOS 15+**: `openat(O_RESOLVE_BENEATH | O_NOFOLLOW)` — equivalent kernel-level containment via BSD-style flags.
-- **POSIX fallback**: `open(O_NOFOLLOW)` followed by inode comparison (`stat` canonical path vs `fstat` fd) to verify the opened fd matches the validated path. This narrows the TOCTOU window to a race between `open()` and `stat()`.
-- **Windows**: `CreateFileW(FILE_FLAG_OPEN_REPARSE_POINT)` opens without following symlinks/junctions, then checks `dwFileAttributes` for reparse points and verifies via inode comparison (`dwVolumeSerialNumber` + `nFileIndexHigh/Low` from `GetFileInformationByHandle()`). Returns a raw OS HANDLE (not a CRT fd) to avoid fd table mismatch across DLL boundaries; Python converts via `msvcrt.open_osfhandle()`.
+- **Linux 5.6+**: `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS)` — atomic kernel containment. No TOCTOU. Falls back on `ENOSYS`.
+- **FreeBSD 13+ / macOS 15+**: `openat(O_RESOLVE_BENEATH | O_NOFOLLOW)` — equivalent BSD-style containment.
+- **POSIX fallback**: `open(O_NOFOLLOW)` + post-open inode comparison (`fstat` fd vs `stat` canonical path).
+- **Windows**: `CreateFileW(FILE_FLAG_OPEN_REPARSE_POINT)` + reparse point attribute check + inode comparison. Converted to CRT fd via `_open_osfhandle()` before returning.
+
+All POSIX fds are opened with `O_CLOEXEC`. All platforms return a CRT file descriptor.
 
 Hardlinks are detected via `fstat()` link count (POSIX) or `GetFileInformationByHandle()` (Windows), always fail closed.
 
@@ -52,15 +54,16 @@ This is defense-in-depth alongside Layer 3's post-open hardlink check. It provid
 
 ## Protected Entry Points
 
-All Python entry points that open external data files use the C++ `open_external_data()` function, which applies Layers 1-4 in a single call. The C++ checker (`resolve_external_data_location`) validates paths without opening files, so Layer 3 does not apply there.
+All Python entry points use the C++ `open_external_data()` function. In **read mode** it applies all four layers (pre-open validation via `resolve_external_data_location` for Layers 1, 2, 4, then Layer 3 post-open). In **write mode** it applies Layers 1 and 3 only — Layers 2 and 4 are skipped because the file may not yet exist. The C++ checker calls `resolve_external_data_location` directly without opening files, so Layer 3 does not apply there.
 
-| Entry Point | File | Layers |
-|---|---|---|
-| `resolve_external_data_location` | `onnx/checker.cc` | 1, 2, 4 |
-| `open_external_data` | `onnx/checker.cc` | 1, 2, 3, 4 |
-| `load_external_data_for_tensor` | `onnx/external_data_helper.py` | 1, 2, 3, 4 (via `open_external_data`) |
-| `save_external_data` | `onnx/external_data_helper.py` | 1, 3 (via `open_external_data`) |
-| `ModelContainer._load_large_initializers` | `onnx/model_container.py` | 1, 2, 3, 4 (via `open_external_data`) |
+| Entry Point | File | Mode | Layers |
+|---|---|---|---|
+| `resolve_external_data_location` | `onnx/checker.cc` | read | 1, 2, 4 |
+| `open_external_data` | `onnx/checker.cc` | read | 1, 2, 3, 4 |
+| `open_external_data` | `onnx/checker.cc` | write | 1, 3 |
+| `load_external_data_for_tensor` | `onnx/external_data_helper.py` | read | 1, 2, 3, 4 (via `open_external_data`) |
+| `save_external_data` | `onnx/external_data_helper.py` | write | 1, 3 (via `open_external_data`) |
+| `ModelContainer._load_large_initializers` | `onnx/model_container.py` | read | 1, 2, 3, 4 (via `open_external_data`) |
 
 ## Known Limitations
 

--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -16,8 +16,39 @@
 #include "onnx/shape_inference/implementation.h"
 
 #ifdef _WIN32
+#include <Windows.h>
+
 #include "onnx/common/path.h"
+#else
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+// Kernel-level path containment: prefer openat2 (Linux 5.6+) or
+// O_RESOLVE_BENEATH (FreeBSD 13+, macOS 15+) when available.
+#ifdef __linux__
+#include <sys/syscall.h>
+#ifdef SYS_openat2
+#define ONNX_HAS_OPENAT2
+#if __has_include(<linux/openat2.h>)
+#include <linux/openat2.h>
+#else
+struct open_how {
+  uint64_t flags;
+  uint64_t mode;
+  uint64_t resolve;
+};
+#define RESOLVE_NO_SYMLINKS 0x04
+#define RESOLVE_BENEATH 0x08
 #endif
+#endif // SYS_openat2
+#endif // __linux__
+
+#ifdef O_RESOLVE_BENEATH
+#define ONNX_HAS_RESOLVE_BENEATH
+#endif
+
+#endif // _WIN32
 
 namespace ONNX_NAMESPACE {
 namespace checker {
@@ -680,7 +711,7 @@ void check_graph(const GraphProto& graph, const CheckerContext& ctx, const Lexic
     ONNX_CATCH(ValidationError & ex) {
       ONNX_HANDLE_EXCEPTION([&]() {
         ex.AppendContext("Bad node spec for node. Name: " + node.name() + " OpType: " + node.op_type());
-        ONNX_THROW_EX(ex);
+        throw;
       });
     }
     // check for SSA form
@@ -969,17 +1000,90 @@ void check_model(
   }
 }
 
-std::string resolve_external_data_location(
+static std::filesystem::path utf8_to_path(const std::string& utf8) {
+#ifdef _WIN32
+  return std::filesystem::path(utf8str_to_wstring(utf8));
+#else
+  return std::filesystem::path(utf8);
+#endif
+}
+
+namespace {
+template <auto Invalid, void (*Close)(decltype(Invalid))>
+class ScopedResource {
+  using T = decltype(Invalid);
+  T val_;
+
+ public:
+  explicit ScopedResource(T v) : val_(v) {}
+  ~ScopedResource() {
+    if (val_ != Invalid) {
+      Close(val_);
+    }
+  }
+  T get() const {
+    return val_;
+  }
+  T release() {
+    T tmp = val_;
+    val_ = Invalid;
+    return tmp;
+  }
+  ScopedResource(const ScopedResource&) = delete;
+  ScopedResource& operator=(const ScopedResource&) = delete;
+};
+
+#ifdef _WIN32
+void close_handle(HANDLE h) {
+  CloseHandle(h);
+}
+using ScopedHandle = ScopedResource<INVALID_HANDLE_VALUE, close_handle>;
+#else
+void close_fd(int fd) {
+  close(fd);
+}
+using ScopedFd = ScopedResource<-1, close_fd>;
+#endif
+} // namespace
+
+#ifdef _WIN32
+// Compare two BY_HANDLE_FILE_INFORMATION structs by volume + file index (inode equivalent).
+static bool same_file(const BY_HANDLE_FILE_INFORMATION& a, const BY_HANDLE_FILE_INFORMATION& b) {
+  return a.dwVolumeSerialNumber == b.dwVolumeSerialNumber && a.nFileIndexHigh == b.nFileIndexHigh &&
+      a.nFileIndexLow == b.nFileIndexLow;
+}
+#endif
+
+// Canonicalize data_path, verify containment within base_dir.
+static std::filesystem::path verify_path_containment(
+    const std::filesystem::path& data_path,
+    const std::string& base_dir,
+    const std::string& tensor_name) {
+  std::error_code ec;
+  auto canonical_data = std::filesystem::weakly_canonical(data_path, ec);
+  if (ec) {
+    fail_check("Tensor ", tensor_name, " external data path could not be canonicalized: ", ec.message());
+  }
+  auto canonical_base = std::filesystem::weakly_canonical(utf8_to_path(base_dir), ec);
+  if (ec) {
+    fail_check("Tensor ", tensor_name, " base directory could not be canonicalized: ", ec.message());
+  }
+  auto base_str = canonical_base.native();
+  if (!base_str.empty() && base_str.back() != std::filesystem::path::preferred_separator) {
+    base_str += std::filesystem::path::preferred_separator;
+  }
+  if (canonical_data.native().find(base_str) != 0 && canonical_data != canonical_base) { // NOSONAR
+    fail_check("Tensor ", tensor_name, " external data resolves outside model directory.");
+  }
+  return canonical_data;
+}
+
+std::filesystem::path resolve_external_data_location(
     const std::string& base_dir,
     const std::string& location,
     const std::string& tensor_name) {
-#ifdef _WIN32
-  std::filesystem::path base_dir_path(utf8str_to_wstring(base_dir));
-  std::filesystem::path file_path(utf8str_to_wstring(location));
-#else // POSIX
-  std::filesystem::path base_dir_path(base_dir);
-  std::filesystem::path file_path(location);
-#endif
+  auto base_dir_path = utf8_to_path(base_dir);
+  auto file_path = utf8_to_path(location);
   if (file_path.empty()) {
     fail_check("Location of external TensorProto ( tensor name: ", tensor_name, ") should not be empty.");
   }
@@ -991,12 +1095,7 @@ std::string resolve_external_data_location(
         location);
   }
   auto relative_path = file_path.lexically_normal().make_preferred();
-  // Check that normalized relative path doesn't contains ".."
-#ifdef _WIN32
-  if (relative_path.native().find(L"..", 0) != std::string::npos) {
-#else // POSIX
-  if (relative_path.native().find("..", 0) != std::string::npos) {
-#endif
+  if (relative_path.native().find(std::filesystem::path("..").native()) != std::filesystem::path::string_type::npos) {
     fail_check(
         "Data of TensorProto ( tensor name: ",
         tensor_name,
@@ -1007,11 +1106,7 @@ std::string resolve_external_data_location(
         "' points outside the directory.");
   }
   auto data_path = base_dir_path / relative_path;
-#ifdef _WIN32
-  auto data_path_str = wstring_to_utf8str(data_path.native());
-#else
-  auto data_path_str = data_path.native();
-#endif
+  auto data_path_str = data_path.string();
   // Do not allow symlinks or directories.
   if (data_path.empty() || std::filesystem::is_symlink(data_path)) {
     fail_check(
@@ -1021,44 +1116,9 @@ std::string resolve_external_data_location(
         data_path_str,
         ", but it is a symbolic link.");
   }
-  // Verify the resolved path stays within the base directory to prevent
-  // path traversal via symlinks in parent directory components.
-  // is_symlink() only checks the final component; a path like
-  // "symlink_subdir/real_file.data" would bypass it.
+  // Verify canonical containment (catches parent-dir symlinks).
   if (data_path_str[0] != '#') {
-    std::error_code ec;
-    auto canonical_base = std::filesystem::weakly_canonical(base_dir_path, ec);
-    if (ec) {
-      fail_check(
-          "Data of TensorProto ( tensor name: ",
-          tensor_name,
-          ") references external data at ",
-          data_path_str,
-          ", but the model directory path could not be resolved.");
-    }
-    auto canonical_data = std::filesystem::weakly_canonical(data_path, ec);
-    if (ec) {
-      fail_check(
-          "Data of TensorProto ( tensor name: ",
-          tensor_name,
-          ") references external data at ",
-          data_path_str,
-          ", but the data path could not be resolved.");
-    }
-    auto canonical_base_native = canonical_base.native();
-    auto canonical_data_native = canonical_data.native();
-    if (!canonical_base_native.empty() && canonical_base_native.back() != std::filesystem::path::preferred_separator) {
-      canonical_base_native += std::filesystem::path::preferred_separator;
-    }
-    if (canonical_data_native.find(canonical_base_native) != 0) {
-      fail_check(
-          "Data of TensorProto ( tensor name: ",
-          tensor_name,
-          ") at ",
-          data_path_str,
-          " resolves to a location outside the model directory, "
-          "indicating a potential path traversal attack via symbolic links in directory components.");
-    }
+    verify_path_containment(data_path, base_dir, tensor_name);
   }
   if (data_path_str[0] != '#' && !std::filesystem::is_regular_file(data_path)) {
     fail_check(
@@ -1077,8 +1137,201 @@ std::string resolve_external_data_location(
         data_path_str,
         ", but it has multiple hard links, indicating a potential hardlink attack.");
   }
-  return data_path_str;
+  return data_path;
 }
+
+static std::filesystem::path
+validate_write_location(const std::string& base_dir, const std::string& location, const std::string& tensor_name) {
+  auto file_path = utf8_to_path(location);
+  if (file_path.empty() || file_path.is_absolute()) {
+    fail_check("External data location for tensor ", tensor_name, " is empty or absolute: ", location);
+  }
+  auto rel = file_path.lexically_normal().make_preferred();
+  if (rel == std::filesystem::path(".")) {
+    fail_check("External data location for tensor ", tensor_name, " is invalid: ", location);
+  }
+  if (rel.native().find(std::filesystem::path("..").native()) !=
+      std::filesystem::path::string_type::npos) { // NOSONAR — C++17, no contains
+    fail_check("External data location for tensor ", tensor_name, " contains '..': ", location);
+  }
+  return utf8_to_path(base_dir) / rel;
+}
+
+#ifdef _WIN32
+
+int64_t open_external_data(
+    const std::string& base_dir,
+    const std::string& location,
+    const std::string& tensor_name,
+    bool read_only) {
+  std::filesystem::path data_path;
+  if (read_only) {
+    data_path = resolve_external_data_location(base_dir, location, tensor_name);
+  } else {
+    data_path = validate_write_location(base_dir, location, tensor_name);
+    // Pre-open parent-dir check (final-component-only flags don't protect parents).
+    verify_path_containment(data_path.parent_path(), base_dir, tensor_name);
+  }
+
+  // CreateFileW with FILE_FLAG_OPEN_REPARSE_POINT: opens reparse point itself
+  // (symlink/junction) without following, and returns CRT-independent HANDLE.
+  DWORD access = read_only ? GENERIC_READ : (GENERIC_READ | GENERIC_WRITE);
+  DWORD creation = read_only ? OPEN_EXISTING : OPEN_ALWAYS;
+  HANDLE h = CreateFileW(
+      data_path.native().c_str(),
+      access,
+      FILE_SHARE_READ,
+      nullptr,
+      creation,
+      FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT,
+      nullptr);
+  if (h == INVALID_HANDLE_VALUE) {
+    fail_check("Cannot open external data for tensor ", tensor_name);
+  }
+  ScopedHandle guard(h);
+
+  // Reject symlinks/junctions.
+  BY_HANDLE_FILE_INFORMATION file_info;
+  if (!GetFileInformationByHandle(h, &file_info)) {
+    fail_check("Tensor ", tensor_name, " external data: cannot query file information.");
+  }
+  if (file_info.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
+    fail_check("Tensor ", tensor_name, " external data is a reparse point (symlink/junction).");
+  }
+
+  // Inode comparison: open canonical path, compare volume + file index.
+  auto canonical_data = verify_path_containment(data_path, base_dir, tensor_name);
+  HANDLE h2 = CreateFileW(
+      canonical_data.native().c_str(), 0, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, 0, nullptr);
+  if (h2 == INVALID_HANDLE_VALUE) {
+    fail_check("Tensor ", tensor_name, " external data: cannot open canonical path for verification.");
+  }
+  BY_HANDLE_FILE_INFORMATION canon_info;
+  bool got_info = GetFileInformationByHandle(h2, &canon_info);
+  CloseHandle(h2);
+  if (!got_info) {
+    fail_check("Tensor ", tensor_name, " external data: cannot query canonical path file information.");
+  }
+  if (!same_file(file_info, canon_info)) {
+    fail_check("Tensor ", tensor_name, " external data: fd/path mismatch (possible TOCTOU attack).");
+  }
+
+  // Hardlink check (fail closed).
+  if (file_info.nNumberOfLinks > 1) {
+    fail_check("Tensor ", tensor_name, " external data has multiple hard links (possible hardlink attack).");
+  }
+
+  return reinterpret_cast<int64_t>(guard.release()); // NOSONAR NOLINT(performance-no-int-to-ptr)
+}
+
+#else // POSIX
+
+// Try kernel-level contained open.
+// Returns fd >= 0 on success, -1 if feature unavailable (fall through to legacy).
+// Calls fail_check on kernel rejection (symlink, escape) — does NOT fall through.
+static int try_kernel_contained_open(
+    const std::string& base_dir,
+    const std::string& location,
+    const std::string& tensor_name,
+    bool read_only) {
+  int raw_dirfd = open(base_dir.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+  if (raw_dirfd < 0) {
+    return -1;
+  }
+  ScopedFd dirfd_guard(raw_dirfd);
+  auto rel = std::filesystem::path(location).lexically_normal().string();
+  int fd = -1;
+
+#ifdef ONNX_HAS_OPENAT2
+  static bool openat2_supported = true;
+  if (openat2_supported) {
+    struct open_how how = {};
+    how.flags = read_only ? static_cast<uint64_t>(O_RDONLY) : static_cast<uint64_t>(O_CREAT | O_RDWR);
+    how.mode = read_only ? 0 : 0600;
+    how.resolve = RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS;
+    fd = static_cast<int>(syscall(SYS_openat2, raw_dirfd, rel.c_str(), &how, sizeof(how)));
+    if (fd < 0) {
+      if (errno == ENOSYS) {
+        openat2_supported = false; // kernel too old, fall through
+      } else {
+        fail_check("Cannot open external data for tensor ", tensor_name, " (kernel rejected path)");
+      }
+    }
+  }
+#elif defined(ONNX_HAS_RESOLVE_BENEATH)
+  int flags = O_RESOLVE_BENEATH;
+#ifdef O_NOFOLLOW
+  flags |= O_NOFOLLOW;
+#endif
+  if (read_only) {
+    fd = openat(raw_dirfd, rel.c_str(), flags | O_RDONLY);
+  } else {
+    fd = openat(raw_dirfd, rel.c_str(), flags | O_CREAT | O_RDWR, 0600);
+  }
+  if (fd < 0) {
+    fail_check("Cannot open external data for tensor ", tensor_name);
+  }
+#endif
+
+  return fd;
+}
+
+int64_t open_external_data(
+    const std::string& base_dir,
+    const std::string& location,
+    const std::string& tensor_name,
+    bool read_only) {
+  // Pre-open validation (defense-in-depth).
+  std::filesystem::path data_path;
+  if (read_only) {
+    data_path = resolve_external_data_location(base_dir, location, tensor_name);
+  } else {
+    data_path = validate_write_location(base_dir, location, tensor_name);
+    // Pre-open parent-dir check (final-component-only flags don't protect parents).
+    verify_path_containment(data_path.parent_path(), base_dir, tensor_name);
+  }
+
+  // Try kernel-level contained open (openat2 or O_RESOLVE_BENEATH).
+  int fd = try_kernel_contained_open(base_dir, location, tensor_name, read_only);
+  bool kernel_verified = (fd >= 0);
+
+  // Fallback: open() + O_NOFOLLOW + post-open inode verification.
+  if (fd < 0) {
+    int flags = read_only ? O_RDONLY : (O_CREAT | O_RDWR);
+#ifdef O_NOFOLLOW
+    flags |= O_NOFOLLOW;
+#endif
+    fd = read_only ? open(data_path.c_str(), flags) : open(data_path.c_str(), flags, 0600);
+    if (fd == -1) {
+      fail_check("Cannot open external data for tensor ", tensor_name);
+    }
+  }
+  ScopedFd guard(fd);
+
+  // Post-open checks (fail closed).
+  struct stat fd_stat{};
+  if (fstat(fd, &fd_stat) != 0) {
+    fail_check("Tensor ", tensor_name, " external data: fstat failed.");
+  }
+  if (!kernel_verified) {
+    // Verify containment via canonical path + inode comparison.
+    auto canonical_data = verify_path_containment(data_path, base_dir, tensor_name);
+    struct stat path_stat{};
+    if (stat(canonical_data.c_str(), &path_stat) != 0) {
+      fail_check("Tensor ", tensor_name, " external data: cannot stat canonical path.");
+    }
+    if (path_stat.st_dev != fd_stat.st_dev || path_stat.st_ino != fd_stat.st_ino) {
+      fail_check("Tensor ", tensor_name, " external data: fd/path mismatch (possible TOCTOU attack).");
+    }
+  }
+  if (fd_stat.st_nlink > 1) {
+    fail_check("Tensor ", tensor_name, " external data has multiple hard links (possible hardlink attack).");
+  }
+
+  return guard.release();
+}
+
+#endif
 
 static std::unordered_set<std::string> experimental_ops = {
     "ATen",

--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -12,13 +12,15 @@
 #include <vector>
 
 #include "onnx/common/file_utils.h"
+#include "onnx/common/path.h"
+#include "onnx/common/scoped_resource.h"
 #include "onnx/defs/tensor_proto_util.h"
 #include "onnx/shape_inference/implementation.h"
 
 #ifdef _WIN32
 #include <Windows.h>
-
-#include "onnx/common/path.h"
+#include <fcntl.h>
+#include <io.h>
 #else
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -711,7 +713,7 @@ void check_graph(const GraphProto& graph, const CheckerContext& ctx, const Lexic
     ONNX_CATCH(ValidationError & ex) {
       ONNX_HANDLE_EXCEPTION([&]() {
         ex.AppendContext("Bad node spec for node. Name: " + node.name() + " OpType: " + node.op_type());
-        throw;
+        ONNX_THROW_EX(ex);
       });
     }
     // check for SSA form
@@ -1000,51 +1002,11 @@ void check_model(
   }
 }
 
-static std::filesystem::path utf8_to_path(const std::string& utf8) {
+using ONNX_NAMESPACE::ScopedFd;
+using ONNX_NAMESPACE::utf8_to_path;
 #ifdef _WIN32
-  return std::filesystem::path(utf8str_to_wstring(utf8));
-#else
-  return std::filesystem::path(utf8);
+using ONNX_NAMESPACE::ScopedHandle;
 #endif
-}
-
-namespace {
-template <auto Invalid, void (*Close)(decltype(Invalid))>
-class ScopedResource {
-  using T = decltype(Invalid);
-  T val_;
-
- public:
-  explicit ScopedResource(T v) : val_(v) {}
-  ~ScopedResource() {
-    if (val_ != Invalid) {
-      Close(val_);
-    }
-  }
-  T get() const {
-    return val_;
-  }
-  T release() {
-    T tmp = val_;
-    val_ = Invalid;
-    return tmp;
-  }
-  ScopedResource(const ScopedResource&) = delete;
-  ScopedResource& operator=(const ScopedResource&) = delete;
-};
-
-#ifdef _WIN32
-void close_handle(HANDLE h) {
-  CloseHandle(h);
-}
-using ScopedHandle = ScopedResource<INVALID_HANDLE_VALUE, close_handle>;
-#else
-void close_fd(int fd) {
-  close(fd);
-}
-using ScopedFd = ScopedResource<-1, close_fd>;
-#endif
-} // namespace
 
 #ifdef _WIN32
 // Compare two BY_HANDLE_FILE_INFORMATION structs by volume + file index (inode equivalent).
@@ -1202,14 +1164,19 @@ int64_t open_external_data(
   // Inode comparison: open canonical path, compare volume + file index.
   auto canonical_data = verify_path_containment(data_path, base_dir, tensor_name);
   HANDLE h2 = CreateFileW(
-      canonical_data.native().c_str(), 0, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, 0, nullptr);
+      canonical_data.native().c_str(),
+      0,
+      FILE_SHARE_READ | FILE_SHARE_WRITE,
+      nullptr,
+      OPEN_EXISTING,
+      FILE_FLAG_OPEN_REPARSE_POINT,
+      nullptr);
   if (h2 == INVALID_HANDLE_VALUE) {
     fail_check("Tensor ", tensor_name, " external data: cannot open canonical path for verification.");
   }
+  ScopedHandle guard2(h2);
   BY_HANDLE_FILE_INFORMATION canon_info;
-  bool got_info = GetFileInformationByHandle(h2, &canon_info);
-  CloseHandle(h2);
-  if (!got_info) {
+  if (!GetFileInformationByHandle(h2, &canon_info)) {
     fail_check("Tensor ", tensor_name, " external data: cannot query canonical path file information.");
   }
   if (!same_file(file_info, canon_info)) {
@@ -1221,7 +1188,15 @@ int64_t open_external_data(
     fail_check("Tensor ", tensor_name, " external data has multiple hard links (possible hardlink attack).");
   }
 
-  return reinterpret_cast<int64_t>(guard.release()); // NOSONAR NOLINT(performance-no-int-to-ptr)
+  // Convert HANDLE → CRT fd so callers get a uniform fd on all platforms.
+  HANDLE h_released = guard.release();
+  int flags = read_only ? (_O_RDONLY | _O_BINARY) : (_O_RDWR | _O_BINARY);
+  int fd = _open_osfhandle(reinterpret_cast<intptr_t>(h_released), flags);
+  if (fd < 0) {
+    CloseHandle(h_released);
+    fail_check("Cannot convert handle to fd for tensor ", tensor_name);
+  }
+  return static_cast<int64_t>(fd);
 }
 
 #else // POSIX
@@ -1243,10 +1218,11 @@ static int try_kernel_contained_open(
   int fd = -1;
 
 #ifdef ONNX_HAS_OPENAT2
-  static bool openat2_supported = true;
+  static thread_local bool openat2_supported = true;
   if (openat2_supported) {
     struct open_how how = {};
-    how.flags = read_only ? static_cast<uint64_t>(O_RDONLY) : static_cast<uint64_t>(O_CREAT | O_RDWR);
+    how.flags =
+        read_only ? static_cast<uint64_t>(O_RDONLY | O_CLOEXEC) : static_cast<uint64_t>(O_CREAT | O_RDWR | O_CLOEXEC);
     how.mode = read_only ? 0 : 0600;
     how.resolve = RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS;
     fd = static_cast<int>(syscall(SYS_openat2, raw_dirfd, rel.c_str(), &how, sizeof(how)));
@@ -1259,7 +1235,7 @@ static int try_kernel_contained_open(
     }
   }
 #elif defined(ONNX_HAS_RESOLVE_BENEATH)
-  int flags = O_RESOLVE_BENEATH;
+  int flags = O_RESOLVE_BENEATH | O_CLOEXEC;
 #ifdef O_NOFOLLOW
   flags |= O_NOFOLLOW;
 #endif
@@ -1298,6 +1274,9 @@ int64_t open_external_data(
   // Fallback: open() + O_NOFOLLOW + post-open inode verification.
   if (fd < 0) {
     int flags = read_only ? O_RDONLY : (O_CREAT | O_RDWR);
+#ifdef O_CLOEXEC
+    flags |= O_CLOEXEC;
+#endif
 #ifdef O_NOFOLLOW
     flags |= O_NOFOLLOW;
 #endif

--- a/onnx/checker.h
+++ b/onnx/checker.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <filesystem>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -181,10 +182,18 @@ ONNX_API void check_model(
     bool full_check = false,
     bool skip_opset_compatibility_check = false,
     bool check_custom_domain = false);
-std::string resolve_external_data_location(
+std::filesystem::path resolve_external_data_location(
     const std::string& base_dir,
     const std::string& location,
     const std::string& tensor_name);
+// Returns a file descriptor (POSIX) or a raw OS HANDLE cast to int64_t (Windows).
+// On Windows, the caller must convert to fd via msvcrt.open_osfhandle() (Python)
+// or _open_osfhandle() (C++) to avoid CRT fd table mismatch across DLL boundaries.
+int64_t open_external_data(
+    const std::string& base_dir,
+    const std::string& location,
+    const std::string& tensor_name,
+    bool read_only);
 ONNX_API bool check_is_experimental_op(const NodeProto& node);
 
 } // namespace checker

--- a/onnx/checker.h
+++ b/onnx/checker.h
@@ -186,9 +186,8 @@ std::filesystem::path resolve_external_data_location(
     const std::string& base_dir,
     const std::string& location,
     const std::string& tensor_name);
-// Returns a file descriptor (POSIX) or a raw OS HANDLE cast to int64_t (Windows).
-// On Windows, the caller must convert to fd via msvcrt.open_osfhandle() (Python)
-// or _open_osfhandle() (C++) to avoid CRT fd table mismatch across DLL boundaries.
+// Returns a CRT file descriptor on all platforms.
+// The caller owns the fd and must close it.
 int64_t open_external_data(
     const std::string& base_dir,
     const std::string& location,

--- a/onnx/common/file_utils.h
+++ b/onnx/common/file_utils.h
@@ -18,7 +18,7 @@ namespace ONNX_NAMESPACE {
 template <typename T>
 void LoadProtoFromPath(const std::string& proto_path, T& proto) {
 #ifdef _WIN32
-  std::filesystem::path proto_u8_path(utf8str_to_wstring(proto_path, true));
+  std::filesystem::path proto_u8_path(utf8str_to_wstring(proto_path));
 #else
   std::filesystem::path proto_u8_path(proto_path);
 #endif

--- a/onnx/common/path.h
+++ b/onnx/common/path.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <filesystem>
 #include <string>
 
 #ifdef _WIN32
@@ -20,29 +21,23 @@
 namespace ONNX_NAMESPACE {
 
 #ifdef _WIN32
-inline std::wstring utf8str_to_wstring(const std::string& utf8str, bool try_decode = false) {
+inline std::wstring utf8str_to_wstring(const std::string& utf8str) {
   if (utf8str.empty()) {
     return std::wstring();
   }
+  int len = static_cast<int>(utf8str.size());
   auto size_required =
-      MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS | MB_PRECOMPOSED, utf8str.c_str(), -1, nullptr, 0);
+      MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS | MB_PRECOMPOSED, utf8str.data(), len, nullptr, 0);
   if (size_required == 0) {
-    if (try_decode) {
-      return std::wstring(
-          reinterpret_cast<const wchar_t*>(utf8str.c_str()), utf8str.size() / sizeof(std::wstring::value_type));
-    }
     auto last_error = GetLastError();
     fail_check("MultiByteToWideChar in utf8str_to_wstring returned error:", last_error);
   }
   std::wstring ws_str(size_required, 0);
   auto converted_size = MultiByteToWideChar(
-      CP_UTF8, MB_ERR_INVALID_CHARS | MB_PRECOMPOSED, utf8str.c_str(), -1, &ws_str[0], size_required);
+      CP_UTF8, MB_ERR_INVALID_CHARS | MB_PRECOMPOSED, utf8str.data(), len, &ws_str[0], size_required);
   if (converted_size == 0) {
     auto last_error = GetLastError();
     fail_check("MultiByteToWideChar in utf8str_to_wstring returned error:", last_error);
-  }
-  if (ws_str.back() == '\0') {
-    ws_str.pop_back();
   }
   return ws_str;
 }
@@ -51,25 +46,43 @@ inline std::string wstring_to_utf8str(const std::wstring& ws_str) {
   if (ws_str.empty()) {
     return std::string();
   }
+  int len = static_cast<int>(ws_str.size());
   auto size_required =
-      WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, ws_str.c_str(), -1, nullptr, 0, nullptr, nullptr);
+      WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, ws_str.data(), len, nullptr, 0, nullptr, nullptr);
   if (size_required == 0) {
     auto last_error = GetLastError();
     fail_check("WideCharToMultiByte in wstring_to_utf8str returned error:", last_error);
   }
   std::string utf8str(size_required, 0);
   auto converted_size = WideCharToMultiByte(
-      CP_UTF8, WC_ERR_INVALID_CHARS, ws_str.c_str(), -1, &utf8str[0], size_required, nullptr, nullptr);
+      CP_UTF8, WC_ERR_INVALID_CHARS, ws_str.data(), len, &utf8str[0], size_required, nullptr, nullptr);
   if (converted_size == 0) {
     auto last_error = GetLastError();
     fail_check("WideCharToMultiByte in wstring_to_utf8str returned error:", last_error);
-  }
-  if (utf8str.back() == '\0') {
-    utf8str.pop_back();
   }
   return utf8str;
 }
 
 #endif
+
+// Construct a std::filesystem::path from a UTF-8 string.
+// On Windows, converts via wide-char so the result is independent of the
+// active code page.  On POSIX, UTF-8 is the native encoding.
+inline std::filesystem::path utf8_to_path(const std::string& utf8) {
+#ifdef _WIN32
+  return std::filesystem::path(utf8str_to_wstring(utf8));
+#else
+  return std::filesystem::path(utf8);
+#endif
+}
+
+// Return the UTF-8 representation of a filesystem path.
+inline std::string path_to_utf8(const std::filesystem::path& p) {
+#ifdef _WIN32
+  return wstring_to_utf8str(p.wstring());
+#else
+  return p.string();
+#endif
+}
 
 } // namespace ONNX_NAMESPACE

--- a/onnx/common/scoped_resource.h
+++ b/onnx/common/scoped_resource.h
@@ -1,0 +1,68 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <io.h>
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace ONNX_NAMESPACE {
+
+// Generic RAII guard for resources identified by a sentinel "invalid" value and
+// a free-function closer.  Non-copyable, non-movable.
+//
+// Usage:
+//   using ScopedFd = ScopedResource<-1, close_fd>;
+//   ScopedFd guard(fd);          // destructor calls close_fd(fd)
+//   int raw = guard.release();   // relinquish ownership
+template <auto Invalid, void (*Close)(decltype(Invalid))>
+class ScopedResource {
+  using T = decltype(Invalid);
+  T val_;
+
+ public:
+  explicit ScopedResource(T v) : val_(v) {}
+  ~ScopedResource() {
+    if (val_ != Invalid) {
+      Close(val_);
+    }
+  }
+  T get() const {
+    return val_;
+  }
+  T release() {
+    T tmp = val_;
+    val_ = Invalid;
+    return tmp;
+  }
+  ScopedResource(const ScopedResource&) = delete;
+  ScopedResource& operator=(const ScopedResource&) = delete;
+};
+
+// Platform-specific type aliases.
+
+#ifdef _WIN32
+inline void close_handle(HANDLE h) {
+  CloseHandle(h);
+}
+using ScopedHandle = ScopedResource<INVALID_HANDLE_VALUE, close_handle>;
+#endif
+
+inline void close_fd(int fd) {
+#ifdef _WIN32
+  _close(fd);
+#else
+  close(fd);
+#endif
+}
+using ScopedFd = ScopedResource<-1, close_fd>;
+
+} // namespace ONNX_NAMESPACE

--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -691,7 +691,7 @@ NB_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
       nb::arg("skip_opset_compatibility_check") = false,
       nb::arg("check_custom_domain") = false);
 
-  checker.def("_resolve_external_data_location", &checker::resolve_external_data_location);
+  checker.def("_open_external_data", &checker::open_external_data);
 
   // Submodule `version_converter`
   auto version_converter = onnx_cpp2py_export.def_submodule("version_converter");

--- a/onnx/external_data_helper.py
+++ b/onnx/external_data_helper.py
@@ -21,9 +21,6 @@ from onnx.onnx_pb import (
     TensorProto,
 )
 
-if sys.platform == "win32":
-    import msvcrt
-
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
@@ -31,12 +28,8 @@ if TYPE_CHECKING:
 def _open_external_data_fd(
     base_dir: str, location: str, tensor_name: str, read_only: bool
 ) -> int:
-    """Open external data via C++ and return a Python-CRT file descriptor."""
-    raw = c_checker._open_external_data(base_dir, location, tensor_name, read_only)
-    if sys.platform == "win32":
-        flags = os.O_RDONLY | os.O_BINARY if read_only else os.O_RDWR | os.O_BINARY
-        return msvcrt.open_osfhandle(raw, flags)
-    return raw
+    """Open external data via C++ and return a CRT file descriptor."""
+    return c_checker._open_external_data(base_dir, location, tensor_name, read_only)
 
 
 # Security: 3-layer defense against malicious external_data entries (GHSA-538c-55jv-c5g9)

--- a/onnx/external_data_helper.py
+++ b/onnx/external_data_helper.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import os
-import pathlib
 import re
 import sys
 import uuid
@@ -22,8 +21,23 @@ from onnx.onnx_pb import (
     TensorProto,
 )
 
+if sys.platform == "win32":
+    import msvcrt
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
+
+
+def _open_external_data_fd(
+    base_dir: str, location: str, tensor_name: str, read_only: bool
+) -> int:
+    """Open external data via C++ and return a Python-CRT file descriptor."""
+    raw = c_checker._open_external_data(base_dir, location, tensor_name, read_only)
+    if sys.platform == "win32":
+        flags = os.O_RDONLY | os.O_BINARY if read_only else os.O_RDWR | os.O_BINARY
+        return msvcrt.open_osfhandle(raw, flags)
+    return raw
+
 
 # Security: 3-layer defense against malicious external_data entries (GHSA-538c-55jv-c5g9)
 #
@@ -134,53 +148,6 @@ def _validate_external_data_file_bounds(
     return data_file.read()
 
 
-def _validate_external_data_path(
-    base_dir: str,
-    data_path: str,
-    tensor_name: str,
-    *,
-    check_exists: bool = True,
-) -> str:
-    """Validate that an external data path is safe to open.
-
-    Performs three security checks:
-    1. Canonical path containment — resolved path must stay within base_dir.
-    2. Symlink rejection — final-component symlinks are not allowed.
-    3. Hardlink count — files with multiple hard links are rejected.
-
-    Args:
-        base_dir: The model base directory that data_path must be contained in.
-        data_path: The external data file path to validate.
-        tensor_name: Tensor name for error messages.
-        check_exists: If True (default), check hardlink count. Set to False
-            for save-side paths where the file may not exist yet.
-
-    Returns:
-        The validated data_path (unchanged).
-
-    Raises:
-        onnx.checker.ValidationError: If any security check fails.
-    """
-    real_base = os.path.realpath(base_dir)
-    real_path = os.path.realpath(data_path)
-    if not real_path.startswith(real_base + os.sep) and real_path != real_base:
-        raise onnx_checker.ValidationError(
-            f"Tensor {tensor_name!r} external data path resolves to "
-            f"{real_path!r} which is outside the model directory {real_base!r}."
-        )
-    if os.path.islink(data_path):
-        raise onnx_checker.ValidationError(
-            f"Tensor {tensor_name!r} external data path {data_path!r} "
-            f"is a symbolic link, which is not allowed for security reasons."
-        )
-    if check_exists and os.path.exists(data_path) and os.stat(data_path).st_nlink > 1:
-        raise onnx_checker.ValidationError(
-            f"Tensor {tensor_name!r} external data path {data_path!r} "
-            f"has multiple hard links, which is not allowed for security reasons."
-        )
-    return data_path
-
-
 def load_external_data_for_tensor(tensor: TensorProto, base_dir: str) -> None:
     """Loads data from an external file for tensor.
     Ideally TensorProto should not hold any raw data but if it does it will be ignored.
@@ -190,16 +157,7 @@ def load_external_data_for_tensor(tensor: TensorProto, base_dir: str) -> None:
         base_dir: directory that contains the external data.
     """
     info = ExternalDataInfo(tensor)
-    external_data_file_path = c_checker._resolve_external_data_location(  # type: ignore[attr-defined]
-        base_dir, info.location, tensor.name
-    )
-    # Security checks (symlink, containment, hardlink) already performed
-    # by C++ _resolve_external_data_location() above.
-    # Use O_NOFOLLOW where available as defense-in-depth for symlink protection
-    open_flags = os.O_RDONLY
-    if hasattr(os, "O_NOFOLLOW"):
-        open_flags |= os.O_NOFOLLOW
-    fd = os.open(external_data_file_path, open_flags)
+    fd = _open_external_data_fd(base_dir, info.location, tensor.name, True)
     with os.fdopen(fd, "rb") as data_file:
         tensor.raw_data = _validate_external_data_file_bounds(
             data_file, info, tensor.name
@@ -339,45 +297,10 @@ def save_external_data(tensor: TensorProto, base_path: str) -> None:
     """
     info = ExternalDataInfo(tensor)
 
-    # Let's check the tensor location is valid.
-    location_path = pathlib.Path(info.location)
-    if location_path.is_absolute():
-        raise onnx_checker.ValidationError(
-            f"Tensor {tensor.name!r} is external and must not be defined "
-            f"with an absolute path such as {info.location!r}, "
-            f"base_path={base_path!r}"
-        )
-    if ".." in location_path.parts:
-        raise onnx_checker.ValidationError(
-            f"Tensor {tensor.name!r} is external and must be placed in folder "
-            f"{base_path!r}, '..' is not needed in {info.location!r}."
-        )
-    if location_path.name in (".", ".."):
-        raise onnx_checker.ValidationError(
-            f"Tensor {tensor.name!r} is external and its name "
-            f"{info.location!r} is invalid."
-        )
-
-    external_data_file_path = os.path.join(base_path, info.location)
-
-    # C++ _resolve_external_data_location() cannot be used on save path
-    # (file may not exist yet), so Python performs its own security validation.
-    _validate_external_data_path(
-        base_path, external_data_file_path, tensor.name, check_exists=True
-    )
-
-    # Retrieve the tensor's data from raw_data or load external file
     if not tensor.HasField("raw_data"):
         raise onnx_checker.ValidationError("raw_data field doesn't exist.")
 
-    # Atomic file creation with symlink protection (O_NOFOLLOW where available)
-    open_flags = os.O_CREAT | os.O_RDWR
-    if hasattr(os, "O_NOFOLLOW"):
-        open_flags |= os.O_NOFOLLOW
-    # Use restrictive permissions: owner read/write only (0o600)
-    fd = os.open(external_data_file_path, open_flags, 0o600)
-
-    # Open file for reading and writing at random locations ('r+b')
+    fd = _open_external_data_fd(base_path, info.location, tensor.name, False)
     with os.fdopen(fd, "r+b") as data_file:
         data_file.seek(0, 2)
         if info.offset is not None:

--- a/onnx/model_container.py
+++ b/onnx/model_container.py
@@ -16,7 +16,6 @@ import numpy as np
 import onnx
 import onnx.external_data_helper as ext_data
 import onnx.helper
-import onnx.onnx_cpp2py_export.checker as c_checker
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -290,19 +289,12 @@ class ModelContainer:
                 continue
 
             info = ext_data.ExternalDataInfo(tensor)
-            external_data_file_path = c_checker._resolve_external_data_location(  # type: ignore[attr-defined]
-                base_dir, info.location, tensor.name
-            )
-            # Security checks (symlink, containment, hardlink) already performed
-            # by C++ _resolve_external_data_location() above.
             key = f"#t{i}"
             _set_external_data(tensor, location=key)
 
-            # Use O_NOFOLLOW where available for symlink protection
-            open_flags = os.O_RDONLY
-            if hasattr(os, "O_NOFOLLOW"):
-                open_flags |= os.O_NOFOLLOW
-            fd = os.open(external_data_file_path, open_flags)
+            fd = ext_data._open_external_data_fd(
+                base_dir, info.location, tensor.name, True
+            )
             with os.fdopen(fd, "rb") as data_file:
                 raw_data = ext_data._validate_external_data_file_bounds(
                     data_file, info, tensor.name

--- a/onnx/onnx_cpp2py_export/checker.pyi
+++ b/onnx/onnx_cpp2py_export/checker.pyi
@@ -43,3 +43,6 @@ def check_model_path(
     skip_opset_compatibility_check: bool,
     check_custom_domain: bool,
 ) -> None: ...
+def _open_external_data(
+    base_dir: str, location: str, tensor_name: str, read_only: bool
+) -> int: ...

--- a/onnx/test/cpp/checker_test.cc
+++ b/onnx/test/cpp/checker_test.cc
@@ -7,6 +7,14 @@
 #include <memory>
 #include <string>
 
+#ifdef _WIN32
+#include <io.h>
+#define CLOSE_FD _close
+#else
+#include <unistd.h>
+#define CLOSE_FD close
+#endif
+
 #include "gtest/gtest.h"
 #include "onnx/checker.h"
 
@@ -97,6 +105,72 @@ TEST(CHECKER, ValidDataLocationParentDirSymLinkTest) {
 
   fs::remove_all(modelDir);
   fs::remove_all(outsideDir);
+#endif
+}
+
+TEST(CHECKER, OpenExternalDataTest) {
+#ifndef ONNX_NO_EXCEPTIONS
+  // Use a UTF-8 directory name (raw bytes for C++20 char8_t compat).
+  fs::path dir = fs::temp_directory_path() / "\xe6\xa8\xa1\xe5\x9e\x8b_onnx_open_test";
+  fs::remove_all(dir);
+  fs::create_directories(dir);
+
+  // Read existing file (UTF-8 filename)
+  std::string utf8_file = "\xe3\x83\x86\xe3\x83\xb3\xe3\x82\xbd\xe3\x83\xab.bin";
+  {
+    std::ofstream ofs(dir / utf8_file, std::ios::binary);
+    ofs << "data";
+  }
+  auto raw = ONNX_NAMESPACE::checker::open_external_data(dir.string(), utf8_file, "t", true);
+  EXPECT_GE(raw, 0);
+  int fd = static_cast<int>(raw);
+  char buf[4];
+  EXPECT_EQ(read(fd, buf, 4), 4);
+  EXPECT_EQ(std::string(buf, 4), "data");
+  CLOSE_FD(fd);
+
+  // Write creates new file
+  raw = ONNX_NAMESPACE::checker::open_external_data(dir.string(), "new.bin", "t", false);
+  EXPECT_GE(raw, 0);
+  CLOSE_FD(static_cast<int>(raw));
+  EXPECT_TRUE(fs::exists(dir / "new.bin"));
+
+  // Reject invalid locations
+  EXPECT_THROW(
+      ONNX_NAMESPACE::checker::open_external_data(dir.string(), "missing.bin", "t", true),
+      ONNX_NAMESPACE::checker::ValidationError);
+  EXPECT_THROW(
+      ONNX_NAMESPACE::checker::open_external_data(dir.string(), "/etc/passwd", "t", true),
+      ONNX_NAMESPACE::checker::ValidationError);
+  EXPECT_THROW(
+      ONNX_NAMESPACE::checker::open_external_data(dir.string(), "../escape", "t", true),
+      ONNX_NAMESPACE::checker::ValidationError);
+  EXPECT_THROW(
+      ONNX_NAMESPACE::checker::open_external_data(dir.string(), ".", "t", false),
+      ONNX_NAMESPACE::checker::ValidationError);
+  // UTF-8 traversal
+  EXPECT_THROW(
+      ONNX_NAMESPACE::checker::open_external_data(
+          dir.string(), "../\xe3\x83\x86\xe3\x83\xb3\xe3\x82\xbd\xe3\x83\xab.bin", "t", true),
+      ONNX_NAMESPACE::checker::ValidationError);
+
+#ifndef _WIN32
+  // Symlink to outside directory
+  fs::path outside = fs::temp_directory_path() / "onnx_open_ext_outside";
+  fs::remove_all(outside);
+  fs::create_directories(outside);
+  {
+    std::ofstream ofs(outside / "secret.data", std::ios::binary);
+    ofs << "secret";
+  }
+  fs::create_symlink(outside / "secret.data", dir / "link.data");
+  EXPECT_THROW(
+      ONNX_NAMESPACE::checker::open_external_data(dir.string(), "link.data", "t", true),
+      ONNX_NAMESPACE::checker::ValidationError);
+  fs::remove_all(outside);
+#endif
+
+  fs::remove_all(dir);
 #endif
 }
 

--- a/onnx/test/cpp/checker_test.cc
+++ b/onnx/test/cpp/checker_test.cc
@@ -4,21 +4,22 @@
 
 #include <filesystem>
 #include <fstream>
-#include <memory>
 #include <string>
 
 #ifdef _WIN32
 #include <io.h>
-#define CLOSE_FD _close
-#else
-#include <unistd.h>
-#define CLOSE_FD close
 #endif
 
 #include "gtest/gtest.h"
 #include "onnx/checker.h"
+#include "onnx/common/path.h"
+#include "onnx/common/scoped_resource.h"
 
 namespace fs = std::filesystem;
+
+using ONNX_NAMESPACE::path_to_utf8;
+using ONNX_NAMESPACE::ScopedFd;
+using ONNX_NAMESPACE::utf8_to_path;
 
 namespace ONNX_NAMESPACE {
 namespace Test {
@@ -111,47 +112,56 @@ TEST(CHECKER, ValidDataLocationParentDirSymLinkTest) {
 TEST(CHECKER, OpenExternalDataTest) {
 #ifndef ONNX_NO_EXCEPTIONS
   // Use a UTF-8 directory name (raw bytes for C++20 char8_t compat).
-  fs::path dir = fs::temp_directory_path() / "\xe6\xa8\xa1\xe5\x9e\x8b_onnx_open_test";
+  fs::path dir = fs::temp_directory_path() / utf8_to_path("\xe6\xa8\xa1\xe5\x9e\x8b_onnx_open_test");
   fs::remove_all(dir);
   fs::create_directories(dir);
+  std::string dir_utf8 = path_to_utf8(dir);
 
   // Read existing file (UTF-8 filename)
   std::string utf8_file = "\xe3\x83\x86\xe3\x83\xb3\xe3\x82\xbd\xe3\x83\xab.bin";
   {
-    std::ofstream ofs(dir / utf8_file, std::ios::binary);
+    std::ofstream ofs(dir / utf8_to_path(utf8_file), std::ios::binary);
     ofs << "data";
   }
-  auto raw = ONNX_NAMESPACE::checker::open_external_data(dir.string(), utf8_file, "t", true);
-  EXPECT_GE(raw, 0);
-  int fd = static_cast<int>(raw);
-  char buf[4];
-  EXPECT_EQ(read(fd, buf, 4), 4);
-  EXPECT_EQ(std::string(buf, 4), "data");
-  CLOSE_FD(fd);
+  auto raw = ONNX_NAMESPACE::checker::open_external_data(dir_utf8, utf8_file, "t", true);
+  ASSERT_GE(raw, 0);
+  {
+    ScopedFd fd(static_cast<int>(raw));
+    ASSERT_GE(fd.get(), 0);
+    char buf[4];
+#ifdef _WIN32
+    EXPECT_EQ(_read(fd.get(), buf, 4), 4);
+#else
+    EXPECT_EQ(read(fd.get(), buf, 4), 4);
+#endif
+    EXPECT_EQ(std::string(buf, 4), "data");
+  } // fd closed by ScopedFd
 
   // Write creates new file
-  raw = ONNX_NAMESPACE::checker::open_external_data(dir.string(), "new.bin", "t", false);
-  EXPECT_GE(raw, 0);
-  CLOSE_FD(static_cast<int>(raw));
+  raw = ONNX_NAMESPACE::checker::open_external_data(dir_utf8, "new.bin", "t", false);
+  ASSERT_GE(raw, 0);
+  {
+    ScopedFd fd(static_cast<int>(raw));
+    ASSERT_GE(fd.get(), 0);
+  } // fd closed by ScopedFd
   EXPECT_TRUE(fs::exists(dir / "new.bin"));
 
   // Reject invalid locations
   EXPECT_THROW(
-      ONNX_NAMESPACE::checker::open_external_data(dir.string(), "missing.bin", "t", true),
+      ONNX_NAMESPACE::checker::open_external_data(dir_utf8, "missing.bin", "t", true),
       ONNX_NAMESPACE::checker::ValidationError);
   EXPECT_THROW(
-      ONNX_NAMESPACE::checker::open_external_data(dir.string(), "/etc/passwd", "t", true),
+      ONNX_NAMESPACE::checker::open_external_data(dir_utf8, "/etc/passwd", "t", true),
       ONNX_NAMESPACE::checker::ValidationError);
   EXPECT_THROW(
-      ONNX_NAMESPACE::checker::open_external_data(dir.string(), "../escape", "t", true),
+      ONNX_NAMESPACE::checker::open_external_data(dir_utf8, "../escape", "t", true),
       ONNX_NAMESPACE::checker::ValidationError);
   EXPECT_THROW(
-      ONNX_NAMESPACE::checker::open_external_data(dir.string(), ".", "t", false),
-      ONNX_NAMESPACE::checker::ValidationError);
+      ONNX_NAMESPACE::checker::open_external_data(dir_utf8, ".", "t", false), ONNX_NAMESPACE::checker::ValidationError);
   // UTF-8 traversal
   EXPECT_THROW(
       ONNX_NAMESPACE::checker::open_external_data(
-          dir.string(), "../\xe3\x83\x86\xe3\x83\xb3\xe3\x82\xbd\xe3\x83\xab.bin", "t", true),
+          dir_utf8, "../\xe3\x83\x86\xe3\x83\xb3\xe3\x82\xbd\xe3\x83\xab.bin", "t", true),
       ONNX_NAMESPACE::checker::ValidationError);
 
 #ifndef _WIN32
@@ -165,7 +175,7 @@ TEST(CHECKER, OpenExternalDataTest) {
   }
   fs::create_symlink(outside / "secret.data", dir / "link.data");
   EXPECT_THROW(
-      ONNX_NAMESPACE::checker::open_external_data(dir.string(), "link.data", "t", true),
+      ONNX_NAMESPACE::checker::open_external_data(dir_utf8, "link.data", "t", true),
       ONNX_NAMESPACE::checker::ValidationError);
   fs::remove_all(outside);
 #endif

--- a/onnx/test/cpp/utf8_conversion_test.cc
+++ b/onnx/test/cpp/utf8_conversion_test.cc
@@ -14,6 +14,7 @@ TEST(UTF8Test, WideStringConversion) {
   EXPECT_EQ(ONNX_NAMESPACE::wstring_to_utf8str(ONNX_NAMESPACE::utf8str_to_wstring(utf8_str)), utf8_str);
 }
 
+#ifndef ONNX_NO_EXCEPTIONS
 TEST(UTF8Test, InvalidUtf8Rejected) {
   // Raw wchar_t bytes are not valid UTF-8 — must be rejected (fail-closed).
   std::string utf8_str(u8"世界，你好！");
@@ -21,5 +22,6 @@ TEST(UTF8Test, InvalidUtf8Rejected) {
   std::string raw_bytes(reinterpret_cast<const char*>(wstr.c_str()), sizeof(std::wstring::value_type) * wstr.size());
   EXPECT_THROW(ONNX_NAMESPACE::utf8str_to_wstring(raw_bytes), ONNX_NAMESPACE::checker::ValidationError);
 }
+#endif
 } // namespace ONNX_NAMESPACE::Test
 #endif

--- a/onnx/test/cpp/utf8_conversion_test.cc
+++ b/onnx/test/cpp/utf8_conversion_test.cc
@@ -14,12 +14,12 @@ TEST(UTF8Test, WideStringConversion) {
   EXPECT_EQ(ONNX_NAMESPACE::wstring_to_utf8str(ONNX_NAMESPACE::utf8str_to_wstring(utf8_str)), utf8_str);
 }
 
-TEST(UTF8Test, TryConvertUTF8) {
+TEST(UTF8Test, InvalidUtf8Rejected) {
+  // Raw wchar_t bytes are not valid UTF-8 — must be rejected (fail-closed).
   std::string utf8_str(u8"世界，你好！");
   auto wstr = ONNX_NAMESPACE::utf8str_to_wstring(utf8_str);
-  auto wstr2 = ONNX_NAMESPACE::utf8str_to_wstring(
-      std::string(reinterpret_cast<const char*>(wstr.c_str()), sizeof(std::wstring::value_type) * wstr.size()), true);
-  EXPECT_EQ(wstr, wstr2);
+  std::string raw_bytes(reinterpret_cast<const char*>(wstr.c_str()), sizeof(std::wstring::value_type) * wstr.size());
+  EXPECT_THROW(ONNX_NAMESPACE::utf8str_to_wstring(raw_bytes), ONNX_NAMESPACE::checker::ValidationError);
 }
 } // namespace ONNX_NAMESPACE::Test
 #endif


### PR DESCRIPTION

### Motivation and Context

Add C++ open_external_data() that validates, opens, and verifies external data files in one call. Post-open fd verification via kernel APIs eliminates the race between check and use on all platforms including Windows.
