### PR TITLE
Change typing_extensions version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.23.2",
     "protobuf>=4.25.1",
-    "typing_extensions>=4.15.0",
+    "typing_extensions>=4.7.1",
     "ml_dtypes>=0.5.4",
 ]
 


### PR DESCRIPTION
Updated typing_extensions dependency version from 4.15.0 to 4.7.1.



### Motivation and Context

Fixes: https://github.com/onnx/onnx/pull/7886#issuecomment-4713118967
