### PR TITLE
Drop redundant semicolons in macros

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -89,6 +89,6 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-StatementMacros:    [define_data]
+StatementMacros:    [define_data, ONNX_ASSERT, ONNX_ASSERTM, TENSOR_ASSERTM]
 TabWidth:        8
 UseTab:          Never

--- a/onnx/checker.h
+++ b/onnx/checker.h
@@ -34,8 +34,7 @@ class ValidationError final : public std::runtime_error {
   std::string expanded_message_;
 };
 
-#define fail_check(...) \
-  ONNX_THROW_EX(ONNX_NAMESPACE::checker::ValidationError(ONNX_NAMESPACE::MakeString(__VA_ARGS__)));
+#define fail_check(...) ONNX_THROW_EX(ONNX_NAMESPACE::checker::ValidationError(ONNX_NAMESPACE::MakeString(__VA_ARGS__)))
 
 class CheckerContext final {
  public:

--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -103,7 +103,7 @@ enum class AttributeKind : uint8_t {
 static inline const char* toString(AttributeKind kind) {
   // NOLINTNEXTLINE(modernize-avoid-c-arrays)
   static constexpr const char* names[] = {"f", "fs", "i", "is", "s", "ss", "t", "ts", "g", "gs", "tp", "tps"};
-  ONNX_ASSERT(size_t(kind) < std::size(names));
+  ONNX_ASSERT(size_t(kind) < std::size(names))
   return names[static_cast<int>(kind)];
 }
 

--- a/onnx/common/ir_pb_converter.h
+++ b/onnx/common/ir_pb_converter.h
@@ -35,7 +35,7 @@ class ConvertError final : public std::runtime_error {
   std::string expanded_message_;
 };
 
-#define fail_convert(...) ONNX_THROW_EX(ConvertError(MakeString(__VA_ARGS__)));
+#define fail_convert(...) ONNX_THROW_EX(ConvertError(MakeString(__VA_ARGS__)))
 
 void ExportModelProto(ModelProto* p_m, const std::shared_ptr<Graph>& g);
 

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -2756,7 +2756,7 @@ ONNX_OPERATOR_SET_SCHEMA(
               // Set last dimension based on operation type
               ONNX_ASSERTM(
                   rank == static_cast<int64_t>(new_shape_proto.dim_size()),
-                  "rank should be equal to new_shape_proto.dim_size()");
+                  "rank should be equal to new_shape_proto.dim_size()")
               if (inverse && is_onesided) {
                 // IRFFT: output is real-valued
                 new_shape_proto.mutable_dim(rank - 1)->set_dim_value(1);

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -1804,7 +1804,7 @@ OpName_Domain_Version_Schema_Map& OpSchemaRegistry::map() {
             "%zu schema were exposed from operator sets and automatically placed into the static registry.  "
             "%zu were expected based on calls to registration macros. Operator set functions may need to be updated.",
             dbg_registered_schema_count,
-            ONNX_DBG_GET_COUNT_IN_OPSETS());
+            ONNX_DBG_GET_COUNT_IN_OPSETS())
       }
 #endif
     }

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -115,7 +115,7 @@ class SchemaError final : public std::runtime_error {
   std::string expanded_message_;
 };
 
-#define fail_schema(...) ONNX_THROW_EX(ONNX_NAMESPACE::SchemaError(ONNX_NAMESPACE::MakeString(__VA_ARGS__)));
+#define fail_schema(...) ONNX_THROW_EX(ONNX_NAMESPACE::SchemaError(ONNX_NAMESPACE::MakeString(__VA_ARGS__)))
 
 using OperatorSetVersion = int;
 

--- a/onnx/version_converter/adapters/Attention_24_23.h
+++ b/onnx/version_converter/adapters/Attention_24_23.h
@@ -31,7 +31,7 @@ class Attention_24_23 final : public Adapter {
           "which is not supported in opset 23. This conversion cannot be performed.",
           name().c_str(),
           static_cast<int64_t>(initial_version().version()),
-          static_cast<int64_t>(target_version().version()));
+          static_cast<int64_t>(target_version().version()))
     }
   }
 

--- a/onnx/version_converter/adapters/batch_normalization_13_14.h
+++ b/onnx/version_converter/adapters/batch_normalization_13_14.h
@@ -15,10 +15,12 @@ class BatchNormalization_13_14 final : public Adapter {
  public:
   explicit BatchNormalization_13_14() : Adapter("BatchNormalization", OpSetID(13), OpSetID(14)) {}
 
-  void adapt_batch_normalization_13_14(Node* node) const {ONNX_ASSERTM(
-      node -> outputs().size() < 4,
-      "BatchNormalization outputs 4 and 5 are not "
-      "supported in Opset 14.")}
+  void adapt_batch_normalization_13_14(Node* node) const {
+    ONNX_ASSERTM(
+        node->outputs().size() < 4,
+        "BatchNormalization outputs 4 and 5 are not "
+        "supported in Opset 14.")
+  }
 
   Node* adapt(std::shared_ptr<Graph> /*unused*/, Node* node) const override {
     adapt_batch_normalization_13_14(node);

--- a/onnx/version_converter/adapters/scatter_18_17.h
+++ b/onnx/version_converter/adapters/scatter_18_17.h
@@ -23,7 +23,7 @@ class Scatter_18_17 : public Adapter {
     if (node->hasAttribute(Symbol("reduction"))) {
       const std::string& r = node->s(Symbol("reduction"));
       ONNX_ASSERTM(
-          r != "max" && r != "min", "Scatter reduction 'max' and 'min' are not supported when downgrading to opset 17");
+          r != "max" && r != "min", "Scatter reduction 'max' and 'min' are not supported when downgrading to opset 17")
     }
     return node;
   }


### PR DESCRIPTION



### Motivation and Context

This PR drops redundant semicolons in macros to reduce linter warnings
