### PR TITLE
Validate Scan num_scan_inputs to prevent shape-inference underflow

### DIFF
--- a/onnx/defs/controlflow/old.cc
+++ b/onnx/defs/controlflow/old.cc
@@ -1053,21 +1053,8 @@ static int handle_negative_axis_validate_opset9(const std::string& attrib, int a
 static void ScanInferenceFunction_opset9(InferenceContext& ctx) {
   auto num_inputs = ctx.getNumInputs();
   auto num_scan_inputs = narrow<size_t>(getRequiredAttributeInt(ctx, "num_scan_inputs"));
-  // Guard the size_t subtractions below against underflow.
-  if (num_scan_inputs > num_inputs) {
-    fail_shape_inference(
-        "num_scan_inputs (", num_scan_inputs, ") cannot exceed the number of Scan inputs (", num_inputs, ").");
-  }
-  auto num_loop_state_vars = num_inputs - num_scan_inputs;
   auto num_outputs = ctx.getNumOutputs();
-  if (num_loop_state_vars > num_outputs) {
-    fail_shape_inference(
-        "The number of outputs of the Scan (",
-        num_outputs,
-        ") should equal the sum of the number of loop state variables (",
-        num_loop_state_vars,
-        ") and the number of scan-outputs.");
-  }
+  auto num_loop_state_vars = ValidateScanCountsAndGetNumLoopStateVars(num_inputs, num_scan_inputs, num_outputs);
   auto num_scan_outputs = num_outputs - num_loop_state_vars;
 
   std::vector<int64_t> axes, output_axes;

--- a/onnx/defs/controlflow/old.cc
+++ b/onnx/defs/controlflow/old.cc
@@ -906,6 +906,16 @@ void ScanInferenceFunction_opset8(InferenceContext& ctx) {
   // inputs in many places below, so the - 1 in multiple places is due to that.
   auto num_inputs = ctx.getNumInputs();
   auto num_scan_inputs = narrow<size_t>(getRequiredAttributeInt(ctx, "num_scan_inputs"));
+  // Guard the size_t subtraction below against underflow. The first input is
+  // sequence_lens, so num_scan_inputs plus it cannot exceed the input count.
+  if (num_scan_inputs + 1 > num_inputs) {
+    fail_shape_inference(
+        "num_scan_inputs (",
+        num_scan_inputs,
+        ") plus the sequence_lens input cannot exceed the number of Scan inputs (",
+        num_inputs,
+        ").");
+  }
   auto num_loop_state_vars = num_inputs - 1 - num_scan_inputs;
 
   std::vector<TypeProto> temporary_type_protos;
@@ -1043,8 +1053,21 @@ static int handle_negative_axis_validate_opset9(const std::string& attrib, int a
 static void ScanInferenceFunction_opset9(InferenceContext& ctx) {
   auto num_inputs = ctx.getNumInputs();
   auto num_scan_inputs = narrow<size_t>(getRequiredAttributeInt(ctx, "num_scan_inputs"));
+  // Guard the size_t subtractions below against underflow.
+  if (num_scan_inputs > num_inputs) {
+    fail_shape_inference(
+        "num_scan_inputs (", num_scan_inputs, ") cannot exceed the number of Scan inputs (", num_inputs, ").");
+  }
   auto num_loop_state_vars = num_inputs - num_scan_inputs;
   auto num_outputs = ctx.getNumOutputs();
+  if (num_loop_state_vars > num_outputs) {
+    fail_shape_inference(
+        "The number of outputs of the Scan (",
+        num_outputs,
+        ") should equal the sum of the number of loop state variables (",
+        num_loop_state_vars,
+        ") and the number of scan-outputs.");
+  }
   auto num_scan_outputs = num_outputs - num_loop_state_vars;
 
   std::vector<int64_t> axes, output_axes;

--- a/onnx/defs/controlflow/old.cc
+++ b/onnx/defs/controlflow/old.cc
@@ -906,8 +906,7 @@ void ScanInferenceFunction_opset8(InferenceContext& ctx) {
   // inputs in many places below, so the - 1 in multiple places is due to that.
   auto num_inputs = ctx.getNumInputs();
   auto num_scan_inputs = narrow<size_t>(getRequiredAttributeInt(ctx, "num_scan_inputs"));
-  // Guard the size_t subtraction below against underflow. The first input is
-  // sequence_lens, so num_scan_inputs plus it cannot exceed the input count.
+  // Guard the subtraction below; opset 8's first input is sequence_lens, hence the + 1.
   if (num_scan_inputs + 1 > num_inputs) {
     fail_shape_inference(
         "num_scan_inputs (",

--- a/onnx/defs/controlflow/utils.cc
+++ b/onnx/defs/controlflow/utils.cc
@@ -198,16 +198,13 @@ int handle_negative_axis_validate(const std::string& attrib, int axis, int rank)
   return (axis >= 0 ? axis : axis + rank);
 }
 
-void ScanInferenceFunction(InferenceContext& ctx) {
-  auto num_inputs = ctx.getNumInputs();
-  auto num_scan_inputs = narrow<size_t>(getRequiredAttributeInt(ctx, "num_scan_inputs"));
-  // Guard the size_t subtractions below against underflow.
+size_t ValidateScanCountsAndGetNumLoopStateVars(size_t num_inputs, size_t num_scan_inputs, size_t num_outputs) {
+  // Guard the size_t subtractions in Scan shape inference against underflow.
   if (num_scan_inputs > num_inputs) {
     fail_shape_inference(
         "num_scan_inputs (", num_scan_inputs, ") cannot exceed the number of Scan inputs (", num_inputs, ").");
   }
-  auto num_loop_state_vars = num_inputs - num_scan_inputs;
-  auto num_outputs = ctx.getNumOutputs();
+  size_t num_loop_state_vars = num_inputs - num_scan_inputs;
   if (num_loop_state_vars > num_outputs) {
     fail_shape_inference(
         "The number of outputs of the Scan (",
@@ -216,6 +213,14 @@ void ScanInferenceFunction(InferenceContext& ctx) {
         num_loop_state_vars,
         ") and the number of scan-outputs.");
   }
+  return num_loop_state_vars;
+}
+
+void ScanInferenceFunction(InferenceContext& ctx) {
+  auto num_inputs = ctx.getNumInputs();
+  auto num_scan_inputs = narrow<size_t>(getRequiredAttributeInt(ctx, "num_scan_inputs"));
+  auto num_outputs = ctx.getNumOutputs();
+  auto num_loop_state_vars = ValidateScanCountsAndGetNumLoopStateVars(num_inputs, num_scan_inputs, num_outputs);
   auto num_scan_outputs = num_outputs - num_loop_state_vars;
 
   std::vector<int64_t> axes, output_axes;

--- a/onnx/defs/controlflow/utils.cc
+++ b/onnx/defs/controlflow/utils.cc
@@ -199,7 +199,7 @@ int handle_negative_axis_validate(const std::string& attrib, int axis, int rank)
 }
 
 size_t ValidateScanCountsAndGetNumLoopStateVars(size_t num_inputs, size_t num_scan_inputs, size_t num_outputs) {
-  // Guard the size_t subtractions in Scan shape inference against underflow.
+  // Guard the subtractions below against underflow.
   if (num_scan_inputs > num_inputs) {
     fail_shape_inference(
         "num_scan_inputs (", num_scan_inputs, ") cannot exceed the number of Scan inputs (", num_inputs, ").");

--- a/onnx/defs/controlflow/utils.cc
+++ b/onnx/defs/controlflow/utils.cc
@@ -210,11 +210,11 @@ void ScanInferenceFunction(InferenceContext& ctx) {
   auto num_outputs = ctx.getNumOutputs();
   if (num_loop_state_vars > num_outputs) {
     fail_shape_inference(
-        "Number of loop state variables (",
-        num_loop_state_vars,
-        ") cannot exceed the number of Scan outputs (",
+        "The number of outputs of the Scan (",
         num_outputs,
-        ").");
+        ") should equal the sum of the number of loop state variables (",
+        num_loop_state_vars,
+        ") and the number of scan-outputs.");
   }
   auto num_scan_outputs = num_outputs - num_loop_state_vars;
 

--- a/onnx/defs/controlflow/utils.cc
+++ b/onnx/defs/controlflow/utils.cc
@@ -201,8 +201,21 @@ int handle_negative_axis_validate(const std::string& attrib, int axis, int rank)
 void ScanInferenceFunction(InferenceContext& ctx) {
   auto num_inputs = ctx.getNumInputs();
   auto num_scan_inputs = narrow<size_t>(getRequiredAttributeInt(ctx, "num_scan_inputs"));
+  // Guard the size_t subtractions below against underflow.
+  if (num_scan_inputs > num_inputs) {
+    fail_shape_inference(
+        "num_scan_inputs (", num_scan_inputs, ") cannot exceed the number of Scan inputs (", num_inputs, ").");
+  }
   auto num_loop_state_vars = num_inputs - num_scan_inputs;
   auto num_outputs = ctx.getNumOutputs();
+  if (num_loop_state_vars > num_outputs) {
+    fail_shape_inference(
+        "Number of loop state variables (",
+        num_loop_state_vars,
+        ") cannot exceed the number of Scan outputs (",
+        num_outputs,
+        ").");
+  }
   auto num_scan_outputs = num_outputs - num_loop_state_vars;
 
   std::vector<int64_t> axes, output_axes;

--- a/onnx/defs/controlflow/utils.h
+++ b/onnx/defs/controlflow/utils.h
@@ -14,9 +14,8 @@ void ClearShape(TypeProto& input_type);
 
 int handle_negative_axis_validate(const std::string& attrib, int axis, int rank);
 
-// Validates the Scan input/output counts, guarding the size_t subtractions in
-// shape inference against underflow, and returns the number of loop state
-// variables. Shared by the current and opset-9 Scan inference functions.
+// Guards the Scan input/output count subtractions against underflow and returns
+// the loop state variable count. Shared by the current and opset-9 paths.
 size_t ValidateScanCountsAndGetNumLoopStateVars(size_t num_inputs, size_t num_scan_inputs, size_t num_outputs);
 
 void IfInferenceFunction(InferenceContext& ctx);

--- a/onnx/defs/controlflow/utils.h
+++ b/onnx/defs/controlflow/utils.h
@@ -14,6 +14,11 @@ void ClearShape(TypeProto& input_type);
 
 int handle_negative_axis_validate(const std::string& attrib, int axis, int rank);
 
+// Validates the Scan input/output counts, guarding the size_t subtractions in
+// shape inference against underflow, and returns the number of loop state
+// variables. Shared by the current and opset-9 Scan inference functions.
+size_t ValidateScanCountsAndGetNumLoopStateVars(size_t num_inputs, size_t num_scan_inputs, size_t num_outputs);
+
 void IfInferenceFunction(InferenceContext& ctx);
 
 void LoopInferenceFunction(InferenceContext& ctx);

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -6106,12 +6106,11 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 8)],
         )
 
-    def test_scan_num_scan_inputs_out_of_range(self) -> None:
-        # num_scan_inputs exceeding the input count must fail, not underflow.
-        # Opset 8 has a leading sequence_lens input; 9 and 21 (latest) use the
-        # separate and shared inference functions respectively.
-        models = {
-            21: """
+    @pytest.mark.parametrize(
+        "model_text",
+        [
+            pytest.param(
+                """
                 <ir_version: 10, opset_import: ["" : 21]>
                 agraph (float[2] in0, float[3, 2] in1) => (out) {
                     out = Scan <num_scan_inputs = 9, body = b (float a, float x) => (float c) {
@@ -6119,7 +6118,10 @@ class TestShapeInference(TestShapeInferenceHelper):
                     }> (in0, in1)
                 }
                 """,
-            9: """
+                id="opset21",
+            ),
+            pytest.param(
+                """
                 <ir_version: 8, opset_import: ["" : 9]>
                 agraph (float[2] in0, float[3, 2] in1) => (out) {
                     out = Scan <num_scan_inputs = 9, body = b (float a, float x) => (float c) {
@@ -6127,7 +6129,10 @@ class TestShapeInference(TestShapeInferenceHelper):
                     }> (in0, in1)
                 }
                 """,
-            8: """
+                id="opset9",
+            ),
+            pytest.param(
+                """
                 <ir_version: 8, opset_import: ["" : 8]>
                 agraph (float[1, 3] ls, float[1, 2, 2] si) => (out) {
                     out = Scan <num_scan_inputs = 9, body = b (float a, float x) => (float c) {
@@ -6135,34 +6140,44 @@ class TestShapeInference(TestShapeInferenceHelper):
                     }> ("", ls, si)
                 }
                 """,
-        }
-        for opset, model_text in models.items():
-            with self.subTest(opset=opset):
-                model = onnx.parser.parse_model(model_text)
-                with self.assertRaisesRegex(
-                    onnx.shape_inference.InferenceError, "num_scan_inputs"
-                ):
-                    self._inferred(model)
+                id="opset8",
+            ),
+        ],
+    )
+    def test_scan_num_scan_inputs_out_of_range(self, model_text: str) -> None:
+        # num_scan_inputs exceeding the input count must fail, not underflow.
+        # Opset 8 has a leading sequence_lens input; 9 and 21 (latest) use the
+        # separate and shared inference functions respectively.
+        model = onnx.parser.parse_model(model_text)
+        with pytest.raises(
+            onnx.shape_inference.InferenceError, match="num_scan_inputs"
+        ):
+            self._inferred(model)
 
-    def test_scan_loop_state_vars_exceed_outputs(self) -> None:
+    @pytest.mark.parametrize(
+        ("opset", "ir_version"),
+        [(21, 10), (9, 8)],
+        ids=["opset21", "opset9"],
+    )
+    def test_scan_loop_state_vars_exceed_outputs(
+        self, opset: int, ir_version: int
+    ) -> None:
         # More loop state vars than outputs must fail, not underflow. Covers the
         # shared (latest) and the separate opset-9 inference functions.
-        for opset, ir_version in ((21, 10), (9, 8)):
-            with self.subTest(opset=opset):
-                model = onnx.parser.parse_model(
-                    f"""
-                    <ir_version: {ir_version}, opset_import: ["" : {opset}]>
-                    agraph (float[2] in0, float[2] in1, float[3, 2] in2) => (out) {{
-                        out = Scan <num_scan_inputs = 1, body = b (float a, float s0, float s1) => (float c) {{
-                            c = Identity(a)
-                        }}> (in0, in1, in2)
-                    }}
-                    """
-                )
-                with self.assertRaisesRegex(
-                    onnx.shape_inference.InferenceError, "loop state variables"
-                ):
-                    self._inferred(model)
+        model = onnx.parser.parse_model(
+            f"""
+            <ir_version: {ir_version}, opset_import: ["" : {opset}]>
+            agraph (float[2] in0, float[2] in1, float[3, 2] in2) => (out) {{
+                out = Scan <num_scan_inputs = 1, body = b (float a, float s0, float s1) => (float c) {{
+                    c = Identity(a)
+                }}> (in0, in1, in2)
+            }}
+            """
+        )
+        with pytest.raises(
+            onnx.shape_inference.InferenceError, match="loop state variables"
+        ):
+            self._inferred(model)
 
     def test_scan_opset9(self) -> None:
         # The whole graph (including the Scan body subgraph) is expressed in one parse_graph call;

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -6145,9 +6145,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         ],
     )
     def test_scan_num_scan_inputs_out_of_range(self, model_text: str) -> None:
-        # num_scan_inputs exceeding the input count must fail, not underflow.
-        # Opset 8 has a leading sequence_lens input; 9 and 21 (latest) use the
-        # separate and shared inference functions respectively.
+        # num_scan_inputs > input count must raise, not underflow (opsets 8, 9, 21).
         model = onnx.parser.parse_model(model_text)
         with pytest.raises(
             onnx.shape_inference.InferenceError, match="num_scan_inputs"
@@ -6162,8 +6160,7 @@ class TestShapeInference(TestShapeInferenceHelper):
     def test_scan_loop_state_vars_exceed_outputs(
         self, opset: int, ir_version: int
     ) -> None:
-        # More loop state vars than outputs must fail, not underflow. Covers the
-        # shared (latest) and the separate opset-9 inference functions.
+        # More loop state vars than outputs must raise, not underflow (opsets 9, 21).
         model = onnx.parser.parse_model(
             f"""
             <ir_version: {ir_version}, opset_import: ["" : {opset}]>
@@ -12824,8 +12821,7 @@ class TestShapeInference(TestShapeInferenceHelper):
 
     @pytest.mark.parametrize("attrs", ["", "num_scan_inputs = -1, "])
     def test_scan_invalid_num_scan_inputs_does_not_crash(self, attrs):
-        # Missing required attribute would null-deref; negative value would
-        # overflow narrow<size_t>. Both must raise InferenceError, not crash.
+        # Missing attr null-derefs; -1 overflows size_t. Both must raise, not crash.
         scan_body = (
             "body = b (float[1] si, float[1] xi) => (float[1] so, float[1] xo) "
             "{ so = Identity(si) xo = Identity(xi) }"

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -6106,6 +6106,72 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 8)],
         )
 
+    def test_scan_num_scan_inputs_out_of_range(self) -> None:
+        # num_scan_inputs exceeding the input count must fail, not underflow.
+        subgraph = helper.make_graph(
+            [make_node("Add", ["a", "b"], ["c"])],
+            "subgraph",
+            [
+                make_tensor_value_info("a", TensorProto.UNDEFINED, None),
+                make_tensor_value_info("b", TensorProto.UNDEFINED, None),
+            ],
+            [make_tensor_value_info("c", TensorProto.UNDEFINED, None)],
+        )
+        graph = self._make_graph(
+            [
+                ("in0", TensorProto.FLOAT, (2,)),
+                ("in1", TensorProto.FLOAT, (3, 2)),
+            ],
+            [
+                make_node(
+                    "Scan",
+                    ["in0", "in1"],
+                    ["out"],
+                    num_scan_inputs=9,
+                    body=subgraph,
+                )
+            ],
+            [],
+        )
+        with self.assertRaisesRegex(
+            onnx.shape_inference.InferenceError, "num_scan_inputs"
+        ):
+            self._inferred(graph)
+
+    def test_scan_loop_state_vars_exceed_outputs(self) -> None:
+        # More loop state vars than outputs must fail, not underflow.
+        subgraph = helper.make_graph(
+            [make_node("Identity", ["a"], ["c"])],
+            "subgraph",
+            [
+                make_tensor_value_info("a", TensorProto.UNDEFINED, None),
+                make_tensor_value_info("s0", TensorProto.UNDEFINED, None),
+                make_tensor_value_info("s1", TensorProto.UNDEFINED, None),
+            ],
+            [make_tensor_value_info("c", TensorProto.UNDEFINED, None)],
+        )
+        graph = self._make_graph(
+            [
+                ("in0", TensorProto.FLOAT, (2,)),
+                ("in1", TensorProto.FLOAT, (2,)),
+                ("in2", TensorProto.FLOAT, (3, 2)),
+            ],
+            [
+                make_node(
+                    "Scan",
+                    ["in0", "in1", "in2"],
+                    ["out"],
+                    num_scan_inputs=1,
+                    body=subgraph,
+                )
+            ],
+            [],
+        )
+        with self.assertRaisesRegex(
+            onnx.shape_inference.InferenceError, "loop state variables"
+        ):
+            self._inferred(graph)
+
     def test_scan_opset9(self) -> None:
         # The whole graph (including the Scan body subgraph) is expressed in one parse_graph call;
         # the Scan outputs are left untyped so that shape inference must compute their type/shape.

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -6108,69 +6108,94 @@ class TestShapeInference(TestShapeInferenceHelper):
 
     def test_scan_num_scan_inputs_out_of_range(self) -> None:
         # num_scan_inputs exceeding the input count must fail, not underflow.
-        subgraph = helper.make_graph(
-            [make_node("Add", ["a", "b"], ["c"])],
-            "subgraph",
-            [
-                make_tensor_value_info("a", TensorProto.UNDEFINED, None),
-                make_tensor_value_info("b", TensorProto.UNDEFINED, None),
-            ],
-            [make_tensor_value_info("c", TensorProto.UNDEFINED, None)],
-        )
-        graph = self._make_graph(
-            [
-                ("in0", TensorProto.FLOAT, (2,)),
-                ("in1", TensorProto.FLOAT, (3, 2)),
-            ],
-            [
-                make_node(
-                    "Scan",
-                    ["in0", "in1"],
-                    ["out"],
-                    num_scan_inputs=9,
-                    body=subgraph,
-                )
-            ],
-            [],
+        model = onnx.parser.parse_model(
+            """
+            <ir_version: 10, opset_import: ["" : 21]>
+            agraph (float[2] in0, float[3, 2] in1) => (out)
+            {
+                out = Scan <num_scan_inputs = 9, body = subgraph (float a, float b) => (float c) {
+                    c = Add(a, b)
+                }> (in0, in1)
+            }
+            """
         )
         with self.assertRaisesRegex(
             onnx.shape_inference.InferenceError, "num_scan_inputs"
         ):
-            self._inferred(graph)
+            self._inferred(model)
 
     def test_scan_loop_state_vars_exceed_outputs(self) -> None:
         # More loop state vars than outputs must fail, not underflow.
-        subgraph = helper.make_graph(
-            [make_node("Identity", ["a"], ["c"])],
-            "subgraph",
-            [
-                make_tensor_value_info("a", TensorProto.UNDEFINED, None),
-                make_tensor_value_info("s0", TensorProto.UNDEFINED, None),
-                make_tensor_value_info("s1", TensorProto.UNDEFINED, None),
-            ],
-            [make_tensor_value_info("c", TensorProto.UNDEFINED, None)],
-        )
-        graph = self._make_graph(
-            [
-                ("in0", TensorProto.FLOAT, (2,)),
-                ("in1", TensorProto.FLOAT, (2,)),
-                ("in2", TensorProto.FLOAT, (3, 2)),
-            ],
-            [
-                make_node(
-                    "Scan",
-                    ["in0", "in1", "in2"],
-                    ["out"],
-                    num_scan_inputs=1,
-                    body=subgraph,
-                )
-            ],
-            [],
+        model = onnx.parser.parse_model(
+            """
+            <ir_version: 10, opset_import: ["" : 21]>
+            agraph (float[2] in0, float[2] in1, float[3, 2] in2) => (out)
+            {
+                out = Scan <num_scan_inputs = 1, body = subgraph (float a, float s0, float s1) => (float c) {
+                    c = Identity(a)
+                }> (in0, in1, in2)
+            }
+            """
         )
         with self.assertRaisesRegex(
             onnx.shape_inference.InferenceError, "loop state variables"
         ):
-            self._inferred(graph)
+            self._inferred(model)
+
+    def test_scan_opset8_num_scan_inputs_out_of_range(self) -> None:
+        # Opset-8 Scan has a leading sequence_lens input; num_scan_inputs
+        # exceeding the remaining inputs must fail, not underflow.
+        model = onnx.parser.parse_model(
+            """
+            <ir_version: 8, opset_import: ["" : 8]>
+            agraph (float[1, 3] loop_state, float[1, 2, 2] scan_input) => (out)
+            {
+                out = Scan <num_scan_inputs = 9, body = subgraph (float a, float b) => (float c) {
+                    c = Add(a, b)
+                }> ("", loop_state, scan_input)
+            }
+            """
+        )
+        with self.assertRaisesRegex(
+            onnx.shape_inference.InferenceError, "num_scan_inputs"
+        ):
+            self._inferred(model)
+
+    def test_scan_opset9_num_scan_inputs_out_of_range(self) -> None:
+        # Opset-9 Scan shares the same underflow risk as the latest opset.
+        model = onnx.parser.parse_model(
+            """
+            <ir_version: 8, opset_import: ["" : 9]>
+            agraph (float[2] in0, float[3, 2] in1) => (out)
+            {
+                out = Scan <num_scan_inputs = 9, body = subgraph (float a, float b) => (float c) {
+                    c = Add(a, b)
+                }> (in0, in1)
+            }
+            """
+        )
+        with self.assertRaisesRegex(
+            onnx.shape_inference.InferenceError, "num_scan_inputs"
+        ):
+            self._inferred(model)
+
+    def test_scan_opset9_loop_state_vars_exceed_outputs(self) -> None:
+        # Opset-9 Scan: more loop state vars than outputs must fail, not underflow.
+        model = onnx.parser.parse_model(
+            """
+            <ir_version: 8, opset_import: ["" : 9]>
+            agraph (float[2] in0, float[2] in1, float[3, 2] in2) => (out)
+            {
+                out = Scan <num_scan_inputs = 1, body = subgraph (float a, float s0, float s1) => (float c) {
+                    c = Identity(a)
+                }> (in0, in1, in2)
+            }
+            """
+        )
+        with self.assertRaisesRegex(
+            onnx.shape_inference.InferenceError, "loop state variables"
+        ):
+            self._inferred(model)
 
     def test_scan_opset9(self) -> None:
         # The whole graph (including the Scan body subgraph) is expressed in one parse_graph call;

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -6108,94 +6108,61 @@ class TestShapeInference(TestShapeInferenceHelper):
 
     def test_scan_num_scan_inputs_out_of_range(self) -> None:
         # num_scan_inputs exceeding the input count must fail, not underflow.
-        model = onnx.parser.parse_model(
-            """
-            <ir_version: 10, opset_import: ["" : 21]>
-            agraph (float[2] in0, float[3, 2] in1) => (out)
-            {
-                out = Scan <num_scan_inputs = 9, body = subgraph (float a, float b) => (float c) {
-                    c = Add(a, b)
-                }> (in0, in1)
-            }
-            """
-        )
-        with self.assertRaisesRegex(
-            onnx.shape_inference.InferenceError, "num_scan_inputs"
-        ):
-            self._inferred(model)
+        # Opset 8 has a leading sequence_lens input; 9 and 21 (latest) use the
+        # separate and shared inference functions respectively.
+        models = {
+            21: """
+                <ir_version: 10, opset_import: ["" : 21]>
+                agraph (float[2] in0, float[3, 2] in1) => (out) {
+                    out = Scan <num_scan_inputs = 9, body = b (float a, float x) => (float c) {
+                        c = Add(a, x)
+                    }> (in0, in1)
+                }
+                """,
+            9: """
+                <ir_version: 8, opset_import: ["" : 9]>
+                agraph (float[2] in0, float[3, 2] in1) => (out) {
+                    out = Scan <num_scan_inputs = 9, body = b (float a, float x) => (float c) {
+                        c = Add(a, x)
+                    }> (in0, in1)
+                }
+                """,
+            8: """
+                <ir_version: 8, opset_import: ["" : 8]>
+                agraph (float[1, 3] ls, float[1, 2, 2] si) => (out) {
+                    out = Scan <num_scan_inputs = 9, body = b (float a, float x) => (float c) {
+                        c = Add(a, x)
+                    }> ("", ls, si)
+                }
+                """,
+        }
+        for opset, model_text in models.items():
+            with self.subTest(opset=opset):
+                model = onnx.parser.parse_model(model_text)
+                with self.assertRaisesRegex(
+                    onnx.shape_inference.InferenceError, "num_scan_inputs"
+                ):
+                    self._inferred(model)
 
     def test_scan_loop_state_vars_exceed_outputs(self) -> None:
-        # More loop state vars than outputs must fail, not underflow.
-        model = onnx.parser.parse_model(
-            """
-            <ir_version: 10, opset_import: ["" : 21]>
-            agraph (float[2] in0, float[2] in1, float[3, 2] in2) => (out)
-            {
-                out = Scan <num_scan_inputs = 1, body = subgraph (float a, float s0, float s1) => (float c) {
-                    c = Identity(a)
-                }> (in0, in1, in2)
-            }
-            """
-        )
-        with self.assertRaisesRegex(
-            onnx.shape_inference.InferenceError, "loop state variables"
-        ):
-            self._inferred(model)
-
-    def test_scan_opset8_num_scan_inputs_out_of_range(self) -> None:
-        # Opset-8 Scan has a leading sequence_lens input; num_scan_inputs
-        # exceeding the remaining inputs must fail, not underflow.
-        model = onnx.parser.parse_model(
-            """
-            <ir_version: 8, opset_import: ["" : 8]>
-            agraph (float[1, 3] loop_state, float[1, 2, 2] scan_input) => (out)
-            {
-                out = Scan <num_scan_inputs = 9, body = subgraph (float a, float b) => (float c) {
-                    c = Add(a, b)
-                }> ("", loop_state, scan_input)
-            }
-            """
-        )
-        with self.assertRaisesRegex(
-            onnx.shape_inference.InferenceError, "num_scan_inputs"
-        ):
-            self._inferred(model)
-
-    def test_scan_opset9_num_scan_inputs_out_of_range(self) -> None:
-        # Opset-9 Scan shares the same underflow risk as the latest opset.
-        model = onnx.parser.parse_model(
-            """
-            <ir_version: 8, opset_import: ["" : 9]>
-            agraph (float[2] in0, float[3, 2] in1) => (out)
-            {
-                out = Scan <num_scan_inputs = 9, body = subgraph (float a, float b) => (float c) {
-                    c = Add(a, b)
-                }> (in0, in1)
-            }
-            """
-        )
-        with self.assertRaisesRegex(
-            onnx.shape_inference.InferenceError, "num_scan_inputs"
-        ):
-            self._inferred(model)
-
-    def test_scan_opset9_loop_state_vars_exceed_outputs(self) -> None:
-        # Opset-9 Scan: more loop state vars than outputs must fail, not underflow.
-        model = onnx.parser.parse_model(
-            """
-            <ir_version: 8, opset_import: ["" : 9]>
-            agraph (float[2] in0, float[2] in1, float[3, 2] in2) => (out)
-            {
-                out = Scan <num_scan_inputs = 1, body = subgraph (float a, float s0, float s1) => (float c) {
-                    c = Identity(a)
-                }> (in0, in1, in2)
-            }
-            """
-        )
-        with self.assertRaisesRegex(
-            onnx.shape_inference.InferenceError, "loop state variables"
-        ):
-            self._inferred(model)
+        # More loop state vars than outputs must fail, not underflow. Covers the
+        # shared (latest) and the separate opset-9 inference functions.
+        for opset, ir_version in ((21, 10), (9, 8)):
+            with self.subTest(opset=opset):
+                model = onnx.parser.parse_model(
+                    f"""
+                    <ir_version: {ir_version}, opset_import: ["" : {opset}]>
+                    agraph (float[2] in0, float[2] in1, float[3, 2] in2) => (out) {{
+                        out = Scan <num_scan_inputs = 1, body = b (float a, float s0, float s1) => (float c) {{
+                            c = Identity(a)
+                        }}> (in0, in1, in2)
+                    }}
+                    """
+                )
+                with self.assertRaisesRegex(
+                    onnx.shape_inference.InferenceError, "loop state variables"
+                ):
+                    self._inferred(model)
 
     def test_scan_opset9(self) -> None:
         # The whole graph (including the Scan body subgraph) is expressed in one parse_graph call;


### PR DESCRIPTION
### Motivation and Context

ScanInferenceFunction computed num_loop_state_vars = num_inputs - num_scan_inputs and num_scan_outputs = num_outputs - num_loop_state_vars as size_t. A num_scan_inputs greater than the input count (or a loop-state-var count exceeding the output count) underflowed these to huge values, after which the code indexed outputs out of bounds (an unchecked getOutputType in propagateElemTypeFromTensorInputToOutput is a null dereference) or fed a garbage size into a vector insert.

Validate both bounds up front and fail_shape_inference with a clear message instead. Shared by all Scan opset versions.




 