### PR TITLE
Add type_builders.h and migrate schema definitions to use it

### DIFF
--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -18,6 +18,7 @@
 #include "onnx/defs/operator_sets.h"
 #include "onnx/defs/operator_sets_preview.h"
 #include "onnx/defs/operator_sets_training.h"
+#include "onnx/defs/type_builders.h"
 
 #ifdef ONNX_ML
 #include "onnx/defs/operator_sets_ml.h"
@@ -954,637 +955,489 @@ void OpSchema::BuildFunction(FunctionProto& function_body) const {
 }
 
 const std::vector<std::string>& OpSchema::numeric_types_for_math_reduction_ir9() {
-  static const std::vector<std::string> numeric_types_for_math_reduction_ir9 = {
-      "tensor(uint32)",
-      "tensor(uint64)",
-      "tensor(int32)",
-      "tensor(int64)",
-      "tensor(float16)",
-      "tensor(float)",
-      "tensor(double)",
-      "tensor(bfloat16)",
-      "tensor(float8e4m3fn)",
-      "tensor(float8e4m3fnuz)",
-      "tensor(float8e5m2)",
-      "tensor(float8e5m2fnuz)"};
-  return numeric_types_for_math_reduction_ir9;
+  static const auto v = types::Tensors(
+      {TensorProto::UINT32,
+       TensorProto::UINT64,
+       TensorProto::INT32,
+       TensorProto::INT64,
+       TensorProto::FLOAT16,
+       TensorProto::FLOAT,
+       TensorProto::DOUBLE,
+       TensorProto::BFLOAT16,
+       TensorProto::FLOAT8E4M3FN,
+       TensorProto::FLOAT8E4M3FNUZ,
+       TensorProto::FLOAT8E5M2,
+       TensorProto::FLOAT8E5M2FNUZ});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::numeric_types_for_math_reduction_ir4() {
-  static const std::vector<std::string> numeric_types_for_math_reduction_ir4 = {
-      "tensor(uint32)",
-      "tensor(uint64)",
-      "tensor(int32)",
-      "tensor(int64)",
-      "tensor(float16)",
-      "tensor(float)",
-      "tensor(double)",
-      "tensor(bfloat16)"};
-  return numeric_types_for_math_reduction_ir4;
+  static const auto v = types::Tensors(
+      {TensorProto::UINT32,
+       TensorProto::UINT64,
+       TensorProto::INT32,
+       TensorProto::INT64,
+       TensorProto::FLOAT16,
+       TensorProto::FLOAT,
+       TensorProto::DOUBLE,
+       TensorProto::BFLOAT16});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::numeric_types_for_math_reduction() {
-  static const std::vector<std::string> numeric_types_for_math_reduction = {
-      "tensor(uint32)",
-      "tensor(uint64)",
-      "tensor(int32)",
-      "tensor(int64)",
-      "tensor(float16)",
-      "tensor(float)",
-      "tensor(double)"};
-  return numeric_types_for_math_reduction;
+  static const auto v = types::Tensors(
+      {TensorProto::UINT32,
+       TensorProto::UINT64,
+       TensorProto::INT32,
+       TensorProto::INT64,
+       TensorProto::FLOAT16,
+       TensorProto::FLOAT,
+       TensorProto::DOUBLE});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_numeric_types_ir12() {
-  static const std::vector<std::string> all_numeric_types_ir12 = {
-      "tensor(uint8)",        "tensor(uint16)",         "tensor(uint32)",     "tensor(uint64)",
-      "tensor(int8)",         "tensor(int16)",          "tensor(int32)",      "tensor(int64)",
-      "tensor(float16)",      "tensor(float)",          "tensor(double)",     "tensor(bfloat16)",
-      "tensor(float8e4m3fn)", "tensor(float8e4m3fnuz)", "tensor(float8e5m2)", "tensor(float8e5m2fnuz)",
-      "tensor(uint4)",        "tensor(int4)",           "tensor(float4e2m1)", "tensor(float8e8m0)"};
-  return all_numeric_types_ir12;
+  static const auto v = types::Tensors(
+      {TensorProto::UINT8,        TensorProto::UINT16,         TensorProto::UINT32,     TensorProto::UINT64,
+       TensorProto::INT8,         TensorProto::INT16,          TensorProto::INT32,      TensorProto::INT64,
+       TensorProto::FLOAT16,      TensorProto::FLOAT,          TensorProto::DOUBLE,     TensorProto::BFLOAT16,
+       TensorProto::FLOAT8E4M3FN, TensorProto::FLOAT8E4M3FNUZ, TensorProto::FLOAT8E5M2, TensorProto::FLOAT8E5M2FNUZ,
+       TensorProto::UINT4,        TensorProto::INT4,           TensorProto::FLOAT4E2M1, TensorProto::FLOAT8E8M0});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_numeric_types_ir13() {
-  static const std::vector<std::string> all_numeric_types_ir13 = {"tensor(uint8)",        "tensor(uint16)",
-                                                                  "tensor(uint32)",       "tensor(uint64)",
-                                                                  "tensor(int8)",         "tensor(int16)",
-                                                                  "tensor(int32)",        "tensor(int64)",
-                                                                  "tensor(float16)",      "tensor(float)",
-                                                                  "tensor(double)",       "tensor(bfloat16)",
-                                                                  "tensor(float8e4m3fn)", "tensor(float8e4m3fnuz)",
-                                                                  "tensor(float8e5m2)",   "tensor(float8e5m2fnuz)",
-                                                                  "tensor(uint4)",        "tensor(int4)",
-                                                                  "tensor(float4e2m1)",   "tensor(float8e8m0)",
-                                                                  "tensor(uint2)",        "tensor(int2)"};
-  return all_numeric_types_ir13;
+  static const auto v = types::Tensors({TensorProto::UINT8,        TensorProto::UINT16,
+                                        TensorProto::UINT32,       TensorProto::UINT64,
+                                        TensorProto::INT8,         TensorProto::INT16,
+                                        TensorProto::INT32,        TensorProto::INT64,
+                                        TensorProto::FLOAT16,      TensorProto::FLOAT,
+                                        TensorProto::DOUBLE,       TensorProto::BFLOAT16,
+                                        TensorProto::FLOAT8E4M3FN, TensorProto::FLOAT8E4M3FNUZ,
+                                        TensorProto::FLOAT8E5M2,   TensorProto::FLOAT8E5M2FNUZ,
+                                        TensorProto::UINT4,        TensorProto::INT4,
+                                        TensorProto::FLOAT4E2M1,   TensorProto::FLOAT8E8M0,
+                                        TensorProto::UINT2,        TensorProto::INT2});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_numeric_types_ir11() {
-  static const std::vector<std::string> all_numeric_types_ir11 = {
-      "tensor(uint8)",
-      "tensor(uint16)",
-      "tensor(uint32)",
-      "tensor(uint64)",
-      "tensor(int8)",
-      "tensor(int16)",
-      "tensor(int32)",
-      "tensor(int64)",
-      "tensor(float16)",
-      "tensor(float)",
-      "tensor(double)",
-      "tensor(bfloat16)",
-      "tensor(float8e4m3fn)",
-      "tensor(float8e4m3fnuz)",
-      "tensor(float8e5m2)",
-      "tensor(float8e5m2fnuz)",
-      "tensor(uint4)",
-      "tensor(int4)",
-      "tensor(float4e2m1)"};
-  return all_numeric_types_ir11;
+  static const auto v = types::Tensors(
+      {TensorProto::UINT8,
+       TensorProto::UINT16,
+       TensorProto::UINT32,
+       TensorProto::UINT64,
+       TensorProto::INT8,
+       TensorProto::INT16,
+       TensorProto::INT32,
+       TensorProto::INT64,
+       TensorProto::FLOAT16,
+       TensorProto::FLOAT,
+       TensorProto::DOUBLE,
+       TensorProto::BFLOAT16,
+       TensorProto::FLOAT8E4M3FN,
+       TensorProto::FLOAT8E4M3FNUZ,
+       TensorProto::FLOAT8E5M2,
+       TensorProto::FLOAT8E5M2FNUZ,
+       TensorProto::UINT4,
+       TensorProto::INT4,
+       TensorProto::FLOAT4E2M1});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_numeric_types_ir10() {
-  static const std::vector<std::string> all_numeric_types_ir10 = {
-      "tensor(uint8)",
-      "tensor(uint16)",
-      "tensor(uint32)",
-      "tensor(uint64)",
-      "tensor(int8)",
-      "tensor(int16)",
-      "tensor(int32)",
-      "tensor(int64)",
-      "tensor(float16)",
-      "tensor(float)",
-      "tensor(double)",
-      "tensor(bfloat16)",
-      "tensor(float8e4m3fn)",
-      "tensor(float8e4m3fnuz)",
-      "tensor(float8e5m2)",
-      "tensor(float8e5m2fnuz)",
-      "tensor(uint4)",
-      "tensor(int4)"};
-  return all_numeric_types_ir10;
+  static const auto v = types::Tensors(
+      {TensorProto::UINT8,
+       TensorProto::UINT16,
+       TensorProto::UINT32,
+       TensorProto::UINT64,
+       TensorProto::INT8,
+       TensorProto::INT16,
+       TensorProto::INT32,
+       TensorProto::INT64,
+       TensorProto::FLOAT16,
+       TensorProto::FLOAT,
+       TensorProto::DOUBLE,
+       TensorProto::BFLOAT16,
+       TensorProto::FLOAT8E4M3FN,
+       TensorProto::FLOAT8E4M3FNUZ,
+       TensorProto::FLOAT8E5M2,
+       TensorProto::FLOAT8E5M2FNUZ,
+       TensorProto::UINT4,
+       TensorProto::INT4});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_numeric_types_ir9() {
-  static const std::vector<std::string> all_numeric_types_ir9 = {
-      "tensor(uint8)",
-      "tensor(uint16)",
-      "tensor(uint32)",
-      "tensor(uint64)",
-      "tensor(int8)",
-      "tensor(int16)",
-      "tensor(int32)",
-      "tensor(int64)",
-      "tensor(float16)",
-      "tensor(float)",
-      "tensor(double)",
-      "tensor(bfloat16)",
-      "tensor(float8e4m3fn)",
-      "tensor(float8e4m3fnuz)",
-      "tensor(float8e5m2)",
-      "tensor(float8e5m2fnuz)"};
-  return all_numeric_types_ir9;
+  static const auto v = types::Tensors(
+      {TensorProto::UINT8,
+       TensorProto::UINT16,
+       TensorProto::UINT32,
+       TensorProto::UINT64,
+       TensorProto::INT8,
+       TensorProto::INT16,
+       TensorProto::INT32,
+       TensorProto::INT64,
+       TensorProto::FLOAT16,
+       TensorProto::FLOAT,
+       TensorProto::DOUBLE,
+       TensorProto::BFLOAT16,
+       TensorProto::FLOAT8E4M3FN,
+       TensorProto::FLOAT8E4M3FNUZ,
+       TensorProto::FLOAT8E5M2,
+       TensorProto::FLOAT8E5M2FNUZ});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_numeric_types_ir4() {
-  static const std::vector<std::string> all_numeric_types_ir4 = {
-      "tensor(uint8)",
-      "tensor(uint16)",
-      "tensor(uint32)",
-      "tensor(uint64)",
-      "tensor(int8)",
-      "tensor(int16)",
-      "tensor(int32)",
-      "tensor(int64)",
-      "tensor(float16)",
-      "tensor(float)",
-      "tensor(double)",
-      "tensor(bfloat16)"};
-  return all_numeric_types_ir4;
+  static const auto v = types::Tensors(
+      {TensorProto::UINT8,
+       TensorProto::UINT16,
+       TensorProto::UINT32,
+       TensorProto::UINT64,
+       TensorProto::INT8,
+       TensorProto::INT16,
+       TensorProto::INT32,
+       TensorProto::INT64,
+       TensorProto::FLOAT16,
+       TensorProto::FLOAT,
+       TensorProto::DOUBLE,
+       TensorProto::BFLOAT16});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_numeric_types() {
-  static const std::vector<std::string> all_numeric_types = {
-      "tensor(uint8)",
-      "tensor(uint16)",
-      "tensor(uint32)",
-      "tensor(uint64)",
-      "tensor(int8)",
-      "tensor(int16)",
-      "tensor(int32)",
-      "tensor(int64)",
-      "tensor(float16)",
-      "tensor(float)",
-      "tensor(double)"};
-  return all_numeric_types;
+  static const auto v = types::Tensors(
+      {TensorProto::UINT8,
+       TensorProto::UINT16,
+       TensorProto::UINT32,
+       TensorProto::UINT64,
+       TensorProto::INT8,
+       TensorProto::INT16,
+       TensorProto::INT32,
+       TensorProto::INT64,
+       TensorProto::FLOAT16,
+       TensorProto::FLOAT,
+       TensorProto::DOUBLE});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_numeric_sequence_types() {
-  static const std::vector<std::string> all_numeric_sequence_types = {
-      "seq(tensor(uint8))",
-      "seq(tensor(uint16))",
-      "seq(tensor(uint32))",
-      "seq(tensor(uint64))",
-      "seq(tensor(int8))",
-      "seq(tensor(int16))",
-      "seq(tensor(int32))",
-      "seq(tensor(int64))",
-      "seq(tensor(float16))",
-      "seq(tensor(float))",
-      "seq(tensor(double))"};
-  return all_numeric_sequence_types;
+  static const auto v = types::Sequence(
+      types::Tensors(
+          {TensorProto::UINT8,
+           TensorProto::UINT16,
+           TensorProto::UINT32,
+           TensorProto::UINT64,
+           TensorProto::INT8,
+           TensorProto::INT16,
+           TensorProto::INT32,
+           TensorProto::INT64,
+           TensorProto::FLOAT16,
+           TensorProto::FLOAT,
+           TensorProto::DOUBLE}));
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_tensor_types() {
-  static const std::vector<std::string> all_tensor_types = {
-      "tensor(uint8)",
-      "tensor(uint16)",
-      "tensor(uint32)",
-      "tensor(uint64)",
-      "tensor(int8)",
-      "tensor(int16)",
-      "tensor(int32)",
-      "tensor(int64)",
-      "tensor(float16)",
-      "tensor(float)",
-      "tensor(double)",
-      "tensor(string)",
-      "tensor(bool)",
-      "tensor(complex64)",
-      "tensor(complex128)"};
-  return all_tensor_types;
+  static const auto v = types::Tensors(
+      {TensorProto::UINT8,
+       TensorProto::UINT16,
+       TensorProto::UINT32,
+       TensorProto::UINT64,
+       TensorProto::INT8,
+       TensorProto::INT16,
+       TensorProto::INT32,
+       TensorProto::INT64,
+       TensorProto::FLOAT16,
+       TensorProto::FLOAT,
+       TensorProto::DOUBLE,
+       TensorProto::STRING,
+       TensorProto::BOOL,
+       TensorProto::COMPLEX64,
+       TensorProto::COMPLEX128});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_tensor_types_ir4() {
-  static const std::vector<std::string> all_tensor_types_ir4 = {
-      "tensor(uint8)",
-      "tensor(uint16)",
-      "tensor(uint32)",
-      "tensor(uint64)",
-      "tensor(int8)",
-      "tensor(int16)",
-      "tensor(int32)",
-      "tensor(int64)",
-      "tensor(bfloat16)",
-      "tensor(float16)",
-      "tensor(float)",
-      "tensor(double)",
-      "tensor(string)",
-      "tensor(bool)",
-      "tensor(complex64)",
-      "tensor(complex128)"};
-  return all_tensor_types_ir4;
+  static const auto v = types::Tensors(
+      {TensorProto::UINT8,
+       TensorProto::UINT16,
+       TensorProto::UINT32,
+       TensorProto::UINT64,
+       TensorProto::INT8,
+       TensorProto::INT16,
+       TensorProto::INT32,
+       TensorProto::INT64,
+       TensorProto::BFLOAT16,
+       TensorProto::FLOAT16,
+       TensorProto::FLOAT,
+       TensorProto::DOUBLE,
+       TensorProto::STRING,
+       TensorProto::BOOL,
+       TensorProto::COMPLEX64,
+       TensorProto::COMPLEX128});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_non_complex_numeric_types_plus_bool_ir4() {
-  static const std::vector<std::string> all_non_complex_numeric_types_plus_bool_ir4 = {
-      "tensor(uint8)",
-      "tensor(uint16)",
-      "tensor(uint32)",
-      "tensor(uint64)",
-      "tensor(int8)",
-      "tensor(int16)",
-      "tensor(int32)",
-      "tensor(int64)",
-      "tensor(bfloat16)",
-      "tensor(float16)",
-      "tensor(float)",
-      "tensor(double)",
-      "tensor(bool)"};
-  return all_non_complex_numeric_types_plus_bool_ir4;
+  static const auto v = types::Tensors(
+      {TensorProto::UINT8,
+       TensorProto::UINT16,
+       TensorProto::UINT32,
+       TensorProto::UINT64,
+       TensorProto::INT8,
+       TensorProto::INT16,
+       TensorProto::INT32,
+       TensorProto::INT64,
+       TensorProto::BFLOAT16,
+       TensorProto::FLOAT16,
+       TensorProto::FLOAT,
+       TensorProto::DOUBLE,
+       TensorProto::BOOL});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_float_types_ir4() {
-  static const std::vector<std::string> all_float_types_ir4 = {
-      "tensor(bfloat16)", "tensor(float16)", "tensor(float)", "tensor(double)"};
-  return all_float_types_ir4;
+  static const auto v =
+      types::Tensors({TensorProto::BFLOAT16, TensorProto::FLOAT16, TensorProto::FLOAT, TensorProto::DOUBLE});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_float_types_plus_Xint8_ir4() {
-  static const std::vector<std::string> all_float_types_ir4 = {
-      "tensor(bfloat16)", "tensor(float16)", "tensor(float)", "tensor(double)", "tensor(int8)", "tensor(uint8)"};
-  return all_float_types_ir4;
+  static const auto v = types::Tensors(
+      {TensorProto::BFLOAT16,
+       TensorProto::FLOAT16,
+       TensorProto::FLOAT,
+       TensorProto::DOUBLE,
+       TensorProto::INT8,
+       TensorProto::UINT8});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_float_types_ir9() {
-  static const std::vector<std::string> all_float_types_ir9 = {
-      "tensor(bfloat16)",
-      "tensor(float16)",
-      "tensor(float)",
-      "tensor(double)",
-      "tensor(float8e4m3fn)",
-      "tensor(float8e4m3fnuz)",
-      "tensor(float8e5m2)",
-      "tensor(float8e5m2fnuz)"};
-  return all_float_types_ir9;
+  static const auto v = types::Tensors(
+      {TensorProto::BFLOAT16,
+       TensorProto::FLOAT16,
+       TensorProto::FLOAT,
+       TensorProto::DOUBLE,
+       TensorProto::FLOAT8E4M3FN,
+       TensorProto::FLOAT8E4M3FNUZ,
+       TensorProto::FLOAT8E5M2,
+       TensorProto::FLOAT8E5M2FNUZ});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_tensor_types_ir9() {
-  static const std::vector<std::string> all_tensor_types_ir9 = {
-      "tensor(uint8)",        "tensor(uint16)",         "tensor(uint32)",     "tensor(uint64)",
-      "tensor(int8)",         "tensor(int16)",          "tensor(int32)",      "tensor(int64)",
-      "tensor(bfloat16)",     "tensor(float16)",        "tensor(float)",      "tensor(double)",
-      "tensor(string)",       "tensor(bool)",           "tensor(complex64)",  "tensor(complex128)",
-      "tensor(float8e4m3fn)", "tensor(float8e4m3fnuz)", "tensor(float8e5m2)", "tensor(float8e5m2fnuz)"};
-  return all_tensor_types_ir9;
+  static const auto v = types::Tensors(
+      {TensorProto::UINT8,        TensorProto::UINT16,         TensorProto::UINT32,     TensorProto::UINT64,
+       TensorProto::INT8,         TensorProto::INT16,          TensorProto::INT32,      TensorProto::INT64,
+       TensorProto::BFLOAT16,     TensorProto::FLOAT16,        TensorProto::FLOAT,      TensorProto::DOUBLE,
+       TensorProto::STRING,       TensorProto::BOOL,           TensorProto::COMPLEX64,  TensorProto::COMPLEX128,
+       TensorProto::FLOAT8E4M3FN, TensorProto::FLOAT8E4M3FNUZ, TensorProto::FLOAT8E5M2, TensorProto::FLOAT8E5M2FNUZ});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_tensor_types_ir10() {
-  static const std::vector<std::string> all_tensor_types_ir10 = {
-      "tensor(uint8)",      "tensor(uint16)",         "tensor(uint32)",
-      "tensor(uint64)",     "tensor(int8)",           "tensor(int16)",
-      "tensor(int32)",      "tensor(int64)",          "tensor(bfloat16)",
-      "tensor(float16)",    "tensor(float)",          "tensor(double)",
-      "tensor(string)",     "tensor(bool)",           "tensor(complex64)",
-      "tensor(complex128)", "tensor(float8e4m3fn)",   "tensor(float8e4m3fnuz)",
-      "tensor(float8e5m2)", "tensor(float8e5m2fnuz)", "tensor(uint4)",
-      "tensor(int4)"};
-  return all_tensor_types_ir10;
+  static const auto v =
+      types::Tensors({TensorProto::UINT8,      TensorProto::UINT16,         TensorProto::UINT32,
+                      TensorProto::UINT64,     TensorProto::INT8,           TensorProto::INT16,
+                      TensorProto::INT32,      TensorProto::INT64,          TensorProto::BFLOAT16,
+                      TensorProto::FLOAT16,    TensorProto::FLOAT,          TensorProto::DOUBLE,
+                      TensorProto::STRING,     TensorProto::BOOL,           TensorProto::COMPLEX64,
+                      TensorProto::COMPLEX128, TensorProto::FLOAT8E4M3FN,   TensorProto::FLOAT8E4M3FNUZ,
+                      TensorProto::FLOAT8E5M2, TensorProto::FLOAT8E5M2FNUZ, TensorProto::UINT4,
+                      TensorProto::INT4});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_non_complex_tensor_types_ir10() {
-  static const std::vector<std::string> all_non_complex_tensor_types_ir10 = {
-      "tensor(uint8)",      "tensor(uint16)",         "tensor(uint32)",       "tensor(uint64)",
-      "tensor(int8)",       "tensor(int16)",          "tensor(int32)",        "tensor(int64)",
-      "tensor(bfloat16)",   "tensor(float16)",        "tensor(float)",        "tensor(double)",
-      "tensor(string)",     "tensor(bool)",           "tensor(float8e4m3fn)", "tensor(float8e4m3fnuz)",
-      "tensor(float8e5m2)", "tensor(float8e5m2fnuz)", "tensor(uint4)",        "tensor(int4)"};
-  return all_non_complex_tensor_types_ir10;
+  static const auto v = types::Tensors(
+      {TensorProto::UINT8,      TensorProto::UINT16,         TensorProto::UINT32,       TensorProto::UINT64,
+       TensorProto::INT8,       TensorProto::INT16,          TensorProto::INT32,        TensorProto::INT64,
+       TensorProto::BFLOAT16,   TensorProto::FLOAT16,        TensorProto::FLOAT,        TensorProto::DOUBLE,
+       TensorProto::STRING,     TensorProto::BOOL,           TensorProto::FLOAT8E4M3FN, TensorProto::FLOAT8E4M3FNUZ,
+       TensorProto::FLOAT8E5M2, TensorProto::FLOAT8E5M2FNUZ, TensorProto::UINT4,        TensorProto::INT4});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_tensor_types_ir11() {
-  static const std::vector<std::string> all_tensor_types_ir11 = {
-      "tensor(uint8)",        "tensor(uint16)",         "tensor(uint32)",     "tensor(uint64)",
-      "tensor(int8)",         "tensor(int16)",          "tensor(int32)",      "tensor(int64)",
-      "tensor(bfloat16)",     "tensor(float16)",        "tensor(float)",      "tensor(double)",
-      "tensor(string)",       "tensor(bool)",           "tensor(complex64)",  "tensor(complex128)",
-      "tensor(float8e4m3fn)", "tensor(float8e4m3fnuz)", "tensor(float8e5m2)", "tensor(float8e5m2fnuz)",
-      "tensor(uint4)",        "tensor(int4)",           "tensor(float4e2m1)"};
-  return all_tensor_types_ir11;
+  static const auto v = types::Tensors(
+      {TensorProto::UINT8,        TensorProto::UINT16,         TensorProto::UINT32,     TensorProto::UINT64,
+       TensorProto::INT8,         TensorProto::INT16,          TensorProto::INT32,      TensorProto::INT64,
+       TensorProto::BFLOAT16,     TensorProto::FLOAT16,        TensorProto::FLOAT,      TensorProto::DOUBLE,
+       TensorProto::STRING,       TensorProto::BOOL,           TensorProto::COMPLEX64,  TensorProto::COMPLEX128,
+       TensorProto::FLOAT8E4M3FN, TensorProto::FLOAT8E4M3FNUZ, TensorProto::FLOAT8E5M2, TensorProto::FLOAT8E5M2FNUZ,
+       TensorProto::UINT4,        TensorProto::INT4,           TensorProto::FLOAT4E2M1});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_non_complex_tensor_types_ir11() {
-  static const std::vector<std::string> all_non_complex_tensor_types_ir11 = {
-      "tensor(uint8)",      "tensor(uint16)",         "tensor(uint32)",       "tensor(uint64)",
-      "tensor(int8)",       "tensor(int16)",          "tensor(int32)",        "tensor(int64)",
-      "tensor(bfloat16)",   "tensor(float16)",        "tensor(float)",        "tensor(double)",
-      "tensor(string)",     "tensor(bool)",           "tensor(float8e4m3fn)", "tensor(float8e4m3fnuz)",
-      "tensor(float8e5m2)", "tensor(float8e5m2fnuz)", "tensor(uint4)",        "tensor(int4)",
-      "tensor(float4e2m1)"};
-  return all_non_complex_tensor_types_ir11;
+  static const auto v = types::Tensors(
+      {TensorProto::UINT8,      TensorProto::UINT16,         TensorProto::UINT32,       TensorProto::UINT64,
+       TensorProto::INT8,       TensorProto::INT16,          TensorProto::INT32,        TensorProto::INT64,
+       TensorProto::BFLOAT16,   TensorProto::FLOAT16,        TensorProto::FLOAT,        TensorProto::DOUBLE,
+       TensorProto::STRING,     TensorProto::BOOL,           TensorProto::FLOAT8E4M3FN, TensorProto::FLOAT8E4M3FNUZ,
+       TensorProto::FLOAT8E5M2, TensorProto::FLOAT8E5M2FNUZ, TensorProto::UINT4,        TensorProto::INT4,
+       TensorProto::FLOAT4E2M1});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_tensor_types_ir12() {
-  static const std::vector<std::string> all_tensor_types_ir12 = {
-      "tensor(uint8)",        "tensor(uint16)",         "tensor(uint32)",     "tensor(uint64)",
-      "tensor(int8)",         "tensor(int16)",          "tensor(int32)",      "tensor(int64)",
-      "tensor(bfloat16)",     "tensor(float16)",        "tensor(float)",      "tensor(double)",
-      "tensor(string)",       "tensor(bool)",           "tensor(complex64)",  "tensor(complex128)",
-      "tensor(float8e4m3fn)", "tensor(float8e4m3fnuz)", "tensor(float8e5m2)", "tensor(float8e5m2fnuz)",
-      "tensor(uint4)",        "tensor(int4)",           "tensor(float4e2m1)", "tensor(float8e8m0)"};
-  return all_tensor_types_ir12;
+  static const auto v = types::Tensors(
+      {TensorProto::UINT8,        TensorProto::UINT16,         TensorProto::UINT32,     TensorProto::UINT64,
+       TensorProto::INT8,         TensorProto::INT16,          TensorProto::INT32,      TensorProto::INT64,
+       TensorProto::BFLOAT16,     TensorProto::FLOAT16,        TensorProto::FLOAT,      TensorProto::DOUBLE,
+       TensorProto::STRING,       TensorProto::BOOL,           TensorProto::COMPLEX64,  TensorProto::COMPLEX128,
+       TensorProto::FLOAT8E4M3FN, TensorProto::FLOAT8E4M3FNUZ, TensorProto::FLOAT8E5M2, TensorProto::FLOAT8E5M2FNUZ,
+       TensorProto::UINT4,        TensorProto::INT4,           TensorProto::FLOAT4E2M1, TensorProto::FLOAT8E8M0});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_non_complex_tensor_types_ir12() {
-  static const std::vector<std::string> all_non_complex_tensor_types_ir12 = {
-      "tensor(uint8)",      "tensor(uint16)",         "tensor(uint32)",       "tensor(uint64)",
-      "tensor(int8)",       "tensor(int16)",          "tensor(int32)",        "tensor(int64)",
-      "tensor(bfloat16)",   "tensor(float16)",        "tensor(float)",        "tensor(double)",
-      "tensor(string)",     "tensor(bool)",           "tensor(float8e4m3fn)", "tensor(float8e4m3fnuz)",
-      "tensor(float8e5m2)", "tensor(float8e5m2fnuz)", "tensor(uint4)",        "tensor(int4)",
-      "tensor(float4e2m1)", "tensor(float8e8m0)"};
-  return all_non_complex_tensor_types_ir12;
+  static const auto v = types::Tensors(
+      {TensorProto::UINT8,      TensorProto::UINT16,         TensorProto::UINT32,       TensorProto::UINT64,
+       TensorProto::INT8,       TensorProto::INT16,          TensorProto::INT32,        TensorProto::INT64,
+       TensorProto::BFLOAT16,   TensorProto::FLOAT16,        TensorProto::FLOAT,        TensorProto::DOUBLE,
+       TensorProto::STRING,     TensorProto::BOOL,           TensorProto::FLOAT8E4M3FN, TensorProto::FLOAT8E4M3FNUZ,
+       TensorProto::FLOAT8E5M2, TensorProto::FLOAT8E5M2FNUZ, TensorProto::UINT4,        TensorProto::INT4,
+       TensorProto::FLOAT4E2M1, TensorProto::FLOAT8E8M0});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_tensor_types_ir13() {
-  static const std::vector<std::string> all_tensor_types_ir13 = {"tensor(uint8)",        "tensor(uint16)",
-                                                                 "tensor(uint32)",       "tensor(uint64)",
-                                                                 "tensor(int8)",         "tensor(int16)",
-                                                                 "tensor(int32)",        "tensor(int64)",
-                                                                 "tensor(bfloat16)",     "tensor(float16)",
-                                                                 "tensor(float)",        "tensor(double)",
-                                                                 "tensor(string)",       "tensor(bool)",
-                                                                 "tensor(complex64)",    "tensor(complex128)",
-                                                                 "tensor(float8e4m3fn)", "tensor(float8e4m3fnuz)",
-                                                                 "tensor(float8e5m2)",   "tensor(float8e5m2fnuz)",
-                                                                 "tensor(uint4)",        "tensor(int4)",
-                                                                 "tensor(float4e2m1)",   "tensor(float8e8m0)",
-                                                                 "tensor(uint2)",        "tensor(int2)"};
-  return all_tensor_types_ir13;
+  static const auto v = types::Tensors({TensorProto::UINT8,        TensorProto::UINT16,
+                                        TensorProto::UINT32,       TensorProto::UINT64,
+                                        TensorProto::INT8,         TensorProto::INT16,
+                                        TensorProto::INT32,        TensorProto::INT64,
+                                        TensorProto::BFLOAT16,     TensorProto::FLOAT16,
+                                        TensorProto::FLOAT,        TensorProto::DOUBLE,
+                                        TensorProto::STRING,       TensorProto::BOOL,
+                                        TensorProto::COMPLEX64,    TensorProto::COMPLEX128,
+                                        TensorProto::FLOAT8E4M3FN, TensorProto::FLOAT8E4M3FNUZ,
+                                        TensorProto::FLOAT8E5M2,   TensorProto::FLOAT8E5M2FNUZ,
+                                        TensorProto::UINT4,        TensorProto::INT4,
+                                        TensorProto::FLOAT4E2M1,   TensorProto::FLOAT8E8M0,
+                                        TensorProto::UINT2,        TensorProto::INT2});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_non_complex_tensor_types_ir13() {
-  static const std::vector<std::string> all_non_complex_tensor_types_ir13 = {
-      "tensor(uint8)",      "tensor(uint16)",         "tensor(uint32)",       "tensor(uint64)",
-      "tensor(int8)",       "tensor(int16)",          "tensor(int32)",        "tensor(int64)",
-      "tensor(bfloat16)",   "tensor(float16)",        "tensor(float)",        "tensor(double)",
-      "tensor(string)",     "tensor(bool)",           "tensor(float8e4m3fn)", "tensor(float8e4m3fnuz)",
-      "tensor(float8e5m2)", "tensor(float8e5m2fnuz)", "tensor(uint4)",        "tensor(int4)",
-      "tensor(float4e2m1)", "tensor(float8e8m0)",     "tensor(uint2)",        "tensor(int2)"};
-  return all_non_complex_tensor_types_ir13;
+  static const auto v = types::Tensors(
+      {TensorProto::UINT8,      TensorProto::UINT16,         TensorProto::UINT32,       TensorProto::UINT64,
+       TensorProto::INT8,       TensorProto::INT16,          TensorProto::INT32,        TensorProto::INT64,
+       TensorProto::BFLOAT16,   TensorProto::FLOAT16,        TensorProto::FLOAT,        TensorProto::DOUBLE,
+       TensorProto::STRING,     TensorProto::BOOL,           TensorProto::FLOAT8E4M3FN, TensorProto::FLOAT8E4M3FNUZ,
+       TensorProto::FLOAT8E5M2, TensorProto::FLOAT8E5M2FNUZ, TensorProto::UINT4,        TensorProto::INT4,
+       TensorProto::FLOAT4E2M1, TensorProto::FLOAT8E8M0,     TensorProto::UINT2,        TensorProto::INT2});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_non_string_tensor_types_ir13() {
-  static const std::vector<std::string> all_non_string_tensor_types_ir13 = {"tensor(uint8)",
-                                                                            "tensor(uint16)",
-                                                                            "tensor(uint32)",
-                                                                            "tensor(uint64)",
-                                                                            "tensor(int8)",
-                                                                            "tensor(int16)",
-                                                                            "tensor(int32)",
-                                                                            "tensor(int64)",
-                                                                            "tensor(bfloat16)",
-                                                                            "tensor(float16)",
-                                                                            "tensor(float)",
-                                                                            "tensor(double)",
-                                                                            "tensor(bool)",
-                                                                            "tensor(complex64)",
-                                                                            "tensor(complex128)",
-                                                                            "tensor(float8e4m3fn)",
-                                                                            "tensor(float8e4m3fnuz)",
-                                                                            "tensor(float8e5m2)",
-                                                                            "tensor(float8e5m2fnuz)",
-                                                                            "tensor(uint4)",
-                                                                            "tensor(int4)",
-                                                                            "tensor(float4e2m1)",
-                                                                            "tensor(float8e8m0)",
-                                                                            "tensor(uint2)",
-                                                                            "tensor(int2)"};
-  return all_non_string_tensor_types_ir13;
+  static const auto v = types::Tensors(
+      {TensorProto::UINT8,
+       TensorProto::UINT16,
+       TensorProto::UINT32,
+       TensorProto::UINT64,
+       TensorProto::INT8,
+       TensorProto::INT16,
+       TensorProto::INT32,
+       TensorProto::INT64,
+       TensorProto::BFLOAT16,
+       TensorProto::FLOAT16,
+       TensorProto::FLOAT,
+       TensorProto::DOUBLE,
+       TensorProto::BOOL,
+       TensorProto::COMPLEX64,
+       TensorProto::COMPLEX128,
+       TensorProto::FLOAT8E4M3FN,
+       TensorProto::FLOAT8E4M3FNUZ,
+       TensorProto::FLOAT8E5M2,
+       TensorProto::FLOAT8E5M2FNUZ,
+       TensorProto::UINT4,
+       TensorProto::INT4,
+       TensorProto::FLOAT4E2M1,
+       TensorProto::FLOAT8E8M0,
+       TensorProto::UINT2,
+       TensorProto::INT2});
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_tensor_sequence_types() {
-  static const std::vector<std::string> all_tensor_sequence_types = {
-      "seq(tensor(uint8))",
-      "seq(tensor(uint16))",
-      "seq(tensor(uint32))",
-      "seq(tensor(uint64))",
-      "seq(tensor(int8))",
-      "seq(tensor(int16))",
-      "seq(tensor(int32))",
-      "seq(tensor(int64))",
-      "seq(tensor(float16))",
-      "seq(tensor(float))",
-      "seq(tensor(double))",
-      "seq(tensor(string))",
-      "seq(tensor(bool))",
-      "seq(tensor(complex64))",
-      "seq(tensor(complex128))"};
-  return all_tensor_sequence_types;
+  static const auto v = types::Sequence(all_tensor_types());
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_tensor_sequence_types_ir4() {
-  static const std::vector<std::string> all_tensor_sequence_types_ir4 = {
-      "seq(tensor(uint8))",
-      "seq(tensor(uint16))",
-      "seq(tensor(uint32))",
-      "seq(tensor(uint64))",
-      "seq(tensor(int8))",
-      "seq(tensor(int16))",
-      "seq(tensor(int32))",
-      "seq(tensor(int64))",
-      "seq(tensor(bfloat16))",
-      "seq(tensor(float16))",
-      "seq(tensor(float))",
-      "seq(tensor(double))",
-      "seq(tensor(string))",
-      "seq(tensor(bool))",
-      "seq(tensor(complex64))",
-      "seq(tensor(complex128))"};
-  return all_tensor_sequence_types_ir4;
+  static const auto v = types::Sequence(all_tensor_types_ir4());
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_tensor_sequence_types_ir9() {
-  static const std::vector<std::string> all_tensor_sequence_types_ir9 = {
-      "seq(tensor(uint8))",      "seq(tensor(uint16))",        "seq(tensor(uint32))",
-      "seq(tensor(uint64))",     "seq(tensor(int8))",          "seq(tensor(int16))",
-      "seq(tensor(int32))",      "seq(tensor(int64))",         "seq(tensor(bfloat16))",
-      "seq(tensor(float16))",    "seq(tensor(float))",         "seq(tensor(double))",
-      "seq(tensor(string))",     "seq(tensor(bool))",          "seq(tensor(complex64))",
-      "seq(tensor(complex128))", "seq(tensor(float8e4m3fn))",  "seq(tensor(float8e4m3fnuz))",
-      "seq(tensor(float8e5m2))", "seq(tensor(float8e5m2fnuz))"};
-  return all_tensor_sequence_types_ir9;
+  static const auto v = types::Sequence(all_tensor_types_ir9());
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_tensor_sequence_types_ir10() {
-  static const std::vector<std::string> all_tensor_sequence_types_ir10 = {
-      "seq(tensor(uint8))",      "seq(tensor(uint16))",         "seq(tensor(uint32))",
-      "seq(tensor(uint64))",     "seq(tensor(int8))",           "seq(tensor(int16))",
-      "seq(tensor(int32))",      "seq(tensor(int64))",          "seq(tensor(bfloat16))",
-      "seq(tensor(float16))",    "seq(tensor(float))",          "seq(tensor(double))",
-      "seq(tensor(string))",     "seq(tensor(bool))",           "seq(tensor(complex64))",
-      "seq(tensor(complex128))", "seq(tensor(float8e4m3fn))",   "seq(tensor(float8e4m3fnuz))",
-      "seq(tensor(float8e5m2))", "seq(tensor(float8e5m2fnuz))", "seq(tensor(uint4))",
-      "seq(tensor(int4))"};
-  return all_tensor_sequence_types_ir10;
+  static const auto v = types::Sequence(all_tensor_types_ir10());
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_tensor_sequence_types_ir11() {
-  static const std::vector<std::string> all_tensor_sequence_types_ir11 = {
-      "seq(tensor(uint8))",      "seq(tensor(uint16))",         "seq(tensor(uint32))",
-      "seq(tensor(uint64))",     "seq(tensor(int8))",           "seq(tensor(int16))",
-      "seq(tensor(int32))",      "seq(tensor(int64))",          "seq(tensor(bfloat16))",
-      "seq(tensor(float16))",    "seq(tensor(float))",          "seq(tensor(double))",
-      "seq(tensor(string))",     "seq(tensor(bool))",           "seq(tensor(complex64))",
-      "seq(tensor(complex128))", "seq(tensor(float8e4m3fn))",   "seq(tensor(float8e4m3fnuz))",
-      "seq(tensor(float8e5m2))", "seq(tensor(float8e5m2fnuz))", "seq(tensor(uint4))",
-      "seq(tensor(int4))",       "seq(tensor(float4e2m1))"};
-  return all_tensor_sequence_types_ir11;
+  static const auto v = types::Sequence(all_tensor_types_ir11());
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_tensor_sequence_types_ir12() {
-  static const std::vector<std::string> all_tensor_sequence_types_ir12 = {
-      "seq(tensor(uint8))",      "seq(tensor(uint16))",         "seq(tensor(uint32))",
-      "seq(tensor(uint64))",     "seq(tensor(int8))",           "seq(tensor(int16))",
-      "seq(tensor(int32))",      "seq(tensor(int64))",          "seq(tensor(bfloat16))",
-      "seq(tensor(float16))",    "seq(tensor(float))",          "seq(tensor(double))",
-      "seq(tensor(string))",     "seq(tensor(bool))",           "seq(tensor(complex64))",
-      "seq(tensor(complex128))", "seq(tensor(float8e4m3fn))",   "seq(tensor(float8e4m3fnuz))",
-      "seq(tensor(float8e5m2))", "seq(tensor(float8e5m2fnuz))", "seq(tensor(uint4))",
-      "seq(tensor(int4))",       "seq(tensor(float4e2m1))",     "seq(tensor(float8e8m0))"};
-  return all_tensor_sequence_types_ir12;
+  static const auto v = types::Sequence(all_tensor_types_ir12());
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_tensor_sequence_types_ir13() {
-  static const std::vector<std::string> all_tensor_sequence_types_ir13 = {
-      "seq(tensor(uint8))",        "seq(tensor(uint16))",
-      "seq(tensor(uint32))",       "seq(tensor(uint64))",
-      "seq(tensor(int8))",         "seq(tensor(int16))",
-      "seq(tensor(int32))",        "seq(tensor(int64))",
-      "seq(tensor(bfloat16))",     "seq(tensor(float16))",
-      "seq(tensor(float))",        "seq(tensor(double))",
-      "seq(tensor(string))",       "seq(tensor(bool))",
-      "seq(tensor(complex64))",    "seq(tensor(complex128))",
-      "seq(tensor(float8e4m3fn))", "seq(tensor(float8e4m3fnuz))",
-      "seq(tensor(float8e5m2))",   "seq(tensor(float8e5m2fnuz))",
-      "seq(tensor(uint4))",        "seq(tensor(int4))",
-      "seq(tensor(float4e2m1))",   "seq(tensor(float8e8m0))",
-      "seq(tensor(uint2))",        "seq(tensor(int2))"};
-  return all_tensor_sequence_types_ir13;
+  static const auto v = types::Sequence(all_tensor_types_ir13());
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_optional_types() {
-  static const std::vector<std::string> all_optional_types = {
-      "optional(seq(tensor(uint8)))",  "optional(seq(tensor(uint16)))",    "optional(seq(tensor(uint32)))",
-      "optional(seq(tensor(uint64)))", "optional(seq(tensor(int8)))",      "optional(seq(tensor(int16)))",
-      "optional(seq(tensor(int32)))",  "optional(seq(tensor(int64)))",     "optional(seq(tensor(float16)))",
-      "optional(seq(tensor(float)))",  "optional(seq(tensor(double)))",    "optional(seq(tensor(string)))",
-      "optional(seq(tensor(bool)))",   "optional(seq(tensor(complex64)))", "optional(seq(tensor(complex128)))",
-      "optional(tensor(uint8))",       "optional(tensor(uint16))",         "optional(tensor(uint32))",
-      "optional(tensor(uint64))",      "optional(tensor(int8))",           "optional(tensor(int16))",
-      "optional(tensor(int32))",       "optional(tensor(int64))",          "optional(tensor(float16))",
-      "optional(tensor(float))",       "optional(tensor(double))",         "optional(tensor(string))",
-      "optional(tensor(bool))",        "optional(tensor(complex64))",      "optional(tensor(complex128))"};
-  return all_optional_types;
+  static const auto v =
+      types::Concat(types::Optional(all_tensor_sequence_types()), types::Optional(all_tensor_types()));
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_optional_types_ir4() {
-  static const std::vector<std::string> all_optional_types = {
-      "optional(seq(tensor(uint8)))",      "optional(seq(tensor(uint16)))", "optional(seq(tensor(uint32)))",
-      "optional(seq(tensor(uint64)))",     "optional(seq(tensor(int8)))",   "optional(seq(tensor(int16)))",
-      "optional(seq(tensor(int32)))",      "optional(seq(tensor(int64)))",  "optional(seq(tensor(bfloat16)))",
-      "optional(seq(tensor(float16)))",    "optional(seq(tensor(float)))",  "optional(seq(tensor(double)))",
-      "optional(seq(tensor(string)))",     "optional(seq(tensor(bool)))",   "optional(seq(tensor(complex64)))",
-      "optional(seq(tensor(complex128)))", "optional(tensor(uint8))",       "optional(tensor(uint16))",
-      "optional(tensor(uint32))",          "optional(tensor(uint64))",      "optional(tensor(int8))",
-      "optional(tensor(int16))",           "optional(tensor(int32))",       "optional(tensor(int64))",
-      "optional(tensor(bfloat16))",        "optional(tensor(float16))",     "optional(tensor(float))",
-      "optional(tensor(double))",          "optional(tensor(string))",      "optional(tensor(bool))",
-      "optional(tensor(complex64))",       "optional(tensor(complex128))"};
-  return all_optional_types;
+  static const auto v =
+      types::Concat(types::Optional(all_tensor_sequence_types_ir4()), types::Optional(all_tensor_types_ir4()));
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_optional_types_ir9() {
-  static const std::vector<std::string> all_optional_types = {
-      "optional(seq(tensor(uint8)))",      "optional(seq(tensor(uint16)))", "optional(seq(tensor(uint32)))",
-      "optional(seq(tensor(uint64)))",     "optional(seq(tensor(int8)))",   "optional(seq(tensor(int16)))",
-      "optional(seq(tensor(int32)))",      "optional(seq(tensor(int64)))",  "optional(seq(tensor(bfloat16)))",
-      "optional(seq(tensor(float16)))",    "optional(seq(tensor(float)))",  "optional(seq(tensor(double)))",
-      "optional(seq(tensor(string)))",     "optional(seq(tensor(bool)))",   "optional(seq(tensor(complex64)))",
-      "optional(seq(tensor(complex128)))", "optional(tensor(uint8))",       "optional(tensor(uint16))",
-      "optional(tensor(uint32))",          "optional(tensor(uint64))",      "optional(tensor(int8))",
-      "optional(tensor(int16))",           "optional(tensor(int32))",       "optional(tensor(int64))",
-      "optional(tensor(bfloat16))",        "optional(tensor(float16))",     "optional(tensor(float))",
-      "optional(tensor(double))",          "optional(tensor(string))",      "optional(tensor(bool))",
-      "optional(tensor(complex64))",       "optional(tensor(complex128))",  "optional(tensor(float8e4m3fn))",
-      "optional(tensor(float8e4m3fnuz))",  "optional(tensor(float8e5m2))",  "optional(tensor(float8e5m2fnuz))"};
-  return all_optional_types;
+  static const auto v =
+      types::Concat(types::Optional(all_tensor_sequence_types_ir4()), types::Optional(all_tensor_types_ir9()));
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_optional_types_ir10() {
-  static const std::vector<std::string> all_optional_types = {
-      "optional(seq(tensor(uint8)))",      "optional(seq(tensor(uint16)))", "optional(seq(tensor(uint32)))",
-      "optional(seq(tensor(uint64)))",     "optional(seq(tensor(int8)))",   "optional(seq(tensor(int16)))",
-      "optional(seq(tensor(int32)))",      "optional(seq(tensor(int64)))",  "optional(seq(tensor(bfloat16)))",
-      "optional(seq(tensor(float16)))",    "optional(seq(tensor(float)))",  "optional(seq(tensor(double)))",
-      "optional(seq(tensor(string)))",     "optional(seq(tensor(bool)))",   "optional(seq(tensor(complex64)))",
-      "optional(seq(tensor(complex128)))", "optional(tensor(uint8))",       "optional(tensor(uint16))",
-      "optional(tensor(uint32))",          "optional(tensor(uint64))",      "optional(tensor(int8))",
-      "optional(tensor(int16))",           "optional(tensor(int32))",       "optional(tensor(int64))",
-      "optional(tensor(bfloat16))",        "optional(tensor(float16))",     "optional(tensor(float))",
-      "optional(tensor(double))",          "optional(tensor(string))",      "optional(tensor(bool))",
-      "optional(tensor(complex64))",       "optional(tensor(complex128))",  "optional(tensor(float8e4m3fn))",
-      "optional(tensor(float8e4m3fnuz))",  "optional(tensor(float8e5m2))",  "optional(tensor(float8e5m2fnuz))",
-      "optional(tensor(uint4))",           "optional(tensor(int4))"};
-  return all_optional_types;
+  static const auto v =
+      types::Concat(types::Optional(all_tensor_sequence_types_ir4()), types::Optional(all_tensor_types_ir10()));
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_optional_types_ir11() {
-  static const std::vector<std::string> all_optional_types = {
-      "optional(seq(tensor(uint8)))",      "optional(seq(tensor(uint16)))", "optional(seq(tensor(uint32)))",
-      "optional(seq(tensor(uint64)))",     "optional(seq(tensor(int8)))",   "optional(seq(tensor(int16)))",
-      "optional(seq(tensor(int32)))",      "optional(seq(tensor(int64)))",  "optional(seq(tensor(bfloat16)))",
-      "optional(seq(tensor(float16)))",    "optional(seq(tensor(float)))",  "optional(seq(tensor(double)))",
-      "optional(seq(tensor(string)))",     "optional(seq(tensor(bool)))",   "optional(seq(tensor(complex64)))",
-      "optional(seq(tensor(complex128)))", "optional(tensor(uint8))",       "optional(tensor(uint16))",
-      "optional(tensor(uint32))",          "optional(tensor(uint64))",      "optional(tensor(int8))",
-      "optional(tensor(int16))",           "optional(tensor(int32))",       "optional(tensor(int64))",
-      "optional(tensor(bfloat16))",        "optional(tensor(float16))",     "optional(tensor(float))",
-      "optional(tensor(double))",          "optional(tensor(string))",      "optional(tensor(bool))",
-      "optional(tensor(complex64))",       "optional(tensor(complex128))",  "optional(tensor(float8e4m3fn))",
-      "optional(tensor(float8e4m3fnuz))",  "optional(tensor(float8e5m2))",  "optional(tensor(float8e5m2fnuz))",
-      "optional(tensor(uint4))",           "optional(tensor(int4))",        "optional(tensor(float4e2m1))"};
-  return all_optional_types;
+  static const auto v =
+      types::Concat(types::Optional(all_tensor_sequence_types_ir4()), types::Optional(all_tensor_types_ir11()));
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_optional_types_ir12() {
-  static const std::vector<std::string> all_optional_types = {
-      "optional(seq(tensor(uint8)))",      "optional(seq(tensor(uint16)))", "optional(seq(tensor(uint32)))",
-      "optional(seq(tensor(uint64)))",     "optional(seq(tensor(int8)))",   "optional(seq(tensor(int16)))",
-      "optional(seq(tensor(int32)))",      "optional(seq(tensor(int64)))",  "optional(seq(tensor(bfloat16)))",
-      "optional(seq(tensor(float16)))",    "optional(seq(tensor(float)))",  "optional(seq(tensor(double)))",
-      "optional(seq(tensor(string)))",     "optional(seq(tensor(bool)))",   "optional(seq(tensor(complex64)))",
-      "optional(seq(tensor(complex128)))", "optional(tensor(uint8))",       "optional(tensor(uint16))",
-      "optional(tensor(uint32))",          "optional(tensor(uint64))",      "optional(tensor(int8))",
-      "optional(tensor(int16))",           "optional(tensor(int32))",       "optional(tensor(int64))",
-      "optional(tensor(bfloat16))",        "optional(tensor(float16))",     "optional(tensor(float))",
-      "optional(tensor(double))",          "optional(tensor(string))",      "optional(tensor(bool))",
-      "optional(tensor(complex64))",       "optional(tensor(complex128))",  "optional(tensor(float8e4m3fn))",
-      "optional(tensor(float8e4m3fnuz))",  "optional(tensor(float8e5m2))",  "optional(tensor(float8e5m2fnuz))",
-      "optional(tensor(uint4))",           "optional(tensor(int4))",        "optional(tensor(float4e2m1))",
-      "optional(tensor(float8e8m0))"};
-  return all_optional_types;
+  static const auto v =
+      types::Concat(types::Optional(all_tensor_sequence_types_ir4()), types::Optional(all_tensor_types_ir12()));
+  return v;
 }
 
 const std::vector<std::string>& OpSchema::all_optional_types_ir13() {
-  static const std::vector<std::string> all_optional_types = {
-      "optional(seq(tensor(uint8)))",      "optional(seq(tensor(uint16)))", "optional(seq(tensor(uint32)))",
-      "optional(seq(tensor(uint64)))",     "optional(seq(tensor(int8)))",   "optional(seq(tensor(int16)))",
-      "optional(seq(tensor(int32)))",      "optional(seq(tensor(int64)))",  "optional(seq(tensor(bfloat16)))",
-      "optional(seq(tensor(float16)))",    "optional(seq(tensor(float)))",  "optional(seq(tensor(double)))",
-      "optional(seq(tensor(string)))",     "optional(seq(tensor(bool)))",   "optional(seq(tensor(complex64)))",
-      "optional(seq(tensor(complex128)))", "optional(tensor(uint8))",       "optional(tensor(uint16))",
-      "optional(tensor(uint32))",          "optional(tensor(uint64))",      "optional(tensor(int8))",
-      "optional(tensor(int16))",           "optional(tensor(int32))",       "optional(tensor(int64))",
-      "optional(tensor(bfloat16))",        "optional(tensor(float16))",     "optional(tensor(float))",
-      "optional(tensor(double))",          "optional(tensor(string))",      "optional(tensor(bool))",
-      "optional(tensor(complex64))",       "optional(tensor(complex128))",  "optional(tensor(float8e4m3fn))",
-      "optional(tensor(float8e4m3fnuz))",  "optional(tensor(float8e5m2))",  "optional(tensor(float8e5m2fnuz))",
-      "optional(tensor(uint4))",           "optional(tensor(int4))",        "optional(tensor(float4e2m1))",
-      "optional(tensor(float8e8m0))",      "optional(tensor(uint2))",       "optional(tensor(int2))"};
-  return all_optional_types;
+  static const auto v =
+      types::Concat(types::Optional(all_tensor_sequence_types_ir4()), types::Optional(all_tensor_types_ir13()));
+  return v;
 }
 
 void OpSchema::Finalize() {

--- a/onnx/defs/type_builders.h
+++ b/onnx/defs/type_builders.h
@@ -19,16 +19,20 @@ namespace ONNX_NAMESPACE::types {
 // drop into the existing string-based OpSchema API. Output is byte-identical
 // to hand-written strings.
 
+namespace internal {
+// Element-type name as it appears inside tensor(...) / sparse_tensor(...) /
+// map(...). Propagates std::invalid_argument if `e` is an unknown enum.
 inline std::string ElemStr(TensorProto::DataType e) {
   return Utils::DataTypeUtils::ToDataTypeString(static_cast<int32_t>(e));
 }
+} // namespace internal
 
 inline std::string Tensor(TensorProto::DataType e) {
-  return "tensor(" + ElemStr(e) + ")";
+  return "tensor(" + internal::ElemStr(e) + ")";
 }
 
 inline std::string SparseTensor(TensorProto::DataType e) {
-  return "sparse_tensor(" + ElemStr(e) + ")";
+  return "sparse_tensor(" + internal::ElemStr(e) + ")";
 }
 
 inline std::string Sequence(std::string inner) {
@@ -49,7 +53,7 @@ inline std::string Map(std::string value) {
           Key == TensorProto::UINT64 || Key == TensorProto::STRING,
       "invalid ONNX map key type — must be an integer type or STRING");
   // Space after the comma matches existing hand-written schema sources.
-  return "map(" + ElemStr(Key) + ", " + std::move(value) + ")";
+  return "map(" + internal::ElemStr(Key) + ", " + std::move(value) + ")";
 }
 
 // Prebuilt "tensor(<elem>)" strings — one per element type.

--- a/onnx/defs/type_builders.h
+++ b/onnx/defs/type_builders.h
@@ -1,0 +1,128 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <initializer_list>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "onnx/defs/data_type_utils.h"
+#include "onnx/onnx_pb.h"
+
+namespace ONNX_NAMESPACE::types {
+
+// Authoring DSL for op schema type strings. Factories return canonical
+// std::string forms ("tensor(float)", "seq(...)", "map(int64, ...)") that
+// drop into the existing string-based OpSchema API. Output is byte-identical
+// to hand-written strings.
+
+inline std::string ElemStr(TensorProto::DataType e) {
+  return Utils::DataTypeUtils::ToDataTypeString(static_cast<int32_t>(e));
+}
+
+inline std::string Tensor(TensorProto::DataType e) {
+  return "tensor(" + ElemStr(e) + ")";
+}
+
+inline std::string SparseTensor(TensorProto::DataType e) {
+  return "sparse_tensor(" + ElemStr(e) + ")";
+}
+
+inline std::string Sequence(std::string inner) {
+  return "seq(" + std::move(inner) + ")";
+}
+
+inline std::string Optional(std::string inner) {
+  return "optional(" + std::move(inner) + ")";
+}
+
+// `Key` must be an integer type or STRING (the ONNX-supported map key types).
+// Enforced at compile time via static_assert.
+template <TensorProto::DataType Key>
+inline std::string Map(std::string value) {
+  static_assert(
+      Key == TensorProto::INT8 || Key == TensorProto::INT16 || Key == TensorProto::INT32 || Key == TensorProto::INT64 ||
+          Key == TensorProto::UINT8 || Key == TensorProto::UINT16 || Key == TensorProto::UINT32 ||
+          Key == TensorProto::UINT64 || Key == TensorProto::STRING,
+      "invalid ONNX map key type — must be an integer type or STRING");
+  // Space after the comma matches existing hand-written schema sources.
+  return "map(" + ElemStr(Key) + ", " + std::move(value) + ")";
+}
+
+// Prebuilt "tensor(<elem>)" strings — one per element type.
+inline constexpr const char* Float16 = "tensor(float16)";
+inline constexpr const char* Float = "tensor(float)";
+inline constexpr const char* Double = "tensor(double)";
+inline constexpr const char* BFloat16 = "tensor(bfloat16)";
+inline constexpr const char* Int8 = "tensor(int8)";
+inline constexpr const char* Int16 = "tensor(int16)";
+inline constexpr const char* Int32 = "tensor(int32)";
+inline constexpr const char* Int64 = "tensor(int64)";
+inline constexpr const char* UInt8 = "tensor(uint8)";
+inline constexpr const char* UInt16 = "tensor(uint16)";
+inline constexpr const char* UInt32 = "tensor(uint32)";
+inline constexpr const char* UInt64 = "tensor(uint64)";
+inline constexpr const char* Bool = "tensor(bool)";
+inline constexpr const char* String = "tensor(string)";
+inline constexpr const char* Complex64 = "tensor(complex64)";
+inline constexpr const char* Complex128 = "tensor(complex128)";
+inline constexpr const char* Float8E4M3FN = "tensor(float8e4m3fn)";
+inline constexpr const char* Float8E4M3FNUZ = "tensor(float8e4m3fnuz)";
+inline constexpr const char* Float8E5M2 = "tensor(float8e5m2)";
+inline constexpr const char* Float8E5M2FNUZ = "tensor(float8e5m2fnuz)";
+inline constexpr const char* Float4E2M1 = "tensor(float4e2m1)";
+inline constexpr const char* Float8E8M0 = "tensor(float8e8m0)";
+inline constexpr const char* UInt4 = "tensor(uint4)";
+inline constexpr const char* Int4 = "tensor(int4)";
+inline constexpr const char* UInt2 = "tensor(uint2)";
+inline constexpr const char* Int2 = "tensor(int2)";
+
+// Vector helpers: build type-string lists from element types, or wrap each
+// entry of an existing list with seq(...) / optional(...).
+
+inline std::vector<std::string> Tensors(std::initializer_list<TensorProto::DataType> elems) {
+  std::vector<std::string> out;
+  out.reserve(elems.size());
+  for (auto e : elems) {
+    out.push_back(Tensor(e));
+  }
+  return out;
+}
+
+inline std::vector<std::string> SparseTensors(std::initializer_list<TensorProto::DataType> elems) {
+  std::vector<std::string> out;
+  out.reserve(elems.size());
+  for (auto e : elems) {
+    out.push_back(SparseTensor(e));
+  }
+  return out;
+}
+
+inline std::vector<std::string> Sequence(const std::vector<std::string>& inner) {
+  std::vector<std::string> out;
+  out.reserve(inner.size());
+  for (const auto& s : inner) {
+    out.push_back(Sequence(s));
+  }
+  return out;
+}
+
+inline std::vector<std::string> Optional(const std::vector<std::string>& inner) {
+  std::vector<std::string> out;
+  out.reserve(inner.size());
+  for (const auto& s : inner) {
+    out.push_back(Optional(s));
+  }
+  return out;
+}
+
+inline std::vector<std::string> Concat(std::vector<std::string> a, const std::vector<std::string>& b) {
+  a.reserve(a.size() + b.size());
+  a.insert(a.end(), b.begin(), b.end());
+  return a;
+}
+
+} // namespace ONNX_NAMESPACE::types

--- a/onnx/test/cpp/type_builders_test.cc
+++ b/onnx/test/cpp/type_builders_test.cc
@@ -1,0 +1,41 @@
+// Copyright (c) ONNX Project Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gtest/gtest.h"
+#include "onnx/defs/schema.h"
+#include "onnx/defs/type_builders.h"
+
+namespace ONNX_NAMESPACE::Test {
+
+namespace t = ONNX_NAMESPACE::types;
+
+TEST(TypeBuildersTest, Factories) {
+  EXPECT_EQ(t::Tensor(TensorProto::FLOAT), t::Float);
+  EXPECT_EQ(t::SparseTensor(TensorProto::FLOAT), "sparse_tensor(float)");
+  EXPECT_EQ(t::Sequence(t::Float), "seq(tensor(float))");
+  EXPECT_EQ(t::Optional(t::Sequence(t::Double)), "optional(seq(tensor(double)))");
+}
+
+TEST(TypeBuildersTest, MapConvention) {
+  // Space after the comma; bare-scalar value form for ai.onnx.ml schemas.
+  EXPECT_EQ(t::Map<TensorProto::INT64>(t::Float), "map(int64, tensor(float))");
+  EXPECT_EQ(t::Map<TensorProto::INT64>("float"), "map(int64, float)");
+}
+
+// Invalid map keys are rejected at compile time via static_assert; uncomment to
+// verify it fails to compile:
+//   t::Map<TensorProto::FLOAT>(t::Int64);
+//   t::Map<TensorProto::BOOL>(t::Int64);
+
+TEST(TypeBuildersTest, DropsIntoOpSchema) {
+  OpSchema schema;
+  schema.TypeConstraint("T", {t::Float, t::Sequence(t::Float), t::Optional(t::Int64)}, "test");
+  const auto& tcp = schema.typeConstraintParams().front();
+  ASSERT_EQ(tcp.allowed_type_strs.size(), 3u);
+  EXPECT_EQ(tcp.allowed_type_strs[0], "tensor(float)");
+  EXPECT_EQ(tcp.allowed_type_strs[1], "seq(tensor(float))");
+  EXPECT_EQ(tcp.allowed_type_strs[2], "optional(tensor(int64))");
+}
+
+} // namespace ONNX_NAMESPACE::Test

--- a/onnx/test/cpp/type_builders_test.cc
+++ b/onnx/test/cpp/type_builders_test.cc
@@ -28,6 +28,18 @@ TEST(TypeBuildersTest, MapConvention) {
 //   t::Map<TensorProto::FLOAT>(t::Int64);
 //   t::Map<TensorProto::BOOL>(t::Int64);
 
+TEST(TypeBuildersTest, VectorHelpers) {
+  EXPECT_EQ(
+      t::Tensors({TensorProto::FLOAT, TensorProto::INT64}),
+      (std::vector<std::string>{"tensor(float)", "tensor(int64)"}));
+  EXPECT_EQ(t::SparseTensors({TensorProto::FLOAT}), (std::vector<std::string>{"sparse_tensor(float)"}));
+  EXPECT_EQ(
+      t::Sequence(std::vector<std::string>{t::Float, t::Int64}),
+      (std::vector<std::string>{"seq(tensor(float))", "seq(tensor(int64))"}));
+  EXPECT_EQ(t::Optional(std::vector<std::string>{t::Bool}), (std::vector<std::string>{"optional(tensor(bool))"}));
+  EXPECT_EQ(t::Concat(std::vector<std::string>{"a", "b"}, {"c"}), (std::vector<std::string>{"a", "b", "c"}));
+}
+
 TEST(TypeBuildersTest, DropsIntoOpSchema) {
   OpSchema schema;
   schema.TypeConstraint("T", {t::Float, t::Sequence(t::Float), t::Optional(t::Int64)}, "test");


### PR DESCRIPTION

### Motivation and Context

This work replaces string type specifications with C++ types for more robust handling of OP schemes.