### PR TITLE
Add unifyInputShape / unifyInputShapePrefix shape inference utilities

### DIFF
--- a/docs/ShapeInference.md
+++ b/docs/ShapeInference.md
@@ -156,6 +156,12 @@ when multiple input dims are expected to be the same, and when input
 dimensions are propagated to specific output dimensions. (See the inference
 for `RoiAlign` for an example.)
 
+* `unifyInputShape` and `unifyInputShapePrefix` are higher-level utilities
+built on `unifyInputDim`. They unify all dimensions (or a prefix of dimensions)
+of an input in one call, enabling a more declarative style. `unifyInputDim`
+remains useful for more complex scenarios where individual dimensions are
+accessed selectively.
+
 * Overloaded operators `*` and `/` can be used on symbolic dimensions when output
 dimensions are computed from input dimensions using arithmetic. (See the inference
 for `SpaceToDepth` for an example.)
@@ -178,4 +184,14 @@ up as below:
    unifyInputDim(ctx, 1, 0, K);
    unifyInputDim(ctx, 1, 1, N);
    updateOutputShape(ctx, 0, {M. N});
+```
+
+The same example can be written more concisely using `unifyInputShape`, which
+checks rank and unifies all dimensions in one call:
+
+```cpp
+   Dim M, K, N;
+   unifyInputShape(ctx, 0, {M, K});
+   unifyInputShape(ctx, 1, {K, N});
+   updateOutputShape(ctx, 0, {M, N});
 ```

--- a/docs/ShapeInference.md
+++ b/docs/ShapeInference.md
@@ -183,7 +183,7 @@ up as below:
    unifyInputDim(ctx, 0, 1, K);
    unifyInputDim(ctx, 1, 0, K);
    unifyInputDim(ctx, 1, 1, N);
-   updateOutputShape(ctx, 0, {M. N});
+   updateOutputShape(ctx, 0, {M, N});
 ```
 
 The same example can be written more concisely using `unifyInputShape`, which

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -1238,14 +1238,14 @@ ONNX_OPERATOR_SET_SCHEMA(
           // A is (M, K) or (K, M) if transA; B is (K, N) or (N, K) if transB
           Dim M, N, K;
           if (transA) {
-            unifyInputShape(ctx, 0, {std::ref(K), std::ref(M)});
+            unifyInputShape(ctx, 0, {K, M});
           } else {
-            unifyInputShape(ctx, 0, {std::ref(M), std::ref(K)});
+            unifyInputShape(ctx, 0, {M, K});
           }
           if (transB) {
-            unifyInputShape(ctx, 1, {std::ref(N), std::ref(K)});
+            unifyInputShape(ctx, 1, {N, K});
           } else {
-            unifyInputShape(ctx, 1, {std::ref(K), std::ref(N)});
+            unifyInputShape(ctx, 1, {K, N});
           }
           // Output shape is (M, N)
           updateOutputShape(ctx, 0, {M, N});

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -1230,21 +1230,25 @@ ONNX_OPERATOR_SET_SCHEMA(
         .Attr("beta", "Scalar multiplier for input tensor C.", AttributeProto::FLOAT, 1.0f)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           propagateElemTypeFromInputToOutput(ctx, 0, 0);
-          if (hasNInputShapes(ctx, 2)) {
-            auto transAAttr = ctx.getAttribute("transA");
-            bool transA = transAAttr ? static_cast<int>(transAAttr->i()) != 0 : false;
-            auto transBAttr = ctx.getAttribute("transB");
-            bool transB = transBAttr ? static_cast<int>(transBAttr->i()) != 0 : false;
-            auto& first_input_shape = getInputShape(ctx, 0);
-            auto& second_input_shape = getInputShape(ctx, 1);
-            if (first_input_shape.dim_size() != 2) {
-              fail_shape_inference("First input does not have rank 2");
-            }
-            if (second_input_shape.dim_size() != 2) {
-              fail_shape_inference("Second input does not have rank 2");
-            }
-            updateOutputShape(ctx, 0, {first_input_shape.dim(transA ? 1 : 0), second_input_shape.dim(transB ? 0 : 1)});
+          auto transAAttr = ctx.getAttribute("transA");
+          bool transA = transAAttr ? static_cast<int>(transAAttr->i()) != 0 : false;
+          auto transBAttr = ctx.getAttribute("transB");
+          bool transB = transBAttr ? static_cast<int>(transBAttr->i()) != 0 : false;
+          // Gemm computes C = alpha * A * B + beta * C
+          // A is (M, K) or (K, M) if transA; B is (K, N) or (N, K) if transB
+          Dim M, N, K;
+          if (transA) {
+            unifyInputShape(ctx, 0, {std::ref(K), std::ref(M)});
+          } else {
+            unifyInputShape(ctx, 0, {std::ref(M), std::ref(K)});
           }
+          if (transB) {
+            unifyInputShape(ctx, 1, {std::ref(N), std::ref(K)});
+          } else {
+            unifyInputShape(ctx, 1, {std::ref(K), std::ref(N)});
+          }
+          // Output shape is (M, N)
+          updateOutputShape(ctx, 0, {M, N});
         }));
 
 ONNX_OPERATOR_SET_SCHEMA(

--- a/onnx/defs/math/defs.cc
+++ b/onnx/defs/math/defs.cc
@@ -1234,8 +1234,8 @@ ONNX_OPERATOR_SET_SCHEMA(
           bool transA = transAAttr ? static_cast<int>(transAAttr->i()) != 0 : false;
           auto transBAttr = ctx.getAttribute("transB");
           bool transB = transBAttr ? static_cast<int>(transBAttr->i()) != 0 : false;
-          // Gemm computes C = alpha * A * B + beta * C
-          // A is (M, K) or (K, M) if transA; B is (K, N) or (N, K) if transB
+          // Gemm computes Y = alpha * A' * B' + beta * C
+          // A' is A or A^T depending on transA; B' is B or B^T depending on transB
           Dim M, N, K;
           if (transA) {
             unifyInputShape(ctx, 0, {K, M});

--- a/onnx/defs/shape_inference.cc
+++ b/onnx/defs/shape_inference.cc
@@ -556,4 +556,60 @@ std::pair<int, int> getAttributeElementTypeAndLength(
   return {elem_type, length};
 }
 
+void unifyInputShape(
+    InferenceContext& ctx,
+    size_t input_index,
+    std::initializer_list<std::reference_wrapper<Dim>> dims) {
+  if (!hasInputShape(ctx, input_index)) {
+    return;
+  }
+  const auto& input_shape = getInputShape(ctx, input_index);
+  if (static_cast<size_t>(input_shape.dim_size()) != dims.size()) {
+    fail_shape_inference(
+        "Input ",
+        input_index,
+        " expected to have rank ",
+        dims.size(),
+        " but has rank ",
+        input_shape.dim_size(),
+        " in ",
+        ctx.getDisplayName(),
+        ".");
+  }
+  int i = 0;
+  for (auto& dim_ref : dims) {
+    const Dim& input_dim = input_shape.dim(i);
+    unifyDim(input_dim, dim_ref.get());
+    ++i;
+  }
+}
+
+void unifyInputShapePrefix(
+    InferenceContext& ctx,
+    size_t input_index,
+    std::initializer_list<std::reference_wrapper<Dim>> prefix) {
+  if (!hasInputShape(ctx, input_index)) {
+    return;
+  }
+  const auto& input_shape = getInputShape(ctx, input_index);
+  if (static_cast<size_t>(input_shape.dim_size()) < prefix.size()) {
+    fail_shape_inference(
+        "Input ",
+        input_index,
+        " expected to have rank >= ",
+        prefix.size(),
+        " but has rank ",
+        input_shape.dim_size(),
+        " in ",
+        ctx.getDisplayName(),
+        ".");
+  }
+  int i = 0;
+  for (auto& dim_ref : prefix) {
+    const Dim& input_dim = input_shape.dim(i);
+    unifyDim(input_dim, dim_ref.get());
+    ++i;
+  }
+}
+
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/shape_inference.cc
+++ b/onnx/defs/shape_inference.cc
@@ -577,7 +577,7 @@ void unifyInputShape(
         ".");
   }
   int i = 0;
-  for (auto& dim_ref : dims) {
+  for (const auto& dim_ref : dims) {
     const Dim& input_dim = input_shape.dim(i);
     unifyDim(input_dim, dim_ref.get());
     ++i;
@@ -605,7 +605,7 @@ void unifyInputShapePrefix(
         ".");
   }
   int i = 0;
-  for (auto& dim_ref : prefix) {
+  for (const auto& dim_ref : prefix) {
     const Dim& input_dim = input_shape.dim(i);
     unifyDim(input_dim, dim_ref.get());
     ++i;

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -908,63 +908,17 @@ inline void unifyInputDim(const InferenceContext& ctx, size_t input_index, int d
 
 // unifyInputShape: unifies all dimensions of an input with the given dim references.
 // Requires the input to have rank exactly equal to the number of dims provided.
-inline void unifyInputShape(
+void unifyInputShape(
     InferenceContext& ctx,
     size_t input_index,
-    std::initializer_list<std::reference_wrapper<Dim>> dims) {
-  if (!hasInputShape(ctx, input_index)) {
-    return;
-  }
-  const auto& input_shape = getInputShape(ctx, input_index);
-  if (static_cast<size_t>(input_shape.dim_size()) != dims.size()) {
-    fail_shape_inference(
-        "Input ",
-        input_index,
-        " expected to have rank ",
-        dims.size(),
-        " but has rank ",
-        input_shape.dim_size(),
-        " in ",
-        ctx.getDisplayName(),
-        ".");
-  }
-  int i = 0;
-  for (auto& dim_ref : dims) {
-    const Dim& input_dim = input_shape.dim(i);
-    unifyDim(input_dim, dim_ref.get());
-    ++i;
-  }
-}
+    std::initializer_list<std::reference_wrapper<Dim>> dims);
 
 // unifyInputShapePrefix: unifies the first N dimensions of an input with the given dim references.
 // Requires the input to have rank at least equal to the number of dims provided.
-inline void unifyInputShapePrefix(
+void unifyInputShapePrefix(
     InferenceContext& ctx,
     size_t input_index,
-    std::initializer_list<std::reference_wrapper<Dim>> prefix) {
-  if (!hasInputShape(ctx, input_index)) {
-    return;
-  }
-  const auto& input_shape = getInputShape(ctx, input_index);
-  if (static_cast<size_t>(input_shape.dim_size()) < prefix.size()) {
-    fail_shape_inference(
-        "Input ",
-        input_index,
-        " expected to have rank >= ",
-        prefix.size(),
-        " but has rank ",
-        input_shape.dim_size(),
-        " in ",
-        ctx.getDisplayName(),
-        ".");
-  }
-  int i = 0;
-  for (auto& dim_ref : prefix) {
-    const Dim& input_dim = input_shape.dim(i);
-    unifyDim(input_dim, dim_ref.get());
-    ++i;
-  }
-}
+    std::initializer_list<std::reference_wrapper<Dim>> prefix);
 
 // unifyDim: unifies a dimension with a constant value. If the dimension
 // already has a value, we check for equality of new value with old value.

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -909,7 +909,7 @@ inline void unifyInputDim(const InferenceContext& ctx, size_t input_index, int d
 // unifyInputShape: unifies all dimensions of an input with the given dim references.
 // Requires the input to have rank exactly equal to the number of dims provided.
 inline void unifyInputShape(
-    const InferenceContext& ctx,
+    InferenceContext& ctx,
     size_t input_index,
     std::initializer_list<std::reference_wrapper<Dim>> dims) {
   if (!hasInputShape(ctx, input_index)) {
@@ -939,7 +939,7 @@ inline void unifyInputShape(
 // unifyInputShapePrefix: unifies the first N dimensions of an input with the given dim references.
 // Requires the input to have rank at least equal to the number of dims provided.
 inline void unifyInputShapePrefix(
-    const InferenceContext& ctx,
+    InferenceContext& ctx,
     size_t input_index,
     std::initializer_list<std::reference_wrapper<Dim>> prefix) {
   if (!hasInputShape(ctx, input_index)) {

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -906,6 +906,66 @@ inline void unifyInputDim(const InferenceContext& ctx, size_t input_index, int d
   }
 }
 
+// unifyInputShape: unifies all dimensions of an input with the given dim references.
+// Requires the input to have rank exactly equal to the number of dims provided.
+inline void unifyInputShape(
+    InferenceContext& ctx,
+    size_t input_index,
+    std::initializer_list<std::reference_wrapper<Dim>> dims) {
+  if (!hasInputShape(ctx, input_index)) {
+    return;
+  }
+  const auto& input_shape = getInputShape(ctx, input_index);
+  if (static_cast<size_t>(input_shape.dim_size()) != dims.size()) {
+    fail_shape_inference(
+        "Input ",
+        input_index,
+        " expected to have rank ",
+        dims.size(),
+        " but has rank ",
+        input_shape.dim_size(),
+        " in ",
+        ctx.getDisplayName(),
+        ".");
+  }
+  int i = 0;
+  for (auto& dim_ref : dims) {
+    const Dim& input_dim = input_shape.dim(i);
+    unifyDim(input_dim, dim_ref.get());
+    ++i;
+  }
+}
+
+// unifyInputShapePrefix: unifies the first N dimensions of an input with the given dim references.
+// Requires the input to have rank at least equal to the number of dims provided.
+inline void unifyInputShapePrefix(
+    InferenceContext& ctx,
+    size_t input_index,
+    std::initializer_list<std::reference_wrapper<Dim>> prefix) {
+  if (!hasInputShape(ctx, input_index)) {
+    return;
+  }
+  const auto& input_shape = getInputShape(ctx, input_index);
+  if (static_cast<size_t>(input_shape.dim_size()) < prefix.size()) {
+    fail_shape_inference(
+        "Input ",
+        input_index,
+        " expected to have rank >= ",
+        prefix.size(),
+        " but has rank ",
+        input_shape.dim_size(),
+        " in ",
+        ctx.getDisplayName(),
+        ".");
+  }
+  int i = 0;
+  for (auto& dim_ref : prefix) {
+    const Dim& input_dim = input_shape.dim(i);
+    unifyDim(input_dim, dim_ref.get());
+    ++i;
+  }
+}
+
 // unifyDim: unifies a dimension with a constant value. If the dimension
 // already has a value, we check for equality of new value with old value.
 inline void unifyDim(Dim& dim, int64_t value) {

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -908,14 +908,14 @@ inline void unifyInputDim(const InferenceContext& ctx, size_t input_index, int d
 
 // unifyInputShape: unifies all dimensions of an input with the given dim references.
 // Requires the input to have rank exactly equal to the number of dims provided.
-void unifyInputShape(
+ONNX_API void unifyInputShape(
     InferenceContext& ctx,
     size_t input_index,
     std::initializer_list<std::reference_wrapper<Dim>> dims);
 
 // unifyInputShapePrefix: unifies the first N dimensions of an input with the given dim references.
 // Requires the input to have rank at least equal to the number of dims provided.
-void unifyInputShapePrefix(
+ONNX_API void unifyInputShapePrefix(
     InferenceContext& ctx,
     size_t input_index,
     std::initializer_list<std::reference_wrapper<Dim>> prefix);

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -909,7 +909,7 @@ inline void unifyInputDim(const InferenceContext& ctx, size_t input_index, int d
 // unifyInputShape: unifies all dimensions of an input with the given dim references.
 // Requires the input to have rank exactly equal to the number of dims provided.
 inline void unifyInputShape(
-    InferenceContext& ctx,
+    const InferenceContext& ctx,
     size_t input_index,
     std::initializer_list<std::reference_wrapper<Dim>> dims) {
   if (!hasInputShape(ctx, input_index)) {
@@ -939,7 +939,7 @@ inline void unifyInputShape(
 // unifyInputShapePrefix: unifies the first N dimensions of an input with the given dim references.
 // Requires the input to have rank at least equal to the number of dims provided.
 inline void unifyInputShapePrefix(
-    InferenceContext& ctx,
+    const InferenceContext& ctx,
     size_t input_index,
     std::initializer_list<std::reference_wrapper<Dim>> prefix) {
   if (!hasInputShape(ctx, input_index)) {


### PR DESCRIPTION
Introduces two higher-level helpers for shape inference that build on `unifyInputDim`:

- `unifyInputShape(ctx, input_index, {dims...})` — verifies input rank matches the list length and unifies each dimension.
- `unifyInputShapePrefix(ctx, input_index, {prefix...})` — verifies input rank >= prefix length and unifies the leading dimensions.

These enable declarative shape constraint specification:

```cpp
Dim M, N, K;
unifyInputShape(ctx, 0, {M, K});  // A is (M, K)
unifyInputShape(ctx, 1, {K, N});  // B is (K, N)
```

Updated Gemm's shape inference to use the new utilities as a demonstration. Updated `docs/ShapeInference.md` with usage documentation.