### PR TITLE
Remove incorrect Deprecate() from GroupNormalization_18

### DIFF
--- a/onnx/defs/nn/old.cc
+++ b/onnx/defs/nn/old.cc
@@ -3992,7 +3992,6 @@ ONNX_OPERATOR_SET_SCHEMA(
     GroupNormalization,
     18,
     OpSchema()
-        .Deprecate()
         .SetDoc(GroupNormalization_ver18_doc)
         .Attr("epsilon", "The epsilon value to use to avoid division by zero.", AttributeProto::FLOAT, 1e-5f)
         .Attr(


### PR DESCRIPTION
## Summary

GroupNormalization_18 should not be marked as .Deprecate() because GroupNormalization_21 exists as its direct same-named successor. Removing this allows onnxruntime to remove a patch from cmake/patches/onnx/onnx.patch.

## History

The .Deprecate() was intentionally added in commit 444e8944f (Fix typo in the GroupNorm description) after discussion between @gramalingam and @AlexandreEichenberger — rationale was that GroupNormalization_18 contained a schema mistake (scale/bias shape was (G) instead of correct (C)).

However, this is a semantic misuse of .Deprecate():

- .Deprecate() in the ONNX checker causes hard failures for any model with opset 18 that uses GroupNormalization (checker.cc:608 calls fail_check)
- The other ops that use .Deprecate() (Scatter_11, Upsample_10) all have no same-name successor — replaced by differently-named ops (ScatterElements, Resize)
- GroupNormalization_21 IS the direct same-named successor to GroupNormalization_18
- All other versioned ops in old.cc with same-name successors are NOT marked deprecated — this is the standard ONNX pattern

## Impact

With .Deprecate() in place, validating an opset-18 model using GroupNormalization fails:
  Op registered for GroupNormalization is deprecated in domain_version of 18

There is also no version adapter for 18->21 (only 20->21 exists), so there is no automatic upgrade path.

This fix aligns GroupNormalization_18 with the standard treatment of old versioned ops and allows onnxruntime to remove its workaround from cmake/patches/onnx/onnx.patch.