### PR TITLE
Inline single-use single-type schema type constraints

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -6294,7 +6294,7 @@ This version of the operator has been available since version 7 of the default O
 #### Outputs
 
 <dl>
-<dt><tt>C</tt> (non-differentiable) : T1</dt>
+<dt><tt>C</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Result tensor.</dd>
 </dl>
 
@@ -6303,8 +6303,6 @@ This version of the operator has been available since version 7 of the default O
 <dl>
 <dt><tt>T</tt> : tensor(bool)</dt>
 <dd>Constrain input to boolean tensor.</dd>
-<dt><tt>T1</tt> : tensor(bool)</dt>
-<dd>Constrain output to boolean tensor.</dd>
 </dl>
 
 ### <a name="Asin-7"></a>**Asin-7**</a>
@@ -7145,7 +7143,7 @@ This version of the operator has been available since version 7 of the default O
 #### Outputs
 
 <dl>
-<dt><tt>C</tt> (non-differentiable) : T1</dt>
+<dt><tt>C</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Result tensor.</dd>
 </dl>
 
@@ -7154,8 +7152,6 @@ This version of the operator has been available since version 7 of the default O
 <dl>
 <dt><tt>T</tt> : tensor(bool)</dt>
 <dd>Constrain input to boolean tensor.</dd>
-<dt><tt>T1</tt> : tensor(bool)</dt>
-<dd>Constrain output to boolean tensor.</dd>
 </dl>
 
 ### <a name="PRelu-7"></a>**PRelu-7**</a>
@@ -7501,7 +7497,7 @@ This version of the operator has been available since version 7 of the default O
 #### Outputs
 
 <dl>
-<dt><tt>C</tt> (non-differentiable) : T1</dt>
+<dt><tt>C</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Result tensor.</dd>
 </dl>
 
@@ -7510,8 +7506,6 @@ This version of the operator has been available since version 7 of the default O
 <dl>
 <dt><tt>T</tt> : tensor(bool)</dt>
 <dd>Constrain input to boolean tensor.</dd>
-<dt><tt>T1</tt> : tensor(bool)</dt>
-<dd>Constrain output to boolean tensor.</dd>
 </dl>
 
 ## Version 8 of the default ONNX operator set
@@ -9195,7 +9189,7 @@ This version of the operator has been available since version 9 of the default O
 #### Outputs
 
 <dl>
-<dt><tt>Y</tt> (non-differentiable) : T1</dt>
+<dt><tt>Y</tt> (non-differentiable) : tensor(float)</dt>
 <dd>Ngram results</dd>
 </dl>
 
@@ -9204,8 +9198,6 @@ This version of the operator has been available since version 9 of the default O
 <dl>
 <dt><tt>T</tt> : tensor(string), tensor(int32), tensor(int64)</dt>
 <dd>Input is ether string UTF-8 or int32/int64</dd>
-<dt><tt>T1</tt> : tensor(float)</dt>
-<dd>1-D tensor of floats</dd>
 </dl>
 
 ### <a name="Upsample-9"></a>**Upsample-9**</a>
@@ -9405,7 +9397,7 @@ This version of the operator has been available since version 10 of the default 
 #### Outputs
 
 <dl>
-<dt><tt>y</tt> : T3</dt>
+<dt><tt>y</tt> : tensor(int32)</dt>
 <dd>Output data tensor that contains the result of the convolution. The output dimensions are functions of the kernel size, stride size, and pad lengths.</dd>
 </dl>
 
@@ -9416,8 +9408,6 @@ This version of the operator has been available since version 10 of the default 
 <dd>Constrain input x and its zero point data type to 8-bit integer tensor.</dd>
 <dt><tt>T2</tt> : tensor(int8), tensor(uint8)</dt>
 <dd>Constrain input w and its zero point data type to 8-bit integer tensor.</dd>
-<dt><tt>T3</tt> : tensor(int32)</dt>
-<dd>Constrain output y data type to 32-bit integer tensor.</dd>
 </dl>
 
 ### <a name="DequantizeLinear-10"></a>**DequantizeLinear-10**</a>
@@ -9566,7 +9556,7 @@ This version of the operator has been available since version 10 of the default 
 #### Outputs
 
 <dl>
-<dt><tt>Y</tt> (non-differentiable) : T3</dt>
+<dt><tt>Y</tt> (non-differentiable) : tensor(int32)</dt>
 <dd>Matrix multiply results from A * B</dd>
 </dl>
 
@@ -9577,8 +9567,6 @@ This version of the operator has been available since version 10 of the default 
 <dd>Constrain input A data type to 8-bit integer tensor.</dd>
 <dt><tt>T2</tt> : tensor(int8), tensor(uint8)</dt>
 <dd>Constrain input B data type to 8-bit integer tensor.</dd>
-<dt><tt>T3</tt> : tensor(int32)</dt>
-<dd>Constrain output Y data type as 32-bit integer tensor.</dd>
 </dl>
 
 ### <a name="MaxPool-10"></a>**MaxPool-10**</a>
@@ -9808,7 +9796,7 @@ This version of the operator has been available since version 10 of the default 
 <dd>Scale tensor for output 'y'. It's a scalar, which means a per-tensor/layer quantization.</dd>
 <dt><tt>y_zero_point</tt> : T3</dt>
 <dd>Zero point tensor for output 'y'. It's a scalar, which means a per-tensor/layer quantization.</dd>
-<dt><tt>B</tt> (optional) : T4</dt>
+<dt><tt>B</tt> (optional) : tensor(int32)</dt>
 <dd>Optional 1D bias to be added to the convolution, has size of M. Bias must be quantized using scale = x_scale * w_scale and zero_point = 0</dd>
 </dl>
 
@@ -9828,8 +9816,6 @@ This version of the operator has been available since version 10 of the default 
 <dd>Constrain filter type to 8-bit integer tensor.</dd>
 <dt><tt>T3</tt> : tensor(int8), tensor(uint8)</dt>
 <dd>Constrain output type to 8-bit integer tensor.</dd>
-<dt><tt>T4</tt> : tensor(int32)</dt>
-<dd>Constrain bias type to 32-bit integer tensor.</dd>
 </dl>
 
 ### <a name="QLinearMatMul-10"></a>**QLinearMatMul-10**</a>
@@ -10587,7 +10573,7 @@ This version of the operator has been available since version 11 of the default 
 <dl>
 <dt><tt>input</tt> (differentiable) : T</dt>
 <dd>Tensor of rank r >= 1.</dd>
-<dt><tt>condition</tt> (non-differentiable) : T1</dt>
+<dt><tt>condition</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Rank 1 tensor of booleans to indicate which slices or data elements to be selected. Its length can be less than the input length along the axis or the flattened input size if axis is not specified. In such cases data slices or elements exceeding the condition length are discarded.</dd>
 </dl>
 
@@ -10603,8 +10589,6 @@ This version of the operator has been available since version 11 of the default 
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128)</dt>
 <dd>Constrain input and output types to all tensor types.</dd>
-<dt><tt>T1</tt> : tensor(bool)</dt>
-<dd>Constrain to boolean tensors.</dd>
 </dl>
 
 ### <a name="Concat-11"></a>**Concat-11**</a>
@@ -11034,7 +11018,7 @@ This version of the operator has been available since version 11 of the default 
 #### Inputs
 
 <dl>
-<dt><tt>x</tt> : T1</dt>
+<dt><tt>x</tt> : tensor(float)</dt>
 <dd>Input tensor</dd>
 </dl>
 
@@ -11052,8 +11036,6 @@ This version of the operator has been available since version 11 of the default 
 #### Type Constraints
 
 <dl>
-<dt><tt>T1</tt> : tensor(float)</dt>
-<dd>Constrain 'x' to float tensor.</dd>
 <dt><tt>T2</tt> : tensor(uint8)</dt>
 <dd>Constrain 'y_zero_point' and 'y' to 8-bit unsigned integer tensor.</dd>
 </dl>
@@ -13418,7 +13400,7 @@ This version of the operator has been available since version 11 of the default 
 #### Outputs
 
 <dl>
-<dt><tt>length</tt> : I</dt>
+<dt><tt>length</tt> : tensor(int64)</dt>
 <dd>Length of input sequence. It must be a scalar(tensor of empty shape).</dd>
 </dl>
 
@@ -13427,8 +13409,6 @@ This version of the operator has been available since version 11 of the default 
 <dl>
 <dt><tt>S</tt> : seq(tensor(uint8)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(int8)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(float16)), seq(tensor(float)), seq(tensor(double)), seq(tensor(string)), seq(tensor(bool)), seq(tensor(complex64)), seq(tensor(complex128))</dt>
 <dd>Constrain to any tensor type.</dd>
-<dt><tt>I</tt> : tensor(int64)</dt>
-<dd>Constrain output to integral tensor. It must be a scalar(tensor of empty shape).</dd>
 </dl>
 
 ### <a name="Slice-11"></a>**Slice-11**</a>
@@ -13735,7 +13715,7 @@ This version of the operator has been available since version 11 of the default 
 <dl>
 <dt><tt>Values</tt> (differentiable) : T</dt>
 <dd>Tensor of shape [a_0, a_1, ..., a_{axis-1}, k, a_{axis+1}, ... a_{n-1}] containing top K values from the input tensor</dd>
-<dt><tt>Indices</tt> (non-differentiable) : I</dt>
+<dt><tt>Indices</tt> (non-differentiable) : tensor(int64)</dt>
 <dd>Tensor of shape [a_0, a_1, ..., a_{axis-1}, k, a_{axis+1}, ... a_{n-1}] containing the corresponding input tensor indices for the top K values.</dd>
 </dl>
 
@@ -13744,8 +13724,6 @@ This version of the operator has been available since version 11 of the default 
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double)</dt>
 <dd>Constrain input and output types to numeric tensors.</dd>
-<dt><tt>I</tt> : tensor(int64)</dt>
-<dd>Constrain index tensor to int64</dd>
 </dl>
 
 ### <a name="Unique-11"></a>**Unique-11**</a>
@@ -14420,7 +14398,7 @@ This version of the operator has been available since version 12 of the default 
 #### Outputs
 
 <dl>
-<dt><tt>C</tt> (non-differentiable) : T1</dt>
+<dt><tt>C</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Result tensor.</dd>
 </dl>
 
@@ -14456,7 +14434,7 @@ This version of the operator has been available since version 12 of the default 
 #### Outputs
 
 <dl>
-<dt><tt>C</tt> (non-differentiable) : T1</dt>
+<dt><tt>C</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Result tensor.</dd>
 </dl>
 
@@ -15520,7 +15498,7 @@ This version of the operator has been available since version 13 of the default 
 #### Outputs
 
 <dl>
-<dt><tt>C</tt> (non-differentiable) : T1</dt>
+<dt><tt>C</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Result tensor.</dd>
 </dl>
 
@@ -16091,7 +16069,7 @@ This version of the operator has been available since version 13 of the default 
 #### Outputs
 
 <dl>
-<dt><tt>C</tt> (non-differentiable) : T1</dt>
+<dt><tt>C</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Result tensor.</dd>
 </dl>
 
@@ -16100,8 +16078,6 @@ This version of the operator has been available since version 13 of the default 
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(bfloat16)</dt>
 <dd>Constrain input types to all numeric tensors.</dd>
-<dt><tt>T1</tt> : tensor(bool)</dt>
-<dd>Constrain output to boolean tensor.</dd>
 </dl>
 
 ### <a name="Hardmax-13"></a>**Hardmax-13**</a>
@@ -16324,7 +16300,7 @@ This version of the operator has been available since version 13 of the default 
 #### Outputs
 
 <dl>
-<dt><tt>C</tt> (non-differentiable) : T1</dt>
+<dt><tt>C</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Result tensor.</dd>
 </dl>
 
@@ -16333,8 +16309,6 @@ This version of the operator has been available since version 13 of the default 
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(bfloat16)</dt>
 <dd>Constrain input types to all numeric tensors.</dd>
-<dt><tt>T1</tt> : tensor(bool)</dt>
-<dd>Constrain output to boolean tensor.</dd>
 </dl>
 
 ### <a name="Log-13"></a>**Log-13**</a>
@@ -18654,7 +18628,7 @@ This version of the operator has been available since version 13 of the default 
 <dl>
 <dt><tt>input</tt> (differentiable) : T</dt>
 <dd>Input tensor of any shape.</dd>
-<dt><tt>repeats</tt> (non-differentiable) : T1</dt>
+<dt><tt>repeats</tt> (non-differentiable) : tensor(int64)</dt>
 <dd>1D int64 tensor of the same length as input's dimension number, includes numbers of repeated copies along input's dimensions.</dd>
 </dl>
 
@@ -18670,8 +18644,6 @@ This version of the operator has been available since version 13 of the default 
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128)</dt>
 <dd>Constrain input and output types to all tensor types.</dd>
-<dt><tt>T1</tt> : tensor(int64)</dt>
-<dd>Constrain repeat's type to int64 tensors.</dd>
 </dl>
 
 ### <a name="Transpose-13"></a>**Transpose-13**</a>
@@ -19988,7 +19960,7 @@ This version of the operator has been available since version 16 of the default 
 #### Outputs
 
 <dl>
-<dt><tt>C</tt> (non-differentiable) : T1</dt>
+<dt><tt>C</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Result tensor.</dd>
 </dl>
 
@@ -19997,8 +19969,6 @@ This version of the operator has been available since version 16 of the default 
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(bfloat16)</dt>
 <dd>Constrain input types to all numeric tensors.</dd>
-<dt><tt>T1</tt> : tensor(bool)</dt>
-<dd>Constrain output to boolean tensor.</dd>
 </dl>
 
 ### <a name="GridSample-16"></a>**GridSample-16**</a>
@@ -20187,7 +20157,7 @@ This version of the operator has been available since version 16 of the default 
 #### Outputs
 
 <dl>
-<dt><tt>C</tt> (non-differentiable) : T1</dt>
+<dt><tt>C</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Result tensor.</dd>
 </dl>
 
@@ -20196,8 +20166,6 @@ This version of the operator has been available since version 16 of the default 
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(bfloat16)</dt>
 <dd>Constrain input types to all numeric tensors.</dd>
-<dt><tt>T1</tt> : tensor(bool)</dt>
-<dd>Constrain output to boolean tensor.</dd>
 </dl>
 
 ### <a name="Loop-16"></a>**Loop-16**</a>
@@ -20864,7 +20832,7 @@ This version of the operator has been available since version 16 of the default 
 #### Inputs
 
 <dl>
-<dt><tt>condition</tt> (non-differentiable) : B</dt>
+<dt><tt>condition</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>When True (nonzero), yield X, otherwise yield Y</dd>
 <dt><tt>X</tt> (differentiable) : T</dt>
 <dd>values selected at indices where condition is True</dd>
@@ -20882,8 +20850,6 @@ This version of the operator has been available since version 16 of the default 
 #### Type Constraints
 
 <dl>
-<dt><tt>B</tt> : tensor(bool)</dt>
-<dd>Constrain to boolean tensors.</dd>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128)</dt>
 <dd>Constrain input and output types to all tensor types (including bfloat).</dd>
 </dl>
@@ -21713,7 +21679,7 @@ This version of the operator has been available since version 18 of the default 
 #### Outputs
 
 <dl>
-<dt><tt>output</tt> : B</dt>
+<dt><tt>output</tt> : tensor(bool)</dt>
 <dd>A scalar boolean tensor. If true, it indicates that optional-type input contains an element. Otherwise, it is empty.</dd>
 </dl>
 
@@ -21722,8 +21688,6 @@ This version of the operator has been available since version 18 of the default 
 <dl>
 <dt><tt>O</tt> : optional(seq(tensor(uint8))), optional(seq(tensor(uint16))), optional(seq(tensor(uint32))), optional(seq(tensor(uint64))), optional(seq(tensor(int8))), optional(seq(tensor(int16))), optional(seq(tensor(int32))), optional(seq(tensor(int64))), optional(seq(tensor(float16))), optional(seq(tensor(float))), optional(seq(tensor(double))), optional(seq(tensor(string))), optional(seq(tensor(bool))), optional(seq(tensor(complex64))), optional(seq(tensor(complex128))), optional(tensor(uint8)), optional(tensor(uint16)), optional(tensor(uint32)), optional(tensor(uint64)), optional(tensor(int8)), optional(tensor(int16)), optional(tensor(int32)), optional(tensor(int64)), optional(tensor(float16)), optional(tensor(float)), optional(tensor(double)), optional(tensor(string)), optional(tensor(bool)), optional(tensor(complex64)), optional(tensor(complex128)), tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128), seq(tensor(uint8)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(int8)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(float16)), seq(tensor(float)), seq(tensor(double)), seq(tensor(string)), seq(tensor(bool)), seq(tensor(complex64)), seq(tensor(complex128))</dt>
 <dd>Constrain input type to optional tensor and optional sequence types.</dd>
