### PR TITLE
Add jax2onnx to converter documentation

### DIFF
--- a/docs/docsgen/source/intro/converters.md
+++ b/docs/docsgen/source/intro/converters.md
@@ -32,7 +32,7 @@ Here is a short list:
 - [tensorflow-onnx](https://github.com/onnx/tensorflow-onnx):
   converts models from [tensorflow](https://www.tensorflow.org/),
 - [jax2onnx](https://github.com/enpasos/jax2onnx):
-  converts JAX-derived callables and models to ONNX,
+  converts models from [JAX](https://docs.jax.dev/),
 - [onnxmltools](https://github.com/onnx/onnxmltools):
   converts models from [lightgbm](https://lightgbm.readthedocs.io/),
   [xgboost](https://xgboost.readthedocs.io/en/stable/),

--- a/docs/docsgen/source/intro/converters.md
+++ b/docs/docsgen/source/intro/converters.md
@@ -31,6 +31,8 @@ Here is a short list:
   converts models from [scikit-learn](https://scikit-learn.org/stable/),
 - [tensorflow-onnx](https://github.com/onnx/tensorflow-onnx):
   converts models from [tensorflow](https://www.tensorflow.org/),
+- [jax2onnx](https://github.com/enpasos/jax2onnx):
+  converts JAX-derived callables and models to ONNX,
 - [onnxmltools](https://github.com/onnx/onnxmltools):
   converts models from [lightgbm](https://lightgbm.readthedocs.io/),
   [xgboost](https://xgboost.readthedocs.io/en/stable/),


### PR DESCRIPTION
## Summary

This PR adds `jax2onnx` to the short converter list in the ONNX converter documentation.

## Motivation

The converter page points users to framework-specific libraries for converting models to ONNX. It also links to the broader `onnx/tutorials` converter table.

JAX is currently not represented in the short converter list. `jax2onnx` provides a community-maintained JAX to ONNX conversion path and is published on PyPI as `jax2onnx`.

This is a small documentation-only update to help users discover an available JAX conversion path.

## Related

- Companion tutorials PR: https://github.com/onnx/tutorials/pull/298

## Scope

- Adds one bullet to `docs/docsgen/source/intro/converters.md`.
- Does not add new code.
- Does not imply official ONNX endorsement.

## Validation

- `git diff --check`

## References

- Repository: https://github.com/enpasos/jax2onnx
- PyPI: https://pypi.org/project/jax2onnx/
- Documentation: https://enpasos.github.io/jax2onnx/
- Getting Started: https://enpasos.github.io/jax2onnx/user_guide/getting_started/
- Validation guide: https://enpasos.github.io/jax2onnx/user_guide/validation/
- Known limitations: https://enpasos.github.io/jax2onnx/user_guide/known_limitations/

## Disclosure

I maintain `jax2onnx`.
