### PR TITLE
Don't try to upload wasm wheels to PyPI

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -227,6 +227,9 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Remove wasm32 wheels unsupported by PyPI
+        run: rm -f dist/*wasm32*.whl
+
       - name: Generate SLSA Build Provenance attestations
         if: hashFiles('dist/**') != ''
         id: attest
@@ -292,6 +295,9 @@ jobs:
             path: dist
             merge-multiple: true
 
+        - name: Remove wasm32 wheels unsupported by PyPI
+          run: rm -f dist/*wasm32*.whl
+
         - name: Generate SLSA Build Provenance attestations
           if: hashFiles('dist/**') != ''
           id: attest
@@ -356,6 +362,9 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Remove wasm32 wheels unsupported by PyPI
+        run: rm -f dist/*wasm32*.whl
+
       - name: Generate SLSA Build Provenance attestations
         if: hashFiles('dist/**') != ''
         id: attest
@@ -408,6 +417,9 @@ jobs:
           pattern: sdist
           path: dist
           merge-multiple: true
+
+      - name: Remove wasm32 wheels unsupported by PyPI
+        run: rm -f dist/*wasm32*.whl
 
       - name: Generate SLSA Build Provenance attestations
         if: hashFiles('dist/**') != ''


### PR DESCRIPTION
The weekly pypi publishing job [failed](https://github.com/onnx/onnx/actions/runs/25915879967/job/76173909626), presumably because we were trying to push unsupported wasm wheels. My understanding is that we actually need to create a pyodide recipe for now (c.f. [here](https://github.com/onnx/onnx/actions/runs/25915879967/job/76173909626)). The relevant [PEP](https://peps.python.org/pep-0783/) to distribute wasm packages via pypi has been accepted only very recently.

This PR simply removes the wasm packages from `dist/` for now.