-<dt><tt>B</tt> : tensor(bool)</dt>
-<dd>Constrain output to a boolean tensor.</dd>
 </dl>
 
 ### <a name="Pad-18"></a>**Pad-18**</a>
@@ -23033,7 +22997,7 @@ This version of the operator has been available since version 19 of the default 
 #### Outputs
 
 <dl>
-<dt><tt>C</tt> (non-differentiable) : T1</dt>
+<dt><tt>C</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Result tensor.</dd>
 </dl>
 
@@ -23042,8 +23006,6 @@ This version of the operator has been available since version 19 of the default 
 <dl>
 <dt><tt>T</tt> : tensor(bool), tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(bfloat16), tensor(string)</dt>
 <dd>Constrain input types to all (non-complex) tensors.</dd>
-<dt><tt>T1</tt> : tensor(bool)</dt>
-<dd>Constrain output to boolean tensor.</dd>
 </dl>
 
 ### <a name="Identity-19"></a>**Identity-19**</a>
@@ -23991,7 +23953,7 @@ This version of the operator has been available since version 20 of the default 
 <dl>
 <dt><tt>theta</tt> (non-differentiable) : T1</dt>
 <dd>input batch of affine matrices with shape (N, 2, 3) for 2D or (N, 3, 4) for 3D</dd>
-<dt><tt>size</tt> (non-differentiable) : T2</dt>
+<dt><tt>size</tt> (non-differentiable) : tensor(int64)</dt>
 <dd>the target output image size (N, C, H, W) for 2D or (N, C, D, H, W) for 3D</dd>
 </dl>
 
@@ -24007,8 +23969,6 @@ This version of the operator has been available since version 20 of the default 
 <dl>
 <dt><tt>T1</tt> : tensor(bfloat16), tensor(float16), tensor(float), tensor(double)</dt>
 <dd>Constrain grid types to float tensors.</dd>
-<dt><tt>T2</tt> : tensor(int64)</dt>
-<dd>Constrain size's type to int64 tensors.</dd>
 </dl>
 
 ### <a name="ConstantOfShape-20"></a>**ConstantOfShape-20**</a>
@@ -24252,25 +24212,19 @@ This version of the operator has been available since version 20 of the default 
 #### Inputs
 
 <dl>
-<dt><tt>encoded_stream</tt> (non-differentiable) : T1</dt>
+<dt><tt>encoded_stream</tt> (non-differentiable) : tensor(uint8)</dt>
 <dd>Encoded stream</dd>
 </dl>
 
 #### Outputs
 
 <dl>
-<dt><tt>image</tt> (non-differentiable) : T2</dt>
+<dt><tt>image</tt> (non-differentiable) : tensor(uint8)</dt>
 <dd>Decoded image</dd>
 </dl>
 
 #### Type Constraints
 
-<dl>
-<dt><tt>T1</tt> : tensor(uint8)</dt>
-<dd>Constrain input types to 8-bit unsigned integer tensor.</dd>
-<dt><tt>T2</tt> : tensor(uint8)</dt>
-<dd>Constrain output types to 8-bit unsigned integer tensor.</dd>
-</dl>
 
 ### <a name="IsInf-20"></a>**IsInf-20**</a>
 
@@ -24299,7 +24253,7 @@ This version of the operator has been available since version 20 of the default 
 #### Outputs
 
 <dl>
-<dt><tt>Y</tt> (non-differentiable) : T2</dt>
+<dt><tt>Y</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>output</dd>
 </dl>
 
@@ -24308,8 +24262,6 @@ This version of the operator has been available since version 20 of the default 
 <dl>
 <dt><tt>T1</tt> : tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz)</dt>
 <dd>Constrain input types to float tensors.</dd>
-<dt><tt>T2</tt> : tensor(bool)</dt>
-<dd>Constrain output types to boolean tensors.</dd>
 </dl>
 
 ### <a name="IsNaN-20"></a>**IsNaN-20**</a>
@@ -24330,7 +24282,7 @@ This version of the operator has been available since version 20 of the default 
 #### Outputs
 
 <dl>
-<dt><tt>Y</tt> (non-differentiable) : T2</dt>
+<dt><tt>Y</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>output</dd>
 </dl>
 
@@ -24339,8 +24291,6 @@ This version of the operator has been available since version 20 of the default 
 <dl>
 <dt><tt>T1</tt> : tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz)</dt>
 <dd>Constrain input types to float tensors.</dd>
-<dt><tt>T2</tt> : tensor(bool)</dt>
-<dd>Constrain output types to boolean tensors.</dd>
 </dl>
 
 ### <a name="ReduceMax-20"></a>**ReduceMax-20**</a>
@@ -24459,25 +24409,19 @@ This version of the operator has been available since version 20 of the default 
 #### Inputs
 
 <dl>
-<dt><tt>X</tt> (non-differentiable) : T1</dt>
+<dt><tt>X</tt> (non-differentiable) : tensor(string)</dt>
 <dd>Tensor with strings to match on.</dd>
 </dl>
 
 #### Outputs
 
 <dl>
-<dt><tt>Y</tt> (non-differentiable) : T2</dt>
+<dt><tt>Y</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Tensor of bools indicating if each input string fully matches the regex pattern specified.</dd>
 </dl>
 
 #### Type Constraints
 
-<dl>
-<dt><tt>T1</tt> : tensor(string)</dt>
-<dd>Inputs must be UTF-8 strings</dd>
-<dt><tt>T2</tt> : tensor(bool)</dt>
-<dd>Outputs are bools and are True where there is a full regex match and False otherwise.</dd>
-</dl>
 
 ### <a name="StringConcat-20"></a>**StringConcat-20**</a>
 
@@ -24534,29 +24478,21 @@ This version of the operator has been available since version 20 of the default 
 #### Inputs
 
 <dl>
-<dt><tt>X</tt> (non-differentiable) : T1</dt>
+<dt><tt>X</tt> (non-differentiable) : tensor(string)</dt>
 <dd>Tensor of strings to split.</dd>
 </dl>
 
 #### Outputs
 
 <dl>
-<dt><tt>Y</tt> (non-differentiable) : T2</dt>
+<dt><tt>Y</tt> (non-differentiable) : tensor(string)</dt>
 <dd>Tensor of substrings representing the outcome of splitting the strings in the input on the delimiter. Note that to ensure the same number of elements are present in the final rank, this tensor will pad any necessary empty strings.</dd>
-<dt><tt>Z</tt> (non-differentiable) : T3</dt>
+<dt><tt>Z</tt> (non-differentiable) : tensor(int64)</dt>
 <dd>The number of substrings generated for each input element.</dd>
 </dl>
 
 #### Type Constraints
 
-<dl>
-<dt><tt>T1</tt> : tensor(string)</dt>
-<dd>The input must be a UTF-8 string tensor</dd>
-<dt><tt>T2</tt> : tensor(string)</dt>
-<dd>Tensor of substrings.</dd>
-<dt><tt>T3</tt> : tensor(int64)</dt>
-<dd>The number of substrings generated.</dd>
-</dl>
 
 ## Version 21 of the default ONNX operator set
 ### <a name="Cast-21"></a>**Cast-21**</a>
@@ -26699,7 +26635,7 @@ This version of the operator has been available since version 22 of the default 
 <dd>The recurrence weight tensor. Concatenation of `R[zrh]` and `RB[zrh]` (if bidirectional) along dimension 0. This tensor has shape `[num_directions, 3*hidden_size, hidden_size]`.</dd>
 <dt><tt>B</tt> (optional, differentiable) : T</dt>
 <dd>The bias tensor for the gates. Concatenation of `[Wb[zrh], Rb[zrh]]` and `[WBb[zrh], RBb[zrh]]` (if bidirectional) along dimension 0. This tensor has shape `[num_directions, 6*hidden_size]`. Optional: If not specified - assumed to be 0</dd>
-<dt><tt>sequence_lens</tt> (optional, non-differentiable) : T1</dt>
+<dt><tt>sequence_lens</tt> (optional, non-differentiable) : tensor(int32)</dt>
 <dd>Optional tensor specifying lengths of the sequences in a batch. If not specified - assumed all sequences in the batch to have length `seq_length`. It has shape `[batch_size]`.</dd>
 <dt><tt>initial_h</tt> (optional, non-differentiable) : T</dt>
 <dd>Optional initial value of the hidden. If not specified - assumed to be 0. It has shape `[num_directions, batch_size, hidden_size]`.</dd>
@@ -26719,8 +26655,6 @@ This version of the operator has been available since version 22 of the default 
 <dl>
 <dt><tt>T</tt> : tensor(bfloat16), tensor(float16), tensor(float), tensor(double)</dt>
 <dd>Constrain input and output types to float tensors.</dd>
-<dt><tt>T1</tt> : tensor(int32)</dt>
-<dd>Constrain seq_lens to integer tensor.</dd>
 </dl>
 
 ### <a name="GlobalAveragePool-22"></a>**GlobalAveragePool-22**</a>
@@ -27089,7 +27023,7 @@ This version of the operator has been available since version 22 of the default 
 <dd>The recurrence weight tensor. Concatenation of `R[iofc]` and `RB[iofc]` (if bidirectional) along dimension 0. This tensor has shape `[num_directions, 4*hidden_size, hidden_size]`.</dd>
 <dt><tt>B</tt> (optional, differentiable) : T</dt>
 <dd>The bias tensor for input gate. Concatenation of `[Wb[iofc], Rb[iofc]]`, and `[WBb[iofc], RBb[iofc]]` (if bidirectional) along dimension 0. This tensor has shape `[num_directions, 8*hidden_size]`. Optional: If not specified - assumed to be 0.</dd>
-<dt><tt>sequence_lens</tt> (optional, non-differentiable) : T1</dt>
+<dt><tt>sequence_lens</tt> (optional, non-differentiable) : tensor(int32)</dt>
 <dd>Optional tensor specifying lengths of the sequences in a batch. If not specified - assumed all sequences in the batch to have length `seq_length`. It has shape `[batch_size]`.</dd>
 <dt><tt>initial_h</tt> (optional, non-differentiable) : T</dt>
 <dd>Optional initial value of the hidden. If not specified - assumed to be 0. It has shape `[num_directions, batch_size, hidden_size]`.</dd>
@@ -27115,8 +27049,6 @@ This version of the operator has been available since version 22 of the default 
 <dl>
 <dt><tt>T</tt> : tensor(bfloat16), tensor(float16), tensor(float), tensor(double)</dt>
 <dd>Constrain input and output types to float tensors.</dd>
-<dt><tt>T1</tt> : tensor(int32)</dt>
-<dd>Constrain seq_lens to integer tensor.</dd>
 </dl>
 
 ### <a name="LpNormalization-22"></a>**LpNormalization-22**</a>
@@ -27300,7 +27232,7 @@ This version of the operator has been available since version 22 of the default 
 <dl>
 <dt><tt>Y</tt> (differentiable) : T</dt>
 <dd>Output data tensor from average or max pooling across the input tensor. Dimensions will vary based on various kernel, stride, and pad sizes. Floor value of the dimension is used</dd>
-<dt><tt>Indices</tt> (optional, non-differentiable) : I</dt>
+<dt><tt>Indices</tt> (optional, non-differentiable) : tensor(int64)</dt>
 <dd>Indices tensor from max pooling across the input tensor. The dimensions of indices are the same as output tensor. The values in indices of are the indices of the selected values during pooling. The indices are computed as flatten 1-D tensor, and the indices do not consider padding. So the values in indices are in [0, N x C x D1 x ... x Dn).</dd>
 </dl>
 
@@ -27309,8 +27241,6 @@ This version of the operator has been available since version 22 of the default 
 <dl>
 <dt><tt>T</tt> : tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(int8), tensor(uint8)</dt>
 <dd>Constrain input and output types to float and 8 bit tensors.</dd>
-<dt><tt>I</tt> : tensor(int64)</dt>
-<dd>Constrain index tensor to int64</dd>
 </dl>
 
 ### <a name="MaxRoiPool-22"></a>**MaxRoiPool-22**</a>
@@ -27717,7 +27647,7 @@ This version of the operator has been available since version 22 of the default 
 <dd>The recurrence weight tensor. Concatenation of `Ri` and `RBi` (if bidirectional). The tensor has shape `[num_directions, hidden_size, hidden_size]`.</dd>
 <dt><tt>B</tt> (optional, differentiable) : T</dt>
 <dd>The bias tensor for input gate. Concatenation of `[Wbi, Rbi]` and `[WBbi, RBbi]` (if bidirectional). The tensor has shape `[num_directions, 2*hidden_size]`. Optional: If not specified - assumed to be 0.</dd>
-<dt><tt>sequence_lens</tt> (optional, non-differentiable) : T1</dt>
+<dt><tt>sequence_lens</tt> (optional, non-differentiable) : tensor(int32)</dt>
 <dd>Optional tensor specifying lengths of the sequences in a batch. If not specified - assumed all sequences in the batch to have length `seq_length`. It has shape `[batch_size]`.</dd>
 <dt><tt>initial_h</tt> (optional, non-differentiable) : T</dt>
 <dd>Optional initial value of the hidden. If not specified - assumed to be 0. It has shape `[num_directions, batch_size, hidden_size]`.</dd>
@@ -27737,8 +27667,6 @@ This version of the operator has been available since version 22 of the default 
 <dl>
 <dt><tt>T</tt> : tensor(bfloat16), tensor(float16), tensor(float), tensor(double)</dt>
 <dd>Constrain input and output types to float tensors.</dd>
-<dt><tt>T1</tt> : tensor(int32)</dt>
-<dd>Constrain seq_lens to integer tensor.</dd>
 </dl>
 
 ### <a name="RandomNormal-22"></a>**RandomNormal-22**</a>
@@ -27974,7 +27902,7 @@ This version of the operator has been available since version 22 of the default 
 <dd>Input data tensor from the previous operator; 4-D feature map of shape (N, C, H, W), where N is the batch size, C is the number of channels, and H and W are the height and the width of the data.</dd>
 <dt><tt>rois</tt> : T1</dt>
 <dd>RoIs (Regions of Interest) to pool over; rois is 2-D input of shape (num_rois, 4) given as [[x1, y1, x2, y2], ...]. The RoIs' coordinates are in the coordinate system of the input image. Each coordinate set has a 1:1 correspondence with the 'batch_indices' input.</dd>
-<dt><tt>batch_indices</tt> : T2</dt>
+<dt><tt>batch_indices</tt> : tensor(int64)</dt>
 <dd>1-D tensor of shape (num_rois,) with each element denoting the index of the corresponding image in the batch.</dd>
 </dl>
 
@@ -27990,8 +27918,6 @@ This version of the operator has been available since version 22 of the default 
 <dl>
 <dt><tt>T1</tt> : tensor(bfloat16), tensor(float16), tensor(float), tensor(double)</dt>
 <dd>Constrain types to float tensors.</dd>
-<dt><tt>T2</tt> : tensor(int64)</dt>
-<dd>Constrain types to int tensors.</dd>
 </dl>
 
 ### <a name="Round-22"></a>**Round-22**</a>
@@ -29417,7 +29343,7 @@ This version of the operator has been available since version 23 of the default 
 <dd>The cosine values for the rotation. 2D tensor with shape `(max_position_id_plus_1, head_size / 2)` for full rotation or `(max_position_id_plus_1, rotary_embedding_dim / 2)` for partial rotation when `position_ids` are provided. 3D tensor with shape `(batch_size, sequence_length, head_size / 2)` for full rotation or `(batch_size, sequence_length, rotary_embedding_dim / 2)` for partial rotation when `position_ids` are not provided. `max_position_id_plus_1` is a parameter to the model.</dd>
 <dt><tt>sin_cache</tt> : T</dt>
 <dd>The sine values for the rotation. 2D tensor with shape `(max_position_id_plus_1, head_size / 2)` for full rotation or `(max_position_id_plus_1, rotary_embedding_dim / 2)` for partial rotation when `position_ids` are provided. 3D tensor with shape `(batch_size, sequence_length, head_size / 2)` for full rotation or `(batch_size, sequence_length, rotary_embedding_dim / 2)` for partial rotation when `position_ids` are not provided. `max_position_id_plus_1` is a parameter to the model.</dd>
-<dt><tt>position_ids</tt> (optional) : M</dt>
+<dt><tt>position_ids</tt> (optional) : tensor(int64)</dt>
 <dd>The position indices for the tokens. 2D tensor with shape `(batch_size, sequence_length)`</dd>
 </dl>
 
