### PR TITLE
Ignore blocked links

### DIFF
--- a/.github/workflows/check_urls.yml
+++ b/.github/workflows/check_urls.yml
@@ -7,6 +7,9 @@ name: Check URLs
 on:
   push:
     branches:  [ "main", rel-* ]
+  pull_request:
+    paths:
+      - "**/*.md"
   schedule:
     # Run every month
     - cron:  '0 0 1 * *'

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -8,3 +8,8 @@ https://github.com/onnx/onnx/pull/0000
 # Behind cloudflare
 https://trademarks.justia.com/877/25/onnx-87725026.html
 https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf
+
+# slack blocks automated requests. This is problematic since the invites expire after ~30 days, but lychee is not going to fix that
+https://join.slack.com/t/lfaifoundation/shared_invite/zt-3wx5vohc3-MeSYi3_dscb~u~cqs7zlPg
+# Also blocked:
+https://en.cppreference.com/c/language/identifier

--- a/docs/IR.md
+++ b/docs/IR.md
@@ -260,7 +260,7 @@ Graphs SHOULD be populated with documentation strings, which MAY be interpreted 
 
 ### Names Within a Graph
 
-All names SHOULD adhere to [C90 identifier syntax rules](https://en.cppreference.com/w/c/language/identifier).
+All names SHOULD adhere to [C90 identifier syntax rules](https://en.cppreference.com/c/language/identifier).
 
 Names of nodes, inputs, outputs, initializers, and attributes are organized into several namespaces. Within a namespace, each name MUST be unique for each given graph. Please see below for further clarification in the case where a graph contains nested subgraphs (as attribute values).
 
@@ -475,7 +475,7 @@ Each size in the list MAY be expressed as an integral value or as a "dimension v
 
 For example, a NxM matrix would have the shape list [N,M].
 
-The name of each dimension variable SHOULD adhere to [C90 identifier syntax rules](https://en.cppreference.com/w/c/language/identifier).
+The name of each dimension variable SHOULD adhere to [C90 identifier syntax rules](https://en.cppreference.com/c/language/identifier).
 
 Currently, dimension variables are not scoped. A dimension variable "N" represents the same value across the entire graph in a model. For example, if the graph has two inputs X and Y each with shape ["N"], then at runtime the values passed in for X and Y MUST be tensors of rank 1 with the same dimension. Nested sub-graphs currently share the same scope for dimension variables as the main-graph. This allows a model to relate the dimensions of tensors inside the subgraph to the dimensions of tensors in the outer graph.
 


### PR DESCRIPTION

### Motivation and Context

CI on main is red due to some link-checking errors. It appears the links in question are actually blocked for basic programmatic access. This is particularly bad for the Slack link, which expires after 30 days, but the link checker is not going to help here. I therefore simply added the links to the ignore file. I also set the link-checker to run whenever a md file is touched. This is not a perfect heuristic, but it seems better than just getting the error on main.
