### PR TITLE
Align Python MAXIMUM_PROTOBUF with C++ 2GiB-1 parser limit

### DIFF
--- a/onnx/checker.py
+++ b/onnx/checker.py
@@ -31,8 +31,8 @@ from onnx.onnx_pb import IR_VERSION
 if TYPE_CHECKING:
     from google.protobuf.message import Message
 
-# Limitation of single protobuf file is 2GiB
-MAXIMUM_PROTOBUF = 2147483648
+# Maximum single-protobuf size; matches the C++ parser limit in proto_utils.h (2 GiB - 1 byte)
+MAXIMUM_PROTOBUF = 2147483647
 
 
 # NB: Please don't edit this context!

--- a/onnx/serialization.py
+++ b/onnx/serialization.py
@@ -102,7 +102,7 @@ class _ProtobufSerializer(ProtoSerializer):
             try:
                 result = proto.SerializeToString()
             except ValueError as e:
-                if proto.ByteSize() >= onnx.checker.MAXIMUM_PROTOBUF:
+                if proto.ByteSize() > onnx.checker.MAXIMUM_PROTOBUF:
                     raise ValueError(
                         "The proto size is larger than the 2 GB limit. "
                         "Please use save_as_external_data to save tensors separately from the model file."


### PR DESCRIPTION



### Motivation and Context

The Python guard used 2147483648 (2^31) with strict >, while the C++ parser in proto_utils.h rejects length > 2147483647 (2^31-1). A buffer of exactly 2^31 bytes passed the Python check but failed C++ parsing with a confusing error. Lower the constant to 2^31-1 and make serialization.py use > like the other three call sites.
