### PR TITLE
onnx: add LICENSE_NOTES.md

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,59 @@
+ONNX is licensed under the Apache License, Version 2.0 (see LICENSE).
+
+This product includes software from the following third-party projects, which
+are linked into ONNX wheel builds. Their copyright notices are reproduced below.
+
+---
+
+## abseil-cpp
+
+Copyright 2017 The Abseil Authors.
+
+Version: 20250127.0
+Source: https://github.com/abseil/abseil-cpp
+License: Apache-2.0 (see LICENSE)
+
+---
+
+## protobuf
+
+Copyright 2008 Google Inc.
+
+Version: 25.1
+Source: https://github.com/protocolbuffers/protobuf
+License: Apache-2.0 (see LICENSE)
+
+---
+
+## nanobind
+
+Copyright (c) 2022 Wenzel Jakob <wenzel.jakob@epfl.ch>
+
+Version: 2.12.0
+Source: https://github.com/wjakob/nanobind
+License: BSD-3-Clause
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -152,7 +152,7 @@ SPDX-FileCopyrightText = "Copyright (c) ONNX Project Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
-path = ["MANIFEST.in", "VERSION_NUMBER", "CODE_OF_CONDUCT.md", "CODEOWNERS", "pyproject**.toml", "requirements**.txt"]
+path = ["MANIFEST.in", "VERSION_NUMBER", "CODE_OF_CONDUCT.md", "CODEOWNERS", "NOTICE", "pyproject**.toml", "requirements**.txt"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "Copyright (c) ONNX Project Contributors"
 SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
Include abseil's copyright and license information in LICENSE_NOTES.md since we link against it in builds.

### Motivation and Context

abseil is being linked in builds, so make sure onnx is properly attributing that part of the code in wheels.

**Note:** This was identified while building riscv64 wheels for onnx as part of the [RISE Project](https://riseproject.dev/)'s efforts to support the RISC-V Python ecosystem via [wheel_builder](https://gitlab.com/riseproject/python/wheel_builder).
