### PR TITLE
Fix KeepAspectRatioHelper precision for scaled output dimensions

### DIFF
--- a/onnx/defs/tensor/utils.cc
+++ b/onnx/defs/tensor/utils.cc
@@ -38,13 +38,13 @@ void KeepAspectRatioHelper(
   if (policy != KeepAspectRatioPolicy::NOT_LARGER && policy != KeepAspectRatioPolicy::NOT_SMALLER) {
     return;
   }
-  float scale = policy == KeepAspectRatioPolicy::NOT_LARGER ? std::numeric_limits<float>::max()
-                                                            : std::numeric_limits<float>::min();
-  std::function<float(float, float)> reduce_f;
+  double scale = policy == KeepAspectRatioPolicy::NOT_LARGER ? std::numeric_limits<double>::max()
+                                                             : std::numeric_limits<double>::lowest();
+  std::function<double(double, double)> reduce_f;
   if (policy == KeepAspectRatioPolicy::NOT_LARGER) {
-    reduce_f = [](float a, float b) { return std::min(a, b); };
+    reduce_f = [](double a, double b) { return std::min(a, b); };
   } else {
-    reduce_f = [](float a, float b) { return std::max(a, b); };
+    reduce_f = [](double a, double b) { return std::max(a, b); };
   }
 
   bool has_unknown_dim = false;
@@ -54,14 +54,16 @@ void KeepAspectRatioHelper(
       has_unknown_dim = true;
       break;
     }
-    float s = sizes_data[i] / static_cast<float>(input_shape.dim(d).dim_value());
+    double s = sizes_data[i] / static_cast<double>(input_shape.dim(d).dim_value());
     scale = reduce_f(scale, s);
   }
   // If there's at least one unknown dim we can't infer the output shape, since it
   // will depend on the original aspect ratio of the input.
   for (size_t i = 0; i < sizes_data.size(); i++) {
     int d = axes.empty() ? i : axes[i];
-    sizes_data[i] = has_unknown_dim ? -1 : std::roundf(scale * input_shape.dim(d).dim_value());
+    sizes_data[i] = has_unknown_dim
+        ? -1
+        : static_cast<int64_t>(std::round(scale * static_cast<double>(input_shape.dim(d).dim_value())));
   }
 }
 

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -1240,6 +1240,82 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
+    def _check_keep_aspect_ratio_precision(
+        self,
+        version: int,
+        policy: str,
+        dims: tuple[int, ...],
+        sizes: tuple[int, ...],
+        expected: tuple[int, ...],
+    ) -> None:
+        # Shared body for KeepAspectRatioHelper precision regression tests.
+        # Builds a Resize graph using the sizes-input path with the given
+        # keep_aspect_ratio_policy and asserts the inferred output shape.
+        graph = self._make_graph(
+            [
+                ("x", TensorProto.INT32, dims),
+                ("roi", TensorProto.FLOAT, (2 * len(dims),)),
+                ("sizes", TensorProto.INT64, (len(sizes),)),
+            ],
+            [
+                make_node(
+                    "Resize",
+                    ["x", "roi", "", "sizes"],
+                    ["y"],
+                    keep_aspect_ratio_policy=policy,
+                )
+            ],
+            [],
+            initializer=[make_tensor("sizes", TensorProto.INT64, (len(sizes),), sizes)],
+        )
+        self._assert_inferred(
+            graph,
+            [make_tensor_value_info("y", TensorProto.INT32, expected)],
+            opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
+        )
+
+    @parameterized.expand(all_versions_for("Resize"))
+    def test_resize_keep_aspect_ratio_precision_not_larger(self, _, version) -> None:
+        # Regression: KeepAspectRatioHelper computed `sizes_data[i] /
+        # static_cast<float>(dim_value)` and `roundf(scale * dim_value)`.
+        # With float32, 2**24 + 1 = 16_777_217 is unrepresentable, so a 1:1
+        # request collapses the inferred dim to 16_777_216.
+        self.skipIf(version < 18, "keep_aspect_ratio_policy is from Version 18")
+        self._check_keep_aspect_ratio_precision(
+            version,
+            "not_larger",
+            dims=(16777217, 16777217),
+            sizes=(16777217, 16777217),
+            expected=(16777217, 16777217),
+        )
+
+    @parameterized.expand(all_versions_for("Resize"))
+    def test_resize_keep_aspect_ratio_precision_not_smaller(self, _, version) -> None:
+        # Same float32 mantissa boundary, NOT_SMALLER policy path.
+        self.skipIf(version < 18, "keep_aspect_ratio_policy is from Version 18")
+        self._check_keep_aspect_ratio_precision(
+            version,
+            "not_smaller",
+            dims=(16777217, 16777217),
+            sizes=(16777217, 16777217),
+            expected=(16777217, 16777217),
+        )
+
+    @parameterized.expand(all_versions_for("Resize"))
+    def test_resize_keep_aspect_ratio_precision_non_unit_scale(
+        self, _, version
+    ) -> None:
+        # Non-unit scale path: dim 16_777_217 scaled by 2 should produce
+        # 33_554_434. With float32 the result collapses to 33_554_432.
+        self.skipIf(version < 18, "keep_aspect_ratio_policy is from Version 18")
+        self._check_keep_aspect_ratio_precision(
+            version,
+            "not_larger",
+            dims=(16777217,),
+            sizes=(33554434,),
+            expected=(33554434,),
+        )
+
     @parameterized.expand(all_versions_for("Resize"))
     def test_resize_scale(self, _, version) -> None:
         self.skipIf(version < 11, "roi input is from Version 11")


