### PR TITLE
Iterate over correct axis in Local Response Normalization (LRN) impl.

### DIFF
--- a/onnx/backend/test/case/node/lrn.py
+++ b/onnx/backend/test/case/node/lrn.py
@@ -28,14 +28,14 @@ class LRN(Base):
             bias=bias,
             size=nsize,
         )
-        x = np.random.randn(5, 5, 5, 5).astype(np.float32)
-        square_sum = np.zeros((5, 5, 5, 5)).astype(np.float32)
+        x = np.random.randn(2, 4, 5, 5).astype(np.float32)
+        square_sum = np.zeros((2, 4, 5, 5)).astype(np.float32)
         for n, c, h, w in np.ndindex(x.shape):
             square_sum[n, c, h, w] = sum(
                 x[
                     n,
                     max(0, c - math.floor((nsize - 1) / 2)) : min(
-                        5, c + math.ceil((nsize - 1) / 2) + 1
+                        4, c + math.ceil((nsize - 1) / 2) + 1
                     ),
                     h,
                     w,
@@ -52,14 +52,14 @@ class LRN(Base):
         bias = 1.0
         nsize = 3
         node = onnx.helper.make_node("LRN", inputs=["x"], outputs=["y"], size=3)
-        x = np.random.randn(5, 5, 5, 5).astype(np.float32)
-        square_sum = np.zeros((5, 5, 5, 5)).astype(np.float32)
+        x = np.random.randn(2, 4, 5, 5).astype(np.float32)
+        square_sum = np.zeros((2, 4, 5, 5)).astype(np.float32)
         for n, c, h, w in np.ndindex(x.shape):
             square_sum[n, c, h, w] = sum(
                 x[
                     n,
                     max(0, c - math.floor((nsize - 1) / 2)) : min(
-                        5, c + math.ceil((nsize - 1) / 2) + 1
+                        4, c + math.ceil((nsize - 1) / 2) + 1
                     ),
                     h,
                     w,

--- a/onnx/reference/ops/op_lrn.py
+++ b/onnx/reference/ops/op_lrn.py
@@ -20,7 +20,7 @@ class LRN(OpRun):
         minc = x.shape[1]
         c1 = math.floor((size - 1) / 2)
         c2 = math.ceil((size - 1) / 2) + 1
-        for c in range(x.shape[0]):
+        for c in range(x.shape[1]):
             begin = max(0, c - c1)
             end = min(minc, c + c2)
             square_sum[:, c, :, :] = np.sum(x[:, begin:end, :, :] ** 2, axis=1)


### PR DESCRIPTION

### Motivation and Context

Fixes #7805.

- Iterate over the channel (i.e. 2nd) dimension instead of the batch (i.e. 1st) dimension
- Update the unit test to have different batch (`N`) and channel (`C`) dimensions to correctly capture this behaviour
