### PR TITLE
Add get_model_initializers_size utility for estimating initializer storage footprint

### DIFF
--- a/onnx/test/utils_test.py
+++ b/onnx/test/utils_test.py
@@ -79,66 +79,65 @@ class TestUtilityFunctions(unittest.TestCase):
             ):
                 onnx.utils._tar_members_filter(tar, base)
 
+    def test_get_model_initializers_size(self) -> None:
+        # Empty
+        graph_empty = helper.make_graph([], "test_empty", [], [])
+        model_empty = helper.make_model(graph_empty)
+        self.assertEqual(utils.get_model_initializers_size(model_empty), 0)
 
-def test_get_model_initializers_size(self) -> None:
-    # Empty
-    graph_empty = helper.make_graph([], "test_empty", [], [])
-    model_empty = helper.make_model(graph_empty)
-    self.assertEqual(utils.get_model_initializers_size(model_empty), 0)
+        # Standard (FLOAT=4 bytes, INT64=8 bytes)
+        t1 = helper.make_tensor(
+            "t1", TensorProto.FLOAT, [2, 2], [1.0, 2.0, 3.0, 4.0]
+        )  # 16 bytes
+        t2 = helper.make_tensor("t2", TensorProto.INT64, [3], [1, 2, 3])  # 24 bytes
+        graph_std = helper.make_graph([], "test_std", [], [], initializer=[t1, t2])
+        model_std = helper.make_model(graph_std)
+        self.assertEqual(utils.get_model_initializers_size(model_std), 40)
 
-    # Standard (FLOAT=4 bytes, INT64=8 bytes)
-    t1 = helper.make_tensor(
-        "t1", TensorProto.FLOAT, [2, 2], [1.0, 2.0, 3.0, 4.0]
-    )  # 16 bytes
-    t2 = helper.make_tensor("t2", TensorProto.INT64, [3], [1, 2, 3])  # 24 bytes
-    graph_std = helper.make_graph([], "test_std", [], [], initializer=[t1, t2])
-    model_std = helper.make_model(graph_std)
-    self.assertEqual(utils.get_model_initializers_size(model_std), 40)
+        # Raw Data
+        t3 = helper.make_tensor("t3", TensorProto.FLOAT, [2], b"12345678", raw=True)
+        graph_raw = helper.make_graph([], "test_raw", [], [], initializer=[t3])
+        model_raw = helper.make_model(graph_raw)
+        self.assertEqual(utils.get_model_initializers_size(model_raw), 8)
 
-    # Raw Data
-    t3 = helper.make_tensor("t3", TensorProto.FLOAT, [2], b"12345678", raw=True)
-    graph_raw = helper.make_graph([], "test_raw", [], [], initializer=[t3])
-    model_raw = helper.make_model(graph_raw)
-    self.assertEqual(utils.get_model_initializers_size(model_raw), 8)
+        # INT4 Packed Tensor
+        t4 = helper.make_tensor(
+            "int4_tensor",
+            TensorProto.INT4,
+            [5],
+            [1, 2, 3, 4, 5],
+        )
+        graph_int4 = helper.make_graph([], "test_int4", [], [], initializer=[t4])
+        model_int4 = helper.make_model(graph_int4)
 
-    # INT4 Packed Tensor
-    t4 = helper.make_tensor(
-        "int4_tensor",
-        TensorProto.INT4,
-        [5],
-        [1, 2, 3, 4, 5],
-    )
-    graph_int4 = helper.make_graph([], "test_int4", [], [], initializer=[t4])
-    model_int4 = helper.make_model(graph_int4)
+        # ceil(5 * 0.5) = 3 bytes
+        self.assertEqual(utils.get_model_initializers_size(model_int4), 3)
 
-    # ceil(5 * 0.5) = 3 bytes
-    self.assertEqual(utils.get_model_initializers_size(model_int4), 3)
+        # UINT2 Packed Tensor
+        t5 = helper.make_tensor(
+            "uint2_tensor",
+            TensorProto.UINT2,
+            [7],
+            [0, 1, 2, 3, 0, 1, 2],
+        )
+        graph_uint2 = helper.make_graph([], "test_uint2", [], [], initializer=[t5])
+        model_uint2 = helper.make_model(graph_uint2)
 
