### PR TITLE
Re-back StringRange with std::string_view

### DIFF
--- a/onnx/defs/data_type_utils.cc
+++ b/onnx/defs/data_type_utils.cc
@@ -243,7 +243,8 @@ int32_t DataTypeUtils::FromDataTypeString(const std::string& type_str) {
 
 namespace {
 
-StringRange::StringRange(const char* p_data, size_t p_size) : view_(p_data, p_size) {
+StringRange::StringRange(const char* p_data, size_t p_size)
+    : view_(p_data != nullptr ? std::string_view{p_data, p_size} : std::string_view{}) {
   assert(p_data != nullptr);
   LAndRStrip();
 }

--- a/onnx/defs/data_type_utils.cc
+++ b/onnx/defs/data_type_utils.cc
@@ -6,6 +6,7 @@
 
 #include <cctype>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -67,8 +68,7 @@ class StringRange final {
   size_t Find(char ch) const;
 
  private:
-  const char* data_;
-  size_t size_;
+  std::string_view view_;
 };
 
 } // namespace
@@ -243,47 +243,44 @@ int32_t DataTypeUtils::FromDataTypeString(const std::string& type_str) {
 
 namespace {
 
-StringRange::StringRange(const char* p_data, size_t p_size) : data_(p_data), size_(p_size) {
+StringRange::StringRange(const char* p_data, size_t p_size) : view_(p_data, p_size) {
   assert(p_data != nullptr);
   LAndRStrip();
 }
 
-StringRange::StringRange(const std::string& p_str) : data_(p_str.data()), size_(p_str.size()) {
+StringRange::StringRange(const std::string& p_str) : view_(p_str) {
   LAndRStrip();
 }
 
-StringRange::StringRange(const char* p_data) : data_(p_data), size_(strlen(p_data)) {
+StringRange::StringRange(const char* p_data) : view_(p_data) {
   LAndRStrip();
 }
 
 const char* StringRange::Data() const {
-  return data_;
+  return view_.data();
 }
 
 size_t StringRange::Size() const {
-  return size_;
+  return view_.size();
 }
 
 bool StringRange::Empty() const {
-  return size_ == 0;
+  return view_.empty();
 }
 
 bool StringRange::StartsWith(const StringRange& str) const {
-  return ((size_ >= str.size_) && (memcmp(data_, str.data_, str.size_) == 0));
+  return view_.substr(0, str.view_.size()) == str.view_;
 }
 
 bool StringRange::EndsWith(const StringRange& str) const {
-  return ((size_ >= str.size_) && (memcmp(data_ + (size_ - str.size_), str.data_, str.size_) == 0));
+  return view_.size() >= str.view_.size() && view_.substr(view_.size() - str.view_.size()) == str.view_;
 }
 
 bool StringRange::LStrip() {
   size_t count = 0;
-  const char* ptr = data_;
-  while (count < size_ && isspace(*ptr)) {
-    count++;
-    ptr++;
+  while (count < view_.size() && isspace(static_cast<unsigned char>(view_[count]))) {
+    ++count;
   }
-
   if (count > 0) {
     return LStrip(count);
   }
@@ -291,9 +288,8 @@ bool StringRange::LStrip() {
 }
 
 bool StringRange::LStrip(size_t size) {
-  if (size <= size_) {
-    data_ += size;
-    size_ -= size;
+  if (size <= view_.size()) {
+    view_.remove_prefix(size);
     return true;
   }
   return false;
@@ -301,19 +297,16 @@ bool StringRange::LStrip(size_t size) {
 
 bool StringRange::LStrip(StringRange str) {
   if (StartsWith(str)) {
-    return LStrip(str.size_);
+    return LStrip(str.view_.size());
   }
   return false;
 }
 
 bool StringRange::RStrip() {
   size_t count = 0;
-  const char* ptr = data_ + size_ - 1;
-  while (count < size_ && isspace(*ptr)) {
+  while (count < view_.size() && isspace(static_cast<unsigned char>(view_[view_.size() - 1 - count]))) {
     ++count;
-    --ptr;
   }
-
   if (count > 0) {
     return RStrip(count);
   }
@@ -321,8 +314,8 @@ bool StringRange::RStrip() {
 }
 
 bool StringRange::RStrip(size_t size) {
-  if (size_ >= size) {
-    size_ -= size;
+  if (size <= view_.size()) {
+    view_.remove_suffix(size);
     return true;
   }
   return false;
@@ -330,7 +323,7 @@ bool StringRange::RStrip(size_t size) {
 
 bool StringRange::RStrip(StringRange str) {
   if (EndsWith(str)) {
-    return RStrip(str.size_);
+    return RStrip(str.view_.size());
   }
   return false;
 }
@@ -350,14 +343,7 @@ void StringRange::ParensWhitespaceStrip() {
 }
 
 size_t StringRange::Find(const char ch) const {
-  size_t idx = 0;
-  while (idx < size_) {
-    if (data_[idx] == ch) {
-      return idx;
-    }
-    idx++;
-  }
-  return std::string::npos;
+  return view_.find(ch);
 }
 
 TypesWrapper& TypesWrapper::GetTypesWrapper() {


### PR DESCRIPTION
### Motivation and Context

Replace the raw const char*/size_t pair in the StringRange type-string parser cursor with a std::string_view. This drops the C memcmp and strlen calls, the hand-written Find loop, and the raw pointer arithmetic in the strip methods in favor of string_view primitives (substr/compare, remove_prefix/remove_suffix, find). The public API and all FromString callers are unchanged. Also cast to unsigned char before isspace to avoid undefined behavior on negative char values.




 