### PR TITLE
Replace windows-latest with windows-2022 to fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
             autogenerate_files: 0
             debug_build: 0
             onnx_ml: 1
-            os: "windows-latest"
+            os: "windows-2022"
             protobuf_type: 'External'
             unity_build: 0
           # build_protobuf_unix.sh appears broken on macos-arm64
@@ -129,7 +129,7 @@ jobs:
           source workflow_scripts/protobuf/build_protobuf_unix.sh 3 $(pwd)/protobuf/protobuf_install
 
       - name: Set up MSBuild (x64)
-        if: startsWith(matrix.os,'windows-latest')
+        if: startsWith(matrix.os,'windows')
         uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
         with:
           msbuild-architecture: x64

--- a/.github/workflows/pixi_build.yml
+++ b/.github/workflows/pixi_build.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         os:
           - ubuntu-24.04-arm
-          - windows-2025
+          - windows-2022
     steps:
       - name: Checkout branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -78,7 +78,7 @@ jobs:
           - ubuntu-24.04-arm
           - ubuntu-latest
           - macos-latest
-          - windows-2025
+          - windows-2022
         environment:
           - default
           - oldies

--- a/.github/workflows/pixi_build.yml
+++ b/.github/workflows/pixi_build.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         os:
           - ubuntu-24.04-arm
-          - windows-latest
+          - windows-2025
     steps:
       - name: Checkout branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -78,7 +78,7 @@ jobs:
           - ubuntu-24.04-arm
           - ubuntu-latest
           - macos-latest
-          - windows-latest
+          - windows-2025
         environment:
           - default
           - oldies

--- a/.github/workflows/win_no_exception_ci.yml
+++ b/.github/workflows/win_no_exception_ci.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       matrix:
         python-version: ['3.10']


### PR DESCRIPTION
This replaces windows-latest with windows-2022 wherever necessary to get green CI again. The core issue is that windows-2025 (which windows-latest used to resolve to) is now suddenly an alias for windows-2025-vs2026, which, as the name suggests, ships the Visual Studio 2026 toolchain.

There is probably a better way to go about this, but I don't have time to dive deeper into it right now.

### Motivation and Context

Fixes #8072 
