### PR TITLE
fix: revert accidental protobuf v33.6 bump and remove requirements-release_build.txt

### DIFF
--- a/.github/install_test.yml
+++ b/.github/install_test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies, build ONNX
         run: |
           python -m pip install -q --upgrade pip
-          python -m pip install -r requirements-release_build.txt
+          python -m pip install scikit-build-core "protobuf==4.25.1"
           git submodule update --init --recursive
 
           source workflow_scripts/protobuf/build_protobuf_unix.sh 3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -79,7 +79,7 @@ jobs:
       if: matrix.language != 'actions'
       run: |
         source workflow_scripts/protobuf/build_protobuf_unix.sh $(nproc)
-        python -m pip install --quiet -r requirements-release_build.txt
+        python -m pip install --quiet scikit-build-core "protobuf==4.25.1"
         export ONNX_ML=1
         export ONNX_BUILD_TESTS=1
         pip install .

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -72,18 +72,21 @@ jobs:
     uses: ./.github/workflows/release_linux_cibw.yml
     with:
       build_mode: ${{ github.event.inputs.build_mode || 'preview' }}
+      protobuf_version: "25.1"
 
   call-win:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run release CIs') || contains(github.event.pull_request.labels.*.name, 'ci-slsa-provenance')
     uses: ./.github/workflows/release_windows_cibw.yml
     with:
       build_mode: ${{ github.event.inputs.build_mode || 'preview' }}
+      protobuf_version: "25.1"
 
   call-mac:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run release CIs') || contains(github.event.pull_request.labels.*.name, 'ci-slsa-provenance')
     uses: ./.github/workflows/release_macos_cibw.yml
     with:
       build_mode: ${{ github.event.inputs.build_mode || 'preview' }}
+      protobuf_version: "25.1"
 
   call-pyodide:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run release CIs') || contains(github.event.pull_request.labels.*.name, 'ci-slsa-provenance')

--- a/.github/workflows/release_linux_cibw.yml
+++ b/.github/workflows/release_linux_cibw.yml
@@ -14,7 +14,7 @@ on:
       protobuf_version:
         required: false
         type: string
-        default: "33.6"
+        default: "25.1"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release_macos_cibw.yml
+++ b/.github/workflows/release_macos_cibw.yml
@@ -14,7 +14,7 @@ on:
       protobuf_version:
         required: false
         type: string
-        default: "33.6"
+        default: "25.1"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release_sdist.yml
+++ b/.github/workflows/release_sdist.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install -q --upgrade pip
-        python -m pip install -q -r requirements-release_build.txt
+        python -m pip install -q build scikit-build-core
 
     - name: Build source distribution (preview build / weekly)
       if: ${{ inputs.build_mode != 'release' }}

--- a/.github/workflows/release_windows_cibw.yml
+++ b/.github/workflows/release_windows_cibw.yml
@@ -14,7 +14,7 @@ on:
       protobuf_version:
         required: false
         type: string
-        default: "33.6"
+        default: "25.1"
   workflow_dispatch:
 
 permissions:

--- a/requirements-release_build.txt
+++ b/requirements-release_build.txt
@@ -1,5 +1,0 @@
-build
-wheel
-protobuf==4.25.1; python_version<"3.14" or sys_platform != "darwin"
-protobuf==6.33.6; python_version>="3.14" and sys_platform == "darwin"
-scikit-build-core>=0.11


### PR DESCRIPTION
## Summary

- The cibuildwheel migration (#7901) accidentally bumped the C++ protobuf version from `25.1` to `33.6` for Linux, macOS, and Windows release builds by copying the default from the Pyodide workflow. This reverts the three new cibuildwheel workflows back to `25.1` to match the version used before the migration. The Pyodide workflow intentionally stays at `33.6`.
- Makes `protobuf_version: "25.1"` explicit in `create_release.yml` for all three platforms, consistent with how Pyodide already passed it explicitly rather than relying on per-workflow defaults.
- Removes `requirements-release_build.txt`, which is no longer used by any release workflow after the cibuildwheel migration. Inlines the required dependencies directly in the three remaining workflows that still needed them (`install_test.yml`, `codeql.yml`, `release_sdist.yml`).

## Test plan

- [ ] Verify Linux/macOS/Windows cibuildwheel release builds use protobuf `25.1` (matching pre-migration behavior)
- [ ] Verify `release_sdist.yml` still builds the sdist successfully with `build` + `scikit-build-core`
- [ ] Verify `install_test.yml` and `codeql.yml` still build correctly with inlined `scikit-build-core` + `protobuf==4.25.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)