### PR TITLE
Update Python version matrix in release workflow; skip 3.13t for a gr…

### DIFF
--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.14t', '3.13t', '3.12', '3.11', '3.10']
+        python-version: ['3.14t', '3.12', '3.11', '3.10']
         architecture: ['x64', 'arm64']
       fail-fast: false
 


### PR DESCRIPTION
…een ci

Removed unsupported Python version '3.13t' from the matrix.



### Motivation and Context

Fixes #
