### PR TITLE
Add operator+ and operator- for Dim

### DIFF
--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -928,10 +928,8 @@ inline void unifyInputDim(const InferenceContext& ctx, size_t input_index, int d
 
 // unifyInputShape: unifies all dimensions of an input with the given dim references.
 // Requires the input to have rank exactly equal to the number of dims provided.
-ONNX_API void unifyInputShape(
-    InferenceContext& ctx,
-    size_t input_index,
-    std::initializer_list<std::reference_wrapper<Dim>> dims);
+ONNX_API void
+unifyInputShape(InferenceContext& ctx, size_t input_index, std::initializer_list<std::reference_wrapper<Dim>> dims);
 
 // unifyInputShapePrefix: unifies the first N dimensions of an input with the given dim references.
 // Requires the input to have rank at least equal to the number of dims provided.

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -249,6 +249,26 @@ inline TensorShapeProto::Dimension operator/(const TensorShapeProto::Dimension& 
   return result;
 }
 
+inline TensorShapeProto::Dimension operator+(const TensorShapeProto::Dimension& dim1, int64_t dim2) {
+  TensorShapeProto::Dimension result;
+  if (dim1.has_dim_value()) {
+    result.set_dim_value(dim1.dim_value() + dim2);
+  } else if (dim2 == 0) {
+    return dim1;
+  }
+  return result;
+}
+
+inline TensorShapeProto::Dimension operator-(const TensorShapeProto::Dimension& dim1, int64_t dim2) {
+  TensorShapeProto::Dimension result;
+  if (dim1.has_dim_value()) {
+    result.set_dim_value(dim1.dim_value() - dim2);
+  } else if (dim2 == 0) {
+    return dim1;
+  }
+  return result;
+}
+
 // if from >= upto_exclusive, return 1.
 // Caller must make sure upto_exclusive is less than or equal to shape.size()
 // Caller must make sure from>=0


### PR DESCRIPTION
Adds arithmetic `operator+` and `operator-` for `TensorShapeProto::Dimension`, following the same pattern as the existing `operator*` and `operator/`. These support symbolic dimension arithmetic in shape inference, with identity element 0 (i.e., `dim + 0` and `dim - 0` return the dim unchanged). Note that this follows existing ONNX conventions (and does not make use of strings representing symbolic expressions yet, which is a proposed extension).

This will help simplify shape-inference, for example, in the proposed ops in https://github.com/onnx/onnx/pull/7950