### PR TITLE
Guard against null schema in FunctionExpandHelper

### DIFF
--- a/onnx/defs/function.cc
+++ b/onnx/defs/function.cc
@@ -72,6 +72,11 @@ void FunctionExpandHelper(
 
   const OpSchemaRegistry* schema_registry = OpSchemaRegistry::Instance();
   const auto* const schema = schema_registry->GetSchema(node.op_type(), domain_version, node.domain());
+  if (schema == nullptr) {
+    ONNX_THROW(
+        "No schema registered for op '" + node.op_type() + "' in domain '" + node.domain() + "' at version " +
+        std::to_string(domain_version) + " while expanding function node " + node_name);
+  }
   const auto& default_attrs = schema->attributes();
 
   for (const auto& [attr_name, attr] : default_attrs) {


### PR DESCRIPTION
`FunctionExpandHelper` looks up the schema of the function node to pull default
attribute values, but dereferenced the result without a null check:

```cpp
const auto* const schema = schema_registry->GetSchema(node.op_type(), domain_version, node.domain());
auto default_attrs = schema->attributes();   // null deref if not registered
```

`OpSchemaRegistry::GetSchema` returns `nullptr` (its documented "not found"
contract) when the op/domain isn't registered, or when every registered version
is greater than the resolved opset version. `FunctionExpandHelper` is a public
`ONNX_API` entry point, so a node referencing an unregistered/custom op (or a
too-low version) reaches this path and dereferences null.

Add a guard that throws a clear error instead, consistent with the existing
`ONNX_THROW` checks in this function and the null checks other `GetSchema`
callers already perform (e.g. `checker.cc`).

Verified: C++ gtests 102/102, lintrunner, clang-tidy clean.