@@ -29433,8 +29359,6 @@ This version of the operator has been available since version 23 of the default 
 <dl>
 <dt><tt>T</tt> : tensor(float), tensor(float16), tensor(bfloat16)</dt>
 <dd>Constrain input and output types to float tensors.</dd>
-<dt><tt>M</tt> : tensor(int64)</dt>
-<dd>Constrain input and output types to integer tensors.</dd>
 </dl>
 
 ### <a name="Scan-23"></a>**Scan-23**</a>
@@ -31336,7 +31260,7 @@ This version of the operator has been available since version 24 of the default 
 <dl>
 <dt><tt>Values</tt> (differentiable) : T</dt>
 <dd>Tensor of shape [a_0, a_1, ..., a_{axis-1}, k, a_{axis+1}, ... a_{n-1}] containing top K values from the input tensor</dd>
-<dt><tt>Indices</tt> (non-differentiable) : I</dt>
+<dt><tt>Indices</tt> (non-differentiable) : tensor(int64)</dt>
 <dd>Tensor of shape [a_0, a_1, ..., a_{axis-1}, k, a_{axis+1}, ... a_{n-1}] containing the corresponding input tensor indices for the top K values.</dd>
 </dl>
 
@@ -31345,8 +31269,6 @@ This version of the operator has been available since version 24 of the default 
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(bfloat16)</dt>
 <dd>Constrain input and output types to numeric tensors.</dd>
-<dt><tt>I</tt> : tensor(int64)</dt>
-<dd>Constrain index tensor to int64</dd>
 </dl>
 
 ### <a name="Transpose-24"></a>**Transpose-24**</a>
@@ -31667,7 +31589,7 @@ This version of the operator has been available since version 25 of the default 
 #### Inputs
 
 <dl>
-<dt><tt>input</tt> : T1</dt>
+<dt><tt>input</tt> : tensor(int64)</dt>
 <dd>1D tensor. The shape of the expected output tensor. If empty tensor is given, the output would be a scalar. All values must be >= 0.</dd>
 </dl>
 
@@ -31681,8 +31603,6 @@ This version of the operator has been available since version 25 of the default 
 #### Type Constraints
 
 <dl>
-<dt><tt>T1</tt> : tensor(int64)</dt>
-<dd>Constrain input types.</dd>
 <dt><tt>T2</tt> : tensor(float16), tensor(float), tensor(double), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint4), tensor(int4), tensor(bool), tensor(bfloat16), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(float4e2m1), tensor(float8e8m0), tensor(uint2), tensor(int2)</dt>
 <dd>Constrain output types to be numerics or boolean.</dd>
 </dl>
@@ -31833,7 +31753,7 @@ This version of the operator has been available since version 25 of the default 
 #### Inputs
 
 <dl>
-<dt><tt>cond</tt> : B</dt>
+<dt><tt>cond</tt> : tensor(bool)</dt>
 <dd>Condition for the if. The tensor must contain a single element.</dd>
 </dl>
 
@@ -31849,8 +31769,6 @@ This version of the operator has been available since version 25 of the default 
 <dl>
 <dt><tt>V</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(uint4), tensor(int4), tensor(float4e2m1), tensor(float8e8m0), tensor(uint2), tensor(int2), seq(tensor(uint8)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(int8)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(bfloat16)), seq(tensor(float16)), seq(tensor(float)), seq(tensor(double)), seq(tensor(string)), seq(tensor(bool)), seq(tensor(complex64)), seq(tensor(complex128)), seq(tensor(float8e4m3fn)), seq(tensor(float8e4m3fnuz)), seq(tensor(float8e5m2)), seq(tensor(float8e5m2fnuz)), seq(tensor(uint4)), seq(tensor(int4)), seq(tensor(float4e2m1)), seq(tensor(float8e8m0)), seq(tensor(uint2)), seq(tensor(int2)), optional(seq(tensor(uint8))), optional(seq(tensor(uint16))), optional(seq(tensor(uint32))), optional(seq(tensor(uint64))), optional(seq(tensor(int8))), optional(seq(tensor(int16))), optional(seq(tensor(int32))), optional(seq(tensor(int64))), optional(seq(tensor(bfloat16))), optional(seq(tensor(float16))), optional(seq(tensor(float))), optional(seq(tensor(double))), optional(seq(tensor(string))), optional(seq(tensor(bool))), optional(seq(tensor(complex64))), optional(seq(tensor(complex128))), optional(tensor(uint8)), optional(tensor(uint16)), optional(tensor(uint32)), optional(tensor(uint64)), optional(tensor(int8)), optional(tensor(int16)), optional(tensor(int32)), optional(tensor(int64)), optional(tensor(bfloat16)), optional(tensor(float16)), optional(tensor(float)), optional(tensor(double)), optional(tensor(string)), optional(tensor(bool)), optional(tensor(complex64)), optional(tensor(complex128)), optional(tensor(float8e4m3fn)), optional(tensor(float8e4m3fnuz)), optional(tensor(float8e5m2)), optional(tensor(float8e5m2fnuz)), optional(tensor(uint4)), optional(tensor(int4)), optional(tensor(float4e2m1)), optional(tensor(float8e8m0)), optional(tensor(uint2)), optional(tensor(int2))</dt>
 <dd>All Tensor, Sequence(Tensor), Optional(Tensor), and Optional(Sequence(Tensor)) types up to IRv13.</dd>
-<dt><tt>B</tt> : tensor(bool)</dt>
-<dd>Only bool</dd>
 </dl>
 
 ### <a name="Loop-25"></a>**Loop-25**</a>
@@ -32005,9 +31923,9 @@ This version of the operator has been available since version 25 of the default 
 #### Inputs (2 - &#8734;)
 
 <dl>
-<dt><tt>M</tt> (optional) : I</dt>
+<dt><tt>M</tt> (optional) : tensor(int64)</dt>
 <dd>A maximum trip-count for the loop specified at runtime. Optional. Pass empty string to skip.</dd>
-<dt><tt>cond</tt> (optional) : B</dt>
+<dt><tt>cond</tt> (optional) : tensor(bool)</dt>
 <dd>A boolean termination condition. Optional. Pass empty string to skip.</dd>
 <dt><tt>v_initial</tt> (variadic, heterogeneous) : V</dt>
 <dd>The initial values of any loop-carried dependencies (values that change across loop iterations)</dd>
@@ -32025,10 +31943,6 @@ This version of the operator has been available since version 25 of the default 
 <dl>
 <dt><tt>V</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(uint4), tensor(int4), tensor(float4e2m1), tensor(float8e8m0), tensor(uint2), tensor(int2), seq(tensor(uint8)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(int8)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(bfloat16)), seq(tensor(float16)), seq(tensor(float)), seq(tensor(double)), seq(tensor(string)), seq(tensor(bool)), seq(tensor(complex64)), seq(tensor(complex128)), seq(tensor(float8e4m3fn)), seq(tensor(float8e4m3fnuz)), seq(tensor(float8e5m2)), seq(tensor(float8e5m2fnuz)), seq(tensor(uint4)), seq(tensor(int4)), seq(tensor(float4e2m1)), seq(tensor(float8e8m0)), seq(tensor(uint2)), seq(tensor(int2)), optional(seq(tensor(uint8))), optional(seq(tensor(uint16))), optional(seq(tensor(uint32))), optional(seq(tensor(uint64))), optional(seq(tensor(int8))), optional(seq(tensor(int16))), optional(seq(tensor(int32))), optional(seq(tensor(int64))), optional(seq(tensor(bfloat16))), optional(seq(tensor(float16))), optional(seq(tensor(float))), optional(seq(tensor(double))), optional(seq(tensor(string))), optional(seq(tensor(bool))), optional(seq(tensor(complex64))), optional(seq(tensor(complex128))), optional(tensor(uint8)), optional(tensor(uint16)), optional(tensor(uint32)), optional(tensor(uint64)), optional(tensor(int8)), optional(tensor(int16)), optional(tensor(int32)), optional(tensor(int64)), optional(tensor(bfloat16)), optional(tensor(float16)), optional(tensor(float)), optional(tensor(double)), optional(tensor(string)), optional(tensor(bool)), optional(tensor(complex64)), optional(tensor(complex128)), optional(tensor(float8e4m3fn)), optional(tensor(float8e4m3fnuz)), optional(tensor(float8e5m2)), optional(tensor(float8e5m2fnuz)), optional(tensor(uint4)), optional(tensor(int4)), optional(tensor(float4e2m1)), optional(tensor(float8e8m0)), optional(tensor(uint2)), optional(tensor(int2))</dt>
 <dd>All Tensor, Sequence(Tensor), Optional(Tensor), and Optional(Sequence(Tensor)) types up to IRv13.</dd>
-<dt><tt>I</tt> : tensor(int64)</dt>
-<dd>tensor of int64, which should be a scalar.</dd>
-<dt><tt>B</tt> : tensor(bool)</dt>
-<dd>tensor of bool, which should be a scalar.</dd>
 </dl>
 
 ### <a name="Pad-25"></a>**Pad-25**</a>
@@ -32534,7 +32448,7 @@ This version of the operator has been available since version 25 of the default 
 #### Outputs
 
 <dl>
-<dt><tt>shape</tt> (non-differentiable) : T1</dt>
+<dt><tt>shape</tt> (non-differentiable) : tensor(int64)</dt>
 <dd>Shape of the input tensor</dd>
 </dl>
 
@@ -32543,8 +32457,6 @@ This version of the operator has been available since version 25 of the default 
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(uint4), tensor(int4), tensor(float4e2m1), tensor(float8e8m0), tensor(uint2), tensor(int2)</dt>
 <dd>Input tensor can be of arbitrary type.</dd>
-<dt><tt>T1</tt> : tensor(int64)</dt>
-<dd>Constrain output to int64 tensor.</dd>
 </dl>
 
 ### <a name="Size-25"></a>**Size-25**</a>
@@ -32565,7 +32477,7 @@ This version of the operator has been available since version 25 of the default 
 #### Outputs
 
 <dl>
-<dt><tt>size</tt> (non-differentiable) : T1</dt>
+<dt><tt>size</tt> (non-differentiable) : tensor(int64)</dt>
 <dd>Total number of elements of the input tensor</dd>
 </dl>
 
@@ -32574,8 +32486,6 @@ This version of the operator has been available since version 25 of the default 
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(uint4), tensor(int4), tensor(float4e2m1), tensor(float8e8m0), tensor(uint2), tensor(int2)</dt>
 <dd>Input tensor can be of arbitrary type.</dd>
-<dt><tt>T1</tt> : tensor(int64)</dt>
-<dd>Constrain output to int64 tensor, which should be a scalar though.</dd>
 </dl>
 
 ### <a name="Squeeze-25"></a>**Squeeze-25**</a>
@@ -32968,7 +32878,7 @@ This version of the operator has been available since version 1 of the 'ai.onnx.
 <dl>
 <dt><tt>R</tt> : T1</dt>
 <dd>The initial learning rate.</dd>
-<dt><tt>T</tt> : T2</dt>
+<dt><tt>T</tt> : tensor(int64)</dt>
 <dd>The update count of "X". It should be a scalar.</dd>
 <dt><tt>inputs</tt> (variadic, heterogeneous) : T3</dt>
 <dd>The current values of optimized tensors, followed by their respective gradients, followed by their respective accumulated squared gradients.For example, if two tensor "X_1" and "X_2" are optimized, The input list would be ["X_1", "X_2", gradient of "X_1", gradient of "X_2", accumulated squared gradient of "X_1", accumulated squared gradient of "X_2"].</dd>
@@ -32986,8 +32896,6 @@ This version of the operator has been available since version 1 of the 'ai.onnx.
 <dl>
 <dt><tt>T1</tt> : tensor(float), tensor(double)</dt>
 <dd>Constrain input types to float scalars.</dd>
-<dt><tt>T2</tt> : tensor(int64)</dt>
-<dd>Constrain input types to 64-bit integer scalars.</dd>
 <dt><tt>T3</tt> : tensor(float), tensor(double)</dt>
 <dd>Constrain input and output types to float tensors.</dd>
 </dl>
@@ -33080,7 +32988,7 @@ This version of the operator has been available since version 1 of the 'ai.onnx.
 <dl>
 <dt><tt>R</tt> : T1</dt>
 <dd>The initial learning rate.</dd>
-<dt><tt>T</tt> : T2</dt>
+<dt><tt>T</tt> : tensor(int64)</dt>
 <dd>The update count of "X". It should be a scalar.</dd>
 <dt><tt>inputs</tt> (variadic, heterogeneous) : T3</dt>
 <dd>The tensors to be optimized, followed by their respective gradients, followed by their respective accumulated gradients (aka momentum), followed by their respective accumulated squared gradients. For example, to optimize tensors "X_1" and "X_2,", the input list would be ["X_1", "X_2", gradient of "X_1", gradient of "X_2", accumulated gradient of "X_1", accumulated gradient of "X_2", accumulated squared gradient of "X_1", accumulated squared gradient of "X_2"].</dd>
@@ -33098,8 +33006,6 @@ This version of the operator has been available since version 1 of the 'ai.onnx.
 <dl>
 <dt><tt>T1</tt> : tensor(float), tensor(double)</dt>
 <dd>Constrain input types to float scalars.</dd>
-<dt><tt>T2</tt> : tensor(int64)</dt>
-<dd>Constrain input types to 64-bit integer scalars.</dd>
 <dt><tt>T3</tt> : tensor(float), tensor(double)</dt>
 <dd>Constrain input and output types to float tensors.</dd>
 </dl>
@@ -33353,7 +33259,7 @@ This version of the operator has been available since version 1 of the 'ai.onnx.
 <dl>
 <dt><tt>R</tt> : T1</dt>
 <dd>The learning rate.</dd>
-<dt><tt>T</tt> : T2</dt>
+<dt><tt>T</tt> : tensor(int64)</dt>
 <dd>Update count of "X". It should be a scalar.</dd>
 <dt><tt>inputs</tt> (variadic, heterogeneous) : T3</dt>
 <dd>It sequentially contains the current values of optimized tensors, then their gradient tensors, and finally their momentum tensors. For example, if two tensors "X_1" and "X_2" are optimized, The expected input list would be ["X_1", "X_2", gradient of "X_1", gradient of "X_2", momentum of "X_1", momentum of "X_2"].</dd>
@@ -33371,8 +33277,6 @@ This version of the operator has been available since version 1 of the 'ai.onnx.
 <dl>
 <dt><tt>T1</tt> : tensor(float), tensor(double)</dt>
 <dd>Constrain input types to float scalars.</dd>
-<dt><tt>T2</tt> : tensor(int64)</dt>
-<dd>Constrain input types to 64-bit integer scalars.</dd>
 <dt><tt>T3</tt> : tensor(float), tensor(double)</dt>
 <dd>Constrain input types to float tensors.</dd>
 </dl>

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -561,7 +561,7 @@ This version of the operator has been available since version 20 of the default 
 <dl>
 <dt><tt>theta</tt> (non-differentiable) : T1</dt>
 <dd>input batch of affine matrices with shape (N, 2, 3) for 2D or (N, 3, 4) for 3D</dd>
-<dt><tt>size</tt> (non-differentiable) : T2</dt>
+<dt><tt>size</tt> (non-differentiable) : tensor(int64)</dt>
 <dd>the target output image size (N, C, H, W) for 2D or (N, C, D, H, W) for 3D</dd>
 </dl>
 
@@ -577,8 +577,6 @@ This version of the operator has been available since version 20 of the default 
 <dl>
 <dt><tt>T1</tt> : tensor(bfloat16), tensor(float16), tensor(float), tensor(double)</dt>
 <dd>Constrain grid types to float tensors.</dd>
-<dt><tt>T2</tt> : tensor(int64)</dt>
-<dd>Constrain size's type to int64 tensors.</dd>
 </dl>
 
 
@@ -673,7 +671,7 @@ Other versions of this operator: <a href="Changelog.md#And-1">1</a>
 #### Outputs
 
 <dl>
-<dt><tt>C</tt> (non-differentiable) : T1</dt>
+<dt><tt>C</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Result tensor.</dd>
 </dl>
 
@@ -682,8 +680,6 @@ Other versions of this operator: <a href="Changelog.md#And-1">1</a>
 <dl>
 <dt><tt>T</tt> : tensor(bool)</dt>
 <dd>Constrain input to boolean tensor.</dd>
-<dt><tt>T1</tt> : tensor(bool)</dt>
-<dd>Constrain output to boolean tensor.</dd>
 </dl>
 
 
@@ -8074,7 +8070,7 @@ Other versions of this operator: <a href="Changelog.md#Compress-9">9</a>
 <dl>
 <dt><tt>input</tt> (differentiable) : T</dt>
 <dd>Tensor of rank r >= 1.</dd>
