### PR TITLE
Use int64_t for version values in internal shape-inference plumbing

### DIFF
--- a/onnx/common/ir_pb_converter.cc
+++ b/onnx/common/ir_pb_converter.cc
@@ -17,7 +17,7 @@
 namespace ONNX_NAMESPACE {
 
 // Part 1: convert ONNX Protobuf to IR
-static std::unique_ptr<Graph> graphProtoToGraph(const GraphProto& gp, bool nested, int ir_version = IR_VERSION);
+static std::unique_ptr<Graph> graphProtoToGraph(const GraphProto& gp, bool nested, int64_t ir_version = IR_VERSION);
 
 static Tensor tensorProtoToTensor(const ONNX_NAMESPACE::TensorProto& tp) {
   Tensor ret;
@@ -119,7 +119,7 @@ static Tensor tensorProtoToTensor(const ONNX_NAMESPACE::TensorProto& tp) {
   return ret;
 }
 
-static void convertAttribute(const ONNX_NAMESPACE::AttributeProto& ap, Node& n, const int ir_version = IR_VERSION) {
+static void convertAttribute(const ONNX_NAMESPACE::AttributeProto& ap, Node& n, const int64_t ir_version = IR_VERSION) {
   Symbol sym = Symbol(ap.name());
   switch (ap.type()) {
     case ONNX_NAMESPACE::AttributeProto_AttributeType_FLOAT:
@@ -204,7 +204,7 @@ static void convertAttribute(const ONNX_NAMESPACE::AttributeProto& ap, Node& n, 
   }
 }
 
-static void convertAttributes(const ONNX_NAMESPACE::NodeProto& np, Node& n, const int ir_version = IR_VERSION) {
+static void convertAttributes(const ONNX_NAMESPACE::NodeProto& np, Node& n, const int64_t ir_version = IR_VERSION) {
   for (int i = 0; i < np.attribute_size(); i++) {
     convertAttribute(np.attribute(i), n, ir_version);
   }
@@ -239,7 +239,7 @@ static Value* createDummyValue(
   return v;
 }
 
-std::unique_ptr<Graph> graphProtoToGraph(const ONNX_NAMESPACE::GraphProto& gp, bool nested, const int ir_version) {
+std::unique_ptr<Graph> graphProtoToGraph(const ONNX_NAMESPACE::GraphProto& gp, bool nested, const int64_t ir_version) {
   auto g = std::make_unique<Graph>();
 
   if (gp.has_name()) {

--- a/onnx/defs/schema.cc
+++ b/onnx/defs/schema.cc
@@ -1529,13 +1529,13 @@ OpSchema::NodeDeterminism OpSchema::GetNodeDeterminism() const {
       return NodeDeterminism::Unknown;
     } else if (const FunctionProto* func_proto = GetFunction(); func_proto) {
       const OpSchemaRegistry& reg = *OpSchemaRegistry::Instance();
-      std::unordered_map<std::string, int> domain_to_opset_version;
+      std::unordered_map<std::string, int64_t> domain_to_opset_version;
       for (const auto& opset : func_proto->opset_import()) {
         domain_to_opset_version[opset.domain()] = opset.version();
       }
       for (const NodeProto& n : func_proto->node()) {
-        const int opset = domain_to_opset_version[n.domain()];
-        const OpSchema* sch = reg.GetSchema(n.op_type(), opset, n.domain());
+        const int64_t opset = domain_to_opset_version[n.domain()];
+        const OpSchema* sch = reg.GetSchema(n.op_type(), static_cast<int>(opset), n.domain());
         if (!sch) {
           return NodeDeterminism::Unknown;
         }

--- a/onnx/shape_inference/implementation.cc
+++ b/onnx/shape_inference/implementation.cc
@@ -684,7 +684,7 @@ class ShapeInferenceImplBase {
       const ModelLocalFunctionsMap& model_local_functions_map_in,
       const ISchemaRegistry* schema_registry_in = OpSchemaRegistry::Instance(),
       DataValueMap* generated_shape_data_by_name_in = nullptr,
-      const int ir_version_in = IR_VERSION,
+      const int64_t ir_version_in = IR_VERSION,
       std::shared_ptr<std::unordered_set<const FunctionProto*>> active_functions_in = nullptr)
       : inferred_types(graph),
         value_types_by_name(outer_scope_value_types_by_name_in),
@@ -741,7 +741,7 @@ class ShapeInferenceImplBase {
   const ModelLocalFunctionsMap& model_local_functions_map;
   const ISchemaRegistry* schema_registry;
   DataValueMap* generated_shape_data_by_name;
-  int ir_version;
+  int64_t ir_version;
   std::shared_ptr<std::unordered_set<const FunctionProto*>> active_functions;
   GraphInferenceContext graph_inference_context;
 
@@ -770,7 +770,7 @@ void InferShapesImpl(
     const ModelLocalFunctionsMap& model_local_functions_map,
     const ISchemaRegistry* schema_registry = OpSchemaRegistry::Instance(),
     DataValueMap* generated_shape_data_by_name = nullptr,
-    const int ir_version = IR_VERSION // default the latest one
+    const int64_t ir_version = IR_VERSION // default the latest one
 ) {
   DataValueMap empty;
   if (generated_shape_data_by_name == nullptr) {

--- a/onnx/shape_inference/implementation.h
+++ b/onnx/shape_inference/implementation.h
@@ -101,7 +101,7 @@ struct GraphInferenceContext {
       const ModelLocalFunctionsMap& model_local_functions_in = {},
       const ISchemaRegistry* schema_registry_in = OpSchemaRegistry::Instance(),
       DataValueMap* generated_shape_data_by_name_in = nullptr,
-      const int ir_version_in = IR_VERSION)
+      const int64_t ir_version_in = IR_VERSION)
       : outer_scope_value_types_by_name{&outer_scope_value_types_by_name_in},
         opset_imports{std::move(opset_imports_in)},
         symbol_table{symbol_table_in},
@@ -116,7 +116,7 @@ struct GraphInferenceContext {
   const ModelLocalFunctionsMap& model_local_functions;
   const ISchemaRegistry* schema_registry;
   DataValueMap* generated_shape_data_by_name;
-  const int ir_version;
+  const int64_t ir_version;
 };
 
 class GraphInferencerImpl : public GraphInferencer {


### PR DESCRIPTION
### Description

`ModelProto::ir_version()` and `OperatorSetIdProto::version()` are `int64_t`, but internal plumbing carried these version values as `int`. This widens the **non-exported** carriers to `int64_t` so they match the proto source:

- the `ir_version` parameter/field threaded through `graphProtoToGraph` / `convertAttribute(s)` (`ir_pb_converter.cc`), `InferShapesImpl`, and `GraphInferenceContext`;
- the local `domain_to_opset_version` map in `OpSchema::GetNodeDeterminism`.

**Public API/ABI is intentionally preserved.** `OperatorSetVersion`, `OpSchema::SinceVersion`, and the pure-virtual `ISchemaRegistry::GetSchema(int)` are left as `int`. The one narrowing that is genuinely forced by the public `GetSchema(int)` boundary is now an explicit `static_cast<int>` there, instead of an implicit truncation at the map assignment.

### Scope / safety

- Change is contained to `ir_pb_converter.cc`, `implementation.{cc,h}`, and `schema.cc`; no other TU constructs `GraphInferenceContext` or calls the (static) `graphProtoToGraph`.
- `ir_version` is only ever compared (`>= 4`), never fed into an `int` sink after widening.
- Verified: the edited TUs plus every TU referencing these symbols compile clean under the full `clang-tidy` config.

### Motivation and Context

Type-consistency cleanup: internal version values now match the `int64_t` proto fields they come from. Opset/IR versions are small, so this is not a bug fix — it removes silent `int64_t`→`int` truncations in internal plumbing without touching the public schema API.
