### PR TITLE
Fix documentation typos and grammar errors in API docs

### DIFF
--- a/docs/PythonAPIOverview.md
+++ b/docs/PythonAPIOverview.md
@@ -188,7 +188,7 @@ print(f"The converted numpy dtype for {helper.tensor_dtype_to_string(TensorProto
 field_name = helper.tensor_dtype_to_field(TensorProto.FLOAT)
 print(f"The field name for {helper.tensor_dtype_to_string(TensorProto.FLOAT)} is {field_name}.")
 
-# There are other useful conversion utilities. Please checker onnx.helper
+# There are other useful conversion utilities. Please check onnx.helper
 ```
 
 ## Checking an ONNX Model

--- a/docs/docsgen/source/api/index.md
+++ b/docs/docsgen/source/api/index.md
@@ -22,7 +22,7 @@ the onnx opset, the IR version. Every new major release increments the opset ver
 
 The intermediate representation (IR) specification is the abstract model for
 graphs and operators and the concrete format that represents them.
-Adding a structure, modifying one them increases the IR version.
+Adding a structure or modifying one of them increases the IR version.
 
 The opset version increases when an operator is added or removed or modified.
 A higher opset means a longer list of operators and more options to
@@ -44,8 +44,8 @@ serialization
 
 ## Functions
 
-An ONNX model can be directly from the classes described
-in previous section but it is faster to create and
+An ONNX model can be created directly from the classes described
+in the previous section, but it is faster to create and
 verify a model with the following helpers.
 
 ```{toctree}


### PR DESCRIPTION
### Motivation and Context

Fixes several documentation typos and grammar errors found in the Python API documentation:

1. **`docs/PythonAPIOverview.md`**: "Please checker onnx.helper" → "Please check onnx.helper"
2. **`docs/docsgen/source/api/index.md`**: "modifying one them" → "modifying one of them"
3. **`docs/docsgen/source/api/index.md`**: "An ONNX model can be directly from" → "An ONNX model can be created directly from"

These are small but affect the readability of the official documentation.