### PR TITLE
Modernize ONNX text parser to use std::string_view

### DIFF
--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -143,42 +143,42 @@ namespace ONNX_NAMESPACE {
 Common::Status ParserBase::Parse(Literal& result) {
   bool decimal_point = false;
   auto nextch = NextChar();
-  const auto* from = next_;
+  size_t from = pos_;
   if (nextch == '"') {
-    ++next_;
+    ++pos_;
     bool has_escape = false;
-    while ((next_ < end_) && (*next_ != '"')) {
-      if (*next_ == '\\') {
+    while (!AtEnd() && (Cur() != '"')) {
+      if (Cur() == '\\') {
         has_escape = true;
-        ++next_;
-        if (next_ >= end_)
+        ++pos_;
+        if (AtEnd())
           return ParseError("Incomplete string literal.");
       }
-      ++next_;
+      ++pos_;
     }
-    if (next_ >= end_)
+    if (AtEnd())
       return ParseError("Incomplete string literal.");
-    ++next_;
+    ++pos_;
     result.type = LiteralType::STRING_LITERAL;
     if (has_escape) {
       std::string& target = result.value;
       target.clear();
-      target.reserve(next_ - from - 2); // upper bound
-      // *from is the starting quote. *(next_-1) is the ending quote.
+      target.reserve(pos_ - from - 2); // upper bound
+      // input_[from] is the starting quote. input_[pos_-1] is the ending quote.
       // Copy what is in-between, except for the escape character
-      while (++from < next_ - 1) {
+      while (++from < pos_ - 1) {
         // Copy current char, if not escape, or next char otherwise.
-        target.push_back(*from != '\\' ? (*from) : *(++from));
+        target.push_back(input_[from] != '\\' ? input_[from] : input_[++from]);
       }
     } else {
-      result.value = std::string(from + 1, next_ - from - 2); // skip enclosing quotes
+      result.value = std::string(input_.substr(from + 1, pos_ - from - 2)); // skip enclosing quotes
     }
     return Common::Status::OK();
   }
 
   // Simplify the next ifs by consuming a possible negative sign.
   if (nextch == '-') {
-    ++next_;
+    ++pos_;
     nextch = NextChar();
   }
 
@@ -186,13 +186,13 @@ Common::Status ParserBase::Parse(Literal& result) {
   if (isalpha(nextch)) {
     // Has to be a special float literal now: (-)*(nan|inf|infinity).
     if (NextIsValidFloatString()) {
-      while (next_ < end_ && isalpha(*next_)) {
-        ++next_;
+      while (!AtEnd() && IsAlpha(Cur())) {
+        ++pos_;
       }
       ONNX_TRY {
-        static_cast<void>(LocaleIndependentStof(std::string(from, next_ - from)));
+        static_cast<void>(LocaleIndependentStof(std::string(input_.substr(from, pos_ - from))));
         result.type = LiteralType::FLOAT_LITERAL;
-        result.value = std::string(from, next_ - from);
+        result.value = std::string(input_.substr(from, pos_ - from));
       }
       ONNX_CATCH(...) {
         ONNX_HANDLE_EXCEPTION([&]() { return ParseError("Encountered invalid float literal!"); });
@@ -205,31 +205,31 @@ Common::Status ParserBase::Parse(Literal& result) {
 
   // Checking for numeric ints or float literal.
   if (isdigit(nextch)) {
-    ++next_;
+    ++pos_;
 
-    while ((next_ < end_) && (isdigit(*next_) || (*next_ == '.'))) {
-      if (*next_ == '.') {
+    while (!AtEnd() && (IsDigit(Cur()) || (Cur() == '.'))) {
+      if (Cur() == '.') {
         if (decimal_point)
           break; // Only one decimal point allowed in numeric literal
         decimal_point = true;
       }
-      ++next_;
+      ++pos_;
     }
 
-    if (next_ == from)
+    if (pos_ == from)
       return ParseError("Value expected but not found.");
 
     // Optional exponent syntax: (e|E)(+|-)?[0-9]+
-    if ((next_ < end_) && ((*next_ == 'e') || (*next_ == 'E'))) {
+    if (!AtEnd() && ((Cur() == 'e') || (Cur() == 'E'))) {
       decimal_point = true; // treat as float-literal
-      ++next_;
-      if ((next_ < end_) && ((*next_ == '+') || (*next_ == '-')))
-        ++next_;
-      while ((next_ < end_) && (isdigit(*next_)))
-        ++next_;
+      ++pos_;
+      if (!AtEnd() && ((Cur() == '+') || (Cur() == '-')))
+        ++pos_;
+      while (!AtEnd() && IsDigit(Cur()))
+        ++pos_;
     }
 
-    result.value = std::string(from, next_ - from);
+    result.value = std::string(input_.substr(from, pos_ - from));
     result.type = decimal_point ? LiteralType::FLOAT_LITERAL : LiteralType::INT_LITERAL;
   }
   return Common::Status::OK();
@@ -237,23 +237,23 @@ Common::Status ParserBase::Parse(Literal& result) {
 
 bool ParserBase::NextIsValidFloatString() {
   auto nextch = NextChar();
-  const auto* const from = next_;
+  const size_t from = pos_;
   constexpr int INFINITY_LENGTH = 8;
 
   if (isalpha(nextch)) {
-    while (next_ < end_ && isalpha(*next_) && (next_ - from) <= INFINITY_LENGTH) {
-      ++next_;
+    while (!AtEnd() && IsAlpha(Cur()) && (pos_ - from) <= INFINITY_LENGTH) {
+      ++pos_;
     }
 
-    if (isdigit(*next_)) { // No trailing digits
-      next_ = from;
+    if (!AtEnd() && IsDigit(Cur())) { // No trailing digits
+      pos_ = from;
       return false;
     }
 
-    std::string candidate = std::string(from, next_ - from);
+    std::string candidate = std::string(input_.substr(from, pos_ - from));
 
     // Reset parser location before continuing.
-    next_ = from;
+    pos_ = from;
 
     std::transform(
         candidate.begin(), candidate.end(), candidate.begin(), [](unsigned char c) { return std::tolower(c); });

--- a/onnx/defs/parser.h
+++ b/onnx/defs/parser.h
@@ -7,8 +7,10 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cctype>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 
 #include "onnx/common/common.h"
@@ -180,23 +182,20 @@ class KeyWordMap {
 
 class ParserBase {
  public:
-  explicit ParserBase(const std::string& str)
-      : start_(str.data()), next_(str.data()), end_(str.data() + str.length()), saved_pos_(next_) {}
-
-  explicit ParserBase(const char* cstr) : start_(cstr), next_(cstr), end_(cstr + strlen(cstr)), saved_pos_(next_) {}
+  explicit ParserBase(std::string_view input) : input_(input) {}
 
   void SavePos() {
-    saved_pos_ = next_;
+    saved_pos_ = pos_;
   }
 
   void RestorePos() {
-    next_ = saved_pos_;
+    pos_ = saved_pos_;
   }
 
   std::string GetCurrentPos() {
     uint32_t line = 1, col = 1;
-    for (const char* p = start_; p < next_; ++p) {
-      if (*p == '\n') {
+    for (size_t i = 0; i < pos_; ++i) {
+      if (input_[i] == '\n') {
         ++line;
         col = 1;
       } else {
@@ -209,17 +208,20 @@ class ParserBase {
   // Return a suitable suffix of what has been parsed to provide error message context:
   // return the line containing the last non-space character preceding the error (if it exists).
   std::string GetErrorContext() {
-    // Special cases: empty input string, and parse-error at first character.
-    const char* p = next_ < end_ ? next_ : next_ - 1;
-    while ((p > start_) && isspace(*p))
+    if (input_.empty())
+      return std::string();
+    // Special case: a parse-error at end of input starts from the last character.
+    size_t p = (pos_ < input_.size()) ? pos_ : input_.size() - 1;
+    while ((p > 0) && IsSpace(input_[p]))
       --p;
-    while ((p > start_) && (*p != '\n'))
+    while ((p > 0) && (input_[p] != '\n'))
       --p;
     // Start at character after '\n' unless we are at start of input
-    const char* context_start = (p > start_) ? (p + 1) : start_;
-    for (p = context_start; (p < end_) && (*p != '\n'); ++p)
-      ;
-    return std::string(context_start, p - context_start);
+    size_t context_start = (p > 0) ? (p + 1) : 0;
+    size_t context_end = context_start;
+    while ((context_end < input_.size()) && (input_[context_end] != '\n'))
+      ++context_end;
+    return std::string(input_.substr(context_start, context_end - context_start));
   }
 
   template <typename... Args>
@@ -233,27 +235,27 @@ class ParserBase {
 
   void SkipWhiteSpace() {
     do {
-      while ((next_ < end_) && (isspace(*next_)))
-        ++next_;
-      if ((next_ >= end_) || ((*next_) != '#'))
+      while (!AtEnd() && IsSpace(Cur()))
+        ++pos_;
+      if (AtEnd() || (Cur() != '#'))
         return;
-      // Skip rest of the line:
-      while ((next_ < end_) && ((*next_) != '\n'))
-        ++next_;
+      // Skip rest of the line; the loop then consumes the newline as whitespace.
+      pos_ = std::min(input_.find('\n', pos_), input_.size());
     } while (true);
   }
 
   int NextChar(bool skipspace = true) {
     if (skipspace)
       SkipWhiteSpace();
-    return (next_ < end_) ? *next_ : 0;
+    // Return as unsigned char so the value is safe to pass to ctype functions.
+    return AtEnd() ? 0 : static_cast<unsigned char>(Cur());
   }
 
   bool Matches(char ch, bool skipspace = true) {
     if (skipspace)
       SkipWhiteSpace();
-    if ((next_ < end_) && (*next_ == ch)) {
-      ++next_;
+    if (!AtEnd() && (Cur() == ch)) {
+      ++pos_;
       return true;
     }
     return false;
@@ -267,7 +269,7 @@ class ParserBase {
 
   bool EndOfInput() {
     SkipWhiteSpace();
-    return (next_ >= end_);
+    return AtEnd();
   }
 
   enum class LiteralType : std::uint8_t { UNDEFINED, INT_LITERAL, FLOAT_LITERAL, STRING_LITERAL };
@@ -284,8 +286,7 @@ class ParserBase {
     CHECK_PARSER_STATUS(Parse(literal))
     if (literal.type != LiteralType::INT_LITERAL)
       return ParseError("Integer value expected, but not found.");
-    std::string s = literal.value;
-    val = std::stoll(s);
+    val = std::stoll(literal.value);
     return Common::Status::OK();
   }
 
@@ -294,8 +295,7 @@ class ParserBase {
     CHECK_PARSER_STATUS(Parse(literal))
     if (literal.type != LiteralType::INT_LITERAL)
       return ParseError("Integer value expected, but not found.");
-    std::string s = literal.value;
-    val = std::stoull(s);
+    val = std::stoull(literal.value);
     return Common::Status::OK();
   }
 
@@ -341,13 +341,13 @@ class ParserBase {
   // return an empty-string identifier.
   std::string ParseOptionalIdentifier() {
     SkipWhiteSpace();
-    const auto* from = next_;
-    if ((next_ < end_) && (isalpha(*next_) || (*next_ == '_'))) {
-      ++next_;
-      while ((next_ < end_) && (isalnum(*next_) || (*next_ == '_')))
-        ++next_;
+    size_t from = pos_;
+    if (!AtEnd() && (IsAlpha(Cur()) || (Cur() == '_'))) {
+      ++pos_;
+      while (!AtEnd() && (IsAlnum(Cur()) || (Cur() == '_')))
+        ++pos_;
     }
-    return std::string(from, next_ - from);
+    return std::string(input_.substr(from, pos_ - from));
   }
 
   Common::Status ParseIdentifier(std::string& id) {
@@ -410,17 +410,38 @@ class ParserBase {
   }
 
  protected:
-  const char* start_;
-  const char* next_;
-  const char* end_;
-  const char* saved_pos_;
+  // True when the cursor has consumed all input.
+  bool AtEnd() const {
+    return pos_ >= input_.size();
+  }
+  // Character at the cursor; only valid when !AtEnd().
+  char Cur() const {
+    return input_[pos_];
+  }
+  // ctype wrappers that pass the character as unsigned char (UB otherwise for bytes > 127).
+  static bool IsSpace(char c) {
+    return std::isspace(static_cast<unsigned char>(c));
+  }
+  static bool IsAlpha(char c) {
+    return std::isalpha(static_cast<unsigned char>(c));
+  }
+  static bool IsAlnum(char c) {
+    return std::isalnum(static_cast<unsigned char>(c));
+  }
+  static bool IsDigit(char c) {
+    return std::isdigit(static_cast<unsigned char>(c));
+  }
+
+  std::string_view input_;
+  size_t pos_ = 0;
+  size_t saved_pos_ = 0;
 
   bool NextIsValidFloatString();
 };
 
 class OnnxParser : public ParserBase {
  public:
-  explicit OnnxParser(const char* cstr) : ParserBase(cstr) {}
+  using ParserBase::ParserBase;
 
   ONNX_API Common::Status Parse(TensorShapeProto& shape);
 
@@ -447,7 +468,7 @@ class OnnxParser : public ParserBase {
   ONNX_API Common::Status Parse(ModelProto& model);
 
   template <typename T>
-  static Common::Status Parse(T& parsedData, const char* input) {
+  static Common::Status Parse(T& parsedData, std::string_view input) {
     OnnxParser parser(input);
     return parser.Parse(parsedData);
   }

--- a/onnx/test/cpp/parser_test.cc
+++ b/onnx/test/cpp/parser_test.cc
@@ -28,8 +28,7 @@ static void Parse(T& parsedData, std::string_view input) {
   // We cannot expect equality between text1 and input due to white-space and syntactic sugar,
   // so, we convert it once more, and check for equality.
   T temp;
-  // Pass a string_view so this resolves to the static Parse(T&, std::string_view)
-  // overload rather than a two-argument member overload.
+  // Pass a string_view to exercise the std::string_view overload explicitly.
   status = OnnxParser::Parse(temp, std::string_view(text1));
   EXPECT_TRUE(status.IsOK()) << status.ErrorMessage();
   std::string text2 = ProtoToString(temp);

--- a/onnx/test/cpp/parser_test.cc
+++ b/onnx/test/cpp/parser_test.cc
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <clocale>
+#include <cmath>
 #include <string>
+#include <string_view>
 
 #include "gtest/gtest.h"
 #include "onnx/checker.h"
@@ -14,7 +16,7 @@ namespace ONNX_NAMESPACE {
 namespace Test {
 
 template <typename T>
-static void Parse(T& parsedData, const char* input) {
+static void Parse(T& parsedData, std::string_view input) {
   OnnxParser parser(input);
   auto status = parser.Parse(parsedData);
   EXPECT_TRUE(status.IsOK()) << status.ErrorMessage();
@@ -26,19 +28,21 @@ static void Parse(T& parsedData, const char* input) {
   // We cannot expect equality between text1 and input due to white-space and syntactic sugar,
   // so, we convert it once more, and check for equality.
   T temp;
-  status = OnnxParser::Parse(temp, text1.c_str());
+  // Pass a string_view so this resolves to the static Parse(T&, std::string_view)
+  // overload rather than a two-argument member overload.
+  status = OnnxParser::Parse(temp, std::string_view(text1));
   EXPECT_TRUE(status.IsOK()) << status.ErrorMessage();
   std::string text2 = ProtoToString(temp);
   EXPECT_EQ(text1, text2);
 }
 
 template <typename T>
-static void ExpectParseFailure(T& parsedData, const char* input) {
+static void ExpectParseFailure(T& parsedData, std::string_view input) {
   auto status = OnnxParser::Parse(parsedData, input);
   EXPECT_FALSE(status.IsOK());
 }
 
-static void CheckModel(const char* code) {
+static void CheckModel(std::string_view code) {
   ModelProto model;
   Parse(model, code);
 
@@ -55,6 +59,19 @@ TEST(ParserTest, EscapeStringLiteral) {
   EXPECT_TRUE(status.IsOK()) << status.ErrorMessage();
   EXPECT_TRUE(parser.EndOfInput()) << "Extra unparsed input unexpected.";
   EXPECT_EQ(s, std::string("123\"56\\89"));
+}
+
+TEST(ParserTest, NonNulTerminatedStringView) {
+  // The view is just "inf"; the backing buffer continues with a digit. A buffer
+  // over-read past the view would see '9' and reject the valid float literal.
+  std::string backing = "inf9";
+  std::string_view view(backing.data(), 3);
+  OnnxParser parser(view);
+  float val = 0.0f;
+  auto status = parser.ParserBase::Parse(val);
+  EXPECT_TRUE(status.IsOK()) << status.ErrorMessage();
+  EXPECT_TRUE(std::isinf(val));
+  EXPECT_TRUE(parser.EndOfInput()) << "Extra unparsed input unexpected.";
 }
 
 TEST(ParserTest, TypeTest) {


### PR DESCRIPTION
### Motivation and Context

ParserBase took the input as a const std::string& or a const char* (the latter computing its end with strlen) and tracked the cursor with four raw const char* members. Replace this with a single std::string_view input and size_t offsets, and use string_view methods (size, operator[], substr, find) throughout the scanning code. OnnxParser now inherits the constructor, and its static Parse helper takes std::string_view. All are implicitly constructible from std::string and string literals, so callers are unaffected.

This also removes a latent out-of-bounds read: NextIsValidFloatString dereferenced *next_ without a bounds check, relying on the buffer being NUL-terminated. That held for the old const char*/std::string inputs but not for an arbitrary string_view, so the read is now guarded. Add a regression test parsing a non-NUL-terminated view.

Also pass characters to the ctype functions through unsigned char, which is undefined behavior otherwise for bytes > 127.




 