### PR TITLE
ci: upload per-artifact attestation bundles to GitHub Release

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -224,7 +224,7 @@ jobs:
         url: https://test.pypi.org/p/onnx
 
       permissions:
-        contents: read
+        contents: write
         id-token: write
         attestations: write
 
@@ -257,6 +257,21 @@ jobs:
           with:
             name: attestation-bundle-testpypi-release
             path: ${{ steps.attest.outputs.bundle-path }}
+
+        - name: Upload per-artifact attestations to GitHub Release
+          if: hashFiles('dist/**') != ''
+          env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          run: |
+            version="${GITHUB_REF_NAME#rel-}"
+            for file in dist/*.whl dist/*.tar.gz; do
+              [ -f "$file" ] || continue
+              filename=$(basename "$file")
+              gh attestation download "$file" \
+                --repo "${{ github.repository }}" \
+                -o "${filename}.sigstore.bundle"
+              gh release upload "v${version}" "${filename}.sigstore.bundle" --clobber
+            done
 
         - name: Upload release build to test.pypi
           id: upload_release_build_to_testpypi
@@ -342,7 +357,7 @@ jobs:
       url: https://pypi.org/p/onnx
 
     permissions:
-      contents: read
+      contents: write
       id-token: write
       attestations: write
 
@@ -374,6 +389,21 @@ jobs:
         with:
           name: attestation-bundle-release
           path: ${{ steps.attest.outputs.bundle-path }}
+
+      - name: Upload per-artifact attestations to GitHub Release
+        if: hashFiles('dist/**') != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version="${GITHUB_REF_NAME#rel-}"
+          for file in dist/*.whl dist/*.tar.gz; do
+            [ -f "$file" ] || continue
+            filename=$(basename "$file")
+            gh attestation download "$file" \
+              --repo "${{ github.repository }}" \
+              -o "${filename}.sigstore.bundle"
+            gh release upload "v${version}" "${filename}.sigstore.bundle" --clobber
+          done
 
       - name: Publish release_build to pypi
         if: (github.repository_owner == 'onnx')


### PR DESCRIPTION
## Summary

- Replaces the single `multiple-subjects-attestation.sigstore.bundle` with individual `<filename>.sigstore.bundle` files, one per wheel and sdist, in both the testpypi-release and pypi-release publish jobs.
- OpenSSF Scorecard **Signed-Releases** check requires a signature/provenance file alongside **each** release asset, using the naming convention `<asset-filename>.<sig-ext>` (`.sigstore.bundle`, `.intoto.jsonl`, etc.). A single multi-subject bundle covering 30+ wheels cannot be correlated per-artifact.
- Individual bundles are retrieved from GitHub attestation store via `gh attestation download` immediately after `actions/attest-build-provenance` registers all file digests — no duplicate attestation generation.

## Why attestation bundles only (no wheels in the release)

Wheels are published to PyPI and not duplicated as GitHub Release assets (30+ wheels × ~4 MB ≈ 150 MB per release). The attestation bundles already provide the immutability guarantee: anyone who installs from PyPI can verify the exact artifact digest against its `.sigstore.bundle` without needing the wheel to be in the GitHub Release. The sdist source tarball remains the canonical non-wheel release asset, and its attestation bundle gives Scorecard a fully signed asset to check.

## How it works

After `actions/attest-build-provenance` registers all `dist/**` digests in GitHub attestation store, a loop runs per artifact:

```
gh attestation download dist/onnx-X.Y.Z-cp312-abi3-linux_x86_64.whl \
  --repo onnx/onnx \
  -o onnx-X.Y.Z-cp312-abi3-linux_x86_64.whl.sigstore.bundle
gh release upload "vX.Y.Z" onnx-X.Y.Z-cp312-abi3-linux_x86_64.whl.sigstore.bundle
```

Repeated for each `.whl` and `.tar.gz`.

## Test plan

- [ ] Trigger a testpypi-release workflow dispatch on a `rel-*` branch and confirm each wheel has a matching `.sigstore.bundle` asset in the GitHub Release
- [ ] Run `gh attestation verify <wheel> --repo onnx/onnx` to confirm individual attestations verify cleanly
- [ ] Check OpenSSF Scorecard Signed-Releases score after next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)