### PR TITLE
fix: prevent cmake parallel build race in proto generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,6 +485,7 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP SRCS)
 
   set(${SRCS} ${${SRCS}} PARENT_SCOPE)
   set(ONNX_PROTO_PY_FILES ${_py_files} PARENT_SCOPE)
+  set(ONNX_GENERATED_PROTO_FILES ${GENERATED_FILES} PARENT_SCOPE)
 endfunction()
 
 # Sources are listed explicitly in subdirectory CMakeLists.txt files via
@@ -505,6 +506,13 @@ set_source_files_properties(${ONNX_PROTO_SRCS}
     PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE
 )
 
+# Dedicated target for the gen_proto.py step only (produces .proto files).
+# Both onnx_core and onnx_proto run gen_proto.py in a parallel build, creating
+# a race where both write to the same generated .proto paths simultaneously.
+# Serialising only the generation step lets protoc and C++ compilation for both
+# targets proceed in parallel afterwards.
+add_custom_target(onnx_proto_gen DEPENDS ${ONNX_GENERATED_PROTO_FILES})
+
 set(LINKED_PROTOBUF_TARGET protobuf::libprotobuf)
 if(ONNX_USE_LITE_PROTO)
   if(TARGET protobuf::libprotobuf-lite)
@@ -513,6 +521,14 @@ if(ONNX_USE_LITE_PROTO)
 endif()
 add_library(onnx_proto ${ONNX_PROTO_SRCS})
 add_onnx_global_defines(onnx_proto)
+add_dependencies(onnx_proto onnx_proto_gen)
+
+# onnx_core lists ONNX_PROTO_SRCS as sources alongside onnx_proto; without an
+# explicit ordering cmake schedules gen_proto.py for both concurrently, causing
+# a write/read race on the generated .proto files. Depending on onnx_proto_gen
+# (the dedicated gen_proto.py step) serialises only the generation, letting
+# protoc and C++ compilation for both targets overlap afterwards.
+add_dependencies(onnx_core onnx_proto_gen)
 
 add_library(onnx $<TARGET_OBJECTS:onnx_core>)
 add_dependencies(onnx onnx_proto onnx_core)


### PR DESCRIPTION
## Summary

- `onnx_core` (OBJECT lib) and `onnx_proto` both list `ONNX_PROTO_SRCS` as sources
- In a parallel build (`cmake --build --parallel`), cmake schedules `gen_proto.py` for both targets concurrently
- Two processes write to the same generated `.proto` paths simultaneously; when `protoc` reads a partially-written `onnx-ml.proto` it fails:
  ```
  onnx/onnx-ml.proto:953:13: Reached end of input in message definition (missing '}')
  ```
- A dedicated `onnx_proto_gen` target is introduced to own only the `gen_proto.py` step (the file generation). Both `onnx_proto` and `onnx_core` declare a dependency on it, so the generation step is serialised while `protoc` compilation and C++ compilation for both targets can still proceed in parallel afterwards.

This fixes the `Test ubuntu-24.04, 3.14, External, debug=0, unity_build=1, onnx_ml=1, autogen=1` CI failure introduced by the cmake refactoring in #7733.

## Test plan

- [ ] CI: `Test ubuntu-24.04, 3.14, External, debug=0, unity_build=1, onnx_ml=1, autogen=1` should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)