### PR TITLE
fix: correct argument order in ONNX_OPERATOR_SET_SCHEMA_DEBUG_VARIABLE macro call

### DIFF
--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -1334,7 +1334,7 @@ class DbgOperatorSetTracker {
   ONNX_API OpSchema GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(domain, ver, name)>() {             \
     return impl.SetName(#name).SetDomain(domain_str).SinceVersion(ver).SetLocation(__FILE__, __LINE__); \
   }                                                                                                     \
-  ONNX_OPERATOR_SET_SCHEMA_DEBUG_VARIABLE(domain, ver, name, dbg_included_in_static_opset)
+  ONNX_OPERATOR_SET_SCHEMA_DEBUG_VARIABLE(name, domain, ver, dbg_included_in_static_opset)
 #ifndef NDEBUG
 #define ONNX_DBG_GET_COUNT_IN_OPSETS() DbgOperatorSetTracker::Instance().GetCount()
 


### PR DESCRIPTION
## Summary

`ONNX_OPERATOR_SET_SCHEMA_EX` passed arguments to `ONNX_OPERATOR_SET_SCHEMA_DEBUG_VARIABLE` in the wrong order — `(domain, ver, name)` instead of `(name, domain, ver)` as the macro signature expects.

This caused debug-variable names to be generated as:
```
dbg_count_check_<domain>_<ver>_ver<name>   // e.g. dbg_count_check_Onnx_11_verRange
```
instead of the intended:
```
dbg_count_check_<name>_<domain>_ver<ver>   // e.g. dbg_count_check_Range_Onnx_ver11
```

The mismatch triggered spurious CodeQL "unused static variable" warnings on every operator schema registered via this macro, despite the `[[maybe_unused]]` attribute already being present on the generated variable. This was first noticed as a CodeQL finding in #7923.

## Change

One-line fix: swap the argument order in the `ONNX_OPERATOR_SET_SCHEMA_EX` macro to match the `ONNX_OPERATOR_SET_SCHEMA_DEBUG_VARIABLE` signature.

## Test plan

- [ ] CI passes (no functional change — only affects generated debug-variable names in debug builds)
- [ ] CodeQL "unused static variable" alerts are no longer triggered for operator schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)