### PR TITLE
ci: add reproducible-build check workflow for Linux, macOS, and Windows

### DIFF
--- a/.github/workflows/release_linux_cibw.yml
+++ b/.github/workflows/release_linux_cibw.yml
@@ -15,6 +15,18 @@ on:
         required: false
         type: string
         default: "33.6"
+      artifact_name_prefix:
+        required: false
+        type: string
+        default: "wheels"
+      builds:
+        required: false
+        type: string
+        default: >-
+          ["cp310-manylinux_x86_64","cp310-manylinux_aarch64",
+          "cp311-manylinux_x86_64","cp311-manylinux_aarch64",
+          "cp312-manylinux_x86_64","cp312-manylinux_aarch64",
+          "cp314t-manylinux_x86_64","cp314t-manylinux_aarch64"]
   workflow_dispatch:
 
 permissions:
@@ -29,15 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build:
-          - "cp310-manylinux_x86_64"
-          - "cp310-manylinux_aarch64"
-          - "cp311-manylinux_x86_64"
-          - "cp311-manylinux_aarch64"
-          - "cp312-manylinux_x86_64"
-          - "cp312-manylinux_aarch64"
-          - "cp314t-manylinux_x86_64"
-          - "cp314t-manylinux_aarch64"
+        build: ${{ fromJSON(inputs.builds) }}
 
     runs-on: ${{ contains(matrix.build, 'aarch64') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
 
@@ -92,7 +96,7 @@ jobs:
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: wheels-linux-${{ matrix.build }}
+          name: ${{ inputs.artifact_name_prefix }}-linux-${{ matrix.build }}
           path: dist/*.whl
 
       - name: Validate wheel
@@ -115,7 +119,7 @@ jobs:
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: wheels-linux-cp312-manylinux_x86_64
+          name: ${{ inputs.artifact_name_prefix }}-linux-cp312-manylinux_x86_64
           path: dist
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/release_macos_cibw.yml
+++ b/.github/workflows/release_macos_cibw.yml
@@ -15,6 +15,16 @@ on:
         required: false
         type: string
         default: "33.6"
+      artifact_name_prefix:
+        required: false
+        type: string
+        default: "wheels"
+      builds:
+        required: false
+        type: string
+        default: >-
+          ["cp310-macosx_universal2","cp311-macosx_universal2",
+          "cp312-macosx_universal2","cp314t-macosx_universal2"]
   workflow_dispatch:
 
 permissions:
@@ -29,11 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build:
-          - "cp310-macosx_universal2"
-          - "cp311-macosx_universal2"
-          - "cp312-macosx_universal2"
-          - "cp314t-macosx_universal2"
+        build: ${{ fromJSON(inputs.builds) }}
 
     runs-on: macos-14
 
@@ -88,7 +94,7 @@ jobs:
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: wheels-macos-${{ matrix.build }}
+          name: ${{ inputs.artifact_name_prefix }}-macos-${{ matrix.build }}
           path: dist/*.whl
 
       - name: Validate wheel
@@ -111,7 +117,7 @@ jobs:
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: wheels-macos-cp312-macosx_universal2
+          name: ${{ inputs.artifact_name_prefix }}-macos-cp312-macosx_universal2
           path: dist
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/release_windows_cibw.yml
+++ b/.github/workflows/release_windows_cibw.yml
@@ -15,6 +15,18 @@ on:
         required: false
         type: string
         default: "33.6"
+      artifact_name_prefix:
+        required: false
+        type: string
+        default: "wheels"
+      builds:
+        required: false
+        type: string
+        default: >-
+          ["cp310-win_amd64","cp310-win32",
+          "cp311-win_amd64","cp311-win32","cp311-win_arm64",
+          "cp312-win_amd64","cp312-win32","cp312-win_arm64",
+          "cp314t-win_amd64","cp314t-win_arm64"]
   workflow_dispatch:
 
 permissions:
@@ -29,17 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build:
-          - "cp310-win_amd64"
-          - "cp310-win32"
-          - "cp311-win_amd64"
-          - "cp311-win32"
-          - "cp311-win_arm64"
-          - "cp312-win_amd64"
-          - "cp312-win32"
-          - "cp312-win_arm64"
-          - "cp314t-win_amd64"
-          - "cp314t-win_arm64"
+        build: ${{ fromJSON(inputs.builds) }}
     runs-on: ${{ contains(matrix.build, 'arm64') && 'windows-11-arm' || 'windows-2022' }}
 
     env:
@@ -98,7 +100,7 @@ jobs:
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: wheels-windows-${{ matrix.build }}
+          name: ${{ inputs.artifact_name_prefix }}-windows-${{ matrix.build }}
           path: dist/*.whl
 
       - name: Validate wheel
@@ -121,7 +123,7 @@ jobs:
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: wheels-windows-cp312-win_amd64
+          name: ${{ inputs.artifact_name_prefix }}-windows-cp312-win_amd64
           path: dist
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/reproducible_build.yml
+++ b/.github/workflows/reproducible_build.yml
@@ -3,9 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Verifies that two successive builds from identical source produce bit-for-bit
-# identical wheels (reproducible builds).  Calls release_linux_cibw.yml twice
-# with a minimal single-target matrix, then compares wheel checksums.
-# On mismatch, diffoscope pinpoints exactly which files or metadata differ.
+# identical wheels (reproducible builds).  Calls the release cibw workflows
+# twice each with a minimal single-target matrix, then compares wheel checksums
+# across all three platforms.  On mismatch, diffoscope pinpoints exactly which
+# files or metadata differ.
 
 name: ReproducibleBuild
 
@@ -18,53 +19,97 @@ permissions:
   contents: read
 
 jobs:
-  build1:
+  linux-build1:
     uses: ./.github/workflows/release_linux_cibw.yml
     with:
       build_mode: release
       builds: '["cp312-manylinux_x86_64"]'
       artifact_name_prefix: repro-build1
 
-  build2:
+  linux-build2:
     uses: ./.github/workflows/release_linux_cibw.yml
     with:
       build_mode: release
       builds: '["cp312-manylinux_x86_64"]'
       artifact_name_prefix: repro-build2
 
+  mac-build1:
+    uses: ./.github/workflows/release_macos_cibw.yml
+    with:
+      build_mode: release
+      builds: '["cp312-macosx_universal2"]'
+      artifact_name_prefix: repro-build1
+
+  mac-build2:
+    uses: ./.github/workflows/release_macos_cibw.yml
+    with:
+      build_mode: release
+      builds: '["cp312-macosx_universal2"]'
+      artifact_name_prefix: repro-build2
+
+  windows-build1:
+    uses: ./.github/workflows/release_windows_cibw.yml
+    with:
+      build_mode: release
+      builds: '["cp312-win_amd64"]'
+      artifact_name_prefix: repro-build1
+
+  windows-build2:
+    uses: ./.github/workflows/release_windows_cibw.yml
+    with:
+      build_mode: release
+      builds: '["cp312-win_amd64"]'
+      artifact_name_prefix: repro-build2
+
   compare:
-    needs: [build1, build2]
+    needs: [linux-build1, linux-build2, mac-build1, mac-build2, windows-build1, windows-build2]
     runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: repro-build1-linux-cp312-manylinux_x86_64
+          pattern: repro-build1-*
           path: /tmp/build1
+          merge-multiple: true
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: repro-build2-linux-cp312-manylinux_x86_64
+          pattern: repro-build2-*
           path: /tmp/build2
+          merge-multiple: true
 
       - name: Compare checksums
         run: |
-          [ "$(ls /tmp/build1/*.whl 2>/dev/null | wc -l)" -eq 1 ] || { echo "ERROR: Expected 1 wheel in /tmp/build1"; exit 1; }
-          [ "$(ls /tmp/build2/*.whl 2>/dev/null | wc -l)" -eq 1 ] || { echo "ERROR: Expected 1 wheel in /tmp/build2"; exit 1; }
+          set -euo pipefail
+          failed=0
 
-          WHEEL1=$(ls /tmp/build1/*.whl)
-          WHEEL2=$(ls /tmp/build2/*.whl)
+          for whl1 in /tmp/build1/*.whl; do
+            name=$(basename "$whl1")
+            whl2="/tmp/build2/$name"
 
-          h1=$(sha256sum "$WHEEL1" | cut -d' ' -f1)
-          h2=$(sha256sum "$WHEEL2" | cut -d' ' -f1)
+            if [ ! -f "$whl2" ]; then
+              echo "MISSING in build2: $name"
+              failed=1
+              continue
+            fi
 
-          echo "Build 1: $(basename "$WHEEL1")  →  $h1"
-          echo "Build 2: $(basename "$WHEEL2")  →  $h2"
+            h1=$(sha256sum "$whl1" | cut -d' ' -f1)
+            h2=$(sha256sum "$whl2" | cut -d' ' -f1)
 
-          if [ "$h1" = "$h2" ]; then
-            echo "Reproducible build confirmed — both wheels have SHA-256 $h1"
+            if [ "$h1" = "$h2" ]; then
+              echo "OK  $name  ($h1)"
+            else
+              echo "MISMATCH  $name"
+              echo "  build1: $h1"
+              echo "  build2: $h2"
+              failed=1
+            fi
+          done
+
+          if [ "$failed" -eq 0 ]; then
+            echo "Reproducible build confirmed for all wheels."
           else
-            echo "Non-reproducible build — SHA-256 mismatch"
+            echo "Non-reproducible build detected."
             exit 1
           fi
         shell: bash
@@ -73,25 +118,29 @@ jobs:
         if: failure()
         run: sudo apt-get install -y --no-install-recommends diffoscope
 
-      - name: Run diffoscope
+      - name: Run diffoscope on mismatched wheels
         if: failure()
         run: |
-          WHEEL1=$(ls /tmp/build1/*.whl)
-          WHEEL2=$(ls /tmp/build2/*.whl)
-          diffoscope "$WHEEL1" "$WHEEL2" \
-            --text /tmp/diffoscope.txt \
-            --html /tmp/diffoscope.html \
-            --max-text-report-size 10000000 \
-            || true
-          echo "--- diffoscope summary (first 100 lines) ---"
-          head -100 /tmp/diffoscope.txt || true
+          mkdir -p /tmp/diffoscope
+          for whl1 in /tmp/build1/*.whl; do
+            name=$(basename "$whl1")
+            whl2="/tmp/build2/$name"
+            [ -f "$whl2" ] || continue
+            [ "$(sha256sum "$whl1" | cut -d' ' -f1)" != "$(sha256sum "$whl2" | cut -d' ' -f1)" ] || continue
+            echo "=== diffoscope: $name ==="
+            diffoscope "$whl1" "$whl2" \
+              --text /tmp/diffoscope/${name}.txt \
+              --html /tmp/diffoscope/${name}.html \
+              --max-text-report-size 10000000 \
+              || true
+            head -100 /tmp/diffoscope/${name}.txt || true
+          done
+        shell: bash
 
       - name: Upload diffoscope report
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: diffoscope-report
-          path: |
-            /tmp/diffoscope.html
-            /tmp/diffoscope.txt
+          path: /tmp/diffoscope/
           retention-days: 30

--- a/.github/workflows/reproducible_build.yml
+++ b/.github/workflows/reproducible_build.yml
@@ -1,0 +1,97 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verifies that two successive builds from identical source produce bit-for-bit
+# identical wheels (reproducible builds).  Calls release_linux_cibw.yml twice
+# with a minimal single-target matrix, then compares wheel checksums.
+# On mismatch, diffoscope pinpoints exactly which files or metadata differ.
+
+name: ReproducibleBuild
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # every Monday 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build1:
+    uses: ./.github/workflows/release_linux_cibw.yml
+    with:
+      build_mode: release
+      builds: '["cp312-manylinux_x86_64"]'
+      artifact_name_prefix: repro-build1
+
+  build2:
+    uses: ./.github/workflows/release_linux_cibw.yml
+    with:
+      build_mode: release
+      builds: '["cp312-manylinux_x86_64"]'
+      artifact_name_prefix: repro-build2
+
+  compare:
+    needs: [build1, build2]
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: repro-build1-linux-cp312-manylinux_x86_64
+          path: /tmp/build1
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: repro-build2-linux-cp312-manylinux_x86_64
+          path: /tmp/build2
+
+      - name: Compare checksums
+        run: |
+          [ "$(ls /tmp/build1/*.whl 2>/dev/null | wc -l)" -eq 1 ] || { echo "ERROR: Expected 1 wheel in /tmp/build1"; exit 1; }
+          [ "$(ls /tmp/build2/*.whl 2>/dev/null | wc -l)" -eq 1 ] || { echo "ERROR: Expected 1 wheel in /tmp/build2"; exit 1; }
+
+          WHEEL1=$(ls /tmp/build1/*.whl)
+          WHEEL2=$(ls /tmp/build2/*.whl)
+
+          h1=$(sha256sum "$WHEEL1" | cut -d' ' -f1)
+          h2=$(sha256sum "$WHEEL2" | cut -d' ' -f1)
+
+          echo "Build 1: $(basename "$WHEEL1")  →  $h1"
+          echo "Build 2: $(basename "$WHEEL2")  →  $h2"
+
+          if [ "$h1" = "$h2" ]; then
+            echo "Reproducible build confirmed — both wheels have SHA-256 $h1"
+          else
+            echo "Non-reproducible build — SHA-256 mismatch"
+            exit 1
+          fi
+        shell: bash
+
+      - name: Install diffoscope
+        if: failure()
+        run: sudo apt-get install -y --no-install-recommends diffoscope
+
+      - name: Run diffoscope
+        if: failure()
+        run: |
+          WHEEL1=$(ls /tmp/build1/*.whl)
+          WHEEL2=$(ls /tmp/build2/*.whl)
+          diffoscope "$WHEEL1" "$WHEEL2" \
+            --text /tmp/diffoscope.txt \
+            --html /tmp/diffoscope.html \
+            --max-text-report-size 10000000 \
+            || true
+          echo "--- diffoscope summary (first 100 lines) ---"
+          head -100 /tmp/diffoscope.txt || true
+
+      - name: Upload diffoscope report
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: diffoscope-report
+          path: |
+            /tmp/diffoscope.html
+            /tmp/diffoscope.txt
+          retention-days: 30


### PR DESCRIPTION
### Motivation and Context

Supersedes #7938, which targeted the now-deleted `release_linux.yml`. Since #7901 merged and replaced the release workflows with cibuildwheel-based variants, the reproducible-build check needs to be adapted accordingly.

### What the workflow does

1. Calls `release_linux_cibw.yml`, `release_macos_cibw.yml`, and `release_windows_cibw.yml` each **twice** with a minimal single-target matrix (`cp312-manylinux_x86_64`, `cp312-macosx_universal2`, `cp312-win_amd64`) using distinct `artifact_name_prefix` values so the two runs don't collide on artifact names.
2. Both builds per platform run in parallel on the same commit, so `SOURCE_DATE_EPOCH` (computed from `git log -1 --pretty=%ct` inside the workflow) is identical for both.
3. A `compare` job downloads all six artifact sets and checks SHA-256 checksums per wheel, reporting mismatches per platform.
4. On mismatch: installs **diffoscope** and produces an HTML + text report for each mismatched wheel pair, uploaded as a workflow artifact (retained 30 days).

### Changes to release workflows

To support caller-configurable matrix and artifact naming, all three cibw release workflows gain two optional inputs (backwards-compatible with existing callers via defaults):

| Input | Default | Purpose |
|---|---|---|
| `artifact_name_prefix` | `"wheels"` | Disambiguate artifacts across two parallel calls |
| `builds` | full matrix | JSON array of cibuildwheel build selectors for callers to run a subset |

`create_release.yml` is unaffected — it downloads artifacts via `pattern: wheels*` which matches the default prefix.

### Trigger

- Weekly schedule (Monday 06:00 UTC) to catch regressions early.
- `workflow_dispatch` for manual runs before releases.