### PR TITLE
fix: validate group >= 1 and in_channels % group == 0 in ConvTranspose shape inference (all opsets)

### DIFF
--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -1096,7 +1096,21 @@ ONNX_API void convTransposeShapeInference(InferenceContext& ctx) {
 
   int64_t group = getAttribute(ctx, "group", 1);
 
+  // Validate group attribute
+  if (group < 1) {
+    fail_shape_inference("group must be greater than or equal to 1, got: ", group);
+  }
+
   auto input_shape = ctx.getInputType(0)->tensor_type().shape();
+  // Validate that input channels are divisible by group
+  if (input_shape.dim(1).has_dim_value()) {
+    int64_t in_channels = input_shape.dim(1).dim_value();
+    if (in_channels % group != 0) {
+      fail_shape_inference(
+          "The number of input channels (", in_channels,
+          ") is not divisible by the group attribute (", group, ").");
+    }
+  }
   if (input_shape.dim_size() < 3) {
     fail_shape_inference(
         "Input tensor must have at least 3 dimensions (N x C x D1...Dn). Got: ", input_shape.dim_size());

--- a/onnx/defs/nn/old.cc
+++ b/onnx/defs/nn/old.cc
@@ -602,7 +602,21 @@ static void convTransposeShapeInference_opset11(InferenceContext& ctx) {
 
   int64_t group = getAttribute(ctx, "group", 1);
 
+  // Validate group attribute
+  if (group < 1) {
+    fail_shape_inference("group must be greater than or equal to 1, got: ", group);
+  }
+
   auto input_shape = ctx.getInputType(0)->tensor_type().shape();
+  // Validate that input channels are divisible by group
+  if (input_shape.dim(1).has_dim_value()) {
+    int64_t in_channels = input_shape.dim(1).dim_value();
+    if (in_channels % group != 0) {
+      fail_shape_inference(
+          "The number of input channels (", in_channels,
+          ") is not divisible by the group attribute (", group, ").");
+    }
+  }
   if (input_shape.dim_size() < 3) {
     fail_shape_inference(
         "Input tensor must have at least 3 dimensions (N x C x D1...Dn). Got: ", input_shape.dim_size());
@@ -2909,7 +2923,21 @@ static void convTransposeShapeInference_opset1(InferenceContext& ctx) {
 
   int64_t group = getAttribute(ctx, "group", 1);
 
+  // Validate group attribute
+  if (group < 1) {
+    fail_shape_inference("group must be greater than or equal to 1, got: ", group);
+  }
+
   auto input_shape = ctx.getInputType(0)->tensor_type().shape();
+  // Validate that input channels are divisible by group
+  if (input_shape.dim(1).has_dim_value()) {
+    int64_t in_channels = input_shape.dim(1).dim_value();
+    if (in_channels % group != 0) {
+      fail_shape_inference(
+          "The number of input channels (", in_channels,
+          ") is not divisible by the group attribute (", group, ").");
+    }
+  }
   if (input_shape.dim_size() < 3) {
     fail_shape_inference(
         "Input tensor must have at least 3 dimensions (N x C x D1...Dn). Got: ", input_shape.dim_size());

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -5758,6 +5758,57 @@ class TestShapeInference(TestShapeInferenceHelper):
             graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (25, 32, 32, 32))]
         )
 
+    def test_conv_transpose_group_not_divisible_opset22(self) -> None:
+        # ConvTranspose with input channels not divisible by group should raise
+        graph = self._make_graph(
+            [
+                ("X", TensorProto.FLOAT, (1, 32, 14, 14)),
+                ("W", TensorProto.FLOAT, (32, 64, 3, 3)),
+            ],
+            [make_node("ConvTranspose", ["X", "W"], "Y", group=3)],
+            [],
+        )
+        self.assertRaises(
+            onnx.shape_inference.InferenceError,
+            self._inferred,
+            graph,
+            opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 22)],
+        )
+
+    def test_conv_transpose_group_not_divisible_opset11(self) -> None:
+        # ConvTranspose with input channels not divisible by group should raise
+        graph = self._make_graph(
+            [
+                ("X", TensorProto.FLOAT, (1, 32, 14, 14)),
+                ("W", TensorProto.FLOAT, (32, 64, 3, 3)),
+            ],
+            [make_node("ConvTranspose", ["X", "W"], "Y", group=3)],
+            [],
+        )
+        self.assertRaises(
+            onnx.shape_inference.InferenceError,
+            self._inferred,
+            graph,
+            opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 11)],
+        )
+
+    def test_conv_transpose_group_not_divisible_opset1(self) -> None:
+        # ConvTranspose with input channels not divisible by group should raise
+        graph = self._make_graph(
+            [
+                ("X", TensorProto.FLOAT, (1, 32, 14, 14)),
+                ("W", TensorProto.FLOAT, (32, 64, 3, 3)),
+            ],
+            [make_node("ConvTranspose", ["X", "W"], "Y", group=3)],
+            [],
+        )
+        self.assertRaises(
+            onnx.shape_inference.InferenceError,
+            self._inferred,
+            graph,
+            opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 1)],
+        )
+
     def test_mvn_function_output_shape(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (25, 48, 16, 16))],


### PR DESCRIPTION
### Motivation and Context

The `onnx.checker.check_model()` was silently accepting `ConvTranspose` operators 
where `in_channels` is not divisible by `group`. This validation error only surfaced 
at runtime when using the model in onnxruntime or ReferenceEvaluator.

The `Conv` operator already has this validation, but `ConvTranspose` was missing it 
across all opsets (1, 11, and 22).

### Changes

- Added validation in ConvTranspose shape inference to check:
  1. `group >= 1` (prevents division by zero)
  2. `in_channels % group == 0` (ensures proper channel division)
- Applied fix to all ConvTranspose opsets
- Added comprehensive test coverage for all three opsets

### Tests

- All 3 new tests pass ✅
- All 19 existing ConvTranspose tests pass ✅
- No regressions