### PR TITLE
Loosening TopK condition to accept single element int64 tensor

### DIFF
--- a/onnx/defs/math/old.cc
+++ b/onnx/defs/math/old.cc
@@ -3163,12 +3163,13 @@ ONNX_OPERATOR_SET_SCHEMA(
           // should be enforced)
           if (nullptr != k && axis_dim.has_dim_value()) {
             int64_t k_value = 0;
-            int64_t k_element_count = 1;
             for (int i = 0; i < k->dims_size(); ++i) {
-              k_element_count *= k->dims(i);
-            }
-            if (k_element_count != 1) {
-              fail_shape_inference("K input must contain exactly one element.");
+              if (k->dims(i) < 0) {
+                fail_shape_inference("K input dimensions must not be negative.");
+              }
+              if (k->dims(i) != 1) {
+                fail_shape_inference("K input must contain exactly one element.");
+              }
             }
 
             if (k->data_type() == TensorProto::INT64) {
@@ -3178,8 +3179,8 @@ ONNX_OPERATOR_SET_SCHEMA(
               fail_shape_inference("K input must be of type int64.");
             }
 
-            if (k_value < 0) {
-              fail_shape_inference("K input must not be negative.");
+            if (k_value <= 0) {
+              fail_shape_inference("K input must be positive.");
             }
 
             if (axis_dim.dim_value() < k_value) {

--- a/onnx/defs/math/old.cc
+++ b/onnx/defs/math/old.cc
@@ -3163,8 +3163,12 @@ ONNX_OPERATOR_SET_SCHEMA(
           // should be enforced)
           if (nullptr != k && axis_dim.has_dim_value()) {
             int64_t k_value = 0;
-            if (k->dims_size() != 1 || k->dims(0) != 1) {
-              fail_shape_inference("K input must be a one-dimensional tensor of size 1.");
+            int64_t k_element_count = 1;
+            for (int i = 0; i < k->dims_size(); ++i) {
+              k_element_count *= k->dims(i);
+            }
+            if (k_element_count != 1) {
+              fail_shape_inference("K input must contain exactly one element.");
             }
 
             if (k->data_type() == TensorProto::INT64) {
@@ -3172,6 +3176,10 @@ ONNX_OPERATOR_SET_SCHEMA(
               k_value = data[0];
             } else {
               fail_shape_inference("K input must be of type int64.");
+            }
+
+            if (k_value < 0) {
+              fail_shape_inference("K input must not be negative.");
             }
 
             if (axis_dim.dim_value() < k_value) {

--- a/onnx/defs/math/utils.cc
+++ b/onnx/defs/math/utils.cc
@@ -116,12 +116,13 @@ std::function<void(OpSchema&)> TopKOpGenerator(std::vector<std::string> allowed_
           // should be enforced)
           if (nullptr != k && axis_dim.has_dim_value()) {
             int64_t k_value = 0;
-            int64_t k_element_count = 1;
             for (int i = 0; i < k->dims_size(); ++i) {
-              k_element_count *= k->dims(i);
-            }
-            if (k_element_count != 1) {
-              fail_shape_inference("K input must contain exactly one element.");
+              if (k->dims(i) < 0) {
+                fail_shape_inference("K input dimensions must not be negative.");
+              }
+              if (k->dims(i) != 1) {
+                fail_shape_inference("K input must contain exactly one element.");
+              }
             }
             if (k->data_type() == TensorProto::INT64) {
               const auto data = ParseData<int64_t>(k);
@@ -129,8 +130,8 @@ std::function<void(OpSchema&)> TopKOpGenerator(std::vector<std::string> allowed_
             } else {
               fail_shape_inference("K input must be of type int64.");
             }
-            if (k_value < 0) {
-              fail_shape_inference("K input must not be negative.");
+            if (k_value <= 0) {
+              fail_shape_inference("K input must be positive.");
             }
             if (axis_dim.dim_value() < k_value) {
               fail_shape_inference("Axis has less than the requested k elements.");

--- a/onnx/defs/math/utils.cc
+++ b/onnx/defs/math/utils.cc
@@ -116,14 +116,21 @@ std::function<void(OpSchema&)> TopKOpGenerator(std::vector<std::string> allowed_
           // should be enforced)
           if (nullptr != k && axis_dim.has_dim_value()) {
             int64_t k_value = 0;
-            if (k->dims_size() != 1 || k->dims(0) != 1) {
-              fail_shape_inference("K input must be a one-dimensional tensor of size 1.");
+            int64_t k_element_count = 1;
+            for (int i = 0; i < k->dims_size(); ++i) {
+              k_element_count *= k->dims(i);
+            }
+            if (k_element_count != 1) {
+              fail_shape_inference("K input must contain exactly one element.");
             }
             if (k->data_type() == TensorProto::INT64) {
               const auto data = ParseData<int64_t>(k);
               k_value = data[0];
             } else {
               fail_shape_inference("K input must be of type int64.");
+            }
+            if (k_value < 0) {
+              fail_shape_inference("K input must not be negative.");
             }
             if (axis_dim.dim_value() < k_value) {
               fail_shape_inference("Axis has less than the requested k elements.");

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -4824,6 +4824,104 @@ class TestShapeInference(TestShapeInferenceHelper):
             ],
         )
 
+    def test_topk_scalar_k(self) -> None:
+        graph = self._make_graph(
+            [("x", TensorProto.FLOAT, (3, 4, 5, 10))],
+            [make_node("TopK", ["x", "k"], ["y", "z"], axis=2)],
+            [],
+            initializer=[make_tensor("k", TensorProto.INT64, (), (2,))],
+        )
+        self._assert_inferred(
+            graph,
+            [
+                make_tensor_value_info("y", TensorProto.FLOAT, (3, 4, 2, 10)),
+                make_tensor_value_info("z", TensorProto.INT64, (3, 4, 2, 10)),
+            ],
+        )
+
+    def test_topk_scalar_k_opset10(self) -> None:
+        graph = self._make_graph(
+            [("x", TensorProto.FLOAT, (3, 4, 5, 10))],
+            [make_node("TopK", ["x", "k"], ["y", "z"], axis=2)],
+            [],
+            initializer=[make_tensor("k", TensorProto.INT64, (), (2,))],
+        )
+        self._assert_inferred(
+            graph,
+            [
+                make_tensor_value_info("y", TensorProto.FLOAT, (3, 4, 2, 10)),
+                make_tensor_value_info("z", TensorProto.INT64, (3, 4, 2, 10)),
+            ],
+            opset_imports=[make_opsetid(ONNX_DOMAIN, 10)],
+        )
+
+    def test_topk_single_element_multi_dimensional_k(self) -> None:
+        graph = self._make_graph(
+            [("x", TensorProto.FLOAT, (3, 4, 5, 10))],
+            [make_node("TopK", ["x", "k"], ["y", "z"], axis=2)],
+            [],
+            initializer=[make_tensor("k", TensorProto.INT64, (1, 1), (2,))],
+        )
+        self._assert_inferred(
+            graph,
+            [
+                make_tensor_value_info("y", TensorProto.FLOAT, (3, 4, 2, 10)),
+                make_tensor_value_info("z", TensorProto.INT64, (3, 4, 2, 10)),
+            ],
+        )
+
+    def test_topk_rejects_multi_element_k(self) -> None:
+        graph = self._make_graph(
+            [("x", TensorProto.FLOAT, (3, 4, 5, 10))],
+            [make_node("TopK", ["x", "k"], ["y", "z"], axis=2)],
+            [],
+            initializer=[make_tensor("k", TensorProto.INT64, (2,), (1, 2))],
+        )
+        self.assertRaises(
+            onnx.shape_inference.InferenceError, self._inferred, graph
+        )
+
+    def test_topk_rejects_non_positive_k(self) -> None:
+        for k_value, opset_imports in itertools.product(
+            (0, -1), (None, [make_opsetid(ONNX_DOMAIN, 10)])
+        ):
+            with self.subTest(k_value=k_value, opset_imports=opset_imports):
+                graph = self._make_graph(
+                    [("x", TensorProto.FLOAT, (3, 4, 5, 10))],
+                    [make_node("TopK", ["x", "k"], ["y", "z"], axis=2)],
+                    [],
+                    initializer=[make_tensor("k", TensorProto.INT64, (), (k_value,))],
+                )
+                kwargs = {}
+                if opset_imports is not None:
+                    kwargs["opset_imports"] = opset_imports
+                self.assertRaises(
+                    onnx.shape_inference.InferenceError,
+                    self._inferred,
+                    graph,
+                    **kwargs,
+                )
+
+    def test_topk_scalar_k_from_shape_gather_data_propagation(self) -> None:
+        graph = self._make_graph(
+            [("x", TensorProto.FLOAT, (3, 4, 5, 10))],
+            [
+                make_node("Shape", ["x"], ["x_shape"]),
+                make_node("Gather", ["x_shape", "axis"], ["k"], axis=0),
+                make_node("TopK", ["x", "k"], ["y", "z"], axis=2),
+            ],
+            [],
+            initializer=[make_tensor("axis", TensorProto.INT64, (), (2,))],
+        )
+        self._assert_inferred(
+            graph,
+            [
+                make_tensor_value_info("y", TensorProto.FLOAT, (3, 4, 5, 10)),
+                make_tensor_value_info("z", TensorProto.INT64, (3, 4, 5, 10)),
+            ],
+            data_prop=True,
+        )
+
     def test_topk_missing_k_value_output_rank_check(self) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3, 4, 5, 10)), ("k", TensorProto.INT64, (1,))],


### PR DESCRIPTION
Changes

Loosened TopK K handling so opset 10+ accepts any single-element int64 tensor, including scalar tensors produced by dynamic shape paths.
Patched bundled ONNX TopK shape inference to validate K by element count instead of requiring rank-1 {1}, while preserving errors for empty/multi-element and negative values.
Added a local rvq_decoder_v1.onnx smoke test and a committed minimal Shape -> Gather -> TopK regression.

Motivation
Additional functionality to pre-compute the K value in the Top.K layer results in model load failures in an OEM model.
Latest ORT successfully follows Shape -> Gather and computes the K value before runtime (none of this happens in 1.19.2). The issue is that it stores that result internally as a scalar TensorProto. Later, when TopK asks for its K input during shape inference, latest ORT converts that scalar into a TensorProto with no dimensions. That scalar TensorProto reaches ONNX TopK shape inference, which expects K to be a rank-1 tensor of size 1. So latest ORT fails at load time.