### PR TITLE
Add topological-gap seeds to version converter fuzz corpus

### DIFF
--- a/onnx/fuzz/make_seed_corpus.py
+++ b/onnx/fuzz/make_seed_corpus.py
@@ -40,6 +40,42 @@ def _make_model(
     return model.SerializeToString()
 
 
+def _make_model_unchecked(
+    op_type: str,
+    opset_version: int,
+    node_inputs: list[str],
+    node_outputs: list[str],
+    graph_inputs: list[str],
+    graph_outputs: list[str],
+    attrs=None,
+) -> bytes:
+    """Serialized ModelProto with explicit, possibly inconsistent graph I/O.
+
+    The graph output need not be produced by the node, so the result can carry
+    a topological gap (an output or node input that nothing produces) to seed
+    the version converter's undefined-name handling.
+    """
+    if attrs is None:
+        attrs = {}
+
+    def vi(name: str):
+        return helper.make_tensor_value_info(name, TensorProto.FLOAT, [1])
+
+    node = helper.make_node(op_type, node_inputs, node_outputs, **attrs)
+    graph = helper.make_graph(
+        [node],
+        f"{op_type.lower()}-unchecked",
+        [vi(n) for n in graph_inputs],
+        [vi(n) for n in graph_outputs],
+    )
+    model = helper.make_model(
+        graph,
+        producer_name="oss-fuzz",
+        opset_imports=[helper.make_opsetid("", opset_version)],
+    )
+    return model.SerializeToString()
+
+
 # Text-format seeds for fuzz_parser, extracted from onnx/test/parser_test.py.
 # Each string is a valid input to onnx.parser.parse_model().
 _PARSER_SEEDS: dict[str, str] = {
@@ -451,6 +487,17 @@ def main() -> int:
         "upsample_6_missing_input.onnx": _make_model("Upsample", 6, []),
         "upsample_9_missing_scales.onnx": _make_model("Upsample", 9, ["X"]),
         "upsample_9_valid.onnx": _make_model("Upsample", 9, ["X", "scales"]),
+        # Models with a topological gap (an output or node input that nothing
+        # produces) seed graphProtoToGraph's undefined-name handling directly.
+        "identity_13_output_undefined.onnx": _make_model_unchecked(
+            "Identity", 13, ["X"], ["Y"], ["X"], ["Z"]
+        ),
+        "add_13_output_partial_undefined.onnx": _make_model_unchecked(
+            "Add", 13, ["X", "X"], ["Y"], ["X"], ["Y", "Z"]
+        ),
+        "add_13_node_input_undefined.onnx": _make_model_unchecked(
+            "Add", 13, ["X", "W"], ["Y"], ["X"], ["Y"]
+        ),
     }
 
     # Seed models for fuzz_checker: valid serialized ModelProtos covering a


### PR DESCRIPTION
## Summary

The `fuzz_version_converter` harness reaches `graphProtoToGraph`, but its seed corpus in `make_seed_corpus.py` only contained well-formed-output models — every graph output was produced by a node. That anchored coverage away from the undefined-name handling that #8121 fixes (a null `Value*` dereference on an undefined top-level graph output), so the fuzzer never explored that region.

## Changes

- Add `_make_model_unchecked`, a builder that — unlike `_make_model` — does not require the graph output to be produced by the node, so a seed can carry a deliberate topological gap.
- Add three `version_converter` seeds with such gaps:
  - `identity_13_output_undefined` — a graph output that nothing produces (the exact trigger for #8121)
  - `add_13_output_partial_undefined` — one output produced, one not (exercises a later iteration of the output loop)
  - `add_13_node_input_undefined` — a node input that nothing produces (anchors the sibling input path)

These seed the fuzzer directly next to the undefined-name handling instead of forcing it to invent the gap from well-formed models.

## Verification

- `make_seed_corpus.py` generates all five corpus zips without error.
- On a build with #8121, each new seed reaches `graphProtoToGraph` and raises `ConvertError` (`Output Z is undefined!` / `Input W is undefined!`) rather than crashing; on an unfixed build the two output-undefined seeds reproduce the SEGV.
- `lintrunner` clean.

## Note

The two `*_output_undefined` seeds dereference a null `Value*` on a build without #8121, so this should land alongside or after #8121.
