### PR TITLE
Pass non-null pointer params by reference in internal C++ helpers

### DIFF
--- a/onnx/common/ir_pb_converter.cc
+++ b/onnx/common/ir_pb_converter.cc
@@ -626,7 +626,7 @@ static void encodeValueInfo(ONNX_NAMESPACE::ValueInfoProto& v, Value& n) {
   }
 }
 
-void encodeGraph(GraphProto& p_g, const std::shared_ptr<Graph>& g) {
+static void encodeGraph(GraphProto& p_g, const std::shared_ptr<Graph>& g) {
   if (g->has_name()) {
     p_g.set_name(g->name());
   }

--- a/onnx/common/ir_pb_converter.cc
+++ b/onnx/common/ir_pb_converter.cc
@@ -120,11 +120,11 @@ static Tensor tensorProtoToTensor(const ONNX_NAMESPACE::TensorProto& tp) {
   return ret;
 }
 
-static void convertAttribute(const ONNX_NAMESPACE::AttributeProto& ap, Node* n, const int ir_version = IR_VERSION) {
+static void convertAttribute(const ONNX_NAMESPACE::AttributeProto& ap, Node& n, const int ir_version = IR_VERSION) {
   Symbol sym = Symbol(ap.name());
   switch (ap.type()) {
     case ONNX_NAMESPACE::AttributeProto_AttributeType_FLOAT:
-      n->f_(sym, ap.f());
+      n.f_(sym, ap.f());
       break;
     case ONNX_NAMESPACE::AttributeProto_AttributeType_FLOATS: {
       std::vector<double> floats;
@@ -132,11 +132,11 @@ static void convertAttribute(const ONNX_NAMESPACE::AttributeProto& ap, Node* n, 
       for (int i = 0; i < ap.floats_size(); i++) {
         floats.push_back(ap.floats(i));
       }
-      n->fs_(sym, std::move(floats));
+      n.fs_(sym, std::move(floats));
       break;
     }
     case ONNX_NAMESPACE::AttributeProto_AttributeType_INT:
-      n->i_(sym, ap.i());
+      n.i_(sym, ap.i());
       break;
     case ONNX_NAMESPACE::AttributeProto_AttributeType_INTS: {
       std::vector<int64_t> ints;
@@ -144,11 +144,11 @@ static void convertAttribute(const ONNX_NAMESPACE::AttributeProto& ap, Node* n, 
       for (int i = 0; i < ap.ints_size(); i++) {
         ints.push_back(ap.ints(i));
       }
-      n->is_(sym, std::move(ints));
+      n.is_(sym, std::move(ints));
       break;
     }
     case ONNX_NAMESPACE::AttributeProto_AttributeType_STRING:
-      n->s_(sym, ap.s());
+      n.s_(sym, ap.s());
       break;
     case ONNX_NAMESPACE::AttributeProto_AttributeType_STRINGS: {
       std::vector<std::string> strings;
@@ -156,11 +156,11 @@ static void convertAttribute(const ONNX_NAMESPACE::AttributeProto& ap, Node* n, 
       for (int i = 0; i < ap.strings_size(); i++) {
         strings.push_back(ap.strings(i));
       }
-      n->ss_(sym, std::move(strings));
+      n.ss_(sym, std::move(strings));
       break;
     }
     case ONNX_NAMESPACE::AttributeProto_AttributeType_TENSOR:
-      n->t_(sym, tensorProtoToTensor(ap.t()));
+      n.t_(sym, tensorProtoToTensor(ap.t()));
       break;
     case ONNX_NAMESPACE::AttributeProto_AttributeType_TENSORS: {
       std::vector<Tensor> tensors;
@@ -168,11 +168,11 @@ static void convertAttribute(const ONNX_NAMESPACE::AttributeProto& ap, Node* n, 
       for (int i = 0; i < ap.tensors_size(); i++) {
         tensors.emplace_back(tensorProtoToTensor(ap.tensors(i)));
       }
-      n->ts_(sym, std::move(tensors));
+      n.ts_(sym, std::move(tensors));
       break;
     }
     case ONNX_NAMESPACE::AttributeProto_AttributeType_TYPE_PROTO:
-      n->tp_(sym, ap.tp());
+      n.tp_(sym, ap.tp());
       break;
     case ONNX_NAMESPACE::AttributeProto_AttributeType_TYPE_PROTOS: {
       std::vector<TypeProto> types;
@@ -180,11 +180,11 @@ static void convertAttribute(const ONNX_NAMESPACE::AttributeProto& ap, Node* n, 
       for (int i = 0; i < ap.type_protos_size(); i++) {
         types.push_back(ap.type_protos(i));
       }
-      n->tps_(sym, std::move(types));
+      n.tps_(sym, std::move(types));
       break;
     }
     case ONNX_NAMESPACE::AttributeProto_AttributeType_GRAPH:
-      n->g_(sym, graphProtoToGraph(ap.g(), true, ir_version));
+      n.g_(sym, graphProtoToGraph(ap.g(), true, ir_version));
       break;
     case ONNX_NAMESPACE::AttributeProto_AttributeType_GRAPHS: {
       std::vector<std::shared_ptr<Graph>> graphs;
@@ -192,7 +192,7 @@ static void convertAttribute(const ONNX_NAMESPACE::AttributeProto& ap, Node* n, 
       for (int i = 0; i < ap.graphs_size(); i++) {
         graphs.push_back(graphProtoToGraph(ap.graphs(i), true, ir_version));
       }
-      n->gs_(sym, std::move(graphs));
+      n.gs_(sym, std::move(graphs));
       break;
     }
     case ONNX_NAMESPACE::AttributeProto_AttributeType_SPARSE_TENSOR:
@@ -205,7 +205,7 @@ static void convertAttribute(const ONNX_NAMESPACE::AttributeProto& ap, Node* n, 
   }
 }
 
-static void convertAttributes(const ONNX_NAMESPACE::NodeProto& np, Node* n, const int ir_version = IR_VERSION) {
+static void convertAttributes(const ONNX_NAMESPACE::NodeProto& np, Node& n, const int ir_version = IR_VERSION) {
   for (int i = 0; i < np.attribute_size(); i++) {
     convertAttribute(np.attribute(i), n, ir_version);
   }
@@ -326,7 +326,7 @@ std::unique_ptr<Graph> graphProtoToGraph(const ONNX_NAMESPACE::GraphProto& gp, b
       out->setUniqueName(np.output(j));
       value_by_name_of[np.output(j)] = out;
     }
-    convertAttributes(np, n, ir_version);
+    convertAttributes(np, *n, ir_version);
     std::vector<std::string> inputs;
     inputs.reserve(np.input_size());
     for (int j = 0; j < np.input_size(); j++) {
@@ -430,31 +430,31 @@ std::unique_ptr<Graph> ImportModelProto(const ModelProto& mp) {
 }
 
 // Part 2: convert IR to ONNX Protobuf
-static std::string value_name(const Value* n) {
-  return n->uniqueName();
+static std::string value_name(const Value& n) {
+  return n.uniqueName();
 }
 
-static void encodeGraph(GraphProto* p_g, const std::shared_ptr<Graph>& g);
+static void encodeGraph(GraphProto& p_g, const std::shared_ptr<Graph>& g);
 
-static void encodeTensor(ONNX_NAMESPACE::TensorProto* p, const Tensor& tensor) {
+static void encodeTensor(ONNX_NAMESPACE::TensorProto& p, const Tensor& tensor) {
   if (tensor.hasName()) {
-    p->set_name(tensor.name());
+    p.set_name(tensor.name());
   }
   if (tensor.is_segment()) {
     ONNX_NAMESPACE::TensorProto_Segment segment;
     segment.set_begin(tensor.segment_begin());
     segment.set_end(tensor.segment_end());
-    p->mutable_segment()->CopyFrom(segment);
+    p.mutable_segment()->CopyFrom(segment);
   }
   for (auto d : tensor.sizes()) {
-    p->add_dims(d);
+    p.add_dims(d);
   }
-  p->set_data_type(tensor.elem_type());
+  p.set_data_type(tensor.elem_type());
   switch (tensor.elem_type()) {
     case ONNX_NAMESPACE::TensorProto_DataType_FLOAT:
     case ONNX_NAMESPACE::TensorProto_DataType_COMPLEX64: {
       for (float x : tensor.floats()) {
-        p->add_float_data(x);
+        p.add_float_data(x);
       }
       break;
     }
@@ -476,33 +476,33 @@ static void encodeTensor(ONNX_NAMESPACE::TensorProto* p, const Tensor& tensor) {
     case ONNX_NAMESPACE::TensorProto_DataType_UINT8:
     case ONNX_NAMESPACE::TensorProto_DataType_UINT16: {
       for (int32_t x : tensor.int32s()) {
-        p->add_int32_data(x);
+        p.add_int32_data(x);
       }
       break;
     }
     case ONNX_NAMESPACE::TensorProto_DataType_INT64: {
       for (int64_t x : tensor.int64s()) {
-        p->add_int64_data(x);
+        p.add_int64_data(x);
       }
       break;
     }
     case ONNX_NAMESPACE::TensorProto_DataType_UINT32:
     case ONNX_NAMESPACE::TensorProto_DataType_UINT64: {
       for (uint64_t x : tensor.uint64s()) {
-        p->add_uint64_data(x);
+        p.add_uint64_data(x);
       }
       break;
     }
     case ONNX_NAMESPACE::TensorProto_DataType_DOUBLE:
     case ONNX_NAMESPACE::TensorProto_DataType_COMPLEX128: {
       for (double x : tensor.doubles()) {
-        p->add_double_data(x);
+        p.add_double_data(x);
       }
       break;
     }
     case ONNX_NAMESPACE::TensorProto_DataType_STRING: {
       for (const std::string& x : tensor.strings()) {
-        p->add_string_data(x);
+        p.add_string_data(x);
       }
       break;
     }
@@ -512,83 +512,83 @@ static void encodeTensor(ONNX_NAMESPACE::TensorProto* p, const Tensor& tensor) {
       fail_convert("Unknown tensor data type");
   }
   if (tensor.is_raw_data()) {
-    p->set_raw_data(tensor.raw());
+    p.set_raw_data(tensor.raw());
   }
   if (!tensor.external_data().empty()) {
     for (const auto& [key, value] : tensor.external_data()) {
-      auto* external_data = p->add_external_data();
+      auto* external_data = p.add_external_data();
       external_data->set_key(key);
       external_data->set_value(value);
     }
   }
   if (tensor.has_data_location()) {
-    p->set_data_location(tensor.data_location());
+    p.set_data_location(tensor.data_location());
   }
 }
 
-static void addAttribute(ONNX_NAMESPACE::NodeProto* n_p, Node* n, Symbol name) {
-  auto* attr = n_p->add_attribute();
+static void addAttribute(ONNX_NAMESPACE::NodeProto& n_p, Node& n, Symbol name) {
+  auto* attr = n_p.add_attribute();
   attr->set_name(name.toString());
-  switch (n->kindOf(name)) {
+  switch (n.kindOf(name)) {
     case AttributeKind::f: {
-      attr->set_f(static_cast<float>(n->f(name)));
+      attr->set_f(static_cast<float>(n.f(name)));
       attr->set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_FLOAT);
     } break;
     case AttributeKind::fs: {
       attr->set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_FLOATS);
-      for (const auto& v : n->fs(name))
+      for (const auto& v : n.fs(name))
         attr->add_floats(static_cast<float>(v));
     } break;
     case AttributeKind::i: {
       attr->set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_INT);
-      attr->set_i(n->i(name));
+      attr->set_i(n.i(name));
     } break;
     case AttributeKind::is: {
       attr->set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_INTS);
-      for (const auto& v : n->is(name))
+      for (const auto& v : n.is(name))
         attr->add_ints(v);
     } break;
     case AttributeKind::s: {
       attr->set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_STRING);
-      attr->set_s(n->s(name));
+      attr->set_s(n.s(name));
     } break;
     case AttributeKind::ss: {
       attr->set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_STRINGS);
-      for (const auto& v : n->ss(name))
+      for (const auto& v : n.ss(name))
         attr->add_strings(v);
     } break;
     case AttributeKind::t: {
       attr->set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_TENSOR);
       auto* t = attr->mutable_t();
-      encodeTensor(t, n->t(name));
+      encodeTensor(*t, n.t(name));
     } break;
     case AttributeKind::ts: {
       attr->set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_TENSORS);
-      for (const auto& v : n->ts(name)) {
+      for (const auto& v : n.ts(name)) {
         auto* t = attr->add_tensors();
-        encodeTensor(t, v);
+        encodeTensor(*t, v);
       }
     } break;
     case AttributeKind::g: {
       attr->set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_GRAPH);
       auto* g = attr->mutable_g();
-      encodeGraph(g, n->g(name));
+      encodeGraph(*g, n.g(name));
     } break;
     case AttributeKind::gs: {
       attr->set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_GRAPHS);
-      for (const auto& v : n->gs(name)) {
+      for (const auto& v : n.gs(name)) {
         auto* g = attr->add_graphs();
-        encodeGraph(g, v);
+        encodeGraph(*g, v);
       }
     } break;
     case AttributeKind::tp: {
       attr->set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_TYPE_PROTO);
       auto* tp = attr->mutable_tp();
-      tp->CopyFrom(n->tp(name));
+      tp->CopyFrom(n.tp(name));
     } break;
     case AttributeKind::tps: {
       attr->set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_TYPE_PROTOS);
-      for (const auto& v : n->tps(name)) {
+      for (const auto& v : n.tps(name)) {
         auto* tp = attr->add_type_protos();
         tp->CopyFrom(v);
       }
@@ -596,13 +596,13 @@ static void addAttribute(ONNX_NAMESPACE::NodeProto* n_p, Node* n, Symbol name) {
   }
 }
 
-static void encodeTypeProtoTensorType(ONNX_NAMESPACE::TypeProto_Tensor* tensor_type, const Value* n) {
-  if (n->elemType() != 0) {
-    tensor_type->set_elem_type(n->elemType());
+static void encodeTypeProtoTensorType(ONNX_NAMESPACE::TypeProto_Tensor& tensor_type, const Value& n) {
+  if (n.elemType() != 0) {
+    tensor_type.set_elem_type(n.elemType());
   }
-  if (n->has_sizes()) {
-    ONNX_NAMESPACE::TensorShapeProto* shape = tensor_type->mutable_shape();
-    for (const Dimension& d : n->sizes()) {
+  if (n.has_sizes()) {
+    ONNX_NAMESPACE::TensorShapeProto* shape = tensor_type.mutable_shape();
+    for (const Dimension& d : n.sizes()) {
       auto* dim = shape->add_dim();
       if (!d.is_unknown) {
         if (d.is_int) {
@@ -615,35 +615,33 @@ static void encodeTypeProtoTensorType(ONNX_NAMESPACE::TypeProto_Tensor* tensor_t
   }
 }
 
-static void encodeValueInfo(ONNX_NAMESPACE::ValueInfoProto* v, Value* n) {
-  v->set_name(value_name(n));
-  if (n->elemType() != 0 || n->has_sizes()) {
-    ONNX_NAMESPACE::TypeProto* t = v->mutable_type();
+static void encodeValueInfo(ONNX_NAMESPACE::ValueInfoProto& v, Value& n) {
+  v.set_name(value_name(n));
+  if (n.elemType() != 0 || n.has_sizes()) {
+    ONNX_NAMESPACE::TypeProto* t = v.mutable_type();
     ONNX_NAMESPACE::TypeProto_Tensor* tensor_type = t->mutable_tensor_type();
-    encodeTypeProtoTensorType(tensor_type, n);
-  } else if (n->type()) {
-    v->mutable_type()->CopyFrom(*n->type());
+    encodeTypeProtoTensorType(*tensor_type, n);
+  } else if (n.type()) {
+    v.mutable_type()->CopyFrom(*n.type());
   }
 }
 
-void encodeGraph(GraphProto* p_g, const std::shared_ptr<Graph>& g) {
-  ONNX_ASSERT(p_g != nullptr)
-
+void encodeGraph(GraphProto& p_g, const std::shared_ptr<Graph>& g) {
   if (g->has_name()) {
-    p_g->set_name(g->name());
+    p_g.set_name(g->name());
   }
 
   if (g->has_doc_string()) {
-    p_g->set_doc_string(g->docString());
+    p_g.set_doc_string(g->docString());
   }
 
   for (auto* input : g->inputs()) {
-    ONNX_NAMESPACE::ValueInfoProto* v = p_g->add_input();
-    encodeValueInfo(v, input);
+    ONNX_NAMESPACE::ValueInfoProto* v = p_g.add_input();
+    encodeValueInfo(*v, *input);
   }
   for (auto* output : g->outputs()) {
-    ONNX_NAMESPACE::ValueInfoProto* v = p_g->add_output();
-    encodeValueInfo(v, output);
+    ONNX_NAMESPACE::ValueInfoProto* v = p_g.add_output();
+    encodeValueInfo(*v, *output);
   }
 
   std::unordered_set<Value*> graph_outputs(g->outputs().begin(), g->outputs().end());
@@ -654,16 +652,16 @@ void encodeGraph(GraphProto* p_g, const std::shared_ptr<Graph>& g) {
       // provided.
       continue;
     }
-    auto* p_n = p_g->add_node();
+    auto* p_n = p_g.add_node();
     for (auto* input : node->inputs()) {
       if (input->node()->kind() == kUndefined) {
         p_n->add_input("");
       } else {
-        p_n->add_input(value_name(input));
+        p_n->add_input(value_name(*input));
       }
     }
     for (auto* output : node->outputs()) {
-      p_n->add_output(value_name(output));
+      p_n->add_output(value_name(*output));
       // only save it if
       //  - it has actual information worth saving
       //  - it's not already saved in the graph outputs value info
@@ -673,12 +671,12 @@ void encodeGraph(GraphProto* p_g, const std::shared_ptr<Graph>& g) {
       if (output->elemType() == TensorProto_DataType_UNDEFINED && output->sizes().empty()) {
         continue;
       }
-      ValueInfoProto* v = p_g->add_value_info();
-      encodeValueInfo(v, output);
+      ValueInfoProto* v = p_g.add_value_info();
+      encodeValueInfo(*v, *output);
     }
     p_n->set_op_type(node->kind().toString());
     for (auto attr_name : node->attributeNames()) {
-      addAttribute(p_n, node, attr_name);
+      addAttribute(*p_n, *node, attr_name);
     }
     if (node->has_doc_string()) {
       p_n->set_doc_string(node->docString());
@@ -696,15 +694,15 @@ void encodeGraph(GraphProto* p_g, const std::shared_ptr<Graph>& g) {
 
   auto num_initializers = g->initializers().size();
   for (unsigned int i = 0; i < num_initializers; i++) {
-    auto* p = p_g->add_initializer();
+    auto* p = p_g.add_initializer();
     p->set_name(g->initializer_names()[i]);
-    encodeTensor(p, g->initializers()[i]);
+    encodeTensor(*p, g->initializers()[i]);
   }
 }
 
 void ExportModelProto(ModelProto* p_m, const std::shared_ptr<Graph>& g) {
   GraphProto* p_g = p_m->mutable_graph();
-  encodeGraph(p_g, g);
+  encodeGraph(*p_g, g);
   // Add new opset_versions
   p_m->clear_opset_import();
   for (const OpSetID& opset : g->opset_versions_mutable()) {

--- a/onnx/common/visitor.h
+++ b/onnx/common/visitor.h
@@ -65,49 +65,49 @@ struct Visitor {
 
 // MutableVisitor: A version of Visitor that allows mutation of the visited objects.
 struct MutableVisitor {
-  virtual void VisitGraph(GraphProto* graph) {
+  virtual void VisitGraph(GraphProto& graph) {
     if (ProcessGraph(graph))
-      for (auto& node : *(graph->mutable_node()))
-        VisitNode(&node);
+      for (auto& node : *(graph.mutable_node()))
+        VisitNode(node);
   }
 
-  virtual void VisitFunction(FunctionProto* function) {
+  virtual void VisitFunction(FunctionProto& function) {
     if (ProcessFunction(function))
-      for (auto& node : *(function->mutable_node()))
-        VisitNode(&node);
+      for (auto& node : *(function.mutable_node()))
+        VisitNode(node);
   }
 
-  virtual void VisitNode(NodeProto* node) {
+  virtual void VisitNode(NodeProto& node) {
     if (ProcessNode(node)) {
-      for (auto& attr : *(node->mutable_attribute())) {
-        VisitAttribute(&attr);
+      for (auto& attr : *(node.mutable_attribute())) {
+        VisitAttribute(attr);
       }
     }
   }
 
-  virtual void VisitAttribute(AttributeProto* attr) {
+  virtual void VisitAttribute(AttributeProto& attr) {
     if (ProcessAttribute(attr)) {
-      if (attr->has_g()) {
-        VisitGraph(attr->mutable_g());
+      if (attr.has_g()) {
+        VisitGraph(*attr.mutable_g());
       }
-      for (auto& graph : *(attr->mutable_graphs()))
-        VisitGraph(&graph);
+      for (auto& graph : *(attr.mutable_graphs()))
+        VisitGraph(graph);
     }
   }
 
-  virtual bool ProcessGraph(GraphProto* graph [[maybe_unused]]) {
+  virtual bool ProcessGraph(GraphProto& graph [[maybe_unused]]) {
     return true;
   }
 
-  virtual bool ProcessFunction(FunctionProto* function [[maybe_unused]]) {
+  virtual bool ProcessFunction(FunctionProto& function [[maybe_unused]]) {
     return true;
   }
 
-  virtual bool ProcessNode(NodeProto* node [[maybe_unused]]) {
+  virtual bool ProcessNode(NodeProto& node [[maybe_unused]]) {
     return true;
   }
 
-  virtual bool ProcessAttribute(AttributeProto* attr [[maybe_unused]]) {
+  virtual bool ProcessAttribute(AttributeProto& attr [[maybe_unused]]) {
     return true;
   }
 

--- a/onnx/defs/shape_inference.cc
+++ b/onnx/defs/shape_inference.cc
@@ -340,15 +340,11 @@ void UnionTypeInfo(const TypeProto& source_type, TypeProto& target_type) {
 // sparse input and outputs dense or vice-versa.
 // If the output value_case is not set, then
 // the input value_case is propagated.
-static void propagateTensorElemTypeWithValidation(const TypeProto* input_type, TypeProto* output_type) {
-  if (nullptr == input_type) {
-    fail_type_inference("Input type was null");
-  }
-
+static void propagateTensorElemTypeWithValidation(const TypeProto& input_type, TypeProto& output_type) {
   int32_t input_elem_type = TensorProto::UNDEFINED;
-  const auto input_value_case = input_type->value_case();
+  const auto input_value_case = input_type.value_case();
   if (input_value_case == TypeProto::kTensorType || input_value_case == TypeProto::kSparseTensorType) {
-    input_elem_type = getTensorElementType(*input_type);
+    input_elem_type = getTensorElementType(input_type);
     if (input_elem_type == TensorProto::UNDEFINED) {
       fail_type_inference("Element type of tensor or sparse tensor input was unknown");
     }
@@ -356,18 +352,18 @@ static void propagateTensorElemTypeWithValidation(const TypeProto* input_type, T
     fail_type_inference("Input was expected to have tensor or sparse tensor type. Got ", input_value_case);
   }
 
-  const auto output_value_case = output_type->value_case();
+  const auto output_value_case = output_type.value_case();
   if (output_value_case == TypeProto::VALUE_NOT_SET) {
-    setTensorElementType(input_elem_type, input_value_case, *output_type);
+    setTensorElementType(input_elem_type, input_value_case, output_type);
   } else if (output_value_case == TypeProto::kTensorType || output_value_case == TypeProto::kSparseTensorType) {
-    const auto output_elem_type = getTensorElementType(*output_type);
+    const auto output_elem_type = getTensorElementType(output_type);
     if (output_elem_type != TensorProto::UNDEFINED) {
       if (input_elem_type != output_elem_type) {
         fail_type_inference(
             "Input element type of ", input_elem_type, " does not match existing output type of ", output_elem_type);
       }
     } else {
-      setTensorElementType(input_elem_type, output_value_case, *output_type);
+      setTensorElementType(input_elem_type, output_value_case, output_type);
     }
   } else {
     // This is not expected to happen
@@ -375,54 +371,42 @@ static void propagateTensorElemTypeWithValidation(const TypeProto* input_type, T
   }
 }
 
-static void propagateSequenceElemTypeWithValidation(const TypeProto* input_type, TypeProto* output_type) {
-  if (nullptr == input_type) {
-    fail_type_inference("Input type was null");
+static void propagateSequenceElemTypeWithValidation(const TypeProto& input_type, TypeProto& output_type) {
+  if (input_type.value_case() != TypeProto::kSequenceType) {
+    fail_type_inference("Input was expected to have sequence type. Got ", input_type.value_case());
   }
 
-  if (input_type->value_case() != TypeProto::kSequenceType) {
-    fail_type_inference("Input was expected to have sequence type. Got ", input_type->value_case());
-  }
-
-  const auto& input_seq_type = input_type->sequence_type();
+  const auto& input_seq_type = input_type.sequence_type();
 
   if (input_seq_type.has_elem_type()) {
     propagateElemTypeWithValidation(
-        &input_seq_type.elem_type(), output_type->mutable_sequence_type()->mutable_elem_type());
+        &input_seq_type.elem_type(), output_type.mutable_sequence_type()->mutable_elem_type());
   } else {
     fail_type_inference("Element type of sequence input was unknown");
   }
 }
 
-static void propagateOptionalElemTypeWithValidation(const TypeProto* input_type, TypeProto* output_type) {
-  if (nullptr == input_type) {
-    fail_type_inference("Input type was null");
+static void propagateOptionalElemTypeWithValidation(const TypeProto& input_type, TypeProto& output_type) {
+  if (input_type.value_case() != TypeProto::kOptionalType) {
+    fail_type_inference("Input was expected to have optional type. Got ", input_type.value_case());
   }
 
-  if (input_type->value_case() != TypeProto::kOptionalType) {
-    fail_type_inference("Input was expected to have optional type. Got ", input_type->value_case());
-  }
-
-  const auto& input_opt_type = input_type->optional_type();
+  const auto& input_opt_type = input_type.optional_type();
 
   if (input_opt_type.has_elem_type()) {
     propagateElemTypeWithValidation(
-        &input_opt_type.elem_type(), output_type->mutable_optional_type()->mutable_elem_type());
+        &input_opt_type.elem_type(), output_type.mutable_optional_type()->mutable_elem_type());
   } else {
     fail_type_inference("Element type of optional input was unknown");
   }
 }
 
-static void propagateMapElemTypeWithValidation(const TypeProto* input_type, TypeProto* output_type) {
-  if (nullptr == input_type) {
-    fail_type_inference("Input type was null");
+static void propagateMapElemTypeWithValidation(const TypeProto& input_type, TypeProto& output_type) {
+  if (input_type.value_case() != TypeProto::kMapType) {
+    fail_type_inference("Input was expected to have map type. Got ", input_type.value_case());
   }
 
-  if (input_type->value_case() != TypeProto::kMapType) {
-    fail_type_inference("Input was expected to have map type. Got ", input_type->value_case());
-  }
-
-  const auto& input_map_type = input_type->map_type();
+  const auto& input_map_type = input_type.map_type();
 
   if (!input_map_type.has_key_type()) {
     fail_type_inference("Key type of map input was unknown");
@@ -430,8 +414,8 @@ static void propagateMapElemTypeWithValidation(const TypeProto* input_type, Type
   if (!input_map_type.has_value_type()) {
     fail_type_inference("Value type of map input was unknown");
   }
-  output_type->mutable_map_type()->set_key_type(input_map_type.key_type());
-  propagateElemTypeWithValidation(&input_map_type.value_type(), output_type->mutable_map_type()->mutable_value_type());
+  output_type.mutable_map_type()->set_key_type(input_map_type.key_type());
+  propagateElemTypeWithValidation(&input_map_type.value_type(), output_type.mutable_map_type()->mutable_value_type());
 }
 
 // propagate the element type from an input type to an output type.
@@ -443,13 +427,13 @@ void propagateElemTypeWithValidation(const TypeProto* input_type, TypeProto* out
 
   const auto input_value_case = input_type->value_case();
   if (input_value_case == TypeProto::kTensorType || input_value_case == TypeProto::kSparseTensorType) {
-    propagateTensorElemTypeWithValidation(input_type, output_type);
+    propagateTensorElemTypeWithValidation(*input_type, *output_type);
   } else if (input_value_case == TypeProto::kSequenceType) {
-    propagateSequenceElemTypeWithValidation(input_type, output_type);
+    propagateSequenceElemTypeWithValidation(*input_type, *output_type);
   } else if (input_value_case == TypeProto::kOptionalType) {
-    propagateOptionalElemTypeWithValidation(input_type, output_type);
+    propagateOptionalElemTypeWithValidation(*input_type, *output_type);
   } else if (input_value_case == TypeProto::kMapType) {
-    propagateMapElemTypeWithValidation(input_type, output_type);
+    propagateMapElemTypeWithValidation(*input_type, *output_type);
   } else {
     fail_type_inference(
         "Input was expected to have either tensor, sequence, optional or map type. Got ", input_value_case);

--- a/onnx/defs/shape_inference.cc
+++ b/onnx/defs/shape_inference.cc
@@ -424,6 +424,9 @@ void propagateElemTypeWithValidation(const TypeProto* input_type, TypeProto* out
   if (nullptr == input_type) {
     fail_type_inference("Input type was null");
   }
+  if (nullptr == output_type) {
+    fail_type_inference("Output type was null");
+  }
 
   const auto input_value_case = input_type->value_case();
   if (input_value_case == TypeProto::kTensorType || input_value_case == TypeProto::kSparseTensorType) {

--- a/onnx/inliner/inliner.cc
+++ b/onnx/inliner/inliner.cc
@@ -246,14 +246,14 @@ class InliningRenamer : public internal::MutableVisitor {
   }
 
   // Process a node:
-  bool ProcessNode(NodeProto* node) override {
-    if (!node->name().empty())
-      node->set_name(MakeUnique(node->name()));
+  bool ProcessNode(NodeProto& node) override {
+    if (!node.name().empty())
+      node.set_name(MakeUnique(node.name()));
 
-    for (auto& x : *node->mutable_input()) {
+    for (auto& x : *node.mutable_input()) {
       LookupOrRename(x, false);
     }
-    for (auto& y : *node->mutable_output()) {
+    for (auto& y : *node.mutable_output()) {
       LookupOrRename(y, true);
     }
     return true; // Process attribute subgraphs in traversal
@@ -262,16 +262,16 @@ class InliningRenamer : public internal::MutableVisitor {
   // Process a sub-graph, contained as an attribute in a control-flow op node.
   // Since we need both pre-processing and post-processing in the traversal, we
   // override the VisitGraph method.
-  void VisitGraph(GraphProto* graph) override {
+  void VisitGraph(GraphProto& graph) override {
     rename_scopes.emplace_back();
-    for (auto& x : *graph->mutable_input())
+    for (auto& x : *graph.mutable_input())
       Rename(*x.mutable_name());
-    for (auto& init : *graph->mutable_initializer())
+    for (auto& init : *graph.mutable_initializer())
       Rename(*init.mutable_name());
-    for (auto& y : *graph->mutable_output())
+    for (auto& y : *graph.mutable_output())
       Rename(*y.mutable_name());
-    for (auto& n : *graph->mutable_node())
-      VisitNode(&n);
+    for (auto& n : *graph.mutable_node())
+      VisitNode(n);
     rename_scopes.pop_back();
   }
 
@@ -313,7 +313,7 @@ class InliningRenamer : public internal::MutableVisitor {
     renamer.Bind<false>(*callee.mutable_input(), callnode.input());
     renamer.Bind<true>(*callee.mutable_output(), callnode.output());
 
-    renamer.VisitFunction(&callee);
+    renamer.VisitFunction(callee);
     for (auto& v : *callee.mutable_value_info())
       renamer.LookupOrRename(*v.mutable_name(), false);
   }
@@ -780,7 +780,7 @@ class Renamer::Impl {
 
   void RenameNode(NodeProto& node) {
     // Use the InliningRenamer's ProcessNode method which handles graph-value attributes
-    renamer_.ProcessNode(&node);
+    renamer_.ProcessNode(node);
   }
 };
 

--- a/onnx/shape_inference/attribute_binder.h
+++ b/onnx/shape_inference/attribute_binder.h
@@ -24,8 +24,8 @@ class AttributeBinder : public MutableVisitor {
   // remove the attribute from the list of attributes of a node (when the attribute
   // has no specified value). Hence, we need to do the processing at a Node level
   // rather than an attribute level.
-  void VisitNode(NodeProto* node) override {
-    auto& attributes = *node->mutable_attribute();
+  void VisitNode(NodeProto& node) override {
+    auto& attributes = *node.mutable_attribute();
     for (auto attr_iter = attributes.begin(); attr_iter != attributes.end();) {
       auto& attr = *attr_iter;
       if (!attr.ref_attr_name().empty()) {
@@ -44,7 +44,7 @@ class AttributeBinder : public MutableVisitor {
         }
       } else {
         // For regular attributes, we process subgraphs, if present, recursively.
-        VisitAttribute(&attr);
+        VisitAttribute(attr);
         ++attr_iter;
       }
     }
@@ -58,7 +58,7 @@ class AttributeBinder : public MutableVisitor {
       map[attr.name()] = &attr;
     }
     AttributeBinder attr_binder(map);
-    attr_binder.VisitFunction(&callee);
+    attr_binder.VisitFunction(callee);
   }
 
  private:

--- a/onnx/shape_inference/implementation.cc
+++ b/onnx/shape_inference/implementation.cc
@@ -602,7 +602,7 @@ class ShapeInferenceImplBase {
 
   void Process(const NodeProto& n, internal::AttributeBinder& attribute_binder) {
     NodeProto copy_n(n);
-    attribute_binder.VisitNode(&copy_n);
+    attribute_binder.VisitNode(copy_n);
     Process(copy_n);
   }
 


### PR DESCRIPTION
Convert always-non-null pointer parameters to references in internal
(non-API) C++ helpers and the `MutableVisitor` interface, removing
null-dereference risk and now-redundant null checks.

- **`common/ir_pb_converter.cc`** — file-local `static` encode/convert helpers
  (`convertAttribute`, `convertAttributes`, `value_name`, `encodeTensor`,
  `addAttribute`, `encodeTypeProtoTensorType`, `encodeValueInfo`, `encodeGraph`)
  switched from `Node*`/`Value*`/`*Proto*` params to references; dropped a
  redundant `ONNX_ASSERT(p_g != nullptr)`.
- **`common/visitor.h`** — `MutableVisitor`'s `Visit*`/`Process*` virtuals
  (`VisitGraph`, `VisitFunction`, `VisitNode`, `VisitAttribute`,
  `ProcessGraph`, `ProcessFunction`, `ProcessNode`, `ProcessAttribute`) take
  proto params by reference instead of pointer.
- **`inliner/inliner.cc`** and **`shape_inference/attribute_binder.h`** —
  `MutableVisitor` subclasses (`InliningRenamer`, `AttributeBinder`) update
  their overrides and call sites to match the new reference signatures.
- **`shape_inference/implementation.cc`** — updated the `VisitNode` call site.
- **`defs/shape_inference.cc`** — the four `static`
  `propagate*ElemTypeWithValidation` helpers take `input_type`/`output_type`
  by reference; removed the now-unreachable `nullptr == input_type` checks
  (the public `propagateElemTypeWithValidation` caller already validates).

No public API changes: all converted free functions have internal linkage,
and the public `propagateElemTypeWithValidation` signature is untouched. The
`MutableVisitor` change is internal (`ONNX_NAMESPACE::internal`).
