### PR TITLE
Add loop test case with static loop bound

### DIFF
--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -7039,6 +7039,30 @@ class TestShapeInference(TestShapeInferenceHelper):
             graph, [make_tensor_value_info("loop_output", TensorProto.FLOAT, (None, 3))]
         )
 
+    def test_loop_with_constant_trip_count_and_early_exit(self) -> None:
+        model = onnx.parser.parse_model(
+            """
+            <ir_version: 8, opset_import: ["" : 13]>
+            test () => ()
+               <int64 max_trip_count = {5}, bool cond_orig = {1}, float[3] outer_scope_input = {1, 2, 3}>
+            {
+               loop_output = Loop (max_trip_count, cond_orig) <body: graph = subgraph (int64 iter_num_in, bool cond_in) => (bool cond_out, float[3] output) {
+                  cond_out = Constant <value: tensor = bool cond_out_value {0}> ()
+                  output = Identity (outer_scope_input)
+               }>
+            }
+            """
+        )
+        inferred_model = self._inferred(model, data_prop=True)
+        loop_output = next(
+            value_info
+            for value_info in inferred_model.graph.value_info
+            if value_info.name == "loop_output"
+        )
+        first_dim = loop_output.type.tensor_type.shape.dim[0]
+        self.assertFalse(first_dim.HasField("dim_value") and first_dim.dim_value == 5)
+        self.assertEqual(loop_output.type.tensor_type.shape.dim[1].dim_value, 3)
+
     def test_constantofshape_with_input_shape(self) -> None:
         graph = self._make_graph(
             [],


### PR DESCRIPTION
Add a test-case for Loops with a statically known trip count that exits early (before the trip count is reached).

### Motivation and Context

PR https://github.com/onnx/onnx/pull/7661 proposed to "improve" the shape-inference for loops in the cases where the trip count is statically known. But it is unsafe to do that without further checks because loops can exit early before the trip count is reached. This PR adds a test-case to cover this scenario.

- **Regression coverage**
  - Add a `shape_inference_test.py` case for `Loop` with a constant `max_trip_count` and a body that forces termination after the first iteration.
  - Verify the inferred scan-output shape keeps an unknown leading dimension instead of specializing it to the trip count.

- **Test shape**
  - Model the trip count and initial condition as initializers so shape inference sees the count as statically known.
  - Keep the per-iteration scan element shape fixed to ensure the assertion isolates the leading-dimension behavior.

```python
first_dim = loop_output.type.tensor_type.shape.dim[0]
self.assertFalse(
    first_dim.HasField("dim_value") and first_dim.dim_value == trip_count
)
```
