### PR TITLE
Make ONNX_ASSERT* type-safe with std::stringstream

### DIFF
--- a/onnx/common/assertions.cc
+++ b/onnx/common/assertions.cc
@@ -7,40 +7,11 @@
 
 #include "onnx/common/assertions.h"
 
-#include <array>
-#include <cstdarg>
-#include <cstdio>
 #include <string>
 
 #include "onnx/common/common.h"
 
 namespace ONNX_NAMESPACE {
-
-std::string barf(const char* fmt, ...) { // NOLINT(modernize-avoid-variadic-functions)
-  constexpr size_t buffer_size = 2048;
-  std::array<char, buffer_size> msg{};
-  va_list args;
-
-  va_start(args, fmt);
-
-// use fixed length for buffer "msg" to avoid buffer overflow
-// Suppress -Wformat-nonliteral: fmt comes from the variadic parameter,
-// and call sites are checked via the format attribute on the declaration.
-#if defined(__clang__) || defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-#endif
-  vsnprintf(static_cast<char*>(msg.data()), msg.size() - 1, fmt, args);
-#if defined(__clang__) || defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
-
-  // ensure null-terminated string to avoid out of bounds read
-  msg.back() = '\0';
-  va_end(args);
-
-  return std::string(msg.data());
-}
 
 void throw_assert_error(const std::string& msg) {
   ONNX_THROW_EX(assert_error(msg));

--- a/onnx/common/assertions.h
+++ b/onnx/common/assertions.h
@@ -10,6 +10,8 @@
 #include <stdexcept>
 #include <string>
 
+#include "onnx/string_utils.h"
+
 namespace ONNX_NAMESPACE {
 
 struct assert_error : public std::runtime_error {
@@ -21,11 +23,6 @@ struct tensor_error : public assert_error {
  public:
   explicit tensor_error(const std::string& msg) : assert_error(msg) {}
 };
-
-#if defined(__GNUC__) || defined(__clang__)
-__attribute__((format(printf, 1, 2)))
-#endif
-std::string barf(const char* fmt, ...);
 
 [[noreturn]] void throw_assert_error(const std::string& /*msg*/);
 
@@ -39,31 +36,27 @@ std::string barf(const char* fmt, ...);
 #define _ONNX_EXPECT(x, y) (x)
 #endif
 
-#define ONNX_ASSERT(cond)                                                                                 \
-  if (_ONNX_EXPECT(!(cond), 0)) { /* NOLINT(readability-simplify-boolean-expr) */                         \
-    std::string error_msg =                                                                               \
-        ::ONNX_NAMESPACE::barf("%s:%u: %s: Assertion `%s` failed.", __FILE__, __LINE__, __func__, #cond); \
-    throw_assert_error(error_msg);                                                                        \
+// The message arguments are concatenated with std::stringstream (via MakeString),
+// so std::string, std::string_view, and numbers are all supported directly without
+// format specifiers or .c_str().
+#define ONNX_ASSERT(cond)                                                                                           \
+  if (_ONNX_EXPECT(!(cond), 0)) { /* NOLINT(readability-simplify-boolean-expr) */                                   \
+    std::string error_msg =                                                                                         \
+        ::ONNX_NAMESPACE::MakeString(__FILE__, ":", __LINE__, ": ", __func__, ": Assertion `", #cond, "` failed."); \
+    throw_assert_error(error_msg);                                                                                  \
   }
 
-// The following is used to prevent MSVC from passing the whole __VA_ARGS__ list
-// as the first parameter value to a macro call.
-#define ONNX_EXPAND(x) x
-
-// Note: msg must be a string literal
-// The ##__VA_ARGS__ extension removes the trailing comma when __VA_ARGS__ is empty.
-// This is supported by GCC, Clang, and MSVC (since VS 2019 16.6).
-#define ONNX_ASSERTM(cond, msg, ...)                                                                   \
-  /* NOLINTNEXTLINE */                                                                                 \
-  if (_ONNX_EXPECT(!(cond), 0)) {                                                                      \
-    std::string error_msg = ::ONNX_NAMESPACE::barf(                                                    \
-        "%s:%u: %s: Assertion `%s` failed: " msg, __FILE__, __LINE__, __func__, #cond, ##__VA_ARGS__); \
-    throw_assert_error(error_msg);                                                                     \
+#define ONNX_ASSERTM(cond, ...)                                                                      \
+  /* NOLINTNEXTLINE */                                                                               \
+  if (_ONNX_EXPECT(!(cond), 0)) {                                                                    \
+    std::string error_msg = ::ONNX_NAMESPACE::MakeString(                                            \
+        __FILE__, ":", __LINE__, ": ", __func__, ": Assertion `", #cond, "` failed: ", __VA_ARGS__); \
+    throw_assert_error(error_msg);                                                                   \
   }
 
-#define TENSOR_ASSERTM(cond, msg, ...)                                                                 \
-  if (_ONNX_EXPECT(!(cond), 0)) {                                                                      \
-    std::string error_msg = ::ONNX_NAMESPACE::barf(                                                    \
-        "%s:%u: %s: Assertion `%s` failed: " msg, __FILE__, __LINE__, __func__, #cond, ##__VA_ARGS__); \
-    throw_tensor_error(error_msg);                                                                     \
+#define TENSOR_ASSERTM(cond, ...)                                                                    \
+  if (_ONNX_EXPECT(!(cond), 0)) {                                                                    \
+    std::string error_msg = ::ONNX_NAMESPACE::MakeString(                                            \
+        __FILE__, ":", __LINE__, ": ", __func__, ": Assertion `", #cond, "` failed: ", __VA_ARGS__); \
+    throw_tensor_error(error_msg);                                                                   \
   }

--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -256,13 +256,7 @@ struct Attributes {
   using const_iterator = std::vector<AVPtr>::const_iterator;
   const_iterator find(Symbol name, bool required) const {
     auto it = std::find_if(values_.begin(), values_.end(), [&](const AVPtr& v) { return v->name == name; });
-    ONNX_ASSERTM(
-        !required || it != values_.end(),
-        "%s:%u: %s: required undefined attribute '%s'",
-        __FILE__,
-        __LINE__,
-        __func__,
-        name.toString())
+    ONNX_ASSERTM(!required || it != values_.end(), "required undefined attribute '", name.toString(), "'")
     return it;
   }
 };
@@ -759,12 +753,12 @@ struct Node : public Attributes<Node> {
   }
   template <typename T>
   T* expect() {
-    ONNX_ASSERTM(T::Kind == kind(), "expected a %s but found a %s", T::Kind.toString(), kind().toString())
+    ONNX_ASSERTM(T::Kind == kind(), "expected a ", T::Kind.toString(), " but found a ", kind().toString())
     return static_cast<T*>(this);
   }
   template <typename T>
   const T* expect() const {
-    ONNX_ASSERTM(T::Kind == kind(), "expected a %s but found a %s", T::Kind.toString(), kind().toString())
+    ONNX_ASSERTM(T::Kind == kind(), "expected a ", T::Kind.toString(), " but found a ", kind().toString())
     return static_cast<const T*>(this);
   }
 
@@ -866,7 +860,7 @@ class OpSetID final {
       return OpSetID(new_domain, new_version);
     }
     ONNX_CATCH(const std::runtime_error& e) {
-      ONNX_HANDLE_EXCEPTION([&]() { ONNX_ASSERTM(false, "Error in fromString: %s", e.what()) });
+      ONNX_HANDLE_EXCEPTION([&]() { ONNX_ASSERTM(false, "Error in fromString: ", e.what()) });
     }
 
     // The control will never reach here.

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -1654,10 +1654,10 @@ OpName_Domain_Version_Schema_Map& OpSchemaRegistry::map() {
       if (OpSchemaRegistry::Instance()->GetLoadedSchemaVersion() == 0) {
         ONNX_ASSERTM(
             dbg_registered_schema_count == ONNX_DBG_GET_COUNT_IN_OPSETS(),
-            "%zu schema were exposed from operator sets and automatically placed into the static registry.  "
-            "%zu were expected based on calls to registration macros. Operator set functions may need to be updated.",
             dbg_registered_schema_count,
-            ONNX_DBG_GET_COUNT_IN_OPSETS())
+            " schema were exposed from operator sets and automatically placed into the static registry.  ",
+            ONNX_DBG_GET_COUNT_IN_OPSETS(),
+            " were expected based on calls to registration macros. Operator set functions may need to be updated.")
       }
 #endif
     }

--- a/onnx/inliner/inliner.cc
+++ b/onnx/inliner/inliner.cc
@@ -414,7 +414,7 @@ const TypeProto& GetType(const ModelProto& model, const std::string& var) {
     if (vi.name() == var)
       return vi.type();
   }
-  ONNX_ASSERTM(false, "Type unknown for %s", var.c_str())
+  ONNX_ASSERTM(false, "Type unknown for ", var)
 }
 
 void ConvertVersion(ModelProto& model, const NodeProto& call_node, FunctionProto& function, int target_version) {

--- a/onnx/version_converter/BaseConverter.h
+++ b/onnx/version_converter/BaseConverter.h
@@ -61,14 +61,14 @@ class BaseVersionConverter {
         if (adapter_ptr != target_map->second.end()) {
           return *(adapter_ptr->second);
         } else {
-          ONNX_ASSERTM(false, "No Adapter To Version %s for %s", target.c_str(), op_name.c_str())
+          ONNX_ASSERTM(false, "No Adapter To Version ", target, " for ", op_name)
         }
       } else {
-        ONNX_ASSERTM(false, "No Adapter From Version %s for %s", initial.c_str(), op_name.c_str())
+        ONNX_ASSERTM(false, "No Adapter From Version ", initial, " for ", op_name)
       }
     } else {
       // No adapters exist for the given op
-      ONNX_ASSERTM(false, "No Adapter For %s", op_name.c_str())
+      ONNX_ASSERTM(false, "No Adapter For ", op_name)
     }
   }
 

--- a/onnx/version_converter/adapters/Attention_24_23.h
+++ b/onnx/version_converter/adapters/Attention_24_23.h
@@ -26,12 +26,12 @@ class Attention_24_23 final : public Adapter {
     if (inputs.size() > 6) {
       ONNX_ASSERTM(
           false,
-          "%s being converted from %" PRId64 " to %" PRId64
-          " has nonpad_kv_seqlen input, "
-          "which is not supported in opset 23. This conversion cannot be performed.",
-          name().c_str(),
+          name(),
+          " being converted from ",
           static_cast<int64_t>(initial_version().version()),
-          static_cast<int64_t>(target_version().version()))
+          " to ",
+          static_cast<int64_t>(target_version().version()),
+          " has nonpad_kv_seqlen input, which is not supported in opset 23. This conversion cannot be performed.")
     }
   }
 

--- a/onnx/version_converter/adapters/broadcast_backward_compatibility.h
+++ b/onnx/version_converter/adapters/broadcast_backward_compatibility.h
@@ -38,12 +38,12 @@ class BroadcastBackwardCompatibility final : public Adapter {
     int req_broadcast = check_numpy_unibroadcastable_and_require_broadcast(A_sizes, B_sizes);
     ONNX_ASSERTM(
         req_broadcast != -1,
-        "%s being converted from %" PRId64 " to %" PRId64
-        " does "
-        "not have broadcastable inputs.",
-        name().c_str(),
+        name(),
+        " being converted from ",
         static_cast<int64_t>(initial_version().version()),
-        static_cast<int64_t>(target_version().version()))
+        " to ",
+        static_cast<int64_t>(target_version().version()),
+        " does not have broadcastable inputs.")
     if (req_broadcast == 1) {
       // If conditional is not fulfilled, we have a default broadcast
       // Add broadcast attribute

--- a/onnx/version_converter/adapters/gemm_7_6.h
+++ b/onnx/version_converter/adapters/gemm_7_6.h
@@ -45,12 +45,12 @@ class Gemm_7_6 final : public Adapter {
     int req_broadcast = check_numpy_unibroadcastable_and_require_broadcast(MN, C_shape);
     ONNX_ASSERTM(
         req_broadcast != -1,
-        "%s being converted from %" PRId64 " to %" PRId64
-        " does "
-        "not have broadcastable inputs.",
-        name().c_str(),
+        name(),
+        " being converted from ",
         static_cast<int64_t>(initial_version().version()),
-        static_cast<int64_t>(target_version().version()))
+        " to ",
+        static_cast<int64_t>(target_version().version()),
+        " does not have broadcastable inputs.")
     if (req_broadcast == 1) {
       node->i_(kbroadcast, 1);
     }

--- a/onnx/version_converter/adapters/no_previous_version.h
+++ b/onnx/version_converter/adapters/no_previous_version.h
@@ -21,7 +21,7 @@ class NoPreviousVersionAdapter final : public Adapter {
       : Adapter(op_name, initial, target) {}
 
   Node* adapt(std::shared_ptr<Graph> /*unused*/, Node* node) const override {
-    ONNX_ASSERTM(false, "No Previous Version of %s exists", name().c_str())
+    ONNX_ASSERTM(false, "No Previous Version of ", name(), " exists")
     return node;
   }
 };

--- a/onnx/version_converter/adapters/q_dq_21_20.h
+++ b/onnx/version_converter/adapters/q_dq_21_20.h
@@ -33,8 +33,9 @@ class QuantizeLinear_21_20 final : public TypeRestriction {
       if ((node->i(kblock_size) != 0)) {
         ONNX_ASSERTM(
             false,
-            "Blocked quantization is not supported for Opset Version %" PRId64 ".",
-            static_cast<int64_t>(target_version().version()))
+            "Blocked quantization is not supported for Opset Version ",
+            static_cast<int64_t>(target_version().version()),
+            ".")
       }
       node->removeAttribute(kblock_size);
     }
@@ -42,8 +43,9 @@ class QuantizeLinear_21_20 final : public TypeRestriction {
       if (node->i(koutput_dtype) != TensorProto_DataType_UINT8 && node->inputs().size() < 3) {
         ONNX_ASSERTM(
             false,
-            "Attribute output_dtype is not supported for Opset Version %" PRId64 ", supply a zero-point tensor instead",
-            static_cast<int64_t>(target_version().version()))
+            "Attribute output_dtype is not supported for Opset Version ",
+            static_cast<int64_t>(target_version().version()),
+            ", supply a zero-point tensor instead")
       }
       node->removeAttribute(koutput_dtype);
     }
@@ -66,8 +68,9 @@ class DequantizeLinear_21_20 final : public TypeRestriction {
       if ((node->i(kblock_size) != 0)) {
         ONNX_ASSERTM(
             false,
-            "Blocked quantization is not supported for Opset Version %" PRId64 ".",
-            static_cast<int64_t>(target_version().version()))
+            "Blocked quantization is not supported for Opset Version ",
+            static_cast<int64_t>(target_version().version()),
+            ".")
       }
       node->removeAttribute(kblock_size);
     }

--- a/onnx/version_converter/adapters/range_27_26.h
+++ b/onnx/version_converter/adapters/range_27_26.h
@@ -27,18 +27,24 @@ class Range_27_26 final : public Adapter {
     for (const Value* input : node->inputs()) {
       ONNX_ASSERTM(
           std::find(unallowed_types_.begin(), unallowed_types_.end(), input->elemType()) == unallowed_types_.end(),
-          "DataType (%d) of input of operator '%s' is not supported in Opset Version %" PRId64 ".",
+          "DataType (",
           input->elemType(),
-          name().c_str(),
-          static_cast<int64_t>(target_version().version()));
+          ") of input of operator '",
+          name(),
+          "' is not supported in Opset Version ",
+          static_cast<int64_t>(target_version().version()),
+          ".");
     }
     for (const Value* output : node->outputs()) {
       ONNX_ASSERTM(
           std::find(unallowed_types_.begin(), unallowed_types_.end(), output->elemType()) == unallowed_types_.end(),
-          "DataType (%d) of output of operator '%s' is not supported in Opset Version %" PRId64 ".",
+          "DataType (",
           output->elemType(),
-          name().c_str(),
-          static_cast<int64_t>(target_version().version()));
+          ") of output of operator '",
+          name(),
+          "' is not supported in Opset Version ",
+          static_cast<int64_t>(target_version().version()),
+          ".");
     }
     // Remove stash_type — Range v11 has no such attribute.
     if (node->hasAttribute(kstash_type)) {

--- a/onnx/version_converter/adapters/scatter_16_15.h
+++ b/onnx/version_converter/adapters/scatter_16_15.h
@@ -52,11 +52,13 @@ class Scatter_16_15 : public Adapter {
     ONNX_ASSERTM(
         std::find(std::begin(unallowed_types_), std::end(unallowed_types_), val->elemType()) ==
             std::end(unallowed_types_),
-        "DataType (%d) of Input or Output"
-        " of operator '%s' is unallowed for Opset Version %" PRId64 ".",
+        "DataType (",
         val->elemType(),
-        name().c_str(),
-        static_cast<int64_t>(target_version().version()))
+        ") of Input or Output of operator '",
+        name(),
+        "' is unallowed for Opset Version ",
+        static_cast<int64_t>(target_version().version()),
+        ".")
   }
 };
 

--- a/onnx/version_converter/adapters/transformers.h
+++ b/onnx/version_converter/adapters/transformers.h
@@ -32,7 +32,7 @@ inline NodeTransformerFunction RemoveAttribute(Symbol attr) {
 inline NodeTransformerFunction RemoveAttribute(Symbol attr, int64_t value) {
   return NODE_TRANSFORMER(node) {
     if (node->hasAttribute(attr)) {
-      ONNX_ASSERTM(node->i(attr) == value, "Attribute %s must have value %" PRId64, attr.toString(), value)
+      ONNX_ASSERTM(node->i(attr) == value, "Attribute ", attr.toString(), " must have value ", value)
       node->removeAttribute(attr);
     }
     return node;
@@ -44,9 +44,11 @@ inline NodeTransformerFunction RemoveAttribute(Symbol attr, const std::string& v
     if (node->hasAttribute(attr)) {
       ONNX_ASSERTM(
           node->s(attr) == value,
-          "Attribute %s must have value %s for this version conversion",
+          "Attribute ",
           attr.toString(),
-          value.c_str())
+          " must have value ",
+          value,
+          " for this version conversion")
       node->removeAttribute(attr);
     }
     return node;
@@ -56,7 +58,7 @@ inline NodeTransformerFunction RemoveAttribute(Symbol attr, const std::string& v
 inline NodeTransformerFunction RemoveAttributeNotEq(Symbol attr, int64_t value) {
   return NODE_TRANSFORMER(node) {
     if (node->hasAttribute(attr)) {
-      ONNX_ASSERTM(node->i(attr) != value, "Attribute %s must not have value %" PRId64, attr.toString(), value)
+      ONNX_ASSERTM(node->i(attr) != value, "Attribute ", attr.toString(), " must not have value ", value)
       node->removeAttribute(attr);
     }
     return node;

--- a/onnx/version_converter/adapters/type_restriction.h
+++ b/onnx/version_converter/adapters/type_restriction.h
@@ -49,11 +49,13 @@ class TypeRestriction : public Adapter {
     ONNX_ASSERTM(
         std::find(std::begin(unallowed_types_), std::end(unallowed_types_), val->elemType()) ==
             std::end(unallowed_types_),
-        "DataType (%d) of Input or Output"
-        " of operator '%s' is unallowed for Opset Version %" PRId64 ".",
+        "DataType (",
         val->elemType(),
-        name().c_str(),
-        static_cast<int64_t>(target_version().version()))
+        ") of Input or Output of operator '",
+        name(),
+        "' is unallowed for Opset Version ",
+        static_cast<int64_t>(target_version().version()),
+        ".")
   }
 };
 

--- a/onnx/version_converter/convert.h
+++ b/onnx/version_converter/convert.h
@@ -90,9 +90,11 @@ class DefaultVersionConverter : public BaseVersionConverter {
   void assertInVersionRange(int64_t version) const {
     ONNX_ASSERTM(
         version >= version_range.first && version <= version_range.second,
-        "Warning: invalid version (must be between %d and %d)",
+        "Warning: invalid version (must be between ",
         version_range.first,
-        version_range.second)
+        " and ",
+        version_range.second,
+        ")")
   }
 
   void assertDefaultDomain(const std::string& initial_domain, const std::string& target_domain) const {

--- a/onnx/version_converter/helper.cc
+++ b/onnx/version_converter/helper.cc
@@ -53,30 +53,29 @@ void assert_numpy_multibroadcastable(
   for (size_t i = 0; i < B_sizes.size(); i++) {
     ONNX_ASSERTM(
         B_sizes[i].dim == A_sizes[axis + i].dim || B_sizes[i].dim == 1 || A_sizes[axis + i].dim == 1,
-        "Dimension %zu of input %d does not match "
-        "dimension %zu of input %d, and neither's value is 1",
+        "Dimension ",
         i,
+        " of input ",
         B,
+        " does not match dimension ",
         axis + i,
-        A)
+        " of input ",
+        A,
+        ", and neither's value is 1")
   }
 }
 
 void assertNotParams(const std::vector<Dimension>& sizes) {
   for (const Dimension& dim : sizes) {
-    ONNX_ASSERTM(dim.is_int, "%s Dimension is a param instead of an int.", dim.param.c_str())
+    ONNX_ASSERTM(dim.is_int, dim.param, " Dimension is a param instead of an int.")
   }
 }
 
 void assertInputsAvailable(const ArrayRef<Value*>& inputs, const char* name, uint64_t num_inputs) {
   ONNX_ASSERTM(
-      inputs.size() == num_inputs,
-      "%s in opset version 6 can only broadcast"
-      " between %" PRIu64 " inputs",
-      name,
-      num_inputs)
+      inputs.size() == num_inputs, name, " in opset version 6 can only broadcast between ", num_inputs, " inputs")
   for (size_t i = 0; i < num_inputs; i++) {
-    ONNX_ASSERTM(inputs[i]->has_sizes(), "Shape of input %zu is not available.", i)
+    ONNX_ASSERTM(inputs[i]->has_sizes(), "Shape of input ", i, " is not available.")
     assertNotParams(inputs[i]->sizes());
   }
 }

--- a/onnx/version_converter/helper.h
+++ b/onnx/version_converter/helper.h
@@ -31,16 +31,18 @@ void assertInputsAvailable(const ArrayRef<Value*>& inputs, const char* name, uin
 inline std::vector<int64_t> ReadInt64Tensor(const Tensor& tensor) {
   ONNX_ASSERTM(
       tensor.elem_type() == ONNX_NAMESPACE::TensorProto_DataType_INT64,
-      "expected INT64 tensor, got elem_type=%d",
+      "expected INT64 tensor, got elem_type=",
       tensor.elem_type())
   if (tensor.is_raw_data()) {
     const size_t raw_bytes = tensor.raw().size();
     // elem_num() returns 1 for scalars, so covers dims=[].
     ONNX_ASSERTM(
         raw_bytes == static_cast<size_t>(tensor.elem_num()) * sizeof(int64_t),
-        "INT64 tensor: %zu raw bytes does not match dims (%lld elements)",
+        "INT64 tensor: ",
         raw_bytes,
-        static_cast<long long>(tensor.elem_num()))
+        " raw bytes does not match dims (",
+        tensor.elem_num(),
+        " elements)")
   }
   return ParseData<int64_t>(&tensor);
 }


### PR DESCRIPTION
Replace the printf `barf` helper behind `ONNX_ASSERT*` with `MakeString` (stringstream), so messages concatenate `std::string`/`std::string_view`/numbers directly — no format specifiers, no `.c_str()`, no 2048-byte truncation. All format call sites are converted.

Removes now-unused public symbols `barf` and `ONNX_EXPAND` from the (EXPERIMENTAL) `assertions.h`; no internal callers. Also fixes a pre-existing doubled `file:line:` prefix in `ir.h`.