### PR TITLE
Remove cpplint (superseded by clang-tidy)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,40 +34,6 @@ jobs:
           pip install -q check-jsonschema
           python -m check_jsonschema --schemafile "https://cyclonedx.org/schema/bom-1.7.schema.json" sbom.cdx.json
 
-  optional-lint:
-    name: Optional Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: misspell # Check spellings as well
-        uses: reviewdog/action-misspell@d6429416b12b09b4e2768307d53bef58d172e962 # v1.27.0
-        with:
-          github_token: ${{ secrets.github_token }}
-          locale: "US"
-          reporter: github-pr-check
-          level: info
-          filter_mode: diff_context
-          ignore: foward,cancelled
-          exclude: |
-            ./docs/docsgen/source/_static/*
-      - name: shellcheck # Static check shell scripts
-        uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e # v1.32.0
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-check
-          level: info
-          filter_mode: diff_context
-      - name: cpplint # Static check C++ code
-        uses: reviewdog/action-cpplint@9552c62f4bd516c1e3a6f84eae56bd864cc304c6 # v1.11.0
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-check
-          level: warning
-          flags: --linelength=120
-          filter: "-runtime/references,-readability/todo"
-
   enforce-style:
     name: Enforce style
     runs-on: ubuntu-latest

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,1 +1,0 @@
-filter=-whitespace,-build/c++17

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -218,12 +218,6 @@ SPDX-FileCopyrightText = "Copyright (c) ONNX Project Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
-path = "CPPLINT.cfg"
-precedence = "aggregate"
-SPDX-FileCopyrightText = "Copyright (c) ONNX Project Contributors"
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
 path = "docs/docsgen/source/technical/**.png"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "Copyright (c) ONNX Project Contributors"

--- a/docs/CIPipelines.md
+++ b/docs/CIPipelines.md
@@ -12,7 +12,6 @@ SPDX-License-Identifier: Apache-2.0
 |---|---|---|
 | [CI](/.github/workflows/main.yml) | Every PR, merge_group, push to main, daily (midnight UTC) | C++ and Python tests across Linux, Windows, macOS; Python 3.10–3.14 (including free-threading variants); doc generation; proto generation; node test generation; daily run reports code coverage to Codecov |
 | [Windows\_No\_Exception\_CI](/.github/workflows/win_no_exception_ci.yml) | Push and PR to main and rel-\* | C++ tests compiled without exceptions; selective schema loading |
-| [Lint / Optional Lint](/.github/workflows/lint.yml) | Every PR | Not required — posts misspell, shellcheck, and cpplint suggestions as PR review comments |
 | [Lint / Enforce style](/.github/workflows/lint.yml) | Every PR | Required — runs lintrunner (ruff, mypy, clang-format, etc.) and verifies auto-generated files are up to date |
 | [Reuse](/.github/workflows/reuse.yml) | Every PR | Checks copyright and license headers; see [https://reuse.software/](https://reuse.software/). Files without a recognized license must be configured in `REUSE.toml`. |
 | [Require label](/.github/workflows/check_pr_label.yml) | Every PR | Requires at least one `topic:` or `module:` label (skipped for Dependabot PRs) |


### PR DESCRIPTION
### Motivation and Context

#7877 fixed our clang-tidy CI jobs. clang-tidy is built on clang and uses compiler tooling to provide confident and precise errors. cpplint is a regex-based tool. It is faster than clang-tidy, but much less precise. Furthermore, Google has discontinued its maintenance. I don't see the benefit of running cpplint on CI these days.

The shellcheck and misspell checks are also [redundant](https://github.com/onnx/onnx/actions/runs/25671926923/job/75359187182#step:5:16) (and I think the latter never worked properly).  