-<dt><tt>condition</tt> (non-differentiable) : T1</dt>
+<dt><tt>condition</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Rank 1 tensor of booleans to indicate which slices or data elements to be selected. Its length can be less than the input length along the axis or the flattened input size if axis is not specified. In such cases data slices or elements exceeding the condition length are discarded.</dd>
 </dl>
 
@@ -8090,8 +8086,6 @@ Other versions of this operator: <a href="Changelog.md#Compress-9">9</a>
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128)</dt>
 <dd>Constrain input and output types to all tensor types.</dd>
-<dt><tt>T1</tt> : tensor(bool)</dt>
-<dd>Constrain to boolean tensors.</dd>
 </dl>
 
 
@@ -8433,7 +8427,7 @@ Other versions of this operator: <a href="Changelog.md#ConstantOfShape-9">9</a>,
 #### Inputs
 
 <dl>
-<dt><tt>input</tt> : T1</dt>
+<dt><tt>input</tt> : tensor(int64)</dt>
 <dd>1D tensor. The shape of the expected output tensor. If empty tensor is given, the output would be a scalar. All values must be >= 0.</dd>
 </dl>
 
@@ -8447,8 +8441,6 @@ Other versions of this operator: <a href="Changelog.md#ConstantOfShape-9">9</a>,
 #### Type Constraints
 
 <dl>
-<dt><tt>T1</tt> : tensor(int64)</dt>
-<dd>Constrain input types.</dd>
 <dt><tt>T2</tt> : tensor(float16), tensor(float), tensor(double), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(uint4), tensor(int4), tensor(bool), tensor(bfloat16), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(float4e2m1), tensor(float8e8m0), tensor(uint2), tensor(int2)</dt>
 <dd>Constrain output types to be numerics or boolean.</dd>
 </dl>
@@ -8887,7 +8879,7 @@ This version of the operator has been available since version 10 of the default 
 #### Outputs
 
 <dl>
-<dt><tt>y</tt> : T3</dt>
+<dt><tt>y</tt> : tensor(int32)</dt>
 <dd>Output data tensor that contains the result of the convolution. The output dimensions are functions of the kernel size, stride size, and pad lengths.</dd>
 </dl>
 
@@ -8898,8 +8890,6 @@ This version of the operator has been available since version 10 of the default 
 <dd>Constrain input x and its zero point data type to 8-bit integer tensor.</dd>
 <dt><tt>T2</tt> : tensor(int8), tensor(uint8)</dt>
 <dd>Constrain input w and its zero point data type to 8-bit integer tensor.</dd>
-<dt><tt>T3</tt> : tensor(int32)</dt>
-<dd>Constrain output y data type to 32-bit integer tensor.</dd>
 </dl>
 
 
@@ -11878,7 +11868,7 @@ This version of the operator has been available since version 11 of the default 
 #### Inputs
 
 <dl>
-<dt><tt>x</tt> : T1</dt>
+<dt><tt>x</tt> : tensor(float)</dt>
 <dd>Input tensor</dd>
 </dl>
 
@@ -11896,8 +11886,6 @@ This version of the operator has been available since version 11 of the default 
 #### Type Constraints
 
 <dl>
-<dt><tt>T1</tt> : tensor(float)</dt>
-<dd>Constrain 'x' to float tensor.</dd>
 <dt><tt>T2</tt> : tensor(uint8)</dt>
 <dd>Constrain 'y_zero_point' and 'y' to 8-bit unsigned integer tensor.</dd>
 </dl>
@@ -12248,7 +12236,7 @@ Other versions of this operator: <a href="Changelog.md#Equal-1">1</a>, <a href="
 #### Outputs
 
 <dl>
-<dt><tt>C</tt> (non-differentiable) : T1</dt>
+<dt><tt>C</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Result tensor.</dd>
 </dl>
 
@@ -12257,8 +12245,6 @@ Other versions of this operator: <a href="Changelog.md#Equal-1">1</a>, <a href="
 <dl>
 <dt><tt>T</tt> : tensor(bool), tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(bfloat16), tensor(string)</dt>
 <dd>Constrain input types to all (non-complex) tensors.</dd>
-<dt><tt>T1</tt> : tensor(bool)</dt>
-<dd>Constrain output to boolean tensor.</dd>
 </dl>
 
 
@@ -12962,7 +12948,7 @@ Other versions of this operator: <a href="Changelog.md#GRU-1">1</a>, <a href="Ch
 <dd>The recurrence weight tensor. Concatenation of `R[zrh]` and `RB[zrh]` (if bidirectional) along dimension 0. This tensor has shape `[num_directions, 3*hidden_size, hidden_size]`.</dd>
 <dt><tt>B</tt> (optional, differentiable) : T</dt>
 <dd>The bias tensor for the gates. Concatenation of `[Wb[zrh], Rb[zrh]]` and `[WBb[zrh], RBb[zrh]]` (if bidirectional) along dimension 0. This tensor has shape `[num_directions, 6*hidden_size]`. Optional: If not specified - assumed to be 0</dd>
-<dt><tt>sequence_lens</tt> (optional, non-differentiable) : T1</dt>
+<dt><tt>sequence_lens</tt> (optional, non-differentiable) : tensor(int32)</dt>
 <dd>Optional tensor specifying lengths of the sequences in a batch. If not specified - assumed all sequences in the batch to have length `seq_length`. It has shape `[batch_size]`.</dd>
 <dt><tt>initial_h</tt> (optional, non-differentiable) : T</dt>
 <dd>Optional initial value of the hidden. If not specified - assumed to be 0. It has shape `[num_directions, batch_size, hidden_size]`.</dd>
@@ -12982,8 +12968,6 @@ Other versions of this operator: <a href="Changelog.md#GRU-1">1</a>, <a href="Ch
 <dl>
 <dt><tt>T</tt> : tensor(bfloat16), tensor(float16), tensor(float), tensor(double)</dt>
 <dd>Constrain input and output types to float tensors.</dd>
-<dt><tt>T1</tt> : tensor(int32)</dt>
-<dd>Constrain seq_lens to integer tensor.</dd>
 </dl>
 
 
@@ -14335,7 +14319,7 @@ Other versions of this operator: <a href="Changelog.md#Greater-1">1</a>, <a href
 #### Outputs
 
 <dl>
-<dt><tt>C</tt> (non-differentiable) : T1</dt>
+<dt><tt>C</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Result tensor.</dd>
 </dl>
 
@@ -14344,8 +14328,6 @@ Other versions of this operator: <a href="Changelog.md#Greater-1">1</a>, <a href
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(bfloat16)</dt>
 <dd>Constrain input types to all numeric tensors.</dd>
-<dt><tt>T1</tt> : tensor(bool)</dt>
-<dd>Constrain output to boolean tensor.</dd>
 </dl>
 
 
@@ -14512,7 +14494,7 @@ Other versions of this operator: <a href="Changelog.md#GreaterOrEqual-12">12</a>
 #### Outputs
 
 <dl>
-<dt><tt>C</tt> (non-differentiable) : T1</dt>
+<dt><tt>C</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Result tensor.</dd>
 </dl>
 
@@ -14521,8 +14503,6 @@ Other versions of this operator: <a href="Changelog.md#GreaterOrEqual-12">12</a>
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(bfloat16)</dt>
 <dd>Constrain input types to all numeric tensors.</dd>
-<dt><tt>T1</tt> : tensor(bool)</dt>
-<dd>Constrain output to boolean tensor.</dd>
 </dl>
 
 
@@ -15944,7 +15924,7 @@ Other versions of this operator: <a href="Changelog.md#If-1">1</a>, <a href="Cha
 #### Inputs
 
 <dl>
-<dt><tt>cond</tt> : B</dt>
+<dt><tt>cond</tt> : tensor(bool)</dt>
 <dd>Condition for the if. The tensor must contain a single element.</dd>
 </dl>
 
@@ -15960,8 +15940,6 @@ Other versions of this operator: <a href="Changelog.md#If-1">1</a>, <a href="Cha
 <dl>
 <dt><tt>V</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(uint4), tensor(int4), tensor(float4e2m1), tensor(float8e8m0), tensor(uint2), tensor(int2), seq(tensor(uint8)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(int8)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(bfloat16)), seq(tensor(float16)), seq(tensor(float)), seq(tensor(double)), seq(tensor(string)), seq(tensor(bool)), seq(tensor(complex64)), seq(tensor(complex128)), seq(tensor(float8e4m3fn)), seq(tensor(float8e4m3fnuz)), seq(tensor(float8e5m2)), seq(tensor(float8e5m2fnuz)), seq(tensor(uint4)), seq(tensor(int4)), seq(tensor(float4e2m1)), seq(tensor(float8e8m0)), seq(tensor(uint2)), seq(tensor(int2)), optional(seq(tensor(uint8))), optional(seq(tensor(uint16))), optional(seq(tensor(uint32))), optional(seq(tensor(uint64))), optional(seq(tensor(int8))), optional(seq(tensor(int16))), optional(seq(tensor(int32))), optional(seq(tensor(int64))), optional(seq(tensor(bfloat16))), optional(seq(tensor(float16))), optional(seq(tensor(float))), optional(seq(tensor(double))), optional(seq(tensor(string))), optional(seq(tensor(bool))), optional(seq(tensor(complex64))), optional(seq(tensor(complex128))), optional(tensor(uint8)), optional(tensor(uint16)), optional(tensor(uint32)), optional(tensor(uint64)), optional(tensor(int8)), optional(tensor(int16)), optional(tensor(int32)), optional(tensor(int64)), optional(tensor(bfloat16)), optional(tensor(float16)), optional(tensor(float)), optional(tensor(double)), optional(tensor(string)), optional(tensor(bool)), optional(tensor(complex64)), optional(tensor(complex128)), optional(tensor(float8e4m3fn)), optional(tensor(float8e4m3fnuz)), optional(tensor(float8e5m2)), optional(tensor(float8e5m2fnuz)), optional(tensor(uint4)), optional(tensor(int4)), optional(tensor(float4e2m1)), optional(tensor(float8e8m0)), optional(tensor(uint2)), optional(tensor(int2))</dt>
 <dd>All Tensor, Sequence(Tensor), Optional(Tensor), and Optional(Sequence(Tensor)) types up to IRv13.</dd>
-<dt><tt>B</tt> : tensor(bool)</dt>
-<dd>Only bool</dd>
 </dl>
 
 
@@ -16217,25 +16195,19 @@ This version of the operator has been available since version 20 of the default 
 #### Inputs
 
 <dl>
-<dt><tt>encoded_stream</tt> (non-differentiable) : T1</dt>
+<dt><tt>encoded_stream</tt> (non-differentiable) : tensor(uint8)</dt>
 <dd>Encoded stream</dd>
 </dl>
 
 #### Outputs
 
 <dl>
-<dt><tt>image</tt> (non-differentiable) : T2</dt>
+<dt><tt>image</tt> (non-differentiable) : tensor(uint8)</dt>
 <dd>Decoded image</dd>
 </dl>
 
 #### Type Constraints
 
-<dl>
-<dt><tt>T1</tt> : tensor(uint8)</dt>
-<dd>Constrain input types to 8-bit unsigned integer tensor.</dd>
-<dt><tt>T2</tt> : tensor(uint8)</dt>
-<dd>Constrain output types to 8-bit unsigned integer tensor.</dd>
-</dl>
 
 
 #### Examples
@@ -16596,7 +16568,7 @@ Other versions of this operator: <a href="Changelog.md#IsInf-10">10</a>
 #### Outputs
 
 <dl>
-<dt><tt>Y</tt> (non-differentiable) : T2</dt>
+<dt><tt>Y</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>output</dd>
 </dl>
 
@@ -16605,8 +16577,6 @@ Other versions of this operator: <a href="Changelog.md#IsInf-10">10</a>
 <dl>
 <dt><tt>T1</tt> : tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz)</dt>
 <dd>Constrain input types to float tensors.</dd>
-<dt><tt>T2</tt> : tensor(bool)</dt>
-<dd>Constrain output types to boolean tensors.</dd>
 </dl>
 
 
@@ -16700,7 +16670,7 @@ Other versions of this operator: <a href="Changelog.md#IsNaN-9">9</a>, <a href="
 #### Outputs
 
 <dl>
-<dt><tt>Y</tt> (non-differentiable) : T2</dt>
+<dt><tt>Y</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>output</dd>
 </dl>
 
@@ -16709,8 +16679,6 @@ Other versions of this operator: <a href="Changelog.md#IsNaN-9">9</a>, <a href="
 <dl>
 <dt><tt>T1</tt> : tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz)</dt>
 <dd>Constrain input types to float tensors.</dd>
-<dt><tt>T2</tt> : tensor(bool)</dt>
-<dd>Constrain output types to boolean tensors.</dd>
 </dl>
 
 
@@ -16967,7 +16935,7 @@ Other versions of this operator: <a href="Changelog.md#LSTM-1">1</a>, <a href="C
 <dd>The recurrence weight tensor. Concatenation of `R[iofc]` and `RB[iofc]` (if bidirectional) along dimension 0. This tensor has shape `[num_directions, 4*hidden_size, hidden_size]`.</dd>
 <dt><tt>B</tt> (optional, differentiable) : T</dt>
 <dd>The bias tensor for input gate. Concatenation of `[Wb[iofc], Rb[iofc]]`, and `[WBb[iofc], RBb[iofc]]` (if bidirectional) along dimension 0. This tensor has shape `[num_directions, 8*hidden_size]`. Optional: If not specified - assumed to be 0.</dd>
-<dt><tt>sequence_lens</tt> (optional, non-differentiable) : T1</dt>
+<dt><tt>sequence_lens</tt> (optional, non-differentiable) : tensor(int32)</dt>
 <dd>Optional tensor specifying lengths of the sequences in a batch. If not specified - assumed all sequences in the batch to have length `seq_length`. It has shape `[batch_size]`.</dd>
 <dt><tt>initial_h</tt> (optional, non-differentiable) : T</dt>
 <dd>Optional initial value of the hidden. If not specified - assumed to be 0. It has shape `[num_directions, batch_size, hidden_size]`.</dd>
@@ -16993,8 +16961,6 @@ Other versions of this operator: <a href="Changelog.md#LSTM-1">1</a>, <a href="C
 <dl>
 <dt><tt>T</tt> : tensor(bfloat16), tensor(float16), tensor(float), tensor(double)</dt>
 <dd>Constrain input and output types to float tensors.</dd>
-<dt><tt>T1</tt> : tensor(int32)</dt>
-<dd>Constrain seq_lens to integer tensor.</dd>
 </dl>
 
 
@@ -17508,7 +17474,7 @@ Other versions of this operator: <a href="Changelog.md#Less-1">1</a>, <a href="C
 #### Outputs
 
 <dl>
-<dt><tt>C</tt> (non-differentiable) : T1</dt>
+<dt><tt>C</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Result tensor.</dd>
 </dl>
 
@@ -17517,8 +17483,6 @@ Other versions of this operator: <a href="Changelog.md#Less-1">1</a>, <a href="C
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(bfloat16)</dt>
 <dd>Constrain input types to all numeric tensors.</dd>
-<dt><tt>T1</tt> : tensor(bool)</dt>
-<dd>Constrain output to boolean tensor.</dd>
 </dl>
 
 
@@ -17685,7 +17649,7 @@ Other versions of this operator: <a href="Changelog.md#LessOrEqual-12">12</a>
 #### Outputs
 
 <dl>
-<dt><tt>C</tt> (non-differentiable) : T1</dt>
+<dt><tt>C</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Result tensor.</dd>
 </dl>
 
@@ -17694,8 +17658,6 @@ Other versions of this operator: <a href="Changelog.md#LessOrEqual-12">12</a>
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(bfloat16)</dt>
 <dd>Constrain input types to all numeric tensors.</dd>
-<dt><tt>T1</tt> : tensor(bool)</dt>
-<dd>Constrain output to boolean tensor.</dd>
 </dl>
 
 
@@ -18045,9 +18007,9 @@ Other versions of this operator: <a href="Changelog.md#Loop-1">1</a>, <a href="C
 #### Inputs (2 - &#8734;)
 
 <dl>
-<dt><tt>M</tt> (optional) : I</dt>
+<dt><tt>M</tt> (optional) : tensor(int64)</dt>
 <dd>A maximum trip-count for the loop specified at runtime. Optional. Pass empty string to skip.</dd>
-<dt><tt>cond</tt> (optional) : B</dt>
+<dt><tt>cond</tt> (optional) : tensor(bool)</dt>
 <dd>A boolean termination condition. Optional. Pass empty string to skip.</dd>
 <dt><tt>v_initial</tt> (variadic, heterogeneous) : V</dt>
 <dd>The initial values of any loop-carried dependencies (values that change across loop iterations)</dd>
