### PR TITLE
Fix Windows CI by dropping hardcoded VS 2022 generator

### DIFF
--- a/.github/workflows/win_no_exception_ci.yml
+++ b/.github/workflows/win_no_exception_ci.yml
@@ -55,7 +55,7 @@ jobs:
 
         cd onnx
         echo "Build ONNX"
-        cmake -G "Visual Studio 17 2022" -A ${{ matrix.architecture }} -DONNX_USE_PROTOBUF_SHARED_LIBS=OFF -DONNX_USE_LITE_PROTO=ON -DONNX_WERROR=ON -DONNX_DISABLE_EXCEPTIONS=ON -DCMAKE_BUILD_TYPE=Release -DONNX_USE_MSVC_STATIC_RUNTIME=OFF -DONNX_ML=1 -DONNX_BUILD_TESTS=ON -S . -B .setuptools-cmake-build\
+        cmake -A ${{ matrix.architecture }} -DONNX_USE_PROTOBUF_SHARED_LIBS=OFF -DONNX_USE_LITE_PROTO=ON -DONNX_WERROR=ON -DONNX_DISABLE_EXCEPTIONS=ON -DCMAKE_BUILD_TYPE=Release -DONNX_USE_MSVC_STATIC_RUNTIME=OFF -DONNX_ML=1 -DONNX_BUILD_TESTS=ON -S . -B .setuptools-cmake-build\
         cd .setuptools-cmake-build\
         cmake --build . --config Release
 
@@ -69,7 +69,7 @@ jobs:
         git clean -xdf
         set ONNX_BUILD_TESTS=1
         echo "Build ONNX with non-static registration for testing selective ONNX schema loading"
-        cmake -G "Visual Studio 17 2022" -A ${{ matrix.architecture }} -DONNX_USE_PROTOBUF_SHARED_LIBS=OFF -DONNX_USE_LITE_PROTO=ON -DONNX_WERROR=ON -DCMAKE_BUILD_TYPE=Release -DONNX_USE_MSVC_STATIC_RUNTIME=OFF -DONNX_ML=1 -DONNX_BUILD_TESTS=ON -DONNX_DISABLE_STATIC_REGISTRATION=ON -S . -B .setuptools-cmake-build\
+        cmake -A ${{ matrix.architecture }} -DONNX_USE_PROTOBUF_SHARED_LIBS=OFF -DONNX_USE_LITE_PROTO=ON -DONNX_WERROR=ON -DCMAKE_BUILD_TYPE=Release -DONNX_USE_MSVC_STATIC_RUNTIME=OFF -DONNX_ML=1 -DONNX_BUILD_TESTS=ON -DONNX_DISABLE_STATIC_REGISTRATION=ON -S . -B .setuptools-cmake-build\
 
         cd .setuptools-cmake-build\
         cmake --build . --config Release

--- a/pixi.toml
+++ b/pixi.toml
@@ -21,7 +21,9 @@ cmd = 'export CMAKE_ARGS="$CMAKE_ARGS $CMAKE_EXTRA_ARGS" && pip install --no-dep
 [tasks.install.env]
 ONNX_ML="1"
 ONNX_BUILD_TESTS="1"
-CMAKE_EXTRA_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=ON -DONNX_HARDENING=ON -DONNX_WERROR=ON"
+# -GNinja overrides the CMAKE_GENERATOR="Visual Studio 17 2022" exported by the
+# conda-forge vs2022 activation, which fails on runners that only have a newer VS.
+CMAKE_EXTRA_ARGS="-GNinja -DONNX_USE_PROTOBUF_SHARED_LIBS=ON -DONNX_HARDENING=ON -DONNX_WERROR=ON"
 
 [tasks.gen-docs]
 cmd = "python onnx/defs/gen_doc.py"
@@ -42,8 +44,8 @@ depends-on = ["gen-docs", "gen-operator-coverage", "gen-proto", "gen-test-data-f
 [tasks.gtest]
 cmd = ".setuptools-cmake-build/onnx_gtests"
 [target.win-64.tasks.gtest]
-# Different path on Windows
-cmd = ".setuptools-cmake-build/Release/onnx_gtests.exe"
+# Ninja is single-config, so no Release/ subdir; only the suffix differs
+cmd = ".setuptools-cmake-build/onnx_gtests.exe"
 
 [tasks.pytest]
 cmd = "pytest"

--- a/pixi.toml
+++ b/pixi.toml
@@ -21,7 +21,9 @@ cmd = 'export CMAKE_ARGS="$CMAKE_ARGS $CMAKE_EXTRA_ARGS" && pip install --no-dep
 [tasks.install.env]
 ONNX_ML="1"
 ONNX_BUILD_TESTS="1"
-CMAKE_EXTRA_ARGS="-DONNX_USE_PROTOBUF_SHARED_LIBS=ON -DONNX_HARDENING=ON -DONNX_WERROR=ON"
+# -GNinja overrides the CMAKE_GENERATOR="Visual Studio 17 2022" exported by the
+# conda-forge vs2022 activation, which fails on runners that only have a newer VS.
+CMAKE_EXTRA_ARGS="-GNinja -DONNX_USE_PROTOBUF_SHARED_LIBS=ON -DONNX_HARDENING=ON -DONNX_WERROR=ON"
 
 [tasks.gen-docs]
 cmd = "python onnx/defs/gen_doc.py"
@@ -38,8 +40,8 @@ depends-on = ["gen-docs", "gen-operator-coverage", "gen-proto"]
 [tasks.gtest]
 cmd = ".setuptools-cmake-build/onnx_gtests"
 [target.win-64.tasks.gtest]
-# Different path on Windows
-cmd = ".setuptools-cmake-build/Release/onnx_gtests.exe"
+# Ninja is single-config, so no Release/ subdir; only the suffix differs
+cmd = ".setuptools-cmake-build/onnx_gtests.exe"
 
 [tasks.pytest]
 cmd = "pytest"

--- a/workflow_scripts/protobuf/build_protobuf_win.ps1
+++ b/workflow_scripts/protobuf/build_protobuf_win.ps1
@@ -24,7 +24,7 @@ mkdir build
 cd build
 $protobuf_root_dir = Get-Location
 
-cmake -G "Visual Studio 17 2022" -A $cmake_arch -Dprotobuf_MSVC_STATIC_RUNTIME=OFF -DABSL_MSVC_STATIC_RUNTIME=OFF -DBUILD_SHARED_LIBS=OFF -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_EXAMPLES=OFF -DABSL_ROOT_DIR="$protobuf_root_dir/../../abseil-cpp-20230802.2" -DCMAKE_CXX_STANDARD=17 -DABSL_PROPAGATE_CXX_STD=on -DCMAKE_INSTALL_PREFIX="$protobuf_install_dir" ..
+cmake -A $cmake_arch -Dprotobuf_MSVC_STATIC_RUNTIME=OFF -DABSL_MSVC_STATIC_RUNTIME=OFF -DBUILD_SHARED_LIBS=OFF -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_EXAMPLES=OFF -DABSL_ROOT_DIR="$protobuf_root_dir/../../abseil-cpp-20230802.2" -DCMAKE_CXX_STANDARD=17 -DABSL_PROPAGATE_CXX_STD=on -DCMAKE_INSTALL_PREFIX="$protobuf_install_dir" ..
 cmake --build . --config $build_type --target install
 echo "Protobuf installation complete."
 echo "Set paths"

--- a/workflow_scripts/protobuf/build_protobuf_win.ps1
+++ b/workflow_scripts/protobuf/build_protobuf_win.ps1
@@ -24,7 +24,7 @@ mkdir build
 cd build
 $protobuf_root_dir = Get-Location
 
-cmake -G "Visual Studio 17 2022" -A $cmake_arch -Dprotobuf_MSVC_STATIC_RUNTIME=OFF -DABSL_MSVC_STATIC_RUNTIME=OFF -DBUILD_SHARED_LIBS=OFF -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_EXAMPLES=OFF -DABSL_ROOT_DIR="$protobuf_root_dir/../../abseil-cpp-20250127.0" -DCMAKE_CXX_STANDARD=17 -DABSL_PROPAGATE_CXX_STD=on -DCMAKE_INSTALL_PREFIX="$protobuf_install_dir" ..
+cmake -A $cmake_arch -Dprotobuf_MSVC_STATIC_RUNTIME=OFF -DABSL_MSVC_STATIC_RUNTIME=OFF -DBUILD_SHARED_LIBS=OFF -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_EXAMPLES=OFF -DABSL_ROOT_DIR="$protobuf_root_dir/../../abseil-cpp-20250127.0" -DCMAKE_CXX_STANDARD=17 -DABSL_PROPAGATE_CXX_STD=on -DCMAKE_INSTALL_PREFIX="$protobuf_install_dir" ..
 cmake --build . --config $build_type --target install
 echo "Protobuf installation complete."
 echo "Set paths"


### PR DESCRIPTION
### Description

Windows CI jobs on `main` started failing on 2026-06-09 (`CI` Windows External-protobuf job, `Windows_No_Exception_CI`, and the pixi-based `Install and lint`/`Install and test` Windows jobs) with:

```
CMake Error at CMakeLists.txt:15 (project):
  Generator

    Visual Studio 17 2022

  could not find any instance of Visual Studio.
```

The `windows-latest` runner image now ships Visual Studio 18 (2026) instead of VS 2022 (the failing logs show `C:\Program Files\Microsoft Visual Studio\18\Enterprise`), so the hardcoded `Visual Studio 17 2022` generator no longer resolves. Two fixes:

1. **Drop the explicit `-G "Visual Studio 17 2022"`** (keeping `-A <arch>`) in `win_no_exception_ci.yml` and `build_protobuf_win.ps1`: CMake then auto-selects the newest installed Visual Studio, which works on both the old and new runner images.

2. **Pass `-GNinja` in the pixi install task**: the pixi jobs get `CMAKE_GENERATOR="Visual Studio 17 2022"` from the conda-forge `vs2022_win-64` activation script, which sets it whenever the variable is unset, so the generator pin is injected by the environment rather than anything in this repo. The activation script still finds the VS 18 compiler via its `vswhere -latest` fallback and runs `vcvars64.bat` (so `cl.exe` is available), but the generator name it exports is stale. An explicit `-G` on the CMake command line takes precedence over the env var (and makes CMake ignore the also-exported `CMAKE_GENERATOR_PLATFORM`/`CMAKE_GENERATOR_TOOLSET`, which would hard-error with Ninja). This also matches the other platforms, which already build with Ninja. Since Ninja is single-config, the Windows `gtest` task path loses its `Release/` subdir.

### Motivation and Context

Fix Windows CI on `main` and avoid future breakage when the runner image updates again.
