### PR TITLE
Update loop shape inference

### DIFF
--- a/onnx/defs/controlflow/utils.cc
+++ b/onnx/defs/controlflow/utils.cc
@@ -7,6 +7,8 @@
 #include <string>
 #include <vector>
 
+#include "onnx/defs/tensor_proto_util.h"
+
 namespace ONNX_NAMESPACE {
 
 void ClearShape(TypeProto& input_type) {
@@ -136,6 +138,17 @@ void LoopInferenceFunction(InferenceContext& ctx) {
           num_outputs + 1);
     }
 
+    // Try to get the trip count from input 0 ('M') to use as the first
+    // dimension of scan outputs when the value is statically known.
+    int64_t trip_count = -1; // -1 means unknown
+    const auto* trip_count_data = ctx.getInputData(0);
+    if (trip_count_data != nullptr && trip_count_data->data_type() == TensorProto_DataType_INT64) {
+      const auto data = ParseData<int64_t>(trip_count_data);
+      if (data.size() == 1 && data[0] >= 0) {
+        trip_count = data[0];
+      }
+    }
+
     // check loop state values match. we should already have type/shape info
     for (size_t i = 0; i < num_outputs; ++i) {
       const auto* const subgraph_output_type = subgraph_output_types[i + 1]; // skip 'cond'
@@ -176,8 +189,11 @@ void LoopInferenceFunction(InferenceContext& ctx) {
 
           mutable_inferred_shape->clear_dim();
 
-          // add empty dimension for number of iterations
-          mutable_inferred_shape->add_dim();
+          // add dimension for number of iterations; use known trip count if available
+          auto* iter_dim = mutable_inferred_shape->add_dim();
+          if (trip_count >= 0) {
+            iter_dim->set_dim_value(trip_count);
+          }
 
           // add dimensions from subgraph output shape
           for (const auto& dim : subgraph_output_type->tensor_type().shape().dim()) {

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -7039,7 +7039,49 @@ class TestShapeInference(TestShapeInferenceHelper):
             graph, [make_tensor_value_info("loop_output", TensorProto.FLOAT, (None, 3))]
         )
 
-    def test_constantofshape_with_input_shape(self) -> None:
+    def test_loop_with_known_trip_count(self) -> None:
+        # Like test_loop_no_state but with a known-value trip count passed as an initializer.
+        # The first dimension of each scan output should be inferred as the trip count.
+        input_value_infos = [
+            make_tensor_value_info("iter_num_in", TensorProto.INT64, (1,)),
+            make_tensor_value_info("cond_in", TensorProto.UNDEFINED, None),
+        ]
+        output_value_infos = [
+            make_tensor_value_info("cond_out", TensorProto.UNDEFINED, None),
+            make_tensor_value_info("output", TensorProto.FLOAT, (3,)),
+        ]
+
+        subgraph = helper.make_graph(
+            [
+                make_node("Identity", ["cond_in"], ["cond_out"]),
+                make_node("Identity", ["outer_scope_input"], ["output"]),
+            ],
+            "subgraph",
+            input_value_infos,
+            output_value_infos,
+        )
+
+        graph = self._make_graph(
+            [
+                ("max_trip_count", TensorProto.INT64, (1,)),
+                ("cond_orig", TensorProto.FLOAT, (1,)),
+                ("outer_scope_input", TensorProto.FLOAT, (3,)),
+            ],
+            [
+                make_node(
+                    "Loop",
+                    ["max_trip_count", "cond_orig"],
+                    ["loop_output"],
+                    body=subgraph,
+                )
+            ],
+            [],
+            initializer=[make_tensor("max_trip_count", TensorProto.INT64, (1,), [5])],
+        )
+
+        self._assert_inferred(
+            graph, [make_tensor_value_info("loop_output", TensorProto.FLOAT, (5, 3))]
+        )
         graph = self._make_graph(
             [],
             [

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -7042,45 +7042,21 @@ class TestShapeInference(TestShapeInferenceHelper):
     def test_loop_with_known_trip_count(self) -> None:
         # Like test_loop_no_state but with a known-value trip count passed as an initializer.
         # The first dimension of each scan output should be inferred as the trip count.
-        input_value_infos = [
-            make_tensor_value_info("iter_num_in", TensorProto.INT64, (1,)),
-            make_tensor_value_info("cond_in", TensorProto.UNDEFINED, None),
-        ]
-        output_value_infos = [
-            make_tensor_value_info("cond_out", TensorProto.UNDEFINED, None),
-            make_tensor_value_info("output", TensorProto.FLOAT, (3,)),
-        ]
-
-        subgraph = helper.make_graph(
-            [
-                make_node("Identity", ["cond_in"], ["cond_out"]),
-                make_node("Identity", ["outer_scope_input"], ["output"]),
-            ],
-            "subgraph",
-            input_value_infos,
-            output_value_infos,
-        )
-
-        graph = self._make_graph(
-            [
-                ("max_trip_count", TensorProto.INT64, (1,)),
-                ("cond_orig", TensorProto.FLOAT, (1,)),
-                ("outer_scope_input", TensorProto.FLOAT, (3,)),
-            ],
-            [
-                make_node(
-                    "Loop",
-                    ["max_trip_count", "cond_orig"],
-                    ["loop_output"],
-                    body=subgraph,
-                )
-            ],
-            [],
-            initializer=[make_tensor("max_trip_count", TensorProto.INT64, (1,), [5])],
-        )
-
+        model = onnx.parser.parse_model("""
+            <ir_version: 10, opset_import: ["" : 22]>
+            test (bool cond_orig, float[3] outer_scope_input) => (loop_output)
+            <int64[1] max_trip_count = {5}>
+            {
+                loop_output = Loop (max_trip_count, cond_orig) <
+                    body = subgraph (int64[1] iter_num_in, bool cond_in) => (bool cond_out, float[3] output) {
+                        cond_out = Identity(cond_in)
+                        output = Identity(outer_scope_input)
+                    }
+                >
+            }
+        """)
         self._assert_inferred(
-            graph, [make_tensor_value_info("loop_output", TensorProto.FLOAT, (5, 3))]
+            model, [make_tensor_value_info("loop_output", TensorProto.FLOAT, (5, 3))]
         )
         graph = self._make_graph(
             [],

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -7058,6 +7058,8 @@ class TestShapeInference(TestShapeInferenceHelper):
         self._assert_inferred(
             model, [make_tensor_value_info("loop_output", TensorProto.FLOAT, (5, 3))]
         )
+
+    def test_constantofshape_with_input_shape(self) -> None:
         graph = self._make_graph(
             [],
             [


### PR DESCRIPTION
When the number of iterations of a loop is statically known, set the first dimension of scan outputs' shape accordingly. (Currently, it is left unset, as "unknown"). 