@@ -18065,10 +18027,6 @@ Other versions of this operator: <a href="Changelog.md#Loop-1">1</a>, <a href="C
 <dl>
 <dt><tt>V</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(uint4), tensor(int4), tensor(float4e2m1), tensor(float8e8m0), tensor(uint2), tensor(int2), seq(tensor(uint8)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(int8)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(bfloat16)), seq(tensor(float16)), seq(tensor(float)), seq(tensor(double)), seq(tensor(string)), seq(tensor(bool)), seq(tensor(complex64)), seq(tensor(complex128)), seq(tensor(float8e4m3fn)), seq(tensor(float8e4m3fnuz)), seq(tensor(float8e5m2)), seq(tensor(float8e5m2fnuz)), seq(tensor(uint4)), seq(tensor(int4)), seq(tensor(float4e2m1)), seq(tensor(float8e8m0)), seq(tensor(uint2)), seq(tensor(int2)), optional(seq(tensor(uint8))), optional(seq(tensor(uint16))), optional(seq(tensor(uint32))), optional(seq(tensor(uint64))), optional(seq(tensor(int8))), optional(seq(tensor(int16))), optional(seq(tensor(int32))), optional(seq(tensor(int64))), optional(seq(tensor(bfloat16))), optional(seq(tensor(float16))), optional(seq(tensor(float))), optional(seq(tensor(double))), optional(seq(tensor(string))), optional(seq(tensor(bool))), optional(seq(tensor(complex64))), optional(seq(tensor(complex128))), optional(tensor(uint8)), optional(tensor(uint16)), optional(tensor(uint32)), optional(tensor(uint64)), optional(tensor(int8)), optional(tensor(int16)), optional(tensor(int32)), optional(tensor(int64)), optional(tensor(bfloat16)), optional(tensor(float16)), optional(tensor(float)), optional(tensor(double)), optional(tensor(string)), optional(tensor(bool)), optional(tensor(complex64)), optional(tensor(complex128)), optional(tensor(float8e4m3fn)), optional(tensor(float8e4m3fnuz)), optional(tensor(float8e5m2)), optional(tensor(float8e5m2fnuz)), optional(tensor(uint4)), optional(tensor(int4)), optional(tensor(float4e2m1)), optional(tensor(float8e8m0)), optional(tensor(uint2)), optional(tensor(int2))</dt>
 <dd>All Tensor, Sequence(Tensor), Optional(Tensor), and Optional(Sequence(Tensor)) types up to IRv13.</dd>
-<dt><tt>I</tt> : tensor(int64)</dt>
-<dd>tensor of int64, which should be a scalar.</dd>
-<dt><tt>B</tt> : tensor(bool)</dt>
-<dd>tensor of bool, which should be a scalar.</dd>
 </dl>
 
 
@@ -19199,7 +19157,7 @@ This version of the operator has been available since version 10 of the default 
 #### Outputs
 
 <dl>
-<dt><tt>Y</tt> (non-differentiable) : T3</dt>
+<dt><tt>Y</tt> (non-differentiable) : tensor(int32)</dt>
 <dd>Matrix multiply results from A * B</dd>
 </dl>
 
@@ -19210,8 +19168,6 @@ This version of the operator has been available since version 10 of the default 
 <dd>Constrain input A data type to 8-bit integer tensor.</dd>
 <dt><tt>T2</tt> : tensor(int8), tensor(uint8)</dt>
 <dd>Constrain input B data type to 8-bit integer tensor.</dd>
-<dt><tt>T3</tt> : tensor(int32)</dt>
-<dd>Constrain output Y data type as 32-bit integer tensor.</dd>
 </dl>
 
 
@@ -19444,7 +19400,7 @@ Other versions of this operator: <a href="Changelog.md#MaxPool-1">1</a>, <a href
 <dl>
 <dt><tt>Y</tt> (differentiable) : T</dt>
 <dd>Output data tensor from average or max pooling across the input tensor. Dimensions will vary based on various kernel, stride, and pad sizes. Floor value of the dimension is used</dd>
-<dt><tt>Indices</tt> (optional, non-differentiable) : I</dt>
+<dt><tt>Indices</tt> (optional, non-differentiable) : tensor(int64)</dt>
 <dd>Indices tensor from max pooling across the input tensor. The dimensions of indices are the same as output tensor. The values in indices of are the indices of the selected values during pooling. The indices are computed as flatten 1-D tensor, and the indices do not consider padding. So the values in indices are in [0, N x C x D1 x ... x Dn).</dd>
 </dl>
 
@@ -19453,8 +19409,6 @@ Other versions of this operator: <a href="Changelog.md#MaxPool-1">1</a>, <a href
 <dl>
 <dt><tt>T</tt> : tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(int8), tensor(uint8)</dt>
 <dd>Constrain input and output types to float and 8 bit tensors.</dd>
-<dt><tt>I</tt> : tensor(int64)</dt>
-<dd>Constrain index tensor to int64</dd>
 </dl>
 
 
@@ -23186,7 +23140,7 @@ Other versions of this operator: <a href="Changelog.md#OptionalHasElement-15">15
 #### Outputs
 
 <dl>
-<dt><tt>output</tt> : B</dt>
+<dt><tt>output</tt> : tensor(bool)</dt>
 <dd>A scalar boolean tensor. If true, it indicates that optional-type input contains an element. Otherwise, it is empty.</dd>
 </dl>
 
@@ -23195,8 +23149,6 @@ Other versions of this operator: <a href="Changelog.md#OptionalHasElement-15">15
 <dl>
 <dt><tt>O</tt> : optional(seq(tensor(uint8))), optional(seq(tensor(uint16))), optional(seq(tensor(uint32))), optional(seq(tensor(uint64))), optional(seq(tensor(int8))), optional(seq(tensor(int16))), optional(seq(tensor(int32))), optional(seq(tensor(int64))), optional(seq(tensor(float16))), optional(seq(tensor(float))), optional(seq(tensor(double))), optional(seq(tensor(string))), optional(seq(tensor(bool))), optional(seq(tensor(complex64))), optional(seq(tensor(complex128))), optional(tensor(uint8)), optional(tensor(uint16)), optional(tensor(uint32)), optional(tensor(uint64)), optional(tensor(int8)), optional(tensor(int16)), optional(tensor(int32)), optional(tensor(int64)), optional(tensor(float16)), optional(tensor(float)), optional(tensor(double)), optional(tensor(string)), optional(tensor(bool)), optional(tensor(complex64)), optional(tensor(complex128)), tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128), seq(tensor(uint8)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(int8)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(float16)), seq(tensor(float)), seq(tensor(double)), seq(tensor(string)), seq(tensor(bool)), seq(tensor(complex64)), seq(tensor(complex128))</dt>
 <dd>Constrain input type to optional tensor and optional sequence types.</dd>
-<dt><tt>B</tt> : tensor(bool)</dt>
-<dd>Constrain output to a boolean tensor.</dd>
 </dl>
 
 
@@ -23385,7 +23337,7 @@ Other versions of this operator: <a href="Changelog.md#Or-1">1</a>
 #### Outputs
 
 <dl>
-<dt><tt>C</tt> (non-differentiable) : T1</dt>
+<dt><tt>C</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Result tensor.</dd>
 </dl>
 
@@ -23394,8 +23346,6 @@ Other versions of this operator: <a href="Changelog.md#Or-1">1</a>
 <dl>
 <dt><tt>T</tt> : tensor(bool)</dt>
 <dd>Constrain input to boolean tensor.</dd>
-<dt><tt>T1</tt> : tensor(bool)</dt>
-<dd>Constrain output to boolean tensor.</dd>
 </dl>
 
 
@@ -24007,7 +23957,7 @@ This version of the operator has been available since version 10 of the default 
 <dd>Scale tensor for output 'y'. It's a scalar, which means a per-tensor/layer quantization.</dd>
 <dt><tt>y_zero_point</tt> : T3</dt>
 <dd>Zero point tensor for output 'y'. It's a scalar, which means a per-tensor/layer quantization.</dd>
-<dt><tt>B</tt> (optional) : T4</dt>
+<dt><tt>B</tt> (optional) : tensor(int32)</dt>
 <dd>Optional 1D bias to be added to the convolution, has size of M. Bias must be quantized using scale = x_scale * w_scale and zero_point = 0</dd>
 </dl>
 
@@ -24027,8 +23977,6 @@ This version of the operator has been available since version 10 of the default 
 <dd>Constrain filter type to 8-bit integer tensor.</dd>
 <dt><tt>T3</tt> : tensor(int8), tensor(uint8)</dt>
 <dd>Constrain output type to 8-bit integer tensor.</dd>
-<dt><tt>T4</tt> : tensor(int32)</dt>
-<dd>Constrain bias type to 32-bit integer tensor.</dd>
 </dl>
 
 
@@ -25256,7 +25204,7 @@ Other versions of this operator: <a href="Changelog.md#RNN-1">1</a>, <a href="Ch
 <dd>The recurrence weight tensor. Concatenation of `Ri` and `RBi` (if bidirectional). The tensor has shape `[num_directions, hidden_size, hidden_size]`.</dd>
 <dt><tt>B</tt> (optional, differentiable) : T</dt>
 <dd>The bias tensor for input gate. Concatenation of `[Wbi, Rbi]` and `[WBbi, RBbi]` (if bidirectional). The tensor has shape `[num_directions, 2*hidden_size]`. Optional: If not specified - assumed to be 0.</dd>
-<dt><tt>sequence_lens</tt> (optional, non-differentiable) : T1</dt>
+<dt><tt>sequence_lens</tt> (optional, non-differentiable) : tensor(int32)</dt>
 <dd>Optional tensor specifying lengths of the sequences in a batch. If not specified - assumed all sequences in the batch to have length `seq_length`. It has shape `[batch_size]`.</dd>
 <dt><tt>initial_h</tt> (optional, non-differentiable) : T</dt>
 <dd>Optional initial value of the hidden. If not specified - assumed to be 0. It has shape `[num_directions, batch_size, hidden_size]`.</dd>
@@ -25276,8 +25224,6 @@ Other versions of this operator: <a href="Changelog.md#RNN-1">1</a>, <a href="Ch
 <dl>
 <dt><tt>T</tt> : tensor(bfloat16), tensor(float16), tensor(float), tensor(double)</dt>
 <dd>Constrain input and output types to float tensors.</dd>
-<dt><tt>T1</tt> : tensor(int32)</dt>
-<dd>Constrain seq_lens to integer tensor.</dd>
 </dl>
 
 
@@ -28507,25 +28453,19 @@ This version of the operator has been available since version 20 of the default 
 #### Inputs
 
 <dl>
-<dt><tt>X</tt> (non-differentiable) : T1</dt>
+<dt><tt>X</tt> (non-differentiable) : tensor(string)</dt>
 <dd>Tensor with strings to match on.</dd>
 </dl>
 
 #### Outputs
 
 <dl>
-<dt><tt>Y</tt> (non-differentiable) : T2</dt>
+<dt><tt>Y</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Tensor of bools indicating if each input string fully matches the regex pattern specified.</dd>
 </dl>
 
 #### Type Constraints
 
-<dl>
-<dt><tt>T1</tt> : tensor(string)</dt>
-<dd>Inputs must be UTF-8 strings</dd>
-<dt><tt>T2</tt> : tensor(bool)</dt>
-<dd>Outputs are bools and are True where there is a full regex match and False otherwise.</dd>
-</dl>
 
 
 #### Examples
@@ -31049,7 +30989,7 @@ Other versions of this operator: <a href="Changelog.md#RoiAlign-10">10</a>, <a h
 <dd>Input data tensor from the previous operator; 4-D feature map of shape (N, C, H, W), where N is the batch size, C is the number of channels, and H and W are the height and the width of the data.</dd>
 <dt><tt>rois</tt> : T1</dt>
 <dd>RoIs (Regions of Interest) to pool over; rois is 2-D input of shape (num_rois, 4) given as [[x1, y1, x2, y2], ...]. The RoIs' coordinates are in the coordinate system of the input image. Each coordinate set has a 1:1 correspondence with the 'batch_indices' input.</dd>
-<dt><tt>batch_indices</tt> : T2</dt>
+<dt><tt>batch_indices</tt> : tensor(int64)</dt>
 <dd>1-D tensor of shape (num_rois,) with each element denoting the index of the corresponding image in the batch.</dd>
 </dl>
 
@@ -31065,8 +31005,6 @@ Other versions of this operator: <a href="Changelog.md#RoiAlign-10">10</a>, <a h
 <dl>
 <dt><tt>T1</tt> : tensor(bfloat16), tensor(float16), tensor(float), tensor(double)</dt>
 <dd>Constrain types to float tensors.</dd>
-<dt><tt>T2</tt> : tensor(int64)</dt>
-<dd>Constrain types to int tensors.</dd>
 </dl>
 
 
@@ -31516,7 +31454,7 @@ This version of the operator has been available since version 23 of the default 
 <dd>The cosine values for the rotation. 2D tensor with shape `(max_position_id_plus_1, head_size / 2)` for full rotation or `(max_position_id_plus_1, rotary_embedding_dim / 2)` for partial rotation when `position_ids` are provided. 3D tensor with shape `(batch_size, sequence_length, head_size / 2)` for full rotation or `(batch_size, sequence_length, rotary_embedding_dim / 2)` for partial rotation when `position_ids` are not provided. `max_position_id_plus_1` is a parameter to the model.</dd>
 <dt><tt>sin_cache</tt> : T</dt>
 <dd>The sine values for the rotation. 2D tensor with shape `(max_position_id_plus_1, head_size / 2)` for full rotation or `(max_position_id_plus_1, rotary_embedding_dim / 2)` for partial rotation when `position_ids` are provided. 3D tensor with shape `(batch_size, sequence_length, head_size / 2)` for full rotation or `(batch_size, sequence_length, rotary_embedding_dim / 2)` for partial rotation when `position_ids` are not provided. `max_position_id_plus_1` is a parameter to the model.</dd>
-<dt><tt>position_ids</tt> (optional) : M</dt>
+<dt><tt>position_ids</tt> (optional) : tensor(int64)</dt>
 <dd>The position indices for the tokens. 2D tensor with shape `(batch_size, sequence_length)`</dd>
 </dl>
 
@@ -31532,8 +31470,6 @@ This version of the operator has been available since version 23 of the default 
 <dl>
 <dt><tt>T</tt> : tensor(float), tensor(float16), tensor(bfloat16)</dt>
 <dd>Constrain input and output types to float tensors.</dd>
-<dt><tt>M</tt> : tensor(int64)</dt>
-<dd>Constrain input and output types to integer tensors.</dd>
 </dl>
 
 
@@ -33441,7 +33377,7 @@ This version of the operator has been available since version 11 of the default 
 #### Outputs
 
 <dl>
-<dt><tt>length</tt> : I</dt>
+<dt><tt>length</tt> : tensor(int64)</dt>
 <dd>Length of input sequence. It must be a scalar(tensor of empty shape).</dd>
 </dl>
 
@@ -33450,8 +33386,6 @@ This version of the operator has been available since version 11 of the default 
 <dl>
 <dt><tt>S</tt> : seq(tensor(uint8)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(int8)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(float16)), seq(tensor(float)), seq(tensor(double)), seq(tensor(string)), seq(tensor(bool)), seq(tensor(complex64)), seq(tensor(complex128))</dt>
 <dd>Constrain to any tensor type.</dd>
-<dt><tt>I</tt> : tensor(int64)</dt>
-<dd>Constrain output to integral tensor. It must be a scalar(tensor of empty shape).</dd>
 </dl>
 
 
@@ -33905,7 +33839,7 @@ Other versions of this operator: <a href="Changelog.md#Shape-1">1</a>, <a href="
 #### Outputs
 
 <dl>
-<dt><tt>shape</tt> (non-differentiable) : T1</dt>
+<dt><tt>shape</tt> (non-differentiable) : tensor(int64)</dt>
 <dd>Shape of the input tensor</dd>
 </dl>
 
@@ -33914,8 +33848,6 @@ Other versions of this operator: <a href="Changelog.md#Shape-1">1</a>, <a href="
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(uint4), tensor(int4), tensor(float4e2m1), tensor(float8e8m0), tensor(uint2), tensor(int2)</dt>
 <dd>Input tensor can be of arbitrary type.</dd>
-<dt><tt>T1</tt> : tensor(int64)</dt>
-<dd>Constrain output to int64 tensor.</dd>
 </dl>
 
 
@@ -34285,7 +34217,7 @@ Other versions of this operator: <a href="Changelog.md#Size-1">1</a>, <a href="C
 #### Outputs
 
 <dl>
-<dt><tt>size</tt> (non-differentiable) : T1</dt>
+<dt><tt>size</tt> (non-differentiable) : tensor(int64)</dt>
 <dd>Total number of elements of the input tensor</dd>
 </dl>
 
@@ -34294,8 +34226,6 @@ Other versions of this operator: <a href="Changelog.md#Size-1">1</a>, <a href="C
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128), tensor(float8e4m3fn), tensor(float8e4m3fnuz), tensor(float8e5m2), tensor(float8e5m2fnuz), tensor(uint4), tensor(int4), tensor(float4e2m1), tensor(float8e8m0), tensor(uint2), tensor(int2)</dt>
 <dd>Input tensor can be of arbitrary type.</dd>
-<dt><tt>T1</tt> : tensor(int64)</dt>
-<dd>Constrain output to int64 tensor, which should be a scalar though.</dd>
 </dl>
 
 
@@ -37460,29 +37390,21 @@ This version of the operator has been available since version 20 of the default 
 #### Inputs
 
 <dl>
-<dt><tt>X</tt> (non-differentiable) : T1</dt>
+<dt><tt>X</tt> (non-differentiable) : tensor(string)</dt>
 <dd>Tensor of strings to split.</dd>
 </dl>
 
 #### Outputs
 
 <dl>
-<dt><tt>Y</tt> (non-differentiable) : T2</dt>
+<dt><tt>Y</tt> (non-differentiable) : tensor(string)</dt>
 <dd>Tensor of substrings representing the outcome of splitting the strings in the input on the delimiter. Note that to ensure the same number of elements are present in the final rank, this tensor will pad any necessary empty strings.</dd>
-<dt><tt>Z</tt> (non-differentiable) : T3</dt>
+<dt><tt>Z</tt> (non-differentiable) : tensor(int64)</dt>
 <dd>The number of substrings generated for each input element.</dd>
 </dl>
 
 #### Type Constraints
 
-<dl>
-<dt><tt>T1</tt> : tensor(string)</dt>
-<dd>The input must be a UTF-8 string tensor</dd>
-<dt><tt>T2</tt> : tensor(string)</dt>
-<dd>Tensor of substrings.</dd>
-<dt><tt>T3</tt> : tensor(int64)</dt>
-<dd>The number of substrings generated.</dd>
-</dl>
 
 
 #### Examples
@@ -38341,7 +38263,7 @@ This version of the operator has been available since version 9 of the default O
 #### Outputs
 
 <dl>
-<dt><tt>Y</tt> (non-differentiable) : T1</dt>
+<dt><tt>Y</tt> (non-differentiable) : tensor(float)</dt>
 <dd>Ngram results</dd>
 </dl>
 
@@ -38350,8 +38272,6 @@ This version of the operator has been available since version 9 of the default O
 <dl>
 <dt><tt>T</tt> : tensor(string), tensor(int32), tensor(int64)</dt>
 <dd>Input is ether string UTF-8 or int32/int64</dd>
-<dt><tt>T1</tt> : tensor(float)</dt>
-<dd>1-D tensor of floats</dd>
 </dl>
 
 
@@ -38702,7 +38622,7 @@ Other versions of this operator: <a href="Changelog.md#Tile-1">1</a>, <a href="C
 <dl>
 <dt><tt>input</tt> (differentiable) : T</dt>
 <dd>Input tensor of any shape.</dd>
-<dt><tt>repeats</tt> (non-differentiable) : T1</dt>
+<dt><tt>repeats</tt> (non-differentiable) : tensor(int64)</dt>
 <dd>1D int64 tensor of the same length as input's dimension number, includes numbers of repeated copies along input's dimensions.</dd>
 </dl>
 
@@ -38718,8 +38638,6 @@ Other versions of this operator: <a href="Changelog.md#Tile-1">1</a>, <a href="C
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128)</dt>
 <dd>Constrain input and output types to all tensor types.</dd>
-<dt><tt>T1</tt> : tensor(int64)</dt>
-<dd>Constrain repeat's type to int64 tensors.</dd>
 </dl>
 
 
@@ -38812,7 +38730,7 @@ Other versions of this operator: <a href="Changelog.md#TopK-1">1</a>, <a href="C
 <dl>
 <dt><tt>Values</tt> (differentiable) : T</dt>
 <dd>Tensor of shape [a_0, a_1, ..., a_{axis-1}, k, a_{axis+1}, ... a_{n-1}] containing top K values from the input tensor</dd>
-<dt><tt>Indices</tt> (non-differentiable) : I</dt>
+<dt><tt>Indices</tt> (non-differentiable) : tensor(int64)</dt>
 <dd>Tensor of shape [a_0, a_1, ..., a_{axis-1}, k, a_{axis+1}, ... a_{n-1}] containing the corresponding input tensor indices for the top K values.</dd>
 </dl>
 
@@ -38821,8 +38739,6 @@ Other versions of this operator: <a href="Changelog.md#TopK-1">1</a>, <a href="C
 <dl>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(bfloat16)</dt>
 <dd>Constrain input and output types to numeric tensors.</dd>
-<dt><tt>I</tt> : tensor(int64)</dt>
-<dd>Constrain index tensor to int64</dd>
 </dl>
 
 
@@ -40420,7 +40336,7 @@ Other versions of this operator: <a href="Changelog.md#Where-9">9</a>
 #### Inputs
 
 <dl>
-<dt><tt>condition</tt> (non-differentiable) : B</dt>
+<dt><tt>condition</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>When True (nonzero), yield X, otherwise yield Y</dd>
 <dt><tt>X</tt> (differentiable) : T</dt>
 <dd>values selected at indices where condition is True</dd>
@@ -40438,8 +40354,6 @@ Other versions of this operator: <a href="Changelog.md#Where-9">9</a>
 #### Type Constraints
 
 <dl>
-<dt><tt>B</tt> : tensor(bool)</dt>
-<dd>Constrain to boolean tensors.</dd>
 <dt><tt>T</tt> : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(bfloat16), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128)</dt>
 <dd>Constrain input and output types to all tensor types (including bfloat).</dd>
 </dl>
@@ -40514,7 +40428,7 @@ Other versions of this operator: <a href="Changelog.md#Xor-1">1</a>
 #### Outputs
 
 <dl>
-<dt><tt>C</tt> (non-differentiable) : T1</dt>
+<dt><tt>C</tt> (non-differentiable) : tensor(bool)</dt>
 <dd>Result tensor.</dd>
 </dl>
 
@@ -40523,8 +40437,6 @@ Other versions of this operator: <a href="Changelog.md#Xor-1">1</a>
 <dl>
 <dt><tt>T</tt> : tensor(bool)</dt>
 <dd>Constrain input to boolean tensor.</dd>
-<dt><tt>T1</tt> : tensor(bool)</dt>
-<dd>Constrain output to boolean tensor.</dd>
 </dl>
 
 
@@ -41227,7 +41139,7 @@ This version of the operator has been available since version 1 of the 'ai.onnx.
 <dl>
 <dt><tt>R</tt> : T1</dt>
 <dd>The initial learning rate.</dd>
-<dt><tt>T</tt> : T2</dt>
+<dt><tt>T</tt> : tensor(int64)</dt>
 <dd>The update count of "X". It should be a scalar.</dd>
 <dt><tt>inputs</tt> (variadic, heterogeneous) : T3</dt>
 <dd>The current values of optimized tensors, followed by their respective gradients, followed by their respective accumulated squared gradients.For example, if two tensor "X_1" and "X_2" are optimized, The input list would be ["X_1", "X_2", gradient of "X_1", gradient of "X_2", accumulated squared gradient of "X_1", accumulated squared gradient of "X_2"].</dd>
@@ -41245,8 +41157,6 @@ This version of the operator has been available since version 1 of the 'ai.onnx.
 <dl>
 <dt><tt>T1</tt> : tensor(float), tensor(double)</dt>
 <dd>Constrain input types to float scalars.</dd>
-<dt><tt>T2</tt> : tensor(int64)</dt>
-<dd>Constrain input types to 64-bit integer scalars.</dd>
 <dt><tt>T3</tt> : tensor(float), tensor(double)</dt>
 <dd>Constrain input and output types to float tensors.</dd>
 </dl>
@@ -41443,7 +41353,7 @@ This version of the operator has been available since version 1 of the 'ai.onnx.
 <dl>
 <dt><tt>R</tt> : T1</dt>
 <dd>The initial learning rate.</dd>
-<dt><tt>T</tt> : T2</dt>
+<dt><tt>T</tt> : tensor(int64)</dt>
 <dd>The update count of "X". It should be a scalar.</dd>
 <dt><tt>inputs</tt> (variadic, heterogeneous) : T3</dt>
 <dd>The tensors to be optimized, followed by their respective gradients, followed by their respective accumulated gradients (aka momentum), followed by their respective accumulated squared gradients. For example, to optimize tensors "X_1" and "X_2,", the input list would be ["X_1", "X_2", gradient of "X_1", gradient of "X_2", accumulated gradient of "X_1", accumulated gradient of "X_2", accumulated squared gradient of "X_1", accumulated squared gradient of "X_2"].</dd>
@@ -41461,8 +41371,6 @@ This version of the operator has been available since version 1 of the 'ai.onnx.
 <dl>
 <dt><tt>T1</tt> : tensor(float), tensor(double)</dt>
 <dd>Constrain input types to float scalars.</dd>
-<dt><tt>T2</tt> : tensor(int64)</dt>
-<dd>Constrain input types to 64-bit integer scalars.</dd>
 <dt><tt>T3</tt> : tensor(float), tensor(double)</dt>
 <dd>Constrain input and output types to float tensors.</dd>
 </dl>
@@ -41939,7 +41847,7 @@ This version of the operator has been available since version 1 of the 'ai.onnx.
 <dl>
 <dt><tt>R</tt> : T1</dt>
 <dd>The learning rate.</dd>
-<dt><tt>T</tt> : T2</dt>
+<dt><tt>T</tt> : tensor(int64)</dt>
 <dd>Update count of "X". It should be a scalar.</dd>
 <dt><tt>inputs</tt> (variadic, heterogeneous) : T3</dt>
 <dd>It sequentially contains the current values of optimized tensors, then their gradient tensors, and finally their momentum tensors. For example, if two tensors "X_1" and "X_2" are optimized, The expected input list would be ["X_1", "X_2", gradient of "X_1", gradient of "X_2", momentum of "X_1", momentum of "X_2"].</dd>
@@ -41957,8 +41865,6 @@ This version of the operator has been available since version 1 of the 'ai.onnx.
 <dl>
 <dt><tt>T1</tt> : tensor(float), tensor(double)</dt>
 <dd>Constrain input types to float scalars.</dd>
-<dt><tt>T2</tt> : tensor(int64)</dt>
-<dd>Constrain input types to 64-bit integer scalars.</dd>
 <dt><tt>T3</tt> : tensor(float), tensor(double)</dt>
 <dd>Constrain input types to float tensors.</dd>
 </dl>

--- a/onnx/defs/controlflow/defs.cc
+++ b/onnx/defs/controlflow/defs.cc
@@ -28,7 +28,7 @@ ONNX_OPERATOR_SET_SCHEMA(
     25,
     OpSchema()
         .SetDoc("If conditional")
-        .Input(0, "cond", "Condition for the if. The tensor must contain a single element.", "B")
+        .Input(0, "cond", "Condition for the if. The tensor must contain a single element.", types::Bool)
         .Output(
             0,
             "outputs",
@@ -67,7 +67,6 @@ ONNX_OPERATOR_SET_SCHEMA(
             "V",
             control_flow_types_ir13(),
             "All Tensor, Sequence(Tensor), Optional(Tensor), and Optional(Sequence(Tensor)) types up to IRv13.")
-        .TypeConstraint("B", {types::Bool}, "Only bool")
         .TypeAndShapeInferenceFunction(IfInferenceFunction));
 
 ONNX_OPERATOR_SET_SCHEMA(
@@ -80,13 +79,13 @@ ONNX_OPERATOR_SET_SCHEMA(
             "M",
             "A maximum trip-count for the loop specified at runtime. Optional."
             " Pass empty string to skip.",
-            "I",
+            types::Int64,
             OpSchema::Optional)
         .Input(
             1,
             "cond",
             "A boolean termination condition. Optional. Pass empty string to skip.",
-            "B",
+            types::Bool,
             OpSchema::Optional)
         .Input(
             2,
@@ -119,8 +118,6 @@ ONNX_OPERATOR_SET_SCHEMA(
             "V",
             control_flow_types_ir13(),
             "All Tensor, Sequence(Tensor), Optional(Tensor), and Optional(Sequence(Tensor)) types up to IRv13.")
-        .TypeConstraint("I", {types::Int64}, "tensor of int64, which should be a scalar.")
-        .TypeConstraint("B", {types::Bool}, "tensor of bool, which should be a scalar.")
         .TypeAndShapeInferenceFunction(LoopInferenceFunction));
 
 ONNX_OPERATOR_SET_SCHEMA(

--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -73,7 +73,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "input",
             "1D tensor. The shape of the expected output tensor. If empty tensor is given, the output would be a scalar."
             " All values must be >= 0.",
-            "T1")
+            types::Int64)
         .Output(
             0,
             "output",
@@ -82,7 +82,6 @@ ONNX_OPERATOR_SET_SCHEMA(
             "If attribute 'value' is not specified, the value in the output defaults to 0, and the datatype "
             "defaults to float32.",
             "T2")
-        .TypeConstraint("T1", {types::Int64}, "Constrain input types.")
         .TypeConstraint(
             "T2",
             {types::Float16,      types::Float,          types::Double,     types::Int8,           types::Int16,

--- a/onnx/defs/image/defs.cc
+++ b/onnx/defs/image/defs.cc
@@ -45,10 +45,16 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Pixel format. Can be one of \"RGB\", \"BGR\", or \"Grayscale\".",
             AttributeProto::STRING,
             std::string("RGB"))
-        .Input(0, "encoded_stream", "Encoded stream", "T1", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
-        .Output(0, "image", "Decoded image", "T2", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
-        .TypeConstraint("T1", {types::UInt8}, "Constrain input types to 8-bit unsigned integer tensor.")
-        .TypeConstraint("T2", {types::UInt8}, "Constrain output types to 8-bit unsigned integer tensor.")
+        .Input(
+            0,
+            "encoded_stream",
+            "Encoded stream",
+            types::UInt8,
+            OpSchema::Single,
+            true,
+            1,
+            OpSchema::NonDifferentiable)
+        .Output(0, "image", "Decoded image", types::UInt8, OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           if (hasInputShape(ctx, 0)) {
             auto& input_shape = getInputShape(ctx, 0);

--- a/onnx/defs/logical/defs.cc
+++ b/onnx/defs/logical/defs.cc
@@ -61,7 +61,7 @@ elementwise on the input tensors `A` and `B` (with Numpy-style broadcasting supp
         true,
         1,
         OpSchema::NonDifferentiable);
-    schema.Output(0, "C", "Result tensor.", "T1", OpSchema::Single, true, 1, OpSchema::NonDifferentiable);
+    schema.Output(0, "C", "Result tensor.", types::Bool, OpSchema::Single, true, 1, OpSchema::NonDifferentiable);
     schema.TypeAndShapeInferenceFunction(binaryLogicalOpInference);
   };
 }
@@ -71,40 +71,35 @@ ONNX_OPERATOR_SET_SCHEMA(
     7,
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator("and"))
-        .TypeConstraint("T", {types::Bool}, "Constrain input to boolean tensor.")
-        .TypeConstraint("T1", {types::Bool}, "Constrain output to boolean tensor."));
+        .TypeConstraint("T", {types::Bool}, "Constrain input to boolean tensor."));
 
 ONNX_OPERATOR_SET_SCHEMA(
     Or,
     7,
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator("or"))
-        .TypeConstraint("T", {types::Bool}, "Constrain input to boolean tensor.")
-        .TypeConstraint("T1", {types::Bool}, "Constrain output to boolean tensor."));
+        .TypeConstraint("T", {types::Bool}, "Constrain input to boolean tensor."));
 
 ONNX_OPERATOR_SET_SCHEMA(
     Xor,
     7,
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator("xor"))
-        .TypeConstraint("T", {types::Bool}, "Constrain input to boolean tensor.")
-        .TypeConstraint("T1", {types::Bool}, "Constrain output to boolean tensor."));
+        .TypeConstraint("T", {types::Bool}, "Constrain input to boolean tensor."));
 
 ONNX_OPERATOR_SET_SCHEMA(
     Greater,
     13,
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator("greater"))
-        .TypeConstraint("T", OpSchema::all_numeric_types_ir4(), "Constrain input types to all numeric tensors.")
-        .TypeConstraint("T1", {types::Bool}, "Constrain output to boolean tensor."));
+        .TypeConstraint("T", OpSchema::all_numeric_types_ir4(), "Constrain input types to all numeric tensors."));
 
 ONNX_OPERATOR_SET_SCHEMA(
     Less,
     13,
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator("less"))
-        .TypeConstraint("T", OpSchema::all_numeric_types_ir4(), "Constrain input types to all numeric tensors.")
-        .TypeConstraint("T1", {types::Bool}, "Constrain output to boolean tensor."));
+        .TypeConstraint("T", OpSchema::all_numeric_types_ir4(), "Constrain input types to all numeric tensors."));
 
 ONNX_OPERATOR_SET_SCHEMA(
     Equal,
@@ -127,8 +122,7 @@ ONNX_OPERATOR_SET_SCHEMA(
              types::Double,
              types::BFloat16,
              types::String},
-            "Constrain input types to all (non-complex) tensors.")
-        .TypeConstraint("T1", {types::Bool}, "Constrain output to boolean tensor."));
+            "Constrain input types to all (non-complex) tensors."));
 
 static constexpr const char* Not_ver1_doc = R"DOC(
 Returns the negation of the input tensor element-wise.
