### PR TITLE
Handle PathLike inputs consistently in infer_shapes

### DIFF
--- a/onnx/shape_inference.py
+++ b/onnx/shape_inference.py
@@ -59,10 +59,10 @@ def infer_shapes(
             model_str, check_type, strict_mode, data_prop
         )
         return onnx.load_from_string(inferred_model_str)
-    if isinstance(model, (str,os.PathLike)):
+    if isinstance(model, (str, os.PathLike)):
         raise TypeError(
             "infer_shapes only accepts ModelProto or bytes,"
-            "you can use infer_shapes_path for the model path (String)."
+            " For Model paths (str or os.PathLike), use infer_shapes_path()."
         )
 
     raise TypeError(

--- a/onnx/shape_inference.py
+++ b/onnx/shape_inference.py
@@ -59,7 +59,7 @@ def infer_shapes(
             model_str, check_type, strict_mode, data_prop
         )
         return onnx.load_from_string(inferred_model_str)
-    if isinstance(model, str):
+    if isinstance(model, (str,os.PathLike)):
         raise TypeError(
             "infer_shapes only accepts ModelProto or bytes,"
             "you can use infer_shapes_path for the model path (String)."

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
-
+from pathlib import Path
 import contextlib
 import itertools
 import unittest
@@ -12197,3 +12197,7 @@ class TestCustomSchemaShapeInference(TestShapeInferenceHelper):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+    
+def test_infer_shapes_pathlike_error():
+    with pytest.raises(TypeError,match="infer_shapes_path"):
+        onnx.shape_inference.infer_shapes(Path("model.onnx"))

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -4,10 +4,10 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import contextlib
 import itertools
 import unittest
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -11926,13 +11926,14 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         # Graceful return without output shape inference is acceptable; must not crash.
         onnx.shape_inference.infer_shapes(model, strict_mode=True)
-    
+
     def test_infer_shapes_pathlike_error(self) -> None:
         with self.assertRaisesRegex(
             TypeError,
-r"For Model paths \(str or os.PathLike\), use infer_shapes_path\(\)\.",
+            r"For Model paths \(str or os.PathLike\), use infer_shapes_path\(\)\.",
         ):
             onnx.shape_inference.infer_shapes(Path("model.onnx"))
+
 
 class TestCustomSchemaShapeInference(TestShapeInferenceHelper):
     custom_op_type: str = "CustomOp"
@@ -12200,7 +12201,7 @@ class TestCustomSchemaShapeInference(TestShapeInferenceHelper):
 
         # clean up
         onnx.defs.deregister_schema(schema.name, schema.since_version, schema.domain)
-        
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
+
 from pathlib import Path
 import contextlib
 import itertools
@@ -11925,7 +11926,13 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         # Graceful return without output shape inference is acceptable; must not crash.
         onnx.shape_inference.infer_shapes(model, strict_mode=True)
-
+    
+    def test_infer_shapes_pathlike_error(self) -> None:
+        with self.assertRaisesRegex(
+            TypeError,
+r"For Model paths \(str or os.PathLike\), use infer_shapes_path\(\)\.",
+        ):
+            onnx.shape_inference.infer_shapes(Path("model.onnx"))
 
 class TestCustomSchemaShapeInference(TestShapeInferenceHelper):
     custom_op_type: str = "CustomOp"
@@ -12193,11 +12200,7 @@ class TestCustomSchemaShapeInference(TestShapeInferenceHelper):
 
         # clean up
         onnx.defs.deregister_schema(schema.name, schema.since_version, schema.domain)
-
+        
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
-    
-def test_infer_shapes_pathlike_error():
-    with pytest.raises(TypeError,match="infer_shapes_path"):
-        onnx.shape_inference.infer_shapes(Path("model.onnx"))

--- a/tools/check_namespace.py
+++ b/tools/check_namespace.py
@@ -15,7 +15,7 @@ import sys
 def main() -> int:
     violations = []
     for path in sys.argv[1:]:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             for line_no, line in enumerate(f, 1):
                 if "namespace onnx" in line or "onnx::" in line:
                     violations.append(f"{path}:{line_no}: {line.rstrip()}")

--- a/tools/check_namespace.py
+++ b/tools/check_namespace.py
@@ -15,7 +15,7 @@ import sys
 def main() -> int:
     violations = []
     for path in sys.argv[1:]:
-        with open(path, encoding="utf-8") as f:
+        with open(path) as f:
             for line_no, line in enumerate(f, 1):
                 if "namespace onnx" in line or "onnx::" in line:
                     violations.append(f"{path}:{line_no}: {line.rstrip()}")


### PR DESCRIPTION
### Motivation and Context

`infer_shapes` currently provides a helpful error message when a string model path is passed, recommending `infer_shapes_path`.

However, `os.PathLike` inputs such as `pathlib.Path` fall through to the generic type error branch and produce a less informative error message.

This PR updates the input validation to handle `os.PathLike` consistently with string paths and adds a regression test for the behavior.

### Testing

```bash id="0w2o5q"
pytest onnx/test/shape_inference_test.py -k pathlike
pytest onnx/test/shape_inference_test.py
```