### PR DESCRIPTION
### Motivation and Context

Follow-up to #7874 (which fixed #4919). `KeepAspectRatioHelper` in `onnx/defs/tensor/utils.cc` has the same `float32` intermediate pattern that #7874 fixed in the other two `Resize` shape inference helpers:

```cpp
// utils.cc:56 (before)
float s = sizes_data[i] / static_cast<float>(input_shape.dim(d).dim_value());

// utils.cc:63 (before)
sizes_data[i] = has_unknown_dim
    ? -1
    : std::roundf(scale * input_shape.dim(d).dim_value());
```

`float32` has a 24-bit mantissa. Any input dimension `> 2**24` is truncated when cast to `float`. With `input dim = 16777217` and a 1:1 `sizes = 16777217` request under `keep_aspect_ratio_policy = "not_larger"`, the inferred output becomes `16777216` instead of `16777217`.

This call path was intentionally left out of #7874 because it is a different `sizes`-input path with `roundf`. The fix is the same kind of widening.

### What changed

`onnx/defs/tensor/utils.cc` - `KeepAspectRatioHelper`:

- Widen the scale variable from `float` to `double`.
- Replace `std::roundf` with `std::round` and add an explicit `static_cast<int64_t>` on the result.
- Use `std::numeric_limits<double>::lowest()` instead of `min()` for the `NOT_SMALLER` initial value. `min()` returns the smallest positive normal in floating point, not the algebraic minimum. In practice both are dominated by the first positive input scale, so this change does not affect the result for valid inputs.

### Tests

Three regression tests added to `onnx/test/shape_inference_test.py`, parameterized over Resize opsets that support `keep_aspect_ratio_policy` (version `>= 18`). All three share a `_check_keep_aspect_ratio_precision` helper:

- `test_resize_keep_aspect_ratio_precision_not_larger`
- `test_resize_keep_aspect_ratio_precision_not_smaller`
- `test_resize_keep_aspect_ratio_precision_non_unit_scale`

#### Before the fix (RED)

```
FAILED ::test_resize_keep_aspect_ratio_precision_not_larger_3_version18
FAILED ::test_resize_keep_aspect_ratio_precision_not_larger_4_version19
FAILED ::test_resize_keep_aspect_ratio_precision_not_smaller_3_version18
FAILED ::test_resize_keep_aspect_ratio_precision_not_smaller_4_version19
FAILED ::test_resize_keep_aspect_ratio_precision_non_unit_scale_3_version18
FAILED ::test_resize_keep_aspect_ratio_precision_non_unit_scale_4_version19

E   AssertionError:
E     assert 16777217 == 16777216
```

#### After the fix (GREEN)

```
6 passed, 9 skipped, 908 deselected
```

The 9 skipped cases are Resize opsets `< 18` that do not support `keep_aspect_ratio_policy`.

Full `shape_inference_test.py` after the fix: 862 passed, 0 failed.