### PR TITLE
Fix generated md files

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -9203,7 +9203,7 @@ This version of the operator has been available since version 9 of the default O
 
 <dl>
 <dt><tt>T</tt> : tensor(string), tensor(int32), tensor(int64)</dt>
-<dd>Input is ether string UTF-8 or int32/int64</dd>
+<dd>Input is either string UTF-8 or int32/int64</dd>
 <dt><tt>T1</tt> : tensor(float)</dt>
 <dd>1-D tensor of floats</dd>
 </dl>

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -38349,7 +38349,7 @@ This version of the operator has been available since version 9 of the default O
 
 <dl>
 <dt><tt>T</tt> : tensor(string), tensor(int32), tensor(int64)</dt>
-<dd>Input is ether string UTF-8 or int32/int64</dd>
+<dd>Input is either string UTF-8 or int32/int64</dd>
 <dt><tt>T1</tt> : tensor(float)</dt>
 <dd>1-D tensor of floats</dd>
 </dl>


### PR DESCRIPTION
#7956 Fixed a spelling mistake in the source code, but didn't update the generated docs. This turned our CI red on main and on all subsequent PRs. The docs can be easily generated with the pre-defined [Pixi](https://pixi.prefix.dev/latest/) tasks ([docs](https://github.com/onnx/onnx/blob/main/CONTRIBUTING.md#pixi-based-development)):

```
pixi run install
pixi run gen-all
```

We should stop the practice of merging PRs that turn our CI red.