### PR TITLE
Catch all exceptions in the noexcept proto from_python caster

### DIFF
--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -52,7 +52,9 @@ using BASE_PROTO_TYPE = ::google::protobuf::Message;
         }                                                                                         \
         auto serialized = nanobind::cast<nanobind::bytes>(py_proto.attr("SerializeToString")());  \
         return ParseProtoFromPyBytes(&value, serialized);                                         \
-      } catch (const nanobind::python_error&) {                                                   \
+      } catch (...) {                                                                             \
+        /* from_python is noexcept: nanobind::cast (cast_error) and ParseProtoFromPyBytes      */ \
+        /* (bad_alloc) can throw non-python_error types, which would otherwise call terminate. */ \
         return false;                                                                             \
       }                                                                                           \
     }                                                                                             \


### PR DESCRIPTION
`from_python` in the generated proto type_caster is `noexcept` but caught only `nanobind::python_error`. `nanobind::cast<bytes>` (`cast_error`) and `ParseProtoFromPyBytes` (`bad_alloc`) can throw other types, escaping the `noexcept` function and calling `std::terminate`.

Broaden to `catch (...) { return false; }`, matching the sibling `from_cpp`. `false` is the nanobind "not convertible" signal, so a `TypeError` is raised instead of terminating. `noexcept` is kept (required for casters).