### PR TITLE
chore: improve Renovate config — cooldown, correct label, PR notes

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -12,9 +12,16 @@
   "dependencyDashboard": false,
   // Wait one week after a release before creating an update PR
   "minimumReleaseAge": "7 days",
-  // Apply label to all Renovate PRs to trigger release CI and satisfy the
-  // "Require topic/module label" branch-protection check
-  "labels": ["dependencies", "run release CIs"],
+  // Apply labels to all Renovate PRs:
+  // - "module: dependencies" satisfies the "Require topic/module label" branch-protection check
+  // - "run release CIs" triggers release CI
+  "labels": ["module: dependencies", "run release CIs"],
+  // Add a note to every Renovate PR body explaining the update context
+  "prBodyNotes": [
+    "This PR was automatically created by [Renovate Bot](https://renovateapp.com/) to keep build dependencies up to date.",
+    "Renovate manages dependencies **not** handled by Dependabot: manylinux Docker images, nanobind (via CMake FetchContent), and googletest (release tarball + SHA256).",
+    "Please review the linked changelog/release notes before merging. A one-week stabilization period (`minimumReleaseAge`) has already elapsed since the new version was published."
+  ],
   // Custom managers for dependencies not auto-detected by Renovate
   "customManagers": [
     {

--- a/renovate.json5
+++ b/renovate.json5
@@ -10,8 +10,11 @@
   "enabledManagers": ["custom.regex"],
   // Disable the Dependency Dashboard issue
   "dependencyDashboard": false,
-  // Apply label to all Renovate PRs to trigger release CI
-  "labels": ["run release CIs"],
+  // Wait one week after a release before creating an update PR
+  "minimumReleaseAge": "7 days",
+  // Apply label to all Renovate PRs to trigger release CI and satisfy the
+  // "Require topic/module label" branch-protection check
+  "labels": ["dependencies", "run release CIs"],
   // Custom managers for dependencies not auto-detected by Renovate
   "customManagers": [
     {


### PR DESCRIPTION
## Summary

Improves the Renovate Bot configuration with three changes:

- **One-week cooldown** (`minimumReleaseAge: "7 days"`): Renovate will wait at least 7 days after a new version is published before opening an update PR. This avoids churn from quickly yanked releases or same-day patch corrections.
- **Correct branch-protection label** (`module: dependencies`): The existing `"dependencies"` label did not satisfy the repo's _"Require topic/module label (prefix-only)"_ branch-protection check, which requires a label prefixed with `topic:` or `module:` (see `.github/workflows/check_pr_label.yml`). Replaced with `"module: dependencies"`.
- **Informative PR body notes** (`prBodyNotes`): Each Renovate-generated PR now includes a short explanation of what Renovate manages (manylinux images, nanobind, googletest) versus Dependabot, and a reminder that the stabilization period has already elapsed.

## Scope

Only `renovate.json5` is changed — no code, schema, or generated files are affected.

## Test plan

- [ ] Verify the next Renovate PR receives the `module: dependencies` and `run release CIs` labels
- [ ] Confirm the branch-protection check _"Require topic/module label (prefix-only) / check-label (pull_request)"_ passes on the next Renovate PR
- [ ] Confirm no Renovate PR is opened sooner than 7 days after the upstream release date

🤖 Generated with [Claude Code](https://claude.com/claude-code)