### PR TITLE
topic: Allow overriding cmake build directory via environment variable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,13 @@ import setuptools.command.build_py
 import setuptools.command.develop
 
 TOP_DIR = os.path.realpath(os.path.dirname(__file__))
-CMAKE_BUILD_DIR = os.path.join(TOP_DIR, ".setuptools-cmake-build")
+_onnx_cmake_build_dir = os.getenv("ONNX_CMAKE_BUILD_DIR")
+CMAKE_BUILD_DIR = os.path.join(
+    TOP_DIR,
+    _onnx_cmake_build_dir.strip()
+    if _onnx_cmake_build_dir and _onnx_cmake_build_dir.strip()
+    else ".setuptools-cmake-build",
+)
 
 WINDOWS = os.name == "nt"
 


### PR DESCRIPTION
Allow distributors and custom build systems to point setup.py at a pre-existing CMake build directory by setting the ONNX_CMAKE_BUILD_DIR environment variable. When unset, the default ".setuptools-cmake-build" is used, preserving existing behavior.

This avoids the need for distro-specific patches (e.g. Fedora, SUSE) that hardcode alternative build directory names.
Signed-off-by: Autumn Nash  <autumnnash@gmail.com>