### PR TITLE
Fix CI link-checker issues

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -2,4 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# Used in RFC template as an example
 https://github.com/onnx/onnx/pull/0000
+
+# Behind cloudflare
+https://trademarks.justia.com/877/25/onnx-87725026.html
+https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Community Meetups are held at least once a year. Content from previous community
 
 # Discuss
 
-We encourage you to open [Issues](https://github.com/onnx/onnx/issues), or use [Slack](https://lfaifoundation.slack.com/) (If you have not joined yet, please use this [link](https://join.slack.com/t/lfaifoundation/shared_invite/zt-o65errpw-gMTbwNr7FnNbVXNVFkmyNA) to join the group) for more real-time discussion.
+We encourage you to open [Issues](https://github.com/onnx/onnx/issues), or use [Slack](https://lfaifoundation.slack.com/) (If you have not joined yet, please use this [link](https://join.slack.com/t/lfaifoundation/shared_invite/zt-3wx5vohc3-MeSYi3_dscb~u~cqs7zlPg) to join the group) for more real-time discussion.
 
 # Follow Us
 

--- a/community/sigs.md
+++ b/community/sigs.md
@@ -10,7 +10,7 @@ As described in the ONNX [governance](/community/readme.md#sig---special-interes
 
 ## Joining a SIG
 
-If you are interested in participating, please [join the discussion](https://join.slack.com/t/lfaifoundation/shared_invite/zt-o65errpw-gMTbwNr7FnNbVXNVFkmyNA) in the respective Slack channels. Details about any upcoming meetings will also be shared in the Slack channels. SIG artifacts can be found in the [sigs repository](https://github.com/onnx/sigs).
+If you are interested in participating, please [join the discussion](https://join.slack.com/t/lfaifoundation/shared_invite/zt-3wx5vohc3-MeSYi3_dscb~u~cqs7zlPg) in the respective Slack channels. Details about any upcoming meetings will also be shared in the Slack channels. SIG artifacts can be found in the [sigs repository](https://github.com/onnx/sigs).
 
 You can find the schedule of SIG meetings on the [LFX calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lfai-onnx?view=month)
 


### PR DESCRIPTION
The link-checker CI is currently red. There are two issues:

1. Slack invite link expires after 30 days...
2. Some links are behind Cloudflare

I updated the former and addressed the latter by ignoring those links when checking in the future.

### Motivation and Context

Beautiful green CI ✨ 
