### PR TITLE
Migrate IR graph node/value ownership to std::unique_ptr

### DIFF
--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -284,7 +284,7 @@ using NodeKind = Symbol;
 
 struct Value final {
   ONNX_DISALLOW_COPY_AND_ASSIGNMENT(Value);
-  Value(Node* node_, size_t offset_);
+  Value(Node& node, size_t offset);
   Value(Value&&) = default;
   Value& operator=(Value&&) = default;
   ~Value() = default;
@@ -431,8 +431,8 @@ struct Node : public Attributes<Node> {
   bool has_overload_{false};
   std::string overload_;
 
- protected:
-  Node(Graph* graph_, NodeKind kind_); // defined after graph
+  // Constructed only by the friend Graph factory, so every Node stays graph-owned.
+  Node(Graph& graph, NodeKind kind); // defined after graph
 
  public:
   bool has_name() const {
@@ -1103,7 +1103,7 @@ struct Graph final {
   }
 
   Node* create(NodeKind kind, size_t num_outputs = 1) {
-    std::unique_ptr<Node> node_owner(new Node(this, kind));
+    std::unique_ptr<Node> node_owner(new Node(*this, kind));
     Node* n = node_owner.get();
     all_nodes.emplace(n, std::move(node_owner));
     for (size_t i = 0; i < num_outputs; i++)
@@ -1112,7 +1112,7 @@ struct Graph final {
   }
 
   // Allocate a Value owned by this graph.
-  Value* createValue(Node* node, size_t offset);
+  Value* createValue(Node& node, size_t offset);
 
   Node* create(NodeKind kind, ArrayRef<Value*> inputs, size_t num_outputs = 1) {
     auto* n = create(kind, num_outputs);
@@ -1243,8 +1243,8 @@ struct Graph final {
   }
 };
 
-inline Value::Value(Node* node, size_t offset)
-    : node_(node), offset_(offset), unique_(node->graph_->getNextUnique()), stage_(node->graph_->new_node_stage_) {}
+inline Value::Value(Node& node, size_t offset)
+    : node_(&node), offset_(offset), unique_(node.graph_->getNextUnique()), stage_(node.graph_->new_node_stage_) {}
 
 inline Graph* Value::owningGraph() {
   return node()->owningGraph();
@@ -1327,9 +1327,9 @@ inline void Value::replaceAllUsesWith(Value* newValue) {
   assert(this->uses().empty());
 }
 
-inline Node::Node(Graph* graph, NodeKind kind) : kind_(kind), graph_(graph), stage_(graph->new_node_stage_) {}
+inline Node::Node(Graph& graph, NodeKind kind) : kind_(kind), graph_(&graph), stage_(graph.new_node_stage_) {}
 
-inline Value* Graph::createValue(Node* node, size_t offset) {
+inline Value* Graph::createValue(Node& node, size_t offset) {
   auto value = std::make_unique<Value>(node, offset);
   Value* v = value.get();
   all_values.emplace(v, std::move(value));
@@ -1337,7 +1337,7 @@ inline Value* Graph::createValue(Node* node, size_t offset) {
 }
 
 inline Value* Node::addOutput() {
-  Value* v = graph_->createValue(this, outputs_.size());
+  Value* v = graph_->createValue(*this, outputs_.size());
   outputs_.push_back(v);
   return v;
 }

--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -800,26 +800,6 @@ struct Node : public Attributes<Node> {
     this->next() = nullptr;
     this->prev() = nullptr;
   }
-
- protected:
-  // subclasses must override
-  // this function is used by createClone to initialize a new version
-  // of a node in another graph. It should allocate a new instance of the same
-  // concrete type as 'this', but in graph 'g' which might be different
-  // than graph_
-  virtual Node* allocNewInstance(Graph* g) {
-    return new Node(g, kind());
-  }
-  // create a copy of all properties of Node s into this.
-  // subclasses should extend if they have additional information to copy.
-  // 'this' will be allocated with s->allocNewInstance(g) so it should have
-  // the same concrete type as 's'
-  //
-  // NB: This does NOT clone stages.  You're expected to set the stage correctly
-  // if you are going to preserve it.
-  virtual void cloneFrom(Node* s) {
-    copyAttributes(*s);
-  }
 };
 
 // A class with the same properties as OperatorSetIdProto, but without protobuf

--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -18,6 +18,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -616,10 +617,7 @@ struct Node : public Attributes<Node> {
     }
   }
 
-  Value* addOutput() {
-    outputs_.push_back(new Value(this, outputs_.size()));
-    return outputs_.back();
-  }
+  Value* addOutput();
 
   void eraseOutput(size_t i);
 
@@ -879,8 +877,8 @@ struct Graph final {
   // actual representation of Graph is done with
   // inputs, outputs, nodes
 
-  std::unordered_set<const Node*> all_nodes;
-  std::unordered_set<const Value*> all_values;
+  std::unordered_map<const Node*, std::unique_ptr<const Node>> all_nodes;
+  std::unordered_map<const Value*, std::unique_ptr<const Value>> all_values;
   size_t next_unique_{0};
 
   size_t new_node_stage_{0};
@@ -909,7 +907,8 @@ struct Graph final {
       return false;
     }
     const auto f = [&name](const Value* v) { return v->uniqueName() == name; };
-    for (const Node* node : all_nodes) {
+    for (const auto& node_entry : all_nodes) {
+      const Node* node = node_entry.first;
       for (const auto& attr : node->attributeNames()) {
         if (node->kindOf(attr) == AttributeKind::g) {
           const auto& subgraph = node->g(attr);
@@ -1104,12 +1103,16 @@ struct Graph final {
   }
 
   Node* create(NodeKind kind, size_t num_outputs = 1) {
-    // NB: Node constructor adds node to all_nodes
-    auto* n = new Node(this, kind);
+    std::unique_ptr<Node> node_owner(new Node(this, kind));
+    Node* n = node_owner.get();
+    all_nodes.emplace(n, std::move(node_owner));
     for (size_t i = 0; i < num_outputs; i++)
       n->addOutput();
     return n;
   }
+
+  // Allocate a Value owned by this graph.
+  Value* createValue(Node* node, size_t offset);
 
   Node* create(NodeKind kind, ArrayRef<Value*> inputs, size_t num_outputs = 1) {
     auto* n = create(kind, num_outputs);
@@ -1160,12 +1163,7 @@ struct Graph final {
     }
   }
 
-  ~Graph() {
-    for (const Node* n : all_nodes)
-      delete n;
-    for (const Value* v : all_values)
-      delete v;
-  }
+  ~Graph() = default;
 
   std::string toString() const {
     std::ostringstream oss;
@@ -1191,7 +1189,8 @@ struct Graph final {
   void forSelfAndEachSubGraph(const std::function<void(Graph*)>& fn) {
     fn(this);
 
-    for (const Node* node : all_nodes) {
+    for (const auto& node_entry : all_nodes) {
+      const Node* node = node_entry.first;
       for (const auto& attr : node->attributeNames()) {
         if (node->kindOf(attr) == AttributeKind::g) {
           std::shared_ptr<Graph> subgraph = node->g(attr);
@@ -1235,21 +1234,17 @@ struct Graph final {
   void freeNode(Node* n) {
     auto it = all_nodes.find(n);
     ONNX_ASSERT(it != all_nodes.end())
-    delete *it;
     all_nodes.erase(it);
   }
   void freeValue(Value* v) {
     auto it = all_values.find(v);
     ONNX_ASSERT(it != all_values.end())
-    delete *it;
     all_values.erase(it);
   }
 };
 
 inline Value::Value(Node* node, size_t offset)
-    : node_(node), offset_(offset), unique_(node->graph_->getNextUnique()), stage_(node->graph_->new_node_stage_) {
-  node->graph_->all_values.emplace(this);
-}
+    : node_(node), offset_(offset), unique_(node->graph_->getNextUnique()), stage_(node->graph_->new_node_stage_) {}
 
 inline Graph* Value::owningGraph() {
   return node()->owningGraph();
@@ -1332,8 +1327,19 @@ inline void Value::replaceAllUsesWith(Value* newValue) {
   assert(this->uses().empty());
 }
 
-inline Node::Node(Graph* graph, NodeKind kind) : kind_(kind), graph_(graph), stage_(graph->new_node_stage_) {
-  graph_->all_nodes.emplace(this);
+inline Node::Node(Graph* graph, NodeKind kind) : kind_(kind), graph_(graph), stage_(graph->new_node_stage_) {}
+
+inline Value* Graph::createValue(Node* node, size_t offset) {
+  auto value = std::make_unique<Value>(node, offset);
+  Value* v = value.get();
+  all_values.emplace(v, std::move(value));
+  return v;
+}
+
+inline Value* Node::addOutput() {
+  Value* v = graph_->createValue(this, outputs_.size());
+  outputs_.push_back(v);
+  return v;
 }
 
 inline void Node::eraseOutput(size_t i) {

--- a/onnx/version_converter/adapters/scan_9_8.h
+++ b/onnx/version_converter/adapters/scan_9_8.h
@@ -62,7 +62,7 @@ struct Scan_9_8 final : public Adapter {
 
     node->removeAllInputs();
 
-    Value* v = node->owningGraph()->createValue(node, 0);
+    Value* v = node->owningGraph()->createValue(*node, 0);
     v->setUniqueName("");
     v->setElemType(TensorProto_DataType::TensorProto_DataType_INT32);
     node->addInput(v);

--- a/onnx/version_converter/adapters/scan_9_8.h
+++ b/onnx/version_converter/adapters/scan_9_8.h
@@ -62,7 +62,7 @@ struct Scan_9_8 final : public Adapter {
 
     node->removeAllInputs();
 
-    Value* v = new Value(node, 0);
+    Value* v = node->owningGraph()->createValue(node, 0);
     v->setUniqueName("");
     v->setElemType(TensorProto_DataType::TensorProto_DataType_INT32);
     node->addInput(v);


### PR DESCRIPTION
## Summary

`Graph` (in the experimental `onnx/common/ir.h`) owned its `Node`s and `Value`s through raw-pointer sets, with manual `delete` loops in `~Graph`/`freeNode`/`freeValue` and `Node`/`Value` constructors that self-registered into those sets.

Replace that with explicit `std::unique_ptr` ownership:

- `all_nodes` / `all_values` become `std::unordered_map<const T*, std::unique_ptr<const T>>` — keyed by the raw observer pointer (O(1) lookup/erase) with the `unique_ptr` holding ownership.
- Creation flows through factories (`Graph::create`, the new `Graph::createValue`, `Node::addOutput`) that build the `unique_ptr` and return a non-owning observer, instead of self-registering constructors.
- `~Graph` is now `= default` and `freeNode`/`freeValue` simply `erase` from the map; destruction is automatic.

The many raw `Node*`/`Value*` pointers elsewhere are observers and correctly stay raw. This is a genuine fix for `cppcoreguidelines-owning-memory` — no raw owning pointers, no `gsl::owner`, no suppressions.

## Validation

- Builds clean with `ONNX_BUILD_TESTS=1`.
- All 102 C++ gtests pass.
- All 141 version-converter Python tests pass (exercises the changed `scan_9_8` adapter).
- `clang-tidy` `cppcoreguidelines-owning-memory` reports zero violations on the IR headers.

## Note

Stacked on #8133 (removes the dead `allocNewInstance`/`cloneFrom` cloning API). Its commit appears here too and will drop out once #8133 merges — review the "Migrate IR graph node/value ownership…" commit for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
