### PR TITLE
Follow up for scikit-build-core migration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,6 +293,8 @@ if(NOT ONNX_PROTOC_EXECUTABLE)
     # Read dependency URLs/hashes from sbom.cdx.json (single source of truth).
     sbom_get_dep("abseil-cpp" _absl)
     sbom_get_dep("protobuf" _protobuf)
+    # Assign ${Protobuf_VERSION} to the version read from sbom.cdx.json like `find_package(Protobuf)` would do.
+    set(Protobuf_VERSION ${_protobuf_VERSION})
     if(NOT DEFINED ABSL_ENABLE_INSTALL)
       if(ONNX_BUILD_PYTHON)
         set(ABSL_ENABLE_INSTALL OFF CACHE BOOL "Enable installation of Abseil targets")

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -5,7 +5,7 @@
 #   sbom_get_dep("abseil-cpp" _absl)
 # sets _absl_URL, _absl_SHA256, _absl_VERSION.
 function(sbom_get_dep dep_name prefix)
-  file(READ "${CMAKE_SOURCE_DIR}/sbom.cdx.json" _sbom)
+  file(READ "${CMAKE_CURRENT_SOURCE_DIR}/sbom.cdx.json" _sbom)
   string(JSON _count LENGTH "${_sbom}" "components")
   foreach(_i RANGE 0 ${_count})
     if(_i EQUAL _count)

--- a/cmake/summary.cmake
+++ b/cmake/summary.cmake
@@ -56,7 +56,7 @@ function(onnx_print_configuration_summary)
   endif()
 
   message(STATUS "")
-  message(STATUS "  Protobuf version                  : ${_protobuf_VERSION}")
+  message(STATUS "  Protobuf version                  : ${Protobuf_VERSION}")
   if(EXISTS "${ONNX_PROTOC_EXECUTABLE}")
     message(STATUS "  Protobuf compiler                 : ${ONNX_PROTOC_EXECUTABLE}")
   else()

--- a/cmake/summary.cmake
+++ b/cmake/summary.cmake
@@ -56,7 +56,7 @@ function(onnx_print_configuration_summary)
   endif()
 
   message(STATUS "")
-  message(STATUS "  Protobuf version                  : ${Protobuf_VERSION}")
+  message(STATUS "  Protobuf version                  : ${_protobuf_VERSION}")
   if(EXISTS "${ONNX_PROTOC_EXECUTABLE}")
     message(STATUS "  Protobuf compiler                 : ${ONNX_PROTOC_EXECUTABLE}")
   else()


### PR DESCRIPTION

### Motivation and Context

Ref https://github.com/onnx/onnx/pull/7859

- Fixes reference to `sbom.cdx.json` for project using onnx as cmake subdirectory
- Fix summary.cmake's protobuf version printing