-    # UINT2 Packed Tensor
-    t5 = helper.make_tensor(
-        "uint2_tensor",
-        TensorProto.UINT2,
-        [7],
-        [0, 1, 2, 3, 0, 1, 2],
-    )
-    graph_uint2 = helper.make_graph([], "test_uint2", [], [], initializer=[t5])
-    model_uint2 = helper.make_model(graph_uint2)
+        # ceil(7 * 0.25) = 2 bytes
+        self.assertEqual(utils.get_model_initializers_size(model_uint2), 2)
 
-    # ceil(7 * 0.25) = 2 bytes
-    self.assertEqual(utils.get_model_initializers_size(model_uint2), 2)
+        # STRING Tensor
+        t6 = helper.make_tensor(
+            "str_tensor",
+            TensorProto.STRING,
+            [3],
+            [b"abc", b"de", b"f"],
+        )
+        graph_string = helper.make_graph([], "test_string", [], [], initializer=[t6])
+        model_string = helper.make_model(graph_string)
 
-    # STRING Tensor
-    t6 = helper.make_tensor(
-        "str_tensor",
-        TensorProto.STRING,
-        [3],
-        [b"abc", b"de", b"f"],
-    )
-    graph_string = helper.make_graph([], "test_string", [], [], initializer=[t6])
-    model_string = helper.make_model(graph_string)
-
-    # 3 + 2 + 1 = 6 bytes
-    self.assertEqual(utils.get_model_initializers_size(model_string), 6)
+        # 3 + 2 + 1 = 6 bytes
+        self.assertEqual(utils.get_model_initializers_size(model_string), 6)
 
 
 if __name__ == "__main__":

--- a/onnx/test/utils_test.py
+++ b/onnx/test/utils_test.py
@@ -11,7 +11,7 @@ import tempfile
 import unittest
 
 import onnx
-from onnx import TensorProto, helper
+from onnx import TensorProto, helper, utils
 
 
 class TestUtilityFunctions(unittest.TestCase):
@@ -78,6 +78,67 @@ class TestUtilityFunctions(unittest.TestCase):
                 self.assertRaisesRegex(RuntimeError, "directory traversal"),
             ):
                 onnx.utils._tar_members_filter(tar, base)
+
+
+def test_get_model_initializers_size(self) -> None:
+    # Empty
+    graph_empty = helper.make_graph([], "test_empty", [], [])
+    model_empty = helper.make_model(graph_empty)
+    self.assertEqual(utils.get_model_initializers_size(model_empty), 0)
+
+    # Standard (FLOAT=4 bytes, INT64=8 bytes)
+    t1 = helper.make_tensor(
+        "t1", TensorProto.FLOAT, [2, 2], [1.0, 2.0, 3.0, 4.0]
+    )  # 16 bytes
+    t2 = helper.make_tensor("t2", TensorProto.INT64, [3], [1, 2, 3])  # 24 bytes
+    graph_std = helper.make_graph([], "test_std", [], [], initializer=[t1, t2])
+    model_std = helper.make_model(graph_std)
+    self.assertEqual(utils.get_model_initializers_size(model_std), 40)
+
+    # Raw Data
+    t3 = helper.make_tensor("t3", TensorProto.FLOAT, [2], b"12345678", raw=True)
+    graph_raw = helper.make_graph([], "test_raw", [], [], initializer=[t3])
+    model_raw = helper.make_model(graph_raw)
+    self.assertEqual(utils.get_model_initializers_size(model_raw), 8)
+
+    # INT4 Packed Tensor
+    t4 = helper.make_tensor(
+        "int4_tensor",
+        TensorProto.INT4,
+        [5],
+        [1, 2, 3, 4, 5],
+    )
+    graph_int4 = helper.make_graph([], "test_int4", [], [], initializer=[t4])
+    model_int4 = helper.make_model(graph_int4)
+
+    # ceil(5 * 0.5) = 3 bytes
+    self.assertEqual(utils.get_model_initializers_size(model_int4), 3)
+
+    # UINT2 Packed Tensor
+    t5 = helper.make_tensor(
+        "uint2_tensor",
+        TensorProto.UINT2,
+        [7],
+        [0, 1, 2, 3, 0, 1, 2],
+    )
+    graph_uint2 = helper.make_graph([], "test_uint2", [], [], initializer=[t5])
+    model_uint2 = helper.make_model(graph_uint2)
+
+    # ceil(7 * 0.25) = 2 bytes
+    self.assertEqual(utils.get_model_initializers_size(model_uint2), 2)
+
+    # STRING Tensor
+    t6 = helper.make_tensor(
+        "str_tensor",
+        TensorProto.STRING,
+        [3],
+        [b"abc", b"de", b"f"],
+    )
+    graph_string = helper.make_graph([], "test_string", [], [], initializer=[t6])
+    model_string = helper.make_model(graph_string)
+
+    # 3 + 2 + 1 = 6 bytes
+    self.assertEqual(utils.get_model_initializers_size(model_string), 6)
 
 
 if __name__ == "__main__":

--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import math
 import os
 import tarfile
 from collections import deque
@@ -11,15 +12,44 @@ from typing import TYPE_CHECKING
 import onnx.checker
 import onnx.helper
 import onnx.shape_inference
+from onnx.helper import tensor_dtype_to_np_dtype
+from onnx.onnx_pb import TensorProto
 
 if TYPE_CHECKING:
     from onnx.onnx_pb import (
         FunctionProto,
         ModelProto,
         NodeProto,
-        TensorProto,
         ValueInfoProto,
     )
+
+
+def get_model_initializers_size(model: ModelProto) -> int:
+    """Calculate the total estimated size in bytes of all initializers in the model.
+    This is useful for quickly estimating the memory footprint of the model parameters.
+    """
+    total_size_bytes = 0
+    for initializer in model.graph.initializer:
+        if getattr(initializer, "raw_data", None):
+            total_size_bytes += len(initializer.raw_data)
+        else:
+            try:
+                np_dtype = tensor_dtype_to_np_dtype(initializer.data_type)
+                if initializer.data_type == TensorProto.STRING:
+                    total_size_bytes += sum(len(s) for s in initializer.string_data)
+                elif initializer.data_type in {
+                    TensorProto.UINT4,
+                    TensorProto.INT4,
+                    TensorProto.FLOAT4E2M1,
+                }:
+                    total_size_bytes += math.ceil(math.prod(initializer.dims) * 0.5)
+                elif initializer.data_type in {TensorProto.UINT2, TensorProto.INT2}:
+                    total_size_bytes += math.ceil(math.prod(initializer.dims) * 0.25)
+                else:
+                    total_size_bytes += np_dtype.itemsize * math.prod(initializer.dims)
+            except KeyError as err:
+                raise TypeError("Unsupported Tensor Data Types") from err
+    return total_size_bytes
 
 
 class Extractor:


### PR DESCRIPTION

### Motivation and Context

Fixes  #7961 

Adds a new utility function to estimate the total storage size of graph initializers in bytes :
```python
onnx.utils.get_model_initializers_size(model: ModelProto) -> int
```


The implementation:
* uses `len(initializer.raw_data)` for raw tensors
* computes `num_elements * dtype.itemsize` for standard tensor types
* handles packed tensor formats:
  * UINT4 / INT4 / FLOAT4E2M1
  * UINT2 / INT2
* sums payload lengths for STRING tensors

### Tests
Added tests covering:
* empty models
* FLOAT + INT64 tensors
* raw_data tensors
* INT4 packed tensors
* UINT2 packed tensors
* STRING tensors
* mixed initializer aggregation

Example test:

```python
def test_size_int4_packing():
    t = helper.make_tensor(
        "int4_tensor",
        TensorProto.INT4,
        [5],
        [1, 2, 3, 4, 5],
    )

    graph = helper.make_graph([], "g", [], [], initializer=[t])
    model = helper.make_model(graph)

    assert onnx.utils.get_model_initializers_size(model) == 3
```

### Validation

```cmd
pytest onnx/test/utils_test.py
```
