### PR TITLE
docs: fix typo in LpNormalization type constraint description

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -9203,7 +9203,7 @@ This version of the operator has been available since version 9 of the default O
 
 <dl>
 <dt><tt>T</tt> : tensor(string), tensor(int32), tensor(int64)</dt>
-<dd>Input is ether string UTF-8 or int32/int64</dd>
+<dd>Input is either string UTF-8 or int32/int64</dd>
 <dt><tt>T1</tt> : tensor(float)</dt>
 <dd>1-D tensor of floats</dd>
 </dl>

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -38349,7 +38349,7 @@ This version of the operator has been available since version 9 of the default O
 
 <dl>
 <dt><tt>T</tt> : tensor(string), tensor(int32), tensor(int64)</dt>
-<dd>Input is ether string UTF-8 or int32/int64</dd>
+<dd>Input is either string UTF-8 or int32/int64</dd>
 <dt><tt>T1</tt> : tensor(float)</dt>
 <dd>1-D tensor of floats</dd>
 </dl>


### PR DESCRIPTION
Fix a one-character typo `ether` → `either` in the `T` type constraint
description of the LpNormalization operator. The C++ source
(`onnx/defs/nn/defs.cc`) already has the correct spelling; this updates
the generated docs to match so the `Check auto-gen files are up-to-date`
CI step passes.

The mismatch was causing `Enforce style` to fail on `main` and on any
PR based on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)