### PR TITLE
Proposal: extend LinearAttention to cover Gated DeltaNet-2 (issue #8027)

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -33008,6 +33008,98 @@ This version of the operator has been available since version 27 of the default 
 <dd>Constrain input types to common numeric type tensors.</dd>
 </dl>
 
+## Version 28 of the default ONNX operator set
+### <a name="LinearAttention-28"></a>**LinearAttention-28**</a>
+
+  Unified linear attention operator for autoregressive decoding (T=1) and prefill (T>1).
+
+  The query, key, value, and (where applicable) decay/beta/erase_gate inputs use 3D packed
+  format [B, T, H*D], where heads are flattened into the last dimension; q_num_heads and
+  kv_num_heads are always required and are used to unpack to 4D internally for computation.
+  The optional past_state and present_state are 4D with shape (B, H_kv, d_k, d_v).
+
+  Group-query attention (GQA) is supported: q_num_heads must be a positive multiple of
+  kv_num_heads. When q_num_heads == kv_num_heads this reduces to multi-headed linear
+  attention; when q_num_heads > kv_num_heads each KV head (and its recurrent state) is
+  shared by `q_num_heads / kv_num_heads` query heads (multi-query attention is the
+  special case kv_num_heads == 1).
+
+  The update_rule attribute selects the recurrence type:
+  - "linear": S_t = S_{t-1} + k_t ⊗ v_t; o_t = scale * q_t^T S_t
+  - "gated": S_t = exp(g_t) * S_{t-1} + k_t ⊗ v_t; o_t = scale * q_t^T S_t
+  - "delta": S_t = S_{t-1} + β_t * k_t ⊗ (v_t - S_{t-1}^T k_t^erase); o_t = scale * q_t^T S_t
+  - "gated_delta": S_t = exp(g_t) * S_{t-1} + β_t * k_t ⊗ (v_t - exp(g_t) * S_{t-1}^T k_t^erase); o_t = scale * q_t^T S_t
+
+  where g_t is the decay (in log-space), β_t is the update rate, ⊗ denotes outer product,
+  and k_t^erase = erase_gate_t ⊙ k_t when the optional erase_gate input is provided,
+  else k_t^erase = k_t.
+
+  The erase_gate input decouples the key used in the erase (retrieval) term from the key
+  used in the write outer product. This enables architectures such as Gated DeltaNet-2,
+  where k_t^erase = b_t ⊙ k_t with b_t ∈ [0,1]^{d_k} controls which state channels are
+  erased independently of the write. The write always uses the original k_t.
+  erase_gate is only valid for 'delta' and 'gated_delta' update rules.
+
+  Semantics: Equivalent to running the recurrent update sequentially for each token,
+  but may be implemented using chunk-parallel algorithms for GPU efficiency.
+
+
+#### Version
+
+This version of the operator has been available since version 28 of the default ONNX operator set.
+
+#### Attributes
+
+<dl>
+<dt><tt>chunk_size</tt> : int (default is 64)</dt>
+<dd>Chunk size for the chunk-parallel WY decomposition during prefill (T>1). Tuning hint; does not affect output correctness.</dd>
+<dt><tt>kv_num_heads</tt> : int (required)</dt>
+<dd>Number of key/value heads. Always required.</dd>
+<dt><tt>q_num_heads</tt> : int (required)</dt>
+<dd>Number of query heads. Always required.</dd>
+<dt><tt>scale</tt> : float (default is 0.0)</dt>
+<dd>Output scaling factor. When 0.0 (default), derives d_k = query.shape[-1] / q_num_heads and uses 1/sqrt(d_k). Set explicitly to override.</dd>
+<dt><tt>update_rule</tt> : string (default is gated_delta)</dt>
+<dd>The update rule for the linear attention recurrence. One of: 'linear', 'gated', 'delta', 'gated_delta'. Default is 'gated_delta'.</dd>
+</dl>
+
+#### Inputs (3 - 7)
+
+<dl>
+<dt><tt>query</tt> (differentiable) : T</dt>
+<dd>Query vectors with 3D packed shape (B, T, H_q * d_k). Heads are packed into the last dimension.</dd>
+<dt><tt>key</tt> (differentiable) : T</dt>
+<dd>Key vectors with 3D packed shape (B, T, H_kv * d_k). Should be L2-normalized for delta/gated_delta modes.</dd>
+<dt><tt>value</tt> (differentiable) : T</dt>
+<dd>Value vectors with 3D packed shape (B, T, H_kv * d_v).</dd>
+<dt><tt>past_state</tt> (optional, non-differentiable) : S</dt>
+<dd>Recurrent state from the previous step with shape (B, H_kv, d_k, d_v). When absent the state is initialized to zeros.</dd>
+<dt><tt>decay</tt> (optional, differentiable) : T</dt>
+<dd>Exponential decay gate in log-space. 3D packed shape: (B, T, H_kv * d_k) for per-key-dimension decay (GLA/RWKV-6), or (B, T, H_kv) for per-head scalar decay (DeltaNet/RetNet). Required for 'gated' and 'gated_delta' modes.</dd>
+<dt><tt>beta</tt> (optional, differentiable) : T</dt>
+<dd>Update rate (sigmoid output). 3D packed shape: (B, T, H_kv) or (B, T, 1). Required for 'delta' and 'gated_delta' modes.</dd>
+<dt><tt>erase_gate</tt> (optional, differentiable) : T</dt>
+<dd>Channel-wise erase gate applied to the key before retrieval. 3D packed shape: (B, T, H_kv * d_k). When provided, the retrieval key becomes erase_gate_t ⊙ k_t while the write outer product continues to use the original k_t. Optional for 'delta' and 'gated_delta' modes only.</dd>
+</dl>
+
+#### Outputs
+
+<dl>
+<dt><tt>output</tt> (differentiable) : T</dt>
+<dd>Attention output with 3D packed shape (B, T, H_q * d_v).</dd>
+<dt><tt>present_state</tt> (non-differentiable) : S</dt>
+<dd>Updated recurrent state with shape (B, H_kv, d_k, d_v). Always 4D.</dd>
+</dl>
+
+#### Type Constraints
+
+<dl>
+<dt><tt>T</tt> : tensor(float16), tensor(bfloat16), tensor(float)</dt>
+<dd>Constrain activation input and output types to float16, bfloat16, or float32 tensors.</dd>
+<dt><tt>S</tt> : tensor(float16), tensor(bfloat16), tensor(float)</dt>
+<dd>Constrain state types to float16, bfloat16, or float32 tensors. Should be float32 or the same as T for numerical stability on long sequences.</dd>
+</dl>
+
 # ai.onnx.preview
 ## Version 1 of the 'ai.onnx.preview' operator set
 ### <a name="ai.onnx.preview.FlexAttention-1"></a>**ai.onnx.preview.FlexAttention-1**</a>

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -190,7 +190,7 @@ For an operator input/output's differentiability, it can be differentiable,
 |<a href="#LayerNormalization">LayerNormalization</a>|<a href="Changelog.md#LayerNormalization-17">17</a>|17, 18|
 |<a href="#LeakyRelu">LeakyRelu</a>|<a href="Changelog.md#LeakyRelu-16">16</a>, <a href="Changelog.md#LeakyRelu-6">6</a>, <a href="Changelog.md#LeakyRelu-1">1</a>|16|
 |<a href="#LessOrEqual">LessOrEqual</a>|<a href="Changelog.md#LessOrEqual-16">16</a>, <a href="Changelog.md#LessOrEqual-12">12</a>|16|
-|<a href="#LinearAttention">LinearAttention</a>|<a href="Changelog.md#LinearAttention-27">27</a>|27|
+|<a href="#LinearAttention">LinearAttention</a>|<a href="Changelog.md#LinearAttention-28">28</a>, <a href="Changelog.md#LinearAttention-27">27</a>|28|
 |<a href="#LogSoftmax">LogSoftmax</a>|<a href="Changelog.md#LogSoftmax-13">13</a>, <a href="Changelog.md#LogSoftmax-11">11</a>, <a href="Changelog.md#LogSoftmax-1">1</a>|13, 18|
 |<a href="#MeanVarianceNormalization">MeanVarianceNormalization</a>|<a href="Changelog.md#MeanVarianceNormalization-13">13</a>, <a href="Changelog.md#MeanVarianceNormalization-9">9</a>|13, 18|
 |<a href="#Mish">Mish</a>|<a href="Changelog.md#Mish-22">22</a>, <a href="Changelog.md#Mish-18">18</a>|22|
@@ -18156,8 +18156,8 @@ Other versions of this operator: <a href="Changelog.md#LessOrEqual-12">12</a>
 
   Unified linear attention operator for autoregressive decoding (T=1) and prefill (T>1).
 
-  The query, key, value, and (where applicable) decay/beta inputs use 3D packed format
-  [B, T, H*D], where heads are flattened into the last dimension; q_num_heads and
+  The query, key, value, and (where applicable) decay/beta/erase_gate inputs use 3D packed
+  format [B, T, H*D], where heads are flattened into the last dimension; q_num_heads and
   kv_num_heads are always required and are used to unpack to 4D internally for computation.
   The optional past_state and present_state are 4D with shape (B, H_kv, d_k, d_v).
 
@@ -18170,10 +18170,18 @@ Other versions of this operator: <a href="Changelog.md#LessOrEqual-12">12</a>
   The update_rule attribute selects the recurrence type:
   - "linear": S_t = S_{t-1} + k_t ⊗ v_t; o_t = scale * q_t^T S_t
   - "gated": S_t = exp(g_t) * S_{t-1} + k_t ⊗ v_t; o_t = scale * q_t^T S_t
-  - "delta": S_t = S_{t-1} + β_t * k_t ⊗ (v_t - S_{t-1}^T k_t); o_t = scale * q_t^T S_t
-  - "gated_delta": S_t = exp(g_t) * S_{t-1} + β_t * k_t ⊗ (v_t - exp(g_t) * S_{t-1}^T k_t); o_t = scale * q_t^T S_t
+  - "delta": S_t = S_{t-1} + β_t * k_t ⊗ (v_t - S_{t-1}^T k_t^erase); o_t = scale * q_t^T S_t
+  - "gated_delta": S_t = exp(g_t) * S_{t-1} + β_t * k_t ⊗ (v_t - exp(g_t) * S_{t-1}^T k_t^erase); o_t = scale * q_t^T S_t
 
-  where g_t is the decay (in log-space), β_t is the update rate, and ⊗ denotes outer product.
+  where g_t is the decay (in log-space), β_t is the update rate, ⊗ denotes outer product,
+  and k_t^erase = erase_gate_t ⊙ k_t when the optional erase_gate input is provided,
+  else k_t^erase = k_t.
+
+  The erase_gate input decouples the key used in the erase (retrieval) term from the key
+  used in the write outer product. This enables architectures such as Gated DeltaNet-2,
+  where k_t^erase = b_t ⊙ k_t with b_t ∈ [0,1]^{d_k} controls which state channels are
+  erased independently of the write. The write always uses the original k_t.
+  erase_gate is only valid for 'delta' and 'gated_delta' update rules.
 
   Semantics: Equivalent to running the recurrent update sequentially for each token,
   but may be implemented using chunk-parallel algorithms for GPU efficiency.
@@ -18181,7 +18189,9 @@ Other versions of this operator: <a href="Changelog.md#LessOrEqual-12">12</a>
 
 #### Version
 
-This version of the operator has been available since version 27 of the default ONNX operator set.
+This version of the operator has been available since version 28 of the default ONNX operator set.
+
+Other versions of this operator: <a href="Changelog.md#LinearAttention-27">27</a>
 
 #### Attributes
 
@@ -18198,7 +18208,7 @@ This version of the operator has been available since version 27 of the default 
 <dd>The update rule for the linear attention recurrence. One of: 'linear', 'gated', 'delta', 'gated_delta'. Default is 'gated_delta'.</dd>
 </dl>
 
-#### Inputs (3 - 6)
+#### Inputs (3 - 7)
 
 <dl>
 <dt><tt>query</tt> (differentiable) : T</dt>
@@ -18208,11 +18218,13 @@ This version of the operator has been available since version 27 of the default 
 <dt><tt>value</tt> (differentiable) : T</dt>
 <dd>Value vectors with 3D packed shape (B, T, H_kv * d_v).</dd>
 <dt><tt>past_state</tt> (optional, non-differentiable) : S</dt>
-<dd>Recurrent state from previous step with shape (B, H_kv, d_k, d_v). Always 4D. If not provided, defaults to zeros.</dd>
+<dd>Recurrent state from the previous step with shape (B, H_kv, d_k, d_v). When absent the state is initialized to zeros.</dd>
 <dt><tt>decay</tt> (optional, differentiable) : T</dt>
 <dd>Exponential decay gate in log-space. 3D packed shape: (B, T, H_kv * d_k) for per-key-dimension decay (GLA/RWKV-6), or (B, T, H_kv) for per-head scalar decay (DeltaNet/RetNet). Required for 'gated' and 'gated_delta' modes.</dd>
 <dt><tt>beta</tt> (optional, differentiable) : T</dt>
 <dd>Update rate (sigmoid output). 3D packed shape: (B, T, H_kv) or (B, T, 1). Required for 'delta' and 'gated_delta' modes.</dd>
+<dt><tt>erase_gate</tt> (optional, differentiable) : T</dt>
+<dd>Channel-wise erase gate applied to the key before retrieval. 3D packed shape: (B, T, H_kv * d_k). When provided, the retrieval key becomes erase_gate_t ⊙ k_t while the write outer product continues to use the original k_t. Optional for 'delta' and 'gated_delta' modes only.</dd>
 </dl>
 
 #### Outputs
@@ -18509,6 +18521,52 @@ expect(
     outputs=[output, present_state],
     name="test_linear_attention_gated_delta_beta_scalar",
     opset_imports=_OPSET,
+)
+```
+
+</details>
+
+
+<details>
+<summary>gated_delta_erase_gate</summary>
+
+```python
+# GDN-2 recurrence: erase_gate b_t ∈ [0,1]^{d_k} decouples the key
+# used in the erase term (S'^T (b_t ⊙ k_t)) from the key used in the
+# write outer product (k_t ⊗ ...).  The write gate w_t is pre-folded
+# into value by the caller (v ← w_t ⊙ v_t) before passing to the op.
+node = onnx.helper.make_node(
+    "LinearAttention",
+    inputs=["query", "key", "value", "", "decay", "beta", "erase_gate"],
+    outputs=["output", "present_state"],
+    q_num_heads=4,
+    kv_num_heads=4,
+)
+b, t, h_q, h_kv, d_k, d_v = 2, 4, 4, 4, 8, 8
+query = np.random.randn(b, t, h_q * d_k).astype(np.float32)
+key = _l2_normalize(np.random.randn(b, t, h_kv * d_k).astype(np.float32), h_kv)
+value = np.random.randn(b, t, h_kv * d_v).astype(np.float32)
+decay = -np.abs(np.random.randn(b, t, h_kv * d_k)).astype(np.float32) * 0.1
+beta = np.random.rand(b, t, h_kv).astype(np.float32)
+# erase_gate ∈ [0,1]^{d_k} per head — sigmoid output in practice.
+erase_gate = np.random.rand(b, t, h_kv * d_k).astype(np.float32)
+
+output, present_state = _compute(
+    query,
+    key,
+    value,
+    decay=decay,
+    beta=beta,
+    erase_gate=erase_gate,
+    q_num_heads=h_q,
+    kv_num_heads=h_kv,
+)
+expect(
+    node,
+    inputs=[query, key, value, decay, beta, erase_gate],
+    outputs=[output, present_state],
+    name="test_linear_attention_gated_delta_erase_gate",
+    opset_imports=_OPSET28,
 )
 ```
 

--- a/docs/proposals/8027-linearattention-gdn2.md
+++ b/docs/proposals/8027-linearattention-gdn2.md
@@ -1,0 +1,78 @@
+<!-- Proposal: Spec gap — LinearAttention (opset 27) cannot represent Gated DeltaNet-2 -->
+# Spec gap: `LinearAttention` (opset 27) cannot represent Gated DeltaNet-2's channel-wise erase gate
+
+Follow-up to #7950 (merged) and RFC #7767.
+
+## Summary
+
+The newly-landed `LinearAttention` op in opset 27 covers Gated DeltaNet (v1), KDA, Mamba-2, GLA, RWKV-6 cleanly via `update_rule="gated_delta"`. However, **Gated DeltaNet-2** (NVlabs, https://github.com/NVlabs/GatedDeltaNet-2, arXiv:2605.22791) cannot be expressed through the first-class op — only through the `Scan` fallback, which is exactly the 10–50× slow path the RFC set out to avoid for hybrid LLMs.
+
+### The GDN-2 recurrence
+
+From the paper / README:
+
+```
+S_t = (I − k_t (b_t ⊙ k_t)ᵀ) D_t S_{t−1}  +  k_t (w_t ⊙ v_t)ᵀ
+```
+
+with:
+- `b_t ∈ [0,1]^{d_k}` — **channel-wise** erase gate (on the key axis)
+- `w_t ∈ [0,1]^{d_v}` — **channel-wise** write gate (on the value axis)
+- `D_t = Diag(α_t)` — channel-wise decay (inherited from KDA)
+
+GDN-2's whole point is *decoupling* erase from write — they act on different axes of the state and are no longer tied to a single scalar.
+
+### What `LinearAttention` currently does (`gated_delta`)
+
+From `onnx/reference/ops/op_linear_attention.py` and the schema:
+
+```
+state *= exp(g_t)                    # decay, per-head scalar OR per-key-dim ✓
+v_t   = beta_t * (v_t − Sᵀ k_t)      # delta correction, beta is per-head scalar
+state += k_t ⊗ v_t                   # write
+```
+
+i.e. `S_t = (I − β_t k_t k_tᵀ) D_t S_{t−1} + β_t k_t v_tᵀ`, with `beta`'s last dim restricted to `{kv_num_heads, 1}` per the schema's input-validation rules.
+
+### Per-input comparison
+
+| GDN-2 needs | Spec today | Status |
+|---|---|---|
+| `D_t` channel-wise on key axis | `decay` last-dim allows `kv_num_heads * d_k` | ✓ covered |
+| `w_t` channel-wise on value axis (write side only) | not in op, but the user can fold it in as a pre-`Mul`: `v ← w ⊙ v` before feeding `LinearAttention` | ✓ workable in-graph |
+| `b_t` channel-wise on key axis (erase side only) | `beta` is per-head scalar; appears only as `β_t · (v_t − retrieved)` | **✗ not representable** |
+
+The erase gate is the hard one: `b_t` lives inside the *second* `k_t` of the rank-one erase `k_t (b_t ⊙ k_t)ᵀ`. We cannot fold it into the input `k` by a pre-`Mul`, because the same `k_t` is also reused in the write term `k_t (w⊙v)ᵀ` and in the readout `q · S` — scaling `k` everywhere changes both. There is no way to express GDN-2 strictly inside the current `gated_delta` rule.
+
+### Proposed extension (opset 28 candidate)
+
+Two minimally-invasive options:
+
+**(A)** Promote `beta` to allow a key-channel-wise shape (mirroring how `decay` already does):
+
+- Allow `beta` last-dim ∈ `{1, kv_num_heads, kv_num_heads * d_k}`.
+- Add a new `update_rule="gated_delta_v2"` (or relax `gated_delta`) whose function body is:
+
+```
+S_t = D_t S_{t−1} − k_t (b_t ⊙ k_tᵀ D_t S_{t−1})  +  k_t v_tᵀ
+```
+
+i.e. apply decay first, compute `retrieved = b_t ⊙ (Sᵀ k_t)` on the *key* side rather than on the output side, then subtract the rank-one update. (Note: this is **not** the same as `b_t ⊙ (v_t − retrieved)` — that scales the wrong axis.) The write gate `w_t` stays out of the op and is folded in by the user via `Mul(w, v)` in the graph.
+
+**(B)** Add an explicit optional `erase_gate` input with shape `(B, T, kv_num_heads * d_k)` so the rules stay orthogonal. `gated_delta` (β scalar) and `gated_delta_v2` (β vector on `d_k`) coexist cleanly, and old `β_t = b_t · 1` is the strict-generalization fallback.
+
+Either way the existing `gated_delta` behavior is preserved (backwards-compatible: GDN-2 with `b_t ≡ β_t · 1` recovers v1).
+
+### Why this matters now
+
+GDN-2's headline result is that it's the strongest 1.3B/100B-token model on RULER multi-key NIAH among recurrent-only and hybrid linear-attention LMs. If the architecture trend follows GDN → KDA → GDN-2, the spec gap here will repeat the situation #7950 just fixed for v1.
+
+### References
+
+- PR #7950 (merged): https://github.com/onnx/onnx/pull/7950
+- RFC #7767: https://github.com/onnx/onnx/pull/7767
+- Discussion #7689: https://github.com/onnx/onnx/issues/7689
+- Gated DeltaNet-2 (NVlabs): https://github.com/NVlabs/GatedDeltaNet-2
+- Paper: https://arxiv.org/abs/2605.22791
+
+cc: reviewers/authors of #7950

--- a/onnx/backend/test/case/node/linear_attention.py
+++ b/onnx/backend/test/case/node/linear_attention.py
@@ -13,6 +13,7 @@ from onnx.reference.ops.op_linear_attention import (
 )
 
 _OPSET = [onnx.helper.make_opsetid("", 27)]
+_OPSET28 = [onnx.helper.make_opsetid("", 28)]
 
 
 def _compute(
@@ -22,6 +23,7 @@ def _compute(
     past_state=None,
     decay=None,
     beta=None,
+    erase_gate=None,
     *,
     q_num_heads,
     kv_num_heads,
@@ -37,6 +39,7 @@ def _compute(
         past_state,
         decay,
         beta,
+        erase_gate,
         chunk_size=chunk_size,
         kv_num_heads=kv_num_heads,
         q_num_heads=q_num_heads,
@@ -504,6 +507,49 @@ class LinearAttention(Base):
             outputs=[output, present_state],
             name="test_linear_attention_fp16",
             opset_imports=_OPSET,
+        )
+
+    # ------------------------------------------------------------------
+    # Opset 28: erase_gate (Gated DeltaNet-2 / GDN-2 recurrence)
+    # ------------------------------------------------------------------
+    @staticmethod
+    def export_gated_delta_erase_gate() -> None:
+        # GDN-2 recurrence: erase_gate b_t ∈ [0,1]^{d_k} decouples the key
+        # used in the erase term (S'^T (b_t ⊙ k_t)) from the key used in the
+        # write outer product (k_t ⊗ ...).  The write gate w_t is pre-folded
+        # into value by the caller (v ← w_t ⊙ v_t) before passing to the op.
+        node = onnx.helper.make_node(
+            "LinearAttention",
+            inputs=["query", "key", "value", "", "decay", "beta", "erase_gate"],
+            outputs=["output", "present_state"],
+            q_num_heads=4,
+            kv_num_heads=4,
+        )
+        b, t, h_q, h_kv, d_k, d_v = 2, 4, 4, 4, 8, 8
+        query = np.random.randn(b, t, h_q * d_k).astype(np.float32)
+        key = _l2_normalize(np.random.randn(b, t, h_kv * d_k).astype(np.float32), h_kv)
+        value = np.random.randn(b, t, h_kv * d_v).astype(np.float32)
+        decay = -np.abs(np.random.randn(b, t, h_kv * d_k)).astype(np.float32) * 0.1
+        beta = np.random.rand(b, t, h_kv).astype(np.float32)
+        # erase_gate ∈ [0,1]^{d_k} per head — sigmoid output in practice.
+        erase_gate = np.random.rand(b, t, h_kv * d_k).astype(np.float32)
+
+        output, present_state = _compute(
+            query,
+            key,
+            value,
+            decay=decay,
+            beta=beta,
+            erase_gate=erase_gate,
+            q_num_heads=h_q,
+            kv_num_heads=h_kv,
+        )
+        expect(
+            node,
+            inputs=[query, key, value, decay, beta, erase_gate],
+            outputs=[output, present_state],
+            name="test_linear_attention_gated_delta_erase_gate",
+            opset_imports=_OPSET28,
         )
 
     # ------------------------------------------------------------------

--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -4700,4 +4700,695 @@ ONNX_OPERATOR_SET_SCHEMA(
           // Output 1: present_state (B, H_kv, d_k, d_v) — always 4D.
           updateOutputShape(ctx, 1, {B, Hkv, Dk, Dv});
         }));
+
+// ---------------------------------------------------------------------------
+// LinearAttention opset 28 — adds optional erase_gate input (index 6).
+// ---------------------------------------------------------------------------
+static constexpr const char* LinearAttention_ver28_doc = R"DOC(
+Unified linear attention operator for autoregressive decoding (T=1) and prefill (T>1).
+
+The query, key, value, and (where applicable) decay/beta/erase_gate inputs use 3D packed
+format [B, T, H*D], where heads are flattened into the last dimension; q_num_heads and
+kv_num_heads are always required and are used to unpack to 4D internally for computation.
+The optional past_state and present_state are 4D with shape (B, H_kv, d_k, d_v).
+
+Group-query attention (GQA) is supported: q_num_heads must be a positive multiple of
+kv_num_heads. When q_num_heads == kv_num_heads this reduces to multi-headed linear
+attention; when q_num_heads > kv_num_heads each KV head (and its recurrent state) is
+shared by `q_num_heads / kv_num_heads` query heads (multi-query attention is the
+special case kv_num_heads == 1).
+
+The update_rule attribute selects the recurrence type:
+- "linear": S_t = S_{t-1} + k_t ⊗ v_t; o_t = scale * q_t^T S_t
+- "gated": S_t = exp(g_t) * S_{t-1} + k_t ⊗ v_t; o_t = scale * q_t^T S_t
+- "delta": S_t = S_{t-1} + β_t * k_t ⊗ (v_t - S_{t-1}^T k_t^erase); o_t = scale * q_t^T S_t
+- "gated_delta": S_t = exp(g_t) * S_{t-1} + β_t * k_t ⊗ (v_t - exp(g_t) * S_{t-1}^T k_t^erase); o_t = scale * q_t^T S_t
+
+where g_t is the decay (in log-space), β_t is the update rate, ⊗ denotes outer product,
+and k_t^erase = erase_gate_t ⊙ k_t when the optional erase_gate input is provided,
+else k_t^erase = k_t.
+
+The erase_gate input decouples the key used in the erase (retrieval) term from the key
+used in the write outer product. This enables architectures such as Gated DeltaNet-2,
+where k_t^erase = b_t ⊙ k_t with b_t ∈ [0,1]^{d_k} controls which state channels are
+erased independently of the write. The write always uses the original k_t.
+erase_gate is only valid for 'delta' and 'gated_delta' update rules.
+
+Semantics: Equivalent to running the recurrent update sequentially for each token,
+but may be implemented using chunk-parallel algorithms for GPU efficiency.
+
+)DOC";
+
+ONNX_OPERATOR_SET_SCHEMA(
+    LinearAttention,
+    28,
+    OpSchema()
+        .SetDoc(LinearAttention_ver28_doc)
+        .Attr(
+            "update_rule",
+            "The update rule for the linear attention recurrence. "
+            "One of: 'linear', 'gated', 'delta', 'gated_delta'. Default is 'gated_delta'.",
+            AttributeProto::STRING,
+            std::string("gated_delta"))
+        .Attr(
+            "scale",
+            "Output scaling factor. When 0.0 (default), derives d_k = query.shape[-1] / q_num_heads "
+            "and uses 1/sqrt(d_k). Set explicitly to override.",
+            AttributeProto::FLOAT,
+            0.0f)
+        .Attr("q_num_heads", "Number of query heads. Always required.", AttributeProto::INT)
+        .Attr("kv_num_heads", "Number of key/value heads. Always required.", AttributeProto::INT)
+        .Attr(
+            "chunk_size",
+            "Chunk size for the chunk-parallel WY decomposition during prefill (T>1). "
+            "Tuning hint; does not affect output correctness.",
+            AttributeProto::INT,
+            static_cast<int64_t>(64))
+        .Input(
+            0,
+            "query",
+            "Query vectors with 3D packed shape (B, T, H_q * d_k). "
+            "Heads are packed into the last dimension.",
+            "T",
+            OpSchema::Single,
+            true,
+            1,
+            OpSchema::Differentiable)
+        .Input(
+            1,
+            "key",
+            "Key vectors with 3D packed shape (B, T, H_kv * d_k). "
+            "Should be L2-normalized for delta/gated_delta modes.",
+            "T",
+            OpSchema::Single,
+            true,
+            1,
+            OpSchema::Differentiable)
+        .Input(
+            2,
+            "value",
+            "Value vectors with 3D packed shape (B, T, H_kv * d_v).",
+            "T",
+            OpSchema::Single,
+            true,
+            1,
+            OpSchema::Differentiable)
+        .Input(
+            3,
+            "past_state",
+            "Recurrent state from the previous step with shape (B, H_kv, d_k, d_v). "
+            "When absent the state is initialized to zeros.",
+            "S",
+            OpSchema::Optional,
+            true,
+            1,
+            OpSchema::NonDifferentiable)
+        .Input(
+            4,
+            "decay",
+            "Exponential decay gate in log-space. 3D packed shape: "
+            "(B, T, H_kv * d_k) for per-key-dimension decay (GLA/RWKV-6), or "
+            "(B, T, H_kv) for per-head scalar decay (DeltaNet/RetNet). "
+            "Required for 'gated' and 'gated_delta' modes.",
+            "T",
+            OpSchema::Optional,
+            true,
+            1,
+            OpSchema::Differentiable)
+        .Input(
+            5,
+            "beta",
+            "Update rate (sigmoid output). 3D packed shape: "
+            "(B, T, H_kv) or (B, T, 1). "
+            "Required for 'delta' and 'gated_delta' modes.",
+            "T",
+            OpSchema::Optional,
+            true,
+            1,
+            OpSchema::Differentiable)
+        .Input(
+            6,
+            "erase_gate",
+            "Channel-wise erase gate applied to the key before retrieval. "
+            "3D packed shape: (B, T, H_kv * d_k). "
+            "When provided, the retrieval key becomes erase_gate_t ⊙ k_t while the "
+            "write outer product continues to use the original k_t. "
+            "Optional for 'delta' and 'gated_delta' modes only.",
+            "T",
+            OpSchema::Optional,
+            true,
+            1,
+            OpSchema::Differentiable)
+        .Output(
+            0,
+            "output",
+            "Attention output with 3D packed shape (B, T, H_q * d_v).",
+            "T",
+            OpSchema::Single,
+            true,
+            1,
+            OpSchema::Differentiable)
+        .Output(
+            1,
+            "present_state",
+            "Updated recurrent state with shape (B, H_kv, d_k, d_v). Always 4D.",
+            "S",
+            OpSchema::Single,
+            true,
+            1,
+            OpSchema::NonDifferentiable)
+        .TypeConstraint(
+            "T",
+            {"tensor(float16)", "tensor(bfloat16)", "tensor(float)"},
+            "Constrain activation input and output types to float16, bfloat16, or float32 tensors.")
+        .TypeConstraint(
+            "S",
+            {"tensor(float16)", "tensor(bfloat16)", "tensor(float)"},
+            "Constrain state types to float16, bfloat16, or float32 tensors. "
+            "Should be float32 or the same as T for numerical stability on long sequences.")
+        .SetContextDependentFunctionBodyBuilder(
+            [](const FunctionBodyBuildContext& ctx, const OpSchema& schema, FunctionProto& functionProto) {
+              // LinearAttention <update_rule, scale, q_num_heads, kv_num_heads, chunk_size>
+              //   (query, key, value, past_state?, decay?, beta?, erase_gate?)
+              //   => (output, present_state)
+              //
+              // Reference decomposition (sequential recurrence via Scan):
+              //   1. Reshape/transpose 3D packed inputs (B, T, H*D) -> 4D (B, H, T, D)
+              //   2. Initialize state (past_state or zeros), shape (B, H_kv, d_k, d_v)
+              //   3. Compute scale factor (attribute or 1/sqrt(d_k))
+              //   4. Run Scan over T axis with body implementing one recurrence step
+              //   5. Transpose/reshape 4D outputs back to 3D (B, T, H_q*d_v)
+
+              // --- Step 1: Extract attributes and validate ---
+              auto* update_rule_attr = ctx.getAttribute("update_rule");
+              std::string update_rule =
+                  (update_rule_attr != nullptr && update_rule_attr->has_s()) ? update_rule_attr->s() : "gated_delta";
+
+              auto* q_num_heads_attr = ctx.getAttribute("q_num_heads");
+              auto* kv_num_heads_attr = ctx.getAttribute("kv_num_heads");
+              if (q_num_heads_attr == nullptr || !q_num_heads_attr->has_i() || kv_num_heads_attr == nullptr ||
+                  !kv_num_heads_attr->has_i()) {
+                return false;
+              }
+              int64_t q_num_heads = q_num_heads_attr->i();
+              int64_t kv_num_heads = kv_num_heads_attr->i();
+
+              auto* scale_attr = ctx.getAttribute("scale");
+              float scale = (scale_attr != nullptr && scale_attr->has_f()) ? scale_attr->f() : 0.0f;
+
+              // Per-rule presence of optional inputs
+              bool has_decay = (update_rule == "gated" || update_rule == "gated_delta");
+              bool has_beta = (update_rule == "delta" || update_rule == "gated_delta");
+              bool has_erase_gate = ctx.hasInput(6);
+
+              // Need query type (for CastLike on zero state) — checked indirectly via input 0 presence.
+              if (ctx.getInputType(0) == nullptr) {
+                return false;
+              }
+
+              // GQA: q_num_heads must be a positive multiple of kv_num_heads.
+              if (q_num_heads <= 0 || kv_num_heads <= 0 || q_num_heads % kv_num_heads != 0) {
+                return false;
+              }
+              int64_t group_size = q_num_heads / kv_num_heads;
+
+              FunctionBuilder builder(functionProto);
+
+              // --- Step 2: Pre-Scan 3D -> 4D reshape and transpose ---
+              builder.Const1D("NegOne1D", static_cast<int64_t>(-1))
+                  .Const1D("One1D", static_cast<int64_t>(1))
+                  .Const1D("HqConst", q_num_heads)
+                  .Const1D("HkvConst", kv_num_heads)
+                  .Add(R"ONNX(
+                BatchDim = Shape <start = 0, end = 1> (query)
+                SeqLenDim = Shape <start = 1, end = 2> (query)
+              )ONNX");
+
+              builder.Add(R"ONNX(
+                QShape4D = Concat <axis = 0> (BatchDim, SeqLenDim, HqConst, NegOne1D)
+                QReshaped = Reshape (query, QShape4D)
+                Q4D = Transpose <perm = [1, 0, 2, 3]> (QReshaped)
+              )ONNX");
+
+              builder.Add(R"ONNX(
+                KVShape4D = Concat <axis = 0> (BatchDim, SeqLenDim, HkvConst, NegOne1D)
+                KReshaped = Reshape (key, KVShape4D)
+                K4D = Transpose <perm = [1, 0, 2, 3]> (KReshaped)
+                VReshaped = Reshape (value, KVShape4D)
+                V4D = Transpose <perm = [1, 0, 2, 3]> (VReshaped)
+              )ONNX");
+
+              if (has_decay) {
+                builder.Add(R"ONNX(
+                  DecayReshaped = Reshape (decay, KVShape4D)
+                  Decay4D = Transpose <perm = [1, 0, 2, 3]> (DecayReshaped)
+                )ONNX");
+              }
+
+              if (has_beta) {
+                builder.Add(R"ONNX(
+                  BetaShape4D = Concat <axis = 0> (BatchDim, SeqLenDim, NegOne1D, One1D)
+                  BetaReshaped = Reshape (beta, BetaShape4D)
+                  Beta4D = Transpose <perm = [1, 0, 2, 3]> (BetaReshaped)
+                )ONNX");
+              }
+
+              if (has_erase_gate) {
+                // erase_gate has shape (B, T, H_kv * d_k) — same layout as per-key-dim decay.
+                builder.Add(R"ONNX(
+                  EraseGateReshaped = Reshape (erase_gate, KVShape4D)
+                  EraseGate4D = Transpose <perm = [1, 0, 2, 3]> (EraseGateReshaped)
+                )ONNX");
+              }
+
+              // --- Step 3: Initialize recurrence state (B, H_kv, d_k, d_v) ---
+              builder.Add(R"ONNX(
+                QLastDim = Shape <start = 2, end = 3> (query)
+                VLastDim = Shape <start = 2, end = 3> (value)
+                DkDim = Div (QLastDim, HqConst)
+                DvDim = Div (VLastDim, HkvConst)
+              )ONNX");
+
+              if (ctx.hasInput(3)) {
+                builder.Add("State0 = Cast <to = 1> (past_state)");
+              } else {
+                builder.Add(R"ONNX(
+                  StateShape = Concat <axis = 0> (BatchDim, HkvConst, DkDim, DvDim)
+                  State0 = ConstantOfShape (StateShape)
+                )ONNX");
+              }
+
+              // --- Step 4: Compute scale factor (scalar, float32) ---
+              if (scale != 0.0f) {
+                builder.Const("ScaleFactor", scale);
+              } else {
+                builder.Add(R"ONNX(
+                  DkScalar = Squeeze (DkDim)
+                  DkFloat = Cast <to = 1> (DkScalar)
+                  SqrtDk = Sqrt (DkFloat)
+                  ScaleFactor = Reciprocal (SqrtDk)
+                )ONNX");
+              }
+
+              // --- Step 4b: Precompute GQA expand/read shapes ---
+              if (group_size > 1) {
+                builder.Const1D("GroupSize", group_size).Const1D("Two1D", static_cast<int64_t>(2)).Add(R"ONNX(
+                  StateExpandShape = Concat <axis = 0> (BatchDim, HkvConst, GroupSize, DkDim, DvDim)
+                  StateReadShape = Concat <axis = 0> (BatchDim, HqConst, DkDim, DvDim)
+                )ONNX");
+              }
+
+              // --- Step 5: Scan node with body subgraph ---
+              builder.Const1D("NegTwo1D", static_cast<int64_t>(-2));
+
+              const std::string read_block = (group_size > 1) ? R"ONNX(
+                StateUnsq = Unsqueeze (state_out, Two1D)
+                StateExpanded = Expand (StateUnsq, StateExpandShape)
+                StateForRead = Reshape (StateExpanded, StateReadShape)
+                QtRow = Unsqueeze (q_t_f, NegTwo1D)
+                ReadOut = MatMul (QtRow, StateForRead)
+                ReadSq = Squeeze (ReadOut, NegTwo1D)
+                output_t_f = Mul (ScaleFactor, ReadSq)
+                output_t = CastLike (output_t_f, q_t)
+              )ONNX"
+                                                              : R"ONNX(
+                QtRow = Unsqueeze (q_t_f, NegTwo1D)
+                ReadOut = MatMul (QtRow, state_out)
+                ReadSq = Squeeze (ReadOut, NegTwo1D)
+                output_t_f = Mul (ScaleFactor, ReadSq)
+                output_t = CastLike (output_t_f, q_t)
+              )ONNX";
+
+              std::string body;
+              std::string body_inputs;
+              std::string scan_inputs;
+              int64_t num_scan_inputs;
+              if (update_rule == "linear") {
+                body_inputs = "state_in, q_t, k_t, v_t";
+                scan_inputs = "State0, Q4D, K4D, V4D";
+                num_scan_inputs = 3;
+                body = R"ONNX(
+                q_t_f = Cast <to = 1> (q_t)
+                k_t_f = Cast <to = 1> (k_t)
+                v_t_f = Cast <to = 1> (v_t)
+                KtCol = Unsqueeze (k_t_f, NegOne1D)
+                WriteRow = Unsqueeze (v_t_f, NegTwo1D)
+                Outer = MatMul (KtCol, WriteRow)
+                state_out = Add (state_in, Outer)
+              )ONNX";
+              } else if (update_rule == "gated") {
+                body_inputs = "state_in, q_t, k_t, v_t, decay_t";
+                scan_inputs = "State0, Q4D, K4D, V4D, Decay4D";
+                num_scan_inputs = 4;
+                body = R"ONNX(
+                q_t_f = Cast <to = 1> (q_t)
+                k_t_f = Cast <to = 1> (k_t)
+                v_t_f = Cast <to = 1> (v_t)
+                decay_t_f = Cast <to = 1> (decay_t)
+                DecayExp = Exp (decay_t_f)
+                DecayExpUnsq = Unsqueeze (DecayExp, NegOne1D)
+                DecayedState = Mul (state_in, DecayExpUnsq)
+                KtCol = Unsqueeze (k_t_f, NegOne1D)
+                WriteRow = Unsqueeze (v_t_f, NegTwo1D)
+                Outer = MatMul (KtCol, WriteRow)
+                state_out = Add (DecayedState, Outer)
+              )ONNX";
+              } else if (update_rule == "delta") {
+                if (has_erase_gate) {
+                  body_inputs = "state_in, q_t, k_t, v_t, beta_t, erase_gate_t";
+                  scan_inputs = "State0, Q4D, K4D, V4D, Beta4D, EraseGate4D";
+                  num_scan_inputs = 5;
+                  body = R"ONNX(
+                  q_t_f = Cast <to = 1> (q_t)
+                  k_t_f = Cast <to = 1> (k_t)
+                  v_t_f = Cast <to = 1> (v_t)
+                  beta_t_f = Cast <to = 1> (beta_t)
+                  erase_gate_t_f = Cast <to = 1> (erase_gate_t)
+                  GatedK = Mul (erase_gate_t_f, k_t_f)
+                  GatedKCol = Unsqueeze (GatedK, NegOne1D)
+                  KtCol = Unsqueeze (k_t_f, NegOne1D)
+                  StateT = Transpose <perm = [0, 1, 3, 2]> (state_in)
+                  Retrieved = MatMul (StateT, GatedKCol)
+                  RetrievedSq = Squeeze (Retrieved, NegOne1D)
+                  Diff = Sub (v_t_f, RetrievedSq)
+                  Delta = Mul (beta_t_f, Diff)
+                  WriteRow = Unsqueeze (Delta, NegTwo1D)
+                  Outer = MatMul (KtCol, WriteRow)
+                  state_out = Add (state_in, Outer)
+                )ONNX";
+                } else {
+                  body_inputs = "state_in, q_t, k_t, v_t, beta_t";
+                  scan_inputs = "State0, Q4D, K4D, V4D, Beta4D";
+                  num_scan_inputs = 4;
+                  body = R"ONNX(
+                  q_t_f = Cast <to = 1> (q_t)
+                  k_t_f = Cast <to = 1> (k_t)
+                  v_t_f = Cast <to = 1> (v_t)
+                  beta_t_f = Cast <to = 1> (beta_t)
+                  KtCol = Unsqueeze (k_t_f, NegOne1D)
+                  StateT = Transpose <perm = [0, 1, 3, 2]> (state_in)
+                  Retrieved = MatMul (StateT, KtCol)
+                  RetrievedSq = Squeeze (Retrieved, NegOne1D)
+                  Diff = Sub (v_t_f, RetrievedSq)
+                  Delta = Mul (beta_t_f, Diff)
+                  WriteRow = Unsqueeze (Delta, NegTwo1D)
+                  Outer = MatMul (KtCol, WriteRow)
+                  state_out = Add (state_in, Outer)
+                )ONNX";
+                }
+              } else { // gated_delta
+                if (has_erase_gate) {
+                  body_inputs = "state_in, q_t, k_t, v_t, decay_t, beta_t, erase_gate_t";
+                  scan_inputs = "State0, Q4D, K4D, V4D, Decay4D, Beta4D, EraseGate4D";
+                  num_scan_inputs = 6;
+                  body = R"ONNX(
+                  q_t_f = Cast <to = 1> (q_t)
+                  k_t_f = Cast <to = 1> (k_t)
+                  v_t_f = Cast <to = 1> (v_t)
+                  decay_t_f = Cast <to = 1> (decay_t)
+                  beta_t_f = Cast <to = 1> (beta_t)
+                  erase_gate_t_f = Cast <to = 1> (erase_gate_t)
+                  DecayExp = Exp (decay_t_f)
+                  DecayExpUnsq = Unsqueeze (DecayExp, NegOne1D)
+                  DecayedState = Mul (state_in, DecayExpUnsq)
+                  GatedK = Mul (erase_gate_t_f, k_t_f)
+                  GatedKCol = Unsqueeze (GatedK, NegOne1D)
+                  KtCol = Unsqueeze (k_t_f, NegOne1D)
+                  StateT = Transpose <perm = [0, 1, 3, 2]> (DecayedState)
+                  Retrieved = MatMul (StateT, GatedKCol)
+                  RetrievedSq = Squeeze (Retrieved, NegOne1D)
+                  Diff = Sub (v_t_f, RetrievedSq)
+                  Delta = Mul (beta_t_f, Diff)
+                  WriteRow = Unsqueeze (Delta, NegTwo1D)
+                  Outer = MatMul (KtCol, WriteRow)
+                  state_out = Add (DecayedState, Outer)
+                )ONNX";
+                } else {
+                  body_inputs = "state_in, q_t, k_t, v_t, decay_t, beta_t";
+                  scan_inputs = "State0, Q4D, K4D, V4D, Decay4D, Beta4D";
+                  num_scan_inputs = 5;
+                  body = R"ONNX(
+                  q_t_f = Cast <to = 1> (q_t)
+                  k_t_f = Cast <to = 1> (k_t)
+                  v_t_f = Cast <to = 1> (v_t)
+                  decay_t_f = Cast <to = 1> (decay_t)
+                  beta_t_f = Cast <to = 1> (beta_t)
+                  DecayExp = Exp (decay_t_f)
+                  DecayExpUnsq = Unsqueeze (DecayExp, NegOne1D)
+                  DecayedState = Mul (state_in, DecayExpUnsq)
+                  KtCol = Unsqueeze (k_t_f, NegOne1D)
+                  StateT = Transpose <perm = [0, 1, 3, 2]> (DecayedState)
+                  Retrieved = MatMul (StateT, KtCol)
+                  RetrievedSq = Squeeze (Retrieved, NegOne1D)
+                  Diff = Sub (v_t_f, RetrievedSq)
+                  Delta = Mul (beta_t_f, Diff)
+                  WriteRow = Unsqueeze (Delta, NegTwo1D)
+                  Outer = MatMul (KtCol, WriteRow)
+                  state_out = Add (DecayedState, Outer)
+                )ONNX";
+                }
+              }
+
+              std::string scan_text =
+                  "FinalState, OutputAccum = Scan <\n"
+                  "  num_scan_inputs = " +
+                  std::to_string(num_scan_inputs) +
+                  ",\n"
+                  "  body = linear_attn_step (" +
+                  body_inputs + ") => (state_out, output_t) {\n" + body + read_block +
+                  "              }\n"
+                  "> (" +
+                  scan_inputs + ")";
+
+              builder.Add(scan_text.c_str());
+
+              // --- Step 6: Post-Scan 4D -> 3D reshape and present_state ---
+              builder.Add(R"ONNX(
+                OutputTransposed = Transpose <perm = [1, 0, 2, 3]> (OutputAccum)
+                OutputShape3D = Concat <axis = 0> (BatchDim, SeqLenDim, NegOne1D)
+                output = Reshape (OutputTransposed, OutputShape3D)
+              )ONNX");
+              if (ctx.hasInput(3)) {
+                builder.Add("present_state = CastLike (FinalState, past_state)");
+              } else {
+                builder.Add("present_state = CastLike (FinalState, query)");
+              }
+
+              schema.BuildFunction(functionProto);
+              return true;
+            })
+        .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+          // Read required attributes
+          auto* q_num_heads_attr = ctx.getAttribute("q_num_heads");
+          auto* kv_num_heads_attr = ctx.getAttribute("kv_num_heads");
+          int64_t q_num_heads = (q_num_heads_attr && q_num_heads_attr->has_i()) ? q_num_heads_attr->i() : 0;
+          int64_t kv_num_heads = (kv_num_heads_attr && kv_num_heads_attr->has_i()) ? kv_num_heads_attr->i() : 0;
+
+          if (q_num_heads <= 0) {
+            fail_type_inference("q_num_heads must be > 0, got ", q_num_heads);
+          }
+          if (kv_num_heads <= 0) {
+            fail_type_inference("kv_num_heads must be > 0, got ", kv_num_heads);
+          }
+          if (q_num_heads % kv_num_heads != 0) {
+            fail_type_inference(
+                "q_num_heads (", q_num_heads, ") must be a multiple of kv_num_heads (", kv_num_heads, ")");
+          }
+
+          auto* update_rule_attr = ctx.getAttribute("update_rule");
+          std::string update_rule = (update_rule_attr != nullptr) ? update_rule_attr->s() : "gated_delta";
+
+          if (update_rule != "linear" && update_rule != "gated" && update_rule != "delta" &&
+              update_rule != "gated_delta") {
+            fail_type_inference("update_rule must be one of: 'linear', 'gated', 'delta', 'gated_delta'");
+          }
+
+          const bool has_past_state = ctx.hasInput(3);
+          const bool has_decay = ctx.hasInput(4);
+          const bool has_beta = ctx.hasInput(5);
+          const bool has_erase_gate = ctx.hasInput(6);
+
+          if (update_rule == "linear") {
+            if (has_decay) {
+              fail_type_inference("update_rule 'linear' forbids decay input");
+            }
+            if (has_beta) {
+              fail_type_inference("update_rule 'linear' forbids beta input");
+            }
+            if (has_erase_gate) {
+              fail_type_inference("update_rule 'linear' forbids erase_gate input");
+            }
+          } else if (update_rule == "gated") {
+            if (!has_decay) {
+              fail_type_inference("update_rule 'gated' requires decay input");
+            }
+            if (has_beta) {
+              fail_type_inference("update_rule 'gated' forbids beta input");
+            }
+            if (has_erase_gate) {
+              fail_type_inference("update_rule 'gated' forbids erase_gate input");
+            }
+          } else if (update_rule == "delta") {
+            if (has_decay) {
+              fail_type_inference("update_rule 'delta' forbids decay input");
+            }
+            if (!has_beta) {
+              fail_type_inference("update_rule 'delta' requires beta input");
+            }
+          } else if (update_rule == "gated_delta") {
+            if (!has_decay) {
+              fail_type_inference("update_rule 'gated_delta' requires decay input");
+            }
+            if (!has_beta) {
+              fail_type_inference("update_rule 'gated_delta' requires beta input");
+            }
+          }
+
+          // Type propagation
+          propagateElemTypeFromInputToOutput(ctx, 0, 0);
+          if (has_past_state && ctx.getInputType(3) != nullptr && ctx.getInputType(3)->has_tensor_type()) {
+            propagateElemTypeFromInputToOutput(ctx, 3, 1);
+          } else {
+            propagateElemTypeFromInputToOutput(ctx, 0, 1);
+          }
+
+          // Shape inference via dimension unification
+          Dim B, T, QPack, KPack, VPack, Hkv, Dk, Dv;
+          if (kv_num_heads > 0) {
+            Hkv.set_dim_value(kv_num_heads);
+          }
+          unifyInputShape(ctx, 0, {B, T, QPack});
+          unifyInputShape(ctx, 1, {B, T, KPack});
+          unifyInputShape(ctx, 2, {B, T, VPack});
+          if (has_past_state) {
+            unifyInputShape(ctx, 3, {B, Hkv, Dk, Dv});
+          }
+          if (has_decay) {
+            Dim DecayLast;
+            unifyInputShape(ctx, 4, {B, T, DecayLast});
+          }
+          if (has_beta) {
+            Dim BetaLast;
+            unifyInputShape(ctx, 5, {B, T, BetaLast});
+          }
+          if (has_erase_gate) {
+            // erase_gate: (B, T, H_kv * d_k) — strictly per-key-dim, no per-head shorthand.
+            Dim EraseGateLast;
+            unifyInputShape(ctx, 6, {B, T, EraseGateLast});
+          }
+
+          if (q_num_heads > 0 && QPack.has_dim_value()) {
+            if (QPack.dim_value() % q_num_heads != 0) {
+              fail_shape_inference(
+                  "Packed query last dim (",
+                  QPack.dim_value(),
+                  ") must be divisible by q_num_heads (",
+                  q_num_heads,
+                  ")");
+            }
+            unifyDim(Dk, QPack.dim_value() / q_num_heads);
+          }
+          if (kv_num_heads > 0 && KPack.has_dim_value()) {
+            if (KPack.dim_value() % kv_num_heads != 0) {
+              fail_shape_inference(
+                  "Packed key last dim (",
+                  KPack.dim_value(),
+                  ") must be divisible by kv_num_heads (",
+                  kv_num_heads,
+                  ")");
+            }
+            unifyDim(Dk, KPack.dim_value() / kv_num_heads);
+          }
+          if (kv_num_heads > 0 && VPack.has_dim_value()) {
+            if (VPack.dim_value() % kv_num_heads != 0) {
+              fail_shape_inference(
+                  "Packed value last dim (",
+                  VPack.dim_value(),
+                  ") must be divisible by kv_num_heads (",
+                  kv_num_heads,
+                  ")");
+            }
+            unifyDim(Dv, VPack.dim_value() / kv_num_heads);
+          }
+
+          // Validate decay last dim
+          if (has_decay && kv_num_heads > 0) {
+            auto* decay_type = ctx.getInputType(4);
+            if (decay_type != nullptr && decay_type->has_tensor_type() && decay_type->tensor_type().has_shape() &&
+                decay_type->tensor_type().shape().dim_size() == 3 &&
+                decay_type->tensor_type().shape().dim(2).has_dim_value()) {
+              const int64_t decay_last = decay_type->tensor_type().shape().dim(2).dim_value();
+              if (Dk.has_dim_value()) {
+                const int64_t dk = Dk.dim_value();
+                if (decay_last != kv_num_heads && decay_last != kv_num_heads * dk) {
+                  fail_shape_inference(
+                      "decay last dim (",
+                      decay_last,
+                      ") must be kv_num_heads (",
+                      kv_num_heads,
+                      ") or kv_num_heads * d_k (",
+                      kv_num_heads * dk,
+                      ")");
+                }
+              } else if (decay_last != kv_num_heads && decay_last % kv_num_heads != 0) {
+                fail_shape_inference(
+                    "decay last dim (",
+                    decay_last,
+                    ") must be kv_num_heads (",
+                    kv_num_heads,
+                    ") or a multiple of kv_num_heads");
+              }
+            }
+          }
+
+          // Validate beta last dim
+          if (has_beta && kv_num_heads > 0) {
+            auto* beta_type = ctx.getInputType(5);
+            if (beta_type != nullptr && beta_type->has_tensor_type() && beta_type->tensor_type().has_shape() &&
+                beta_type->tensor_type().shape().dim_size() == 3 &&
+                beta_type->tensor_type().shape().dim(2).has_dim_value()) {
+              const int64_t beta_last = beta_type->tensor_type().shape().dim(2).dim_value();
+              if (beta_last != 1 && beta_last != kv_num_heads) {
+                fail_shape_inference("beta last dim (", beta_last, ") must be 1 or kv_num_heads (", kv_num_heads, ")");
+              }
+            }
+          }
+
+          // Validate erase_gate last dim: must be H_kv * d_k (no per-head shorthand).
+          if (has_erase_gate && kv_num_heads > 0) {
+            auto* eg_type = ctx.getInputType(6);
+            if (eg_type != nullptr && eg_type->has_tensor_type() && eg_type->tensor_type().has_shape() &&
+                eg_type->tensor_type().shape().dim_size() == 3 &&
+                eg_type->tensor_type().shape().dim(2).has_dim_value()) {
+              const int64_t eg_last = eg_type->tensor_type().shape().dim(2).dim_value();
+              if (Dk.has_dim_value()) {
+                if (eg_last != kv_num_heads * Dk.dim_value()) {
+                  fail_shape_inference(
+                      "erase_gate last dim (",
+                      eg_last,
+                      ") must be kv_num_heads * d_k (",
+                      kv_num_heads * Dk.dim_value(),
+                      ")");
+                }
+              } else if (eg_last % kv_num_heads != 0) {
+                fail_shape_inference(
+                    "erase_gate last dim (",
+                    eg_last,
+                    ") must be a multiple of kv_num_heads (",
+                    kv_num_heads,
+                    ")");
+              }
+            }
+          }
+
+          // Output 0: (B, T, H_q * d_v) — 3D packed.
+          Dim OutLast;
+          if (q_num_heads > 0 && Dv.has_dim_value()) {
+            OutLast.set_dim_value(q_num_heads * Dv.dim_value());
+          }
+          updateOutputShape(ctx, 0, {B, T, OutLast});
+
+          // Output 1: present_state (B, H_kv, d_k, d_v) — always 4D.
+          updateOutputShape(ctx, 1, {B, Hkv, Dk, Dv});
+        }));
 } // namespace ONNX_NAMESPACE

--- a/onnx/defs/operator_sets.h
+++ b/onnx/defs/operator_sets.h
@@ -1469,6 +1469,17 @@ class OpSet_Onnx_ver27 {
   }
 };
 
+// Forward declarations for ai.onnx version 28
+class ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 28, LinearAttention);
+
+// Iterate over schema from ai.onnx version 28
+class OpSet_Onnx_ver28 {
+ public:
+  static void ForEachSchema(std::function<void(OpSchema&&)> fn) {
+    fn(GetOpSchema<ONNX_OPERATOR_SET_SCHEMA_CLASS_NAME(Onnx, 28, LinearAttention)>());
+  }
+};
+
 ONNX_API inline void RegisterOnnxOperatorSetSchema() {
   RegisterOpSetSchema<OpSet_Onnx_ver1>();
   RegisterOpSetSchema<OpSet_Onnx_ver2>();
@@ -1497,6 +1508,7 @@ ONNX_API inline void RegisterOnnxOperatorSetSchema() {
   RegisterOpSetSchema<OpSet_Onnx_ver25>();
   RegisterOpSetSchema<OpSet_Onnx_ver26>();
   RegisterOpSetSchema<OpSet_Onnx_ver27>();
+  RegisterOpSetSchema<OpSet_Onnx_ver28>();
   // 0 means all versions of ONNX schema have been loaded
   OpSchemaRegistry::Instance()->SetLoadedSchemaVersion(0);
 }
@@ -1506,6 +1518,7 @@ ONNX_API inline void RegisterOnnxOperatorSetSchema(int target_version, bool fail
   // These calls for schema registration here are required to be in descending order for this to work correctly
   //
   // Version-specific registration sees duplicate schema version request as error if fail_duplicate_schema
+  RegisterOpSetSchema<OpSet_Onnx_ver28>(target_version, fail_duplicate_schema);
   RegisterOpSetSchema<OpSet_Onnx_ver27>(target_version, fail_duplicate_schema);
   RegisterOpSetSchema<OpSet_Onnx_ver26>(target_version, fail_duplicate_schema);
   RegisterOpSetSchema<OpSet_Onnx_ver25>(target_version, fail_duplicate_schema);

--- a/onnx/defs/schema.h
+++ b/onnx/defs/schema.h
@@ -912,7 +912,7 @@ class OpSchemaRegistry final : public ISchemaRegistry {
       // Increase the highest version when you make BC-breaking changes to the
       // operator schema on specific domain. Update the lowest version when it's
       // determined to remove too old version history.
-      map_[ONNX_DOMAIN] = std::make_pair(1, 27);
+      map_[ONNX_DOMAIN] = std::make_pair(1, 28);
       map_[AI_ONNX_ML_DOMAIN] = std::make_pair(1, 5);
       map_[AI_ONNX_TRAINING_DOMAIN] = std::make_pair(1, 1);
       map_[AI_ONNX_PREVIEW_DOMAIN] = std::make_pair(1, 1);

--- a/onnx/helper.py
+++ b/onnx/helper.py
@@ -76,6 +76,8 @@ VERSION_TABLE: VersionTableType = [
     ("1.20.0", 13, 25, 5, 1),
     ("1.20.1", 13, 25, 5, 1),
     ("1.21.0", 13, 26, 5, 1),
+    ("1.22.0-dev", 13, 27, 5, 1),
+    ("1.22.0-dev", 13, 28, 5, 1),
 ]
 
 VersionMapType = dict[tuple[str, int], int]

--- a/onnx/reference/ops/op_linear_attention.py
+++ b/onnx/reference/ops/op_linear_attention.py
@@ -28,6 +28,7 @@ class LinearAttention(OpRun):
         past_state=None,
         decay=None,
         beta=None,
+        erase_gate=None,
         chunk_size=None,  # noqa: ARG002 — tuning hint, no effect on output
         kv_num_heads=None,
         q_num_heads=None,
@@ -61,6 +62,8 @@ class LinearAttention(OpRun):
             raise ValueError(f"update_rule '{update_rule}' requires beta input.")
         if not delta_correction and beta is not None:
             raise ValueError(f"update_rule '{update_rule}' forbids beta input.")
+        if erase_gate is not None and not delta_correction:
+            raise ValueError(f"update_rule '{update_rule}' forbids erase_gate input.")
 
         for name, arr in (("query", query), ("key", key), ("value", value)):
             if arr.ndim != 3:
@@ -111,6 +114,18 @@ class LinearAttention(OpRun):
             beta4 = beta.reshape(b, t, beta_last, 1).transpose(0, 2, 1, 3)
             beta4 = beta4.astype(np.float32)
 
+        # --- Step 4b: unpack erase_gate (B, T, H_kv*d_k) -> (B, H_kv, T, d_k) ---
+        if erase_gate is not None:
+            if erase_gate.ndim != 3:
+                raise ValueError(f"erase_gate must be rank 3, got shape {erase_gate.shape}.")
+            eg_last = erase_gate.shape[-1]
+            if kv_num_heads > 0 and eg_last % kv_num_heads != 0:
+                raise ValueError(
+                    f"erase_gate last dim {eg_last} must be a multiple of "
+                    f"kv_num_heads ({kv_num_heads})."
+                )
+            erase_gate4 = _unpack_3d_to_4d(erase_gate, kv_num_heads).astype(np.float32)
+
         # --- Step 5: initialize state in float32 ---
         # TODO(review): The proposal allows S != T (e.g., float32 state with
         # float16/bfloat16 activations). We accumulate internally in float32
@@ -151,10 +166,11 @@ class LinearAttention(OpRun):
                 g_t = decay4[:, :, i, :]  # (B, H_kv, 1) or (B, H_kv, d_k)
                 state = state * np.exp(g_t)[..., None]  # broadcast over d_v
 
-            # Delta correction: v_t <- beta_t * (v_t - S^T @ k_t)
+            # Delta correction: v_t <- beta_t * (v_t - S^T @ k_erase_t)
+            # where k_erase_t = erase_gate_t ⊙ k_t when erase_gate is provided, else k_t.
             if delta_correction:
-                # retrieved[b, h, m] = sum_d state[b, h, d, m] * k_t[b, h, d]
-                retrieved = np.einsum("bhdm,bhd->bhm", state, k_t)
+                k_erase_t = erase_gate4[:, :, i, :] * k_t if erase_gate is not None else k_t
+                retrieved = np.einsum("bhdm,bhd->bhm", state, k_erase_t)
                 v_t = beta4[:, :, i, :] * (v_t - retrieved)
 
             # Write: state += k_t ⊗ v_t  (outer product over last dims)

--- a/onnx/test/version_converter/automatic_downgrade_test.py
+++ b/onnx/test/version_converter/automatic_downgrade_test.py
@@ -114,6 +114,21 @@ class TestAutomaticDowngrade(automatic_conversion_test_base.TestAutomaticConvers
         """,
         )
 
+    def test_LinearAttention_opset28_downgrade_fails(self) -> None:
+        # LinearAttention opset 28 cannot be downgraded below opset 27; the
+        # op didn't exist before that version.
+        self._test_model_conversion_fails(
+            to_opset=26,
+            model="""
+            <ir_version: 10, opset_import: [ "" : 28]>
+            linear_attention28 (float[2, 4, 64] Q, float[2, 4, 64] K, float[2, 4, 64] V)
+                => (float[2, 4, 64] output, float[2, 4, 16, 16] present_state)
+            {
+                output, present_state = LinearAttention <q_num_heads = 4, kv_num_heads = 4, update_rule = "linear"> (Q, K, V)
+            }
+        """,
+        )
+
     def test_CausalConvWithState_downgrade_fails(self) -> None:
         # CausalConvWithState was introduced at opset 27; no decomposition
         # adapter exists for downgrading to opset 24. The version converter

--- a/onnx/test/version_converter/automatic_upgrade_test.py
+++ b/onnx/test/version_converter/automatic_upgrade_test.py
@@ -2080,6 +2080,39 @@ class TestAutomaticUpgrade(automatic_conversion_test_base.TestAutomaticConversio
             },
         )
 
+    def test_LinearAttention_erase_gate(self) -> None:
+        # opset 28: optional erase_gate input decouples retrieval key from write
+        # key (GDN-2 recurrence).  Shape: (B, T, H_kv * d_k) = (2, 4, 64).
+        self._test_op_upgrade(
+            "LinearAttention",
+            28,
+            [
+                [2, 4, 64],  # query  (B=2, T=4, H_q*d_k = 4*16 = 64)
+                [2, 4, 64],  # key
+                [2, 4, 64],  # value
+                "",  # past_state: absent
+                [2, 4, 64],  # decay: per-key-dim (H_kv*d_k = 4*16 = 64)
+                [2, 4, 4],  # beta: (B, T, H_kv=4)
+                [2, 4, 64],  # erase_gate: (B, T, H_kv*d_k = 64)
+            ],
+            [[2, 4, 64], [2, 4, 16, 16]],
+            [
+                TensorProto.FLOAT,
+                TensorProto.FLOAT,
+                TensorProto.FLOAT,
+                TensorProto.FLOAT,
+                TensorProto.FLOAT,
+                TensorProto.FLOAT,
+                TensorProto.FLOAT,
+            ],
+            [TensorProto.FLOAT, TensorProto.FLOAT],
+            attrs={
+                "q_num_heads": 4,
+                "kv_num_heads": 4,
+                "update_rule": "gated_delta",
+            },
+        )
+
     def test_ops_tested(self) -> None:
         # NOTE: This test is order dependent and needs to run last in this class
         all_schemas = onnx.defs.get_all_schemas()

--- a/onnx/version_converter/convert.h
+++ b/onnx/version_converter/convert.h
@@ -976,6 +976,16 @@ class DefaultVersionConverter : public BaseVersionConverter {
     const std::vector<TensorProto_DataType> range_27_unallowed_types = {
         TensorProto_DataType_FLOAT16, TensorProto_DataType_BFLOAT16};
     registerAdapter(std::make_unique<Range_27_26>(range_27_unallowed_types));
+
+    /******** 27 -> 28 ********/
+    // LinearAttention v28 adds optional erase_gate (input 6); upgrading from v27 is always
+    // compatible — the new input is absent and the existing semantics are unchanged.
+    registerAdapter(std::make_unique<CompatibleAdapter>("LinearAttention", OpSetID(27), OpSetID(28)));
+
+    /******** 28 -> 27 ********/
+    // LinearAttention v28 -> v27: compatible when erase_gate is absent. Models that use
+    // erase_gate will produce an invalid opset-27 model; validation will catch that.
+    registerAdapter(std::make_unique<CompatibleAdapter>("LinearAttention", OpSetID(28), OpSetID(27)));
   }
 
   ModelProto convert_version(const ModelProto& mp_in, const OpSetID& initial_version, const OpSetID& target_version)


### PR DESCRIPTION
Proposal for opset extension to cover Gated DeltaNet-2's channel-wise erase gate.

Details live in the proposal file: docs/proposals/8027-linearattention-gdn2.md

This PR adds the proposal document and proposes adding a new `gated_delta_v2` update_rule (or an optional `erase_gate` input) so `LinearAttention` can represent Gated DeltaNet-2 without Scan fallback.

See issue #8027 for discussion.