### PR TITLE
Fix LRN reference impl: iterate over channel axis, not batch

### DIFF
--- a/onnx/reference/ops/op_lrn.py
+++ b/onnx/reference/ops/op_lrn.py
@@ -20,7 +20,7 @@ class LRN(OpRun):
         minc = x.shape[1]
         c1 = math.floor((size - 1) / 2)
         c2 = math.ceil((size - 1) / 2) + 1
-        for c in range(x.shape[0]):
+        for c in range(x.shape[1]):
             begin = max(0, c - c1)
             end = min(minc, c + c2)
             square_sum[:, c, :, :] = np.sum(x[:, begin:end, :, :] ** 2, axis=1)


### PR DESCRIPTION
## Summary
- Fix the LRN reference implementation loop to iterate over `x.shape[1]` (channels) instead of `x.shape[0]` (batch), matching the ONNX spec
- The bug was masked because the existing test uses `N == C == 5`

Fixes #7805.

## Test plan
- [x] Verified the one-line change matches the spec's channel-wise normalization
- [x] Existing tests still pass (they happen to use N == C == 5)