### PR TITLE
fix(fuzz): remove unused from __future__ import annotations from fuzz harnesses

### DIFF
--- a/onnx/fuzz/fuzz_checker.py
+++ b/onnx/fuzz/fuzz_checker.py
@@ -1,6 +1,5 @@
 # Copyright (c) ONNX Project Contributors
 # SPDX-License-Identifier: Apache-2.0
-from __future__ import annotations
 
 import sys
 

--- a/onnx/fuzz/fuzz_model_loader.py
+++ b/onnx/fuzz/fuzz_model_loader.py
@@ -1,6 +1,5 @@
 # Copyright (c) ONNX Project Contributors
 # SPDX-License-Identifier: Apache-2.0
-from __future__ import annotations
 
 import sys
 

--- a/onnx/fuzz/fuzz_parser.py
+++ b/onnx/fuzz/fuzz_parser.py
@@ -1,6 +1,5 @@
 # Copyright (c) ONNX Project Contributors
 # SPDX-License-Identifier: Apache-2.0
-from __future__ import annotations
 
 import sys
 

--- a/onnx/fuzz/fuzz_shape_inference.py
+++ b/onnx/fuzz/fuzz_shape_inference.py
@@ -1,5 +1,6 @@
 # Copyright (c) ONNX Project Contributors
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 """Atheris fuzz harness for onnx.shape_inference.
 
 Two input paths are exercised per iteration, selected by a fuzzer-controlled
@@ -18,8 +19,6 @@ candidate for the raw-bytes path):
 
 Both strict_mode values and both check_type values are sampled.
 """
-
-from __future__ import annotations
 
 import sys
 

--- a/onnx/fuzz/fuzz_shape_inference.py
+++ b/onnx/fuzz/fuzz_shape_inference.py
@@ -1,6 +1,5 @@
 # Copyright (c) ONNX Project Contributors
 # SPDX-License-Identifier: Apache-2.0
-from __future__ import annotations
 """Atheris fuzz harness for onnx.shape_inference.
 
 Two input paths are exercised per iteration, selected by a fuzzer-controlled

--- a/onnx/fuzz/fuzz_version_converter.py
+++ b/onnx/fuzz/fuzz_version_converter.py
@@ -1,6 +1,5 @@
 # Copyright (c) ONNX Project Contributors
 # SPDX-License-Identifier: Apache-2.0
-from __future__ import annotations
 
 import sys
 


### PR DESCRIPTION
## Summary

The OSS-Fuzz coverage build uses `compile_python_fuzzer`, which prepends a coverage stub containing real Python statements (`import atexit`, `import coverage`, etc.) to each fuzzer file before packaging it with PyInstaller. Any `from __future__` import that appears after those prepended statements is invalid Python and causes:

```
SyntaxError: from __future__ imports must occur at the beginning of the file
```

`from __future__ import annotations` is not actually used in any of the five fuzz harnesses (none of them have type annotations in function signatures or variables), so the simplest correct fix is to remove it from all five files.

## Files changed

- `onnx/fuzz/fuzz_checker.py`
- `onnx/fuzz/fuzz_model_loader.py`
- `onnx/fuzz/fuzz_parser.py`
- `onnx/fuzz/fuzz_shape_inference.py`
- `onnx/fuzz/fuzz_version_converter.py`

## Test plan

- [ ] `python -m py_compile onnx/fuzz/fuzz_*.py` passes
- [ ] OSS-Fuzz coverage build no longer raises `SyntaxError` for any fuzz harness