@@ -200,7 +194,6 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator("less_equal"))
         .TypeConstraint("T", OpSchema::all_numeric_types_ir4(), "Constrain input types to all numeric tensors.")
-        .TypeConstraint("T1", {types::Bool}, "Constrain output to boolean tensor.")
         .TypeAndShapeInferenceFunction(binaryLogicalOpInference)
         .FunctionBody(R"ONNX(
         {
@@ -216,7 +209,6 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .FillUsing(BinaryLogicDocGenerator("greater_equal"))
         .TypeConstraint("T", OpSchema::all_numeric_types_ir4(), "Constrain input types to all numeric tensors.")
-        .TypeConstraint("T1", {types::Bool}, "Constrain output to boolean tensor.")
         .TypeAndShapeInferenceFunction(binaryLogicalOpInference)
         .FunctionBody(R"ONNX(
         {

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -1422,7 +1422,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             1,
             "shape",
             "A 1-D tensor indicates the shape you want to expand to, following the broadcast rule",
-            "tensor(int64)",
+            types::Int64,
             OpSchema::Single,
             true,
             1,
@@ -1705,14 +1705,13 @@ ONNX_OPERATOR_SET_SCHEMA(
             0,
             "Y",
             "Matrix multiply results from A * B",
-            "T3",
+            types::Int32,
             OpSchema::Single,
             true,
             1,
             OpSchema::NonDifferentiable)
         .TypeConstraint("T1", {types::Int8, types::UInt8}, "Constrain input A data type to 8-bit integer tensor.")
         .TypeConstraint("T2", {types::Int8, types::UInt8}, "Constrain input B data type to 8-bit integer tensor.")
-        .TypeConstraint("T3", {types::Int32}, "Constrain output Y data type as 32-bit integer tensor.")
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
           auto a_type = ctx.getInputType(0);
           auto b_type = ctx.getInputType(1);
@@ -2605,7 +2604,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The axis as a scalar on which to perform the DFT. Default is `-2` (last signal axis). "
             "Negative value means counting dimensions from the back. Accepted range is $[-r, -2] \\cup [0, r-2]$ where `r = rank(input)`. "
             "The last dimension is for representing complex numbers and thus is an invalid axis.",
-            "tensor(int64)",
+            types::Int64,
             OpSchema::Optional,
             true,
             1,

--- a/onnx/defs/math/utils.cc
+++ b/onnx/defs/math/utils.cc
@@ -49,7 +49,7 @@ std::function<void(OpSchema&)> TopKOpGenerator(std::vector<std::string> allowed_
             1,
             "K",
             "A 1-D tensor containing a single positive value corresponding to the number of top elements to retrieve",
-            "tensor(int64)",
+            types::Int64,
             OpSchema::Single,
             true,
             1,
@@ -70,13 +70,12 @@ std::function<void(OpSchema&)> TopKOpGenerator(std::vector<std::string> allowed_
             "Tensor of shape [a_0, a_1, ..., a_{axis-1}, k, a_{axis+1}, ... a_{n-1}] "
             "containing the corresponding input tensor indices for the top K "
             "values.",
-            "I",
+            types::Int64,
             OpSchema::Single,
             true,
             1,
             OpSchema::NonDifferentiable)
         .TypeConstraint("T", allowed_types, "Constrain input and output types to numeric tensors.")
-        .TypeConstraint("I", {types::Int64}, "Constrain index tensor to int64")
         .Attr(
             "axis",
             "Dimension on which to do the sort. Negative value means counting dimensions "

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -362,12 +362,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The indices are computed as flatten 1-D tensor, "
             "and the indices do not consider padding. "
             "So the values in indices are in [0, N x C x D1 x ... x Dn).",
-            "I",
+            types::Int64,
             OpSchema::Optional,
             true,
             1,
-            OpSchema::NonDifferentiable)
-        .TypeConstraint("I", {types::Int64}, "Constrain index tensor to int64"));
+            OpSchema::NonDifferentiable));
 
 static void maxUnpoolShapeInference(InferenceContext& ctx) {
   // we need at least two inputs to have a shape for this inference.
@@ -842,7 +841,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             1,
             "x_scale",
             "Scale tensor for input 'x'. It's a scalar, which means a per-tensor/layer quantization.",
-            "tensor(float)")
+            types::Float)
         .Input(
             2,
             "x_zero_point",
@@ -870,7 +869,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             4,
             "w_scale",
             "Scale tensor for input 'w'. It could be a scalar or a 1-D tensor, which means a per-tensor/layer or per output channel quantization. If it's a 1-D tensor, its number of elements should be equal to the number of output channels (M).",
-            "tensor(float)")
+            types::Float)
         .Input(
             5,
             "w_zero_point",
@@ -880,7 +879,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             6,
             "y_scale",
             "Scale tensor for output 'y'. It's a scalar, which means a per-tensor/layer quantization.",
-            "tensor(float)")
+            types::Float)
         .Input(
             7,
             "y_zero_point",
@@ -891,7 +890,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "B",
             "Optional 1D bias to be added to the convolution, has size of M. "
             "Bias must be quantized using scale = x_scale * w_scale and zero_point = 0",
-            "T4",
+            types::Int32,
             OpSchema::Optional)
         .Output(
             0,
@@ -903,7 +902,6 @@ ONNX_OPERATOR_SET_SCHEMA(
         .TypeConstraint("T1", {types::Int8, types::UInt8}, "Constrain input type to 8-bit integer tensor.")
         .TypeConstraint("T2", {types::Int8, types::UInt8}, "Constrain filter type to 8-bit integer tensor.")
         .TypeConstraint("T3", {types::Int8, types::UInt8}, "Constrain output type to 8-bit integer tensor.")
-        .TypeConstraint("T4", {types::Int32}, "Constrain bias type to 32-bit integer tensor.")
         .Attr("auto_pad", conv_auto_pad_doc, AttributeProto::STRING, std::string("NOTSET"))
         .Attr(
             "kernel_shape",
@@ -1023,7 +1021,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Output data tensor that contains the result of the "
             "convolution. The output dimensions are functions "
             "of the kernel size, stride size, and pad lengths.",
-            "T3")
+            types::Int32)
         .TypeConstraint(
             "T1",
             {types::Int8, types::UInt8},
@@ -1032,7 +1030,6 @@ ONNX_OPERATOR_SET_SCHEMA(
             "T2",
             {types::Int8, types::UInt8},
             "Constrain input w and its zero point data type to 8-bit integer tensor.")
-        .TypeConstraint("T3", {types::Int32}, "Constrain output y data type to 32-bit integer tensor.")
         .Attr("auto_pad", conv_auto_pad_doc, AttributeProto::STRING, std::string("NOTSET"))
         .Attr(
             "kernel_shape",
@@ -2057,9 +2054,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     9,
     OpSchema()
         .Input(0, "X", "Input for n-gram extraction", "T", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
-        .Output(0, "Y", "Ngram results", "T1", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
+        .Output(0, "Y", "Ngram results", types::Float, OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
         .TypeConstraint("T", {types::String, types::Int32, types::Int64}, "Input is either string UTF-8 or int32/int64")
-        .TypeConstraint("T1", {types::Float}, "1-D tensor of floats")
         .Attr(
             "max_gram_length",
             "Maximum n-gram length. If this value is 3, 3-grams will be used to generate the output.",
@@ -2357,7 +2353,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The shape of the spatial dimensions of the image after rearranging the column blocks."
             "This is a 1-dimensional tensor with size of at least 2, containing the value [H_img, W_img] "
             " for a 2-D image or [dim_i1, dim_i2, ..., dim_iN] for a N-D image.",
-            "tensor(int64)",
+            types::Int64,
             OpSchema::Single,
             true,
             1,
@@ -2369,7 +2365,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "This is a 1-dimensional tensor of size of at least 2, containing the value [H_block, W_block] "
             " for a 2-D image or [dim_b1, dim_b2, ..., dim_bN] for a N-D block."
             "This is the block-shape before dilation is applied to it.",
-            "tensor(int64)",
+            types::Int64,
             OpSchema::Single,
             true,
             1,
@@ -3068,14 +3064,13 @@ ONNX_OPERATOR_SET_SCHEMA(
             3,
             "position_ids",
             "The position indices for the tokens. 2D tensor with shape `(batch_size, sequence_length)`",
-            "M",
+            types::Int64,
             OpSchema::Optional)
         .Output(0, "Y", "Tensor with same shape as input.", "T")
         .TypeConstraint(
             "T",
             {types::Float, types::Float16, types::BFloat16},
             "Constrain input and output types to float tensors.")
-        .TypeConstraint("M", {types::Int64}, "Constrain input and output types to integer tensors.")
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
           propagateShapeFromInputToOutput(ctx, 0, 0);
@@ -3422,7 +3417,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "tokens in each sample. A padding mask can be derived from this. This should not be used together with "
             "`past_key` and `past_value` inputs or `present_key` and `present_value` outputs "
             "(See the KV cache use cases in the operator description).",
-            "tensor(int64)",
+            types::Int64,
             OpSchema::Optional)
         .Output(
             0,

--- a/onnx/defs/object_detection/defs.cc
+++ b/onnx/defs/object_detection/defs.cc
@@ -70,7 +70,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "batch_indices",
             "1-D tensor of shape (num_rois,) with each element denoting "
             "the index of the corresponding image in the batch.",
-            "T2")
+            types::Int64)
         .Output(
             0,
             "Y",
@@ -79,7 +79,6 @@ ONNX_OPERATOR_SET_SCHEMA(
             "is a pooled feature map corresponding to the r-th RoI X[r-1].",
             "T1")
         .TypeConstraint("T1", OpSchema::all_float_types_ir4(), "Constrain types to float tensors.")
-        .TypeConstraint("T2", {types::Int64}, "Constrain types to int tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
 
@@ -118,31 +117,31 @@ ONNX_OPERATOR_SET_SCHEMA(
             0,
             "boxes",
             "An input tensor with shape [num_batches, spatial_dimension, 4]. The single box data format is indicated by center_point_box.",
-            "tensor(float)")
-        .Input(1, "scores", "An input tensor with shape [num_batches, num_classes, spatial_dimension]", "tensor(float)")
+            types::Float)
+        .Input(1, "scores", "An input tensor with shape [num_batches, num_classes, spatial_dimension]", types::Float)
         .Input(
             2,
             "max_output_boxes_per_class",
             "Integer representing the maximum number of boxes to be selected per batch per class. It is a scalar. Default to 0, which means no output.",
-            "tensor(int64)",
+            types::Int64,
             OpSchema::Optional)
         .Input(
             3,
             "iou_threshold",
             "Float representing the threshold for deciding whether boxes overlap too much with respect to IOU. Boxes with IoU strictly greater than this threshold are suppressed. It is scalar. Value range [0, 1]. Default to 0.",
-            "tensor(float)",
+            types::Float,
             OpSchema::Optional)
         .Input(
             4,
             "score_threshold",
             "Float representing the threshold for deciding when to remove boxes based on score. It is a scalar.",
-            "tensor(float)",
+            types::Float,
             OpSchema::Optional)
         .Output(
             0,
             "selected_indices",
             "selected indices from the boxes tensor. [num_selected_indices, 3], the selected index format is [batch_index, class_index, box_index].",
-            "tensor(int64)")
+            types::Int64)
         .Attr(
             "center_point_box",
             "Integer indicate the format of the box data. The default is 0. "

--- a/onnx/defs/optional/defs.cc
+++ b/onnx/defs/optional/defs.cc
@@ -86,12 +86,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             0,
             "output",
             "A scalar boolean tensor. If true, it indicates that optional-type input contains an element. Otherwise, it is empty.",
-            "B")
+            types::Bool)
         .TypeConstraint(
             "O",
             optional_and_tensor_types(),
             "Constrain input type to optional tensor and optional sequence types.")
-        .TypeConstraint("B", {types::Bool}, "Constrain output to a boolean tensor.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           const size_t numInputs = ctx.getNumInputs();
           if (numInputs != 0 && numInputs != 1) {

--- a/onnx/defs/quantization/defs.cc
+++ b/onnx/defs/quantization/defs.cc
@@ -268,19 +268,14 @@ ONNX_OPERATOR_SET_SCHEMA(
     11,
     OpSchema()
         .SetDoc(DynamicQuantizeLinear_ver11_doc)
-        .Input(0, "x", "Input tensor", "T1")
+        .Input(0, "x", "Input tensor", types::Float)
         .Output(0, "y", "Quantized output tensor", "T2")
-        .Output(
-            1,
-            "y_scale",
-            "Output scale. It's a scalar, which means a per-tensor/layer quantization.",
-            "tensor(float)")
+        .Output(1, "y_scale", "Output scale. It's a scalar, which means a per-tensor/layer quantization.", types::Float)
         .Output(
             2,
             "y_zero_point",
             "Output zero point. It's a scalar, which means a per-tensor/layer quantization.",
             "T2")
-        .TypeConstraint("T1", {types::Float}, "Constrain 'x' to float tensor.")
         .TypeConstraint("T2", {types::UInt8}, "Constrain 'y_zero_point' and 'y' to 8-bit unsigned integer tensor.")
         .FunctionBody(R"ONNX(
         {

--- a/onnx/defs/rnn/defs.cc
+++ b/onnx/defs/rnn/defs.cc
@@ -137,7 +137,7 @@ static std::function<void(OpSchema&)> RNNDocGenerator(const char* /*name*/) {
         "Optional tensor specifying lengths of the sequences in a batch. "
         "If not specified - assumed all sequences in the batch to have "
         "length `seq_length`. It has shape `[batch_size]`.",
-        "T1",
+        types::Int32,
         OpSchema::Optional,
         true,
         1,
@@ -173,7 +173,6 @@ static std::function<void(OpSchema&)> RNNDocGenerator(const char* /*name*/) {
         1,
         OpSchema::Differentiable);
     schema.TypeConstraint("T", OpSchema::all_float_types_ir4(), "Constrain input and output types to float tensors.");
-    schema.TypeConstraint("T1", {types::Int32}, "Constrain seq_lens to integer tensor.");
     schema.TypeAndShapeInferenceFunction(RNNShapeInference);
   };
 }

--- a/onnx/defs/sequence/defs.cc
+++ b/onnx/defs/sequence/defs.cc
@@ -245,12 +245,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .SetDoc(SequenceLength_ver11_doc)
         .Input(0, "input_sequence", "Input sequence.", "S")
-        .Output(0, "length", "Length of input sequence. It must be a scalar(tensor of empty shape).", "I")
+        .Output(0, "length", "Length of input sequence. It must be a scalar(tensor of empty shape).", types::Int64)
         .TypeConstraint("S", OpSchema::all_tensor_sequence_types(), "Constrain to any tensor type.")
-        .TypeConstraint(
-            "I",
-            {types::Int64},
-            "Constrain output to integral tensor. It must be a scalar(tensor of empty shape).")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           auto output_tensor_type = ctx.getOutputType(0)->mutable_tensor_type();
           output_tensor_type->set_elem_type(TensorProto::INT64);

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -265,7 +265,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             1,
             "shape",
             "Specified shape for output.",
-            "tensor(int64)",
+            types::Int64,
             OpSchema::Single,
             true,
             1,
@@ -401,7 +401,15 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .SetDoc(kDoc_Shape_ver24)
         .Input(0, "data", "An input tensor.", "T", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
-        .Output(0, "shape", "Shape of the input tensor", "T1", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
+        .Output(
+            0,
+            "shape",
+            "Shape of the input tensor",
+            types::Int64,
+            OpSchema::Single,
+            true,
+            1,
+            OpSchema::NonDifferentiable)
         .Attr(
             "start",
             "(Optional) Starting axis for slicing the shape. Default value is 0."
@@ -416,7 +424,6 @@ ONNX_OPERATOR_SET_SCHEMA(
             AttributeProto::INT,
             OPTIONAL_VALUE)
         .TypeConstraint("T", OpSchema::all_tensor_types_ir13(), "Input tensor can be of arbitrary type.")
-        .TypeConstraint("T1", {types::Int64}, "Constrain output to int64 tensor.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           ctx.getOutputType(0)->mutable_tensor_type()->set_elem_type(TensorProto::INT64);
           auto output_shape = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
@@ -467,13 +474,12 @@ ONNX_OPERATOR_SET_SCHEMA(
             0,
             "size",
             "Total number of elements of the input tensor",
-            "T1",
+            types::Int64,
             OpSchema::Single,
             true,
             1,
             OpSchema::NonDifferentiable)
         .TypeConstraint("T", OpSchema::all_tensor_types_ir13(), "Input tensor can be of arbitrary type.")
-        .TypeConstraint("T1", {types::Int64}, "Constrain output to int64 tensor, which should be a scalar though.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           ctx.getOutputType(0)->mutable_tensor_type()->set_elem_type(TensorProto::INT64);
           ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();
@@ -607,7 +613,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "split",
             "Optional length of each output. Values should be >= 0."
             "Sum of the values must be equal to the dim value at 'axis' specified.",
-            "tensor(int64)",
+            types::Int64,
             OpSchema::Optional,
             true,
             1,
@@ -1338,7 +1344,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             1,
             "indices",
             "Tensor of rank q >= 1.",
-            "tensor(int64)",
+            types::Int64,
             OpSchema::Single,
             true,
             1,
@@ -1724,7 +1730,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "axes",
             "1D tensor of integers indicating the dimensions to squeeze. Negative value means counting dimensions "
             "from the back. Accepted range is [-r, r-1] where r = rank(data).",
-            "tensor(int64)",
+            types::Int64,
             OpSchema::Optional,
             true,
             1,
@@ -1812,7 +1818,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "axes",
             "1D tensor of integers indicating the dimensions to be inserted. Negative value means counting dimensions "
             "from the back. Accepted range is [-r, r-1] where r = rank(expanded).",
-            "tensor(int64)",
+            types::Int64,
             OpSchema::Single,
             true,
             1,
@@ -2010,7 +2016,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "repeats",
             "1D int64 tensor of the same length as input's dimension number, "
             "includes numbers of repeated copies along input's dimensions.",
-            "T1",
+            types::Int64,
             OpSchema::Single,
             true,
             1,
@@ -2026,7 +2032,6 @@ ONNX_OPERATOR_SET_SCHEMA(
             1,
             OpSchema::Differentiable)
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain input and output types to all tensor types.")
-        .TypeConstraint("T1", {types::Int64}, "Constrain repeat's type to int64 tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           // Type inference
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
@@ -2094,7 +2099,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "scales",
             "The scale array along each dimension. It takes value greater than or equal to 1."
             " The number of elements of 'scales' should be the same as the rank of input 'X'.",
-            "tensor(float)",
+            types::Float,
             OpSchema::Single)
         .Output(0, "Y", "N-D tensor after resizing", "T", OpSchema::Single)
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input 'X' and output 'Y' to all tensor types.")
@@ -2258,7 +2263,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             " it's sampling down, otherwise, it's upsampling. The number of elements of 'scales' should"
             " be the same as the rank of input 'X' or the length of 'axes', if provided. "
             "One of 'scales' and 'sizes' MUST be specified and it is an error if both are specified. If 'sizes' is needed, the user can use an empty string as the name of 'scales' in this operator's input list.",
-            "tensor(float)",
+            types::Float,
             OpSchema::Optional,
             true,
             1,
@@ -2269,7 +2274,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Target size of the output tensor. Its interpretation depends on the 'keep_aspect_ratio_policy' value."
             "The number of elements of 'sizes' should be the same as the"
             " rank of input 'X', or the length of 'axes', if provided. Only one of 'scales' and 'sizes' can be specified. ",
-            "tensor(int64)",
+            types::Int64,
             OpSchema::Optional,
             true,
             1,
@@ -2410,7 +2415,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             1,
             "size",
             "the target output image size (N, C, H, W) for 2D or (N, C, D, H, W) for 3D",
-            "T2",
+            types::Int64,
             OpSchema::Single,
             true,
             1,
@@ -2425,7 +2430,6 @@ ONNX_OPERATOR_SET_SCHEMA(
             1,
             OpSchema::Differentiable)
         .TypeConstraint("T1", OpSchema::all_float_types_ir4(), "Constrain grid types to float tensors.")
-        .TypeConstraint("T2", {types::Int64}, "Constrain size's type to int64 tensors.")
         .SetDoc(AffineGrid_ver20_doc)
         .FunctionBody(R"ONNX(
         {
@@ -2679,7 +2683,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "Its length can be less than the input length along the axis "
             "or the flattened input size if axis is not specified. "
             "In such cases data slices or elements exceeding the condition length are discarded.",
-            "T1",
+            types::Bool,
             OpSchema::Single,
             true,
             1,
@@ -2694,7 +2698,6 @@ ONNX_OPERATOR_SET_SCHEMA(
             1,
             OpSchema::Differentiable)
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Constrain input and output types to all tensor types.")
-        .TypeConstraint("T1", {types::Bool}, "Constrain to boolean tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
           auto axisAttr = ctx.getAttribute("axis");
@@ -2900,9 +2903,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .SetDoc(R"DOC(Returns which elements of the input are NaN.)DOC")
         .Input(0, "X", "input", "T1", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
-        .Output(0, "Y", "output", "T2", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
+        .Output(0, "Y", "output", types::Bool, OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
         .TypeConstraint("T1", OpSchema::all_float_types_ir9(), "Constrain input types to float tensors.")
-        .TypeConstraint("T2", {types::Bool}, "Constrain output types to boolean tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           updateOutputElemType(ctx, 0, TensorProto::BOOL);
           if (hasInputShape(ctx, 0)) {
@@ -2916,7 +2918,7 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .SetDoc(R"DOC(Map infinity to true and other values to false.)DOC")
         .Input(0, "X", "input", "T1", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
-        .Output(0, "Y", "output", "T2", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
+        .Output(0, "Y", "output", types::Bool, OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
         .Attr(
             "detect_positive",
             "(Optional) Whether map positive infinity to true. Default to 1 "
@@ -2932,7 +2934,6 @@ ONNX_OPERATOR_SET_SCHEMA(
             AttributeProto::INT,
             static_cast<int64_t>(1))
         .TypeConstraint("T1", OpSchema::all_float_types_ir9(), "Constrain input types to float tensors.")
-        .TypeConstraint("T2", {types::Bool}, "Constrain output types to boolean tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           updateOutputElemType(ctx, 0, TensorProto::BOOL);
           if (hasInputShape(ctx, 0)) {
@@ -2949,7 +2950,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             0,
             "condition",
             "When True (nonzero), yield X, otherwise yield Y",
-            "B",
+            types::Bool,
             OpSchema::Single,
             true,
             1,
@@ -2981,7 +2982,6 @@ ONNX_OPERATOR_SET_SCHEMA(
             true,
             1,
             OpSchema::Differentiable)
-        .TypeConstraint("B", {types::Bool}, "Constrain to boolean tensors.")
         .TypeConstraint(
             "T",
             OpSchema::all_tensor_types_ir4(),
@@ -3004,7 +3004,7 @@ ONNX_OPERATOR_SET_SCHEMA(
     OpSchema()
         .SetDoc(NonZero_ver9_doc)
         .Input(0, "X", "input", "T", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
-        .Output(0, "Y", "output", "tensor(int64)", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
+        .Output(0, "Y", "output", types::Int64, OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
         .TypeConstraint("T", OpSchema::all_tensor_types_ir4(), "Constrain to all tensor types.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           updateOutputElemType(ctx, 0, TensorProto::INT64);
@@ -3074,7 +3074,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             1,
             "sequence_lens",
             "Tensor specifying lengths of the sequences in a batch. It has shape `[batch_size]`.",
-            "tensor(int64)",
+            types::Int64,
             OpSchema::Single)
         .Output(0, "Y", "Tensor with same shape of input.", "T", OpSchema::Single)
         .TypeConstraint("T", OpSchema::all_tensor_types(), "Input and output types can be of any tensor type.")
@@ -3241,7 +3241,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "containing indices of 'Y' elements' first occurrence in 'X'. "
             "When 'axis' is provided, it contains indices to subtensors in input 'X' on the 'axis'. "
             "When 'axis' is not provided, it contains indices to values in the flattened input tensor. ",
-            "tensor(int64)",
+            types::Int64,
             OpSchema::Optional,
             true,
             1,
@@ -3253,7 +3253,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "containing, for elements of 'X', its corresponding indices in 'Y'. "
             "When 'axis' is provided, it contains indices to subtensors in output 'Y' on the 'axis'. "
             "When 'axis' is not provided, it contains indices to values in output 'Y'. ",
-            "tensor(int64)",
+            types::Int64,
             OpSchema::Optional,
             true,
             1,
@@ -3264,7 +3264,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "A 1-D INT64 tensor containing "
             "the count of each element "
             "of 'Y' in input 'X'",
-            "tensor(int64)",
+            types::Int64,
             OpSchema::Optional,
             true,
             1,
@@ -3434,7 +3434,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "indices",
             "Tensor of rank q >= 1. All index values are expected to be within bounds [-s, s-1] "
             "along axis of size s. It is an error if any of the index values are out of bounds.",
-            "tensor(int64)",
+            types::Int64,
             OpSchema::Single,
             true,
             1,
@@ -3543,7 +3543,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "k",
             "A 0-D tensor containing a single value corresponding to the number diagonals above or below the main diagonal to exclude or include. "
             "Default value is 0 if it's not specified.",
-            "tensor(int64)",
+            types::Int64,
             OpSchema::Optional,
             true,
             1,
@@ -3808,7 +3808,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             2,
             "write_indices",
             "Write indices for the incoming update tensor in the cache. Shape is `(batch_size,)`. Assumed to be all zeros if not provided.",
-            "tensor(int64)",
+            types::Int64,
             OpSchema::Optional,
             true,
             1,

--- a/onnx/defs/text/defs.cc
+++ b/onnx/defs/text/defs.cc
@@ -42,22 +42,25 @@ ONNX_OPERATOR_SET_SCHEMA(
     RegexFullMatch,
     20,
     OpSchema()
-        .Input(0, "X", "Tensor with strings to match on.", "T1", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
+        .Input(
+            0,
+            "X",
+            "Tensor with strings to match on.",
+            types::String,
+            OpSchema::Single,
+            true,
+            1,
+            OpSchema::NonDifferentiable)
         .Attr("pattern", "Regex pattern to match on. This must be valid RE2 syntax.", AttributeProto::STRING, false)
         .Output(
             0,
             "Y",
             "Tensor of bools indicating if each input string fully matches the regex pattern specified.",
-            "T2",
+            types::Bool,
             OpSchema::Single,
             true,
             1,
             OpSchema::NonDifferentiable)
-        .TypeConstraint("T1", {types::String}, "Inputs must be UTF-8 strings")
-        .TypeConstraint(
-            "T2",
-            {types::Bool},
-            "Outputs are bools and are True where there is a full regex match and False otherwise.")
         .SetDoc(RegexFullMatch_doc)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           updateOutputElemType(ctx, 0, TensorProto::BOOL);
@@ -75,7 +78,15 @@ ONNX_OPERATOR_SET_SCHEMA(
     StringSplit,
     20,
     OpSchema()
-        .Input(0, "X", "Tensor of strings to split.", "T1", OpSchema::Single, true, 1, OpSchema::NonDifferentiable)
+        .Input(
+            0,
+            "X",
+            "Tensor of strings to split.",
+            types::String,
+            OpSchema::Single,
+            true,
+            1,
+            OpSchema::NonDifferentiable)
         .Attr(
             "delimiter",
             "Delimiter to split on. If left unset or set to the empty string (\"\"), the input is split on consecutive whitespace.",
@@ -90,7 +101,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             0,
             "Y",
             "Tensor of substrings representing the outcome of splitting the strings in the input on the delimiter. Note that to ensure the same number of elements are present in the final rank, this tensor will pad any necessary empty strings.",
-            "T2",
+            types::String,
             OpSchema::Single,
             true,
             1,
@@ -99,14 +110,11 @@ ONNX_OPERATOR_SET_SCHEMA(
             1,
             "Z",
             "The number of substrings generated for each input element.",
-            "T3",
+            types::Int64,
             OpSchema::Single,
             true,
             1,
             OpSchema::NonDifferentiable)
-        .TypeConstraint("T1", {types::String}, "The input must be a UTF-8 string tensor")
-        .TypeConstraint("T2", {types::String}, "Tensor of substrings.")
-        .TypeConstraint("T3", {types::Int64}, "The number of substrings generated.")
         .SetDoc(StringSplit_doc)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           if (!hasInputShape(ctx, 0)) {
@@ -147,8 +155,8 @@ ONNX_OPERATOR_SET_SCHEMA(
     StringNormalizer,
     10,
     OpSchema()
-        .Input(0, "X", "UTF-8 strings to normalize", "tensor(string)")
-        .Output(0, "Y", "UTF-8 Normalized strings", "tensor(string)")
+        .Input(0, "X", "UTF-8 strings to normalize", types::String)
+        .Output(0, "Y", "UTF-8 Normalized strings", types::String)
         .Attr(
             std::string("case_change_action"),
             std::string(

--- a/onnx/defs/training/defs.cc
+++ b/onnx/defs/training/defs.cc
@@ -249,7 +249,7 @@ ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA(
     OpSchema()
         .SetDoc(Adagrad_ver1_doc)
         .Input(0, "R", "The initial learning rate.", "T1")
-        .Input(1, "T", "The update count of \"X\". It should be a scalar.", "T2")
+        .Input(1, "T", "The update count of \"X\". It should be a scalar.", types::Int64)
         .Input(
             2,
             "inputs",
@@ -292,7 +292,6 @@ ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA(
             AttributeProto::FLOAT,
             0.0f)
         .TypeConstraint("T1", {types::Float, types::Double}, "Constrain input types to float scalars.")
-        .TypeConstraint("T2", {types::Int64}, "Constrain input types to 64-bit integer scalars.")
         .TypeConstraint("T3", {types::Float, types::Double}, "Constrain input and output types to float tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           // In comments below, we assume that the input list is
@@ -385,7 +384,7 @@ ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA(
     OpSchema()
         .SetDoc(Momentum_ver1_doc)
         .Input(0, "R", "The learning rate.", "T1")
-        .Input(1, "T", "Update count of \"X\". It should be a scalar.", "T2")
+        .Input(1, "T", "Update count of \"X\". It should be a scalar.", types::Int64)
         .Input(
             2,
             "inputs",
@@ -419,7 +418,6 @@ ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA(
             "using standard momentum",
             AttributeProto::STRING)
         .TypeConstraint("T1", {types::Float, types::Double}, "Constrain input types to float scalars.")
-        .TypeConstraint("T2", {types::Int64}, "Constrain input types to 64-bit integer scalars.")
         .TypeConstraint("T3", {types::Float, types::Double}, "Constrain input types to float tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           // Assume that the input list is [R, T, X1, X2, G1, G2, V1, V2] and
@@ -522,7 +520,7 @@ ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA(
     OpSchema()
         .SetDoc(Adam_ver1_doc)
         .Input(0, "R", "The initial learning rate.", "T1")
-        .Input(1, "T", "The update count of \"X\". It should be a scalar.", "T2")
+        .Input(1, "T", "The update count of \"X\". It should be a scalar.", types::Int64)
         .Input(
             2,
             "inputs",
@@ -577,7 +575,6 @@ ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA(
             0.0f)
         .Attr("epsilon", "Small scalar to avoid dividing by zero.", AttributeProto::FLOAT, 1e-6f)
         .TypeConstraint("T1", {types::Float, types::Double}, "Constrain input types to float scalars.")
-        .TypeConstraint("T2", {types::Int64}, "Constrain input types to 64-bit integer scalars.")
         .TypeConstraint("T3", {types::Float, types::Double}, "Constrain input and output types to float tensors.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           // Assume that the input list is [R, T, X1, X2, G1, G2, V1, V2, H1, H2] and


### PR DESCRIPTION
 



### Motivation and Context

This PR substitutes the concrete tensor-type string directly and remove the redundant TypeConstraint declaration.
