### PR TITLE
fix: guard sparse-tensor dim-product against int64 overflow in checker

### DIFF
--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -16,6 +16,7 @@
 #include "onnx/common/file_utils.h"
 #include "onnx/common/path.h"
 #include "onnx/common/proto_util.h"
+#include "onnx/common/safe_math.h"
 #include "onnx/common/scoped_resource.h"
 #include "onnx/defs/tensor_proto_util.h"
 #include "onnx/shape_inference/implementation.h"
@@ -347,9 +348,9 @@ void check_map(const MapProto& map, const CheckerContext& ctx) {
 static void
 check_sparse_tensor_indices_1(const TensorProto& indices, const SparseTensorProto& sparse_tensor_proto, size_t nnz) {
   int dense_rank = sparse_tensor_proto.dims_size();
-  int64_t dense_size = 1;
-  for (int i = 0; i < dense_rank; ++i)
-    dense_size *= sparse_tensor_proto.dims(i);
+  int64_t dense_size = safe_dim_product(
+      sparse_tensor_proto.dims(),
+      [&](const char* msg) { fail_check(msg, " (sparse tensor '", indices.name(), "')"); });
   if (static_cast<size_t>(indices.dims(0)) != nnz) {
     fail_check("Sparse tensor indices (", indices.name(), ") has ", indices.dims(0), " values, but NNZ is ", nnz);
   }
@@ -391,6 +392,13 @@ check_sparse_tensor_indices_2(const TensorProto& indices, const SparseTensorProt
   if (indices.dims(1) != dense_rank) {
     fail_check("Sparse tensor indices (", indices.name(), ") second dimension size does not match rank of tensor.");
   }
+
+  // Guard against overflow in the linearised sort-order accumulator below.
+  // If the total dense size overflows int64_t, curr_index would wrap and the
+  // lexicographic order check would produce incorrect results.
+  safe_dim_product(
+      sparse_tensor_proto.dims(),
+      [&](const char* msg) { fail_check(msg, " (sparse tensor '", indices.name(), "')"); });
 
   // Check if indices appear in ascending order, and if they have valid
   // values.

--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -347,7 +347,6 @@ void check_map(const MapProto& map, const CheckerContext& ctx) {
 // linearized index value for the i-th nonzero value.
 static void
 check_sparse_tensor_indices_1(const TensorProto& indices, const SparseTensorProto& sparse_tensor_proto, size_t nnz) {
-  int dense_rank = sparse_tensor_proto.dims_size();
   int64_t dense_size = safe_dim_product(
       sparse_tensor_proto.dims(),
       [&](const char* msg) { fail_check(msg, " (sparse tensor '", indices.name(), "')"); });

--- a/onnx/common/safe_math.h
+++ b/onnx/common/safe_math.h
@@ -1,0 +1,66 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <limits>
+
+namespace ONNX_NAMESPACE {
+
+// Returns true on overflow. Uses __builtin on GCC/Clang, manual check on MSVC.
+// Both a and b must be non-negative; safe_dim_product enforces this by checking
+// each dim before calling, and the accumulated result stays non-negative because
+// we abort on overflow.
+inline bool checked_mul_overflow(int64_t a, int64_t b, int64_t* result) {
+#if defined(__GNUC__) || defined(__clang__)
+  return __builtin_mul_overflow(a, b, result);
+#else
+  if (a > 0 && b > std::numeric_limits<int64_t>::max() / a) {
+    return true;
+  }
+  *result = a * b;
+  return false;
+#endif
+}
+
+// Safe product of dims over an iterator range. Calls on_error(const char*) on
+// negative dim or overflow. on_error must not return (i.e. must throw or abort).
+template <typename Iter, typename ErrorHandler>
+[[nodiscard]] inline int64_t safe_dim_product(Iter begin, Iter end, ErrorHandler on_error) {
+  int64_t result = 1;
+  for (auto it = begin; it != end; ++it) {
+    auto dim = static_cast<int64_t>(*it);
+    if (dim < 0) {
+      on_error("Negative dimension value");
+      return result; // unreachable if on_error throws; guards against misuse
+    }
+    if (checked_mul_overflow(result, dim, &result)) {
+      on_error("Tensor dimension product overflow");
+      return result;
+    }
+  }
+  return result;
+}
+
+// Container overload — delegates to the iterator-pair version.
+template <typename DimsContainer, typename ErrorHandler>
+[[nodiscard]] inline int64_t safe_dim_product(const DimsContainer& dims, ErrorHandler on_error) {
+  return safe_dim_product(std::begin(dims), std::end(dims), on_error);
+}
+
+// Safe cast from int64_t to size_t. Calls on_error if the value exceeds
+// size_t range (relevant for 32-bit platforms where size_t is 32 bits).
+// value must be non-negative (callers ensure this via prior overflow checks).
+template <typename ErrorHandler>
+[[nodiscard]] inline size_t safe_cast_to_size(int64_t value, ErrorHandler on_error) {
+  if (static_cast<uint64_t>(value) > std::numeric_limits<size_t>::max()) {
+    on_error("Value too large for this platform");
+  }
+  return static_cast<size_t>(value);
+}
+
+} // namespace ONNX_NAMESPACE


### PR DESCRIPTION
### Motivation and Context

`check_sparse_tensor_indices_1` computed `dense_size` by multiplying all
dimension values with bare `int64_t` multiplication. Overflowing dimension
values (e.g. `[3037000499, 3037000501]`) wrap `dense_size` negative,
causing the subsequent bounds check:

```cpp
if (curr_index < 0 || curr_index >= dense_size)
```

to pass for any non-negative `curr_index` — silently bypassing index
validation. A model with such dimensions passes `check_model()` but has
unchecked indices that downstream runtimes trusting the checker may
process without re-validation, potentially leading to out-of-bounds
memory access.

`check_sparse_tensor_indices_2` linearises the per-dimension index tuple
into a single integer for the sort-order check via the same unchecked
multiplication; overflow there corrupts the lexicographic order
comparison.

Note: PR #7822 introduces `safe_dim_product` for `check_tensor()`,
`Tensor::elem_num()`, and Reshape shape inference, but does **not** cover
the two sparse-tensor index checker functions fixed here.

### Changes

- `onnx/common/safe_math.h` — new header with `checked_mul_overflow` and
  `safe_dim_product` (identical content to PR #7822; whichever merges
  second will have a trivial conflict to resolve).
- `onnx/checker.cc` — replace the bare `dense_size *= dims(i)` loop in
  `check_sparse_tensor_indices_1` with `safe_dim_product`, and add a
  `safe_dim_product` guard at the top of `check_sparse_tensor_indices_2`
  to catch overflowing dim products before the linearisation loop runs.

### Testing

Existing sparse-tensor checker tests in `onnx/test/basic_test.py` cover
the normal paths. The overflow fix is exercised by the PoC in the
advisory (dims `[3037000499, 3037000501]`) which previously produced a
silent bypass and will now raise a `check_model` error.

Assisted with [Claude Code](https://claude.com/claude-code)