### PR TITLE
Fix nanobind arg name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,7 +467,7 @@ if(ONNX_BUILD_PYTHON)
   # find system nanobind
   if(NOT DEFINED nanobind_DIR OR "${nanobind_DIR}" STREQUAL "")
     execute_process(
-      COMMAND ${Python_EXECUTABLE} -m nanobind --cmake-dir
+      COMMAND ${Python_EXECUTABLE} -m nanobind --cmake_dir
       RESULT_VARIABLE NANOBIND_CMAKE_RESULT
       OUTPUT_VARIABLE NANOBIND_CMAKE_DIR
       OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -245,7 +245,7 @@ For full list refer to CMakeLists.txt
 **Default**: `ONNX_WERROR=OFF` in local builds, `ON` in CI and release pipelines.
 
 * `nanobind_DIR` can be set to the directory that contains `nanobindConfig.cmake` (for example,
-  `python -m nanobind --cmake-dir`) if CMake cannot find nanobind. You can also set
+  `python -m nanobind --cmake_dir`) if CMake cannot find nanobind. You can also set
   `CMAKE_PREFIX_PATH` instead.
 
 * `FETCHCONTENT_FULLY_DISCONNECTED` is intended for subsequent re-configures after


### PR DESCRIPTION
The nanobind cli argument is called `--cmake_dir` not `--cmake-dir`. This can gives raise to warnings during the build and makes it ignore the preinstalled nanobind. The naming is also confirmed by the cli help:
```
pixi exec -w nanobind python -m nanobind
usage: python -m nanobind [-h] [--version] [--include_dir] [--cmake_dir]

options:
  -h, --help     show this help message and exit
  --version      Print the version number.
  --include_dir  Print the path to the nanobind C++ header directory.
  --cmake_dir    Print the path to the nanobind CMake module directory.
```

