### PR TITLE
Collapse redundant shape-inference helper overloads

### DIFF
--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -185,17 +185,9 @@ inline int64_t getRequiredAttributeInt(const InferenceContext& ctx, const std::s
   return attr.i();
 }
 
-inline int64_t getAttribute(const InferenceContext& ctx, const std::string& attributeName, int64_t defaultValue) {
-  const auto* attr_proto = ctx.getAttribute(attributeName);
-  if ((nullptr != attr_proto) && attr_proto->has_i())
-    return attr_proto->i();
-  else if (nullptr != attr_proto)
-    return 0; // protobuf default for integers
-  else
-    return defaultValue;
-}
-
-inline int64_t getAttribute(const DataPropagationContext& ctx, const std::string& attributeName, int64_t defaultValue) {
+// Works for both InferenceContext and DataPropagationContext.
+template <typename Context>
+int64_t getAttribute(const Context& ctx, const std::string& attributeName, int64_t defaultValue) {
   const auto* attr_proto = ctx.getAttribute(attributeName);
   if ((nullptr != attr_proto) && attr_proto->has_i())
     return attr_proto->i();
@@ -320,7 +312,7 @@ inline void propagateElemTypeFromDtypeToOutput(
     InferenceContext& ctx,
     const int data_type,
     size_t outputIndex,
-    TypeProto::ValueCase expected_value_case) {
+    TypeProto::ValueCase expected_value_case = TypeProto::kTensorType) {
   const auto attribute_tensor_datatype = data_type;
   auto* output_type = ctx.getOutputType(outputIndex);
   const auto output_value_case = output_type->value_case();
@@ -339,10 +331,6 @@ inline void propagateElemTypeFromDtypeToOutput(
         ctx.getDisplayName(),
         ".");
   }
-}
-
-inline void propagateElemTypeFromDtypeToOutput(InferenceContext& ctx, const int data_type, size_t outputIndex) {
-  propagateElemTypeFromDtypeToOutput(ctx, data_type, outputIndex, TypeProto::kTensorType);
 }
 
 inline void propagateElemTypeFromDtypeToOutput(InferenceContext& ctx, const AttributeProto* attr, size_t outputIndex) {
@@ -522,8 +510,11 @@ ONNX_API inline void propagateShapeAndTypeFromFirstInput(InferenceContext& ctx) 
   propagateShapeFromInputToOutput(ctx, 0, 0);
 }
 
-inline void
-updateOutputElemType(InferenceContext& ctx, size_t outputIndex, int32_t elemType, TypeProto::ValueCase expected_type) {
+inline void updateOutputElemType(
+    InferenceContext& ctx,
+    size_t outputIndex,
+    int32_t elemType,
+    TypeProto::ValueCase expected_type = TypeProto::kTensorType) {
   auto* output_type = ctx.getOutputType(outputIndex);
   if (output_type == nullptr) {
     fail_type_inference("Output ", outputIndex, " is null");
@@ -541,10 +532,6 @@ updateOutputElemType(InferenceContext& ctx, size_t outputIndex, int32_t elemType
         ctx.getDisplayName(),
         ".");
   }
-}
-
-inline void updateOutputElemType(InferenceContext& ctx, size_t outputIndex, int32_t elemType) {
-  updateOutputElemType(ctx, outputIndex, elemType, TypeProto::kTensorType);
 }
 
 // Infer type of an output from the value of a specified attribute, which is


### PR DESCRIPTION
Collapse three redundant overload sets in `shape_inference.h` (header-inline, source-compatible, call sites unchanged):

- `updateOutputElemType` / `propagateElemTypeFromDtypeToOutput`: default the trailing `ValueCase` to `kTensorType`, drop the thin forwarders.
- `getAttribute(..., int64_t)`: merge the `InferenceContext`/`DataPropagationContext` overloads (identical bodies) into one template.

No behavior change. Verified: full rebuild, gtests 102/102, lintrunner, clang-tidy.
