### PR TITLE
Enable modernize-concat-nested-namespaces

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -36,7 +36,6 @@ Checks: >-
   -misc-use-anonymous-namespace,
   modernize-*,
   -modernize-avoid-c-arrays,
-  -modernize-concat-nested-namespaces,
   -modernize-return-braced-init-list,
   -modernize-use-auto,
   -modernize-use-constraints,

--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -57,8 +57,7 @@ struct open_how {
 
 #endif // _WIN32
 
-namespace ONNX_NAMESPACE {
-namespace checker {
+namespace ONNX_NAMESPACE::checker {
 
 #define enforce_has_field(proto, field)                                              \
   do {                                                                               \
@@ -1572,5 +1571,4 @@ bool check_is_experimental_op(const NodeProto& node) {
 #undef enforce_has_field
 #undef enforce_non_empty_field
 
-} // namespace checker
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::checker

--- a/onnx/checker.h
+++ b/onnx/checker.h
@@ -15,8 +15,7 @@
 #include "onnx/onnx-data.pb.h"
 #include "onnx/string_utils.h"
 
-namespace ONNX_NAMESPACE {
-namespace checker {
+namespace ONNX_NAMESPACE::checker {
 // std::string member means copy may throw when allocation fails
 // NOLINTNEXTLINE(bugprone-exception-copy-constructor-throws)
 class ValidationError final : public std::runtime_error {
@@ -200,5 +199,4 @@ int64_t open_external_data(
     bool read_only);
 ONNX_API bool check_is_experimental_op(const NodeProto& node);
 
-} // namespace checker
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::checker

--- a/onnx/common/status.cc
+++ b/onnx/common/status.cc
@@ -10,8 +10,7 @@
 
 #include "onnx/string_utils.h"
 
-namespace ONNX_NAMESPACE {
-namespace Common {
+namespace ONNX_NAMESPACE::Common {
 
 Status::Status(StatusCategory category, StatusCode code, const std::string& msg) {
   assert(StatusCode::OK != code);
@@ -85,5 +84,4 @@ const std::string& Status::EmptyString() {
   return empty_str;
 }
 
-} // namespace Common
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::Common

--- a/onnx/common/status.h
+++ b/onnx/common/status.h
@@ -12,8 +12,7 @@
 
 #include "onnx/onnx_pb.h"
 
-namespace ONNX_NAMESPACE {
-namespace Common {
+namespace ONNX_NAMESPACE::Common {
 
 enum class StatusCategory : std::uint8_t {
   NONE = 0,
@@ -95,5 +94,4 @@ inline std::ostream& operator<<(std::ostream& out, const Status& status) {
   return out << status.ToString();
 }
 
-} // namespace Common
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::Common

--- a/onnx/common/visitor.h
+++ b/onnx/common/visitor.h
@@ -5,8 +5,7 @@
 #pragma once
 #include "onnx/onnx_pb.h"
 
-namespace ONNX_NAMESPACE {
-namespace internal {
+namespace ONNX_NAMESPACE::internal {
 
 // Visitor: A readonly visitor class for ONNX Proto objects.
 // This class is restricted to Nodes, Graphs, Attributes, and Functions.
@@ -114,5 +113,4 @@ struct MutableVisitor {
   virtual ~MutableVisitor() = default;
 };
 
-} // namespace internal
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::internal

--- a/onnx/defs/data_type_utils.cc
+++ b/onnx/defs/data_type_utils.cc
@@ -9,8 +9,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
-namespace ONNX_NAMESPACE {
-namespace Utils {
+namespace ONNX_NAMESPACE::Utils {
 namespace {
 
 // ASCII-only whitespace check; isspace is locale-dependent.
@@ -405,5 +404,4 @@ TypesWrapper::TypesWrapper() {
 
 } // namespace
 
-} // namespace Utils
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::Utils

--- a/onnx/defs/math/utils.cc
+++ b/onnx/defs/math/utils.cc
@@ -10,10 +10,7 @@
 
 #include "onnx/defs/type_builders.h"
 
-namespace ONNX_NAMESPACE {
-namespace defs {
-namespace math {
-namespace utils {
+namespace ONNX_NAMESPACE::defs::math::utils {
 
 static constexpr const char* TopK_ver11_doc = R"DOC(
 Retrieve the top-K largest or smallest elements along a specified axis. Given an input tensor of
@@ -283,7 +280,4 @@ Production must never overflow, and accumulation may overflow if and only if in 
   return QLinearMatMul_doc;
 }
 
-} // namespace utils
-} // namespace math
-} // namespace defs
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::defs::math::utils

--- a/onnx/defs/math/utils.h
+++ b/onnx/defs/math/utils.h
@@ -12,10 +12,7 @@
 #include "onnx/defs/tensor_proto_util.h"
 #include "onnx/onnx_pb.h"
 
-namespace ONNX_NAMESPACE {
-namespace defs {
-namespace math {
-namespace utils {
+namespace ONNX_NAMESPACE::defs::math::utils {
 
 std::function<void(OpSchema&)> TopKOpGenerator(std::vector<std::string> allowed_types);
 
@@ -54,7 +51,4 @@ const char* QLinearMatMulDoc();
 
 int64_t MathOpTwoIntegers(const std::string& op_type, int64_t a, int64_t b);
 
-} // namespace utils
-} // namespace math
-} // namespace defs
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::defs::math::utils

--- a/onnx/defs/nn/utils.cc
+++ b/onnx/defs/nn/utils.cc
@@ -6,10 +6,7 @@
 
 #include <algorithm>
 
-namespace ONNX_NAMESPACE {
-namespace defs {
-namespace nn {
-namespace utils {
+namespace ONNX_NAMESPACE::defs::nn::utils {
 
 std::vector<int64_t> getConvPoolStrides(InferenceContext& ctx, size_t n_input_dims) {
   std::vector<int64_t> strides;
@@ -253,7 +250,4 @@ bool AttentionAppendFunctionCausalMask(const FunctionBodyBuildContext& ctx, Func
   return true;
 }
 
-} // namespace utils
-} // namespace nn
-} // namespace defs
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::defs::nn::utils

--- a/onnx/defs/nn/utils.h
+++ b/onnx/defs/nn/utils.h
@@ -9,10 +9,7 @@
 #include "onnx/defs/function.h"
 #include "onnx/defs/schema.h"
 
-namespace ONNX_NAMESPACE {
-namespace defs {
-namespace nn {
-namespace utils {
+namespace ONNX_NAMESPACE::defs::nn::utils {
 
 /**
  * Reads and validates the 'strides' attribute for Conv/Pool shape inference.
@@ -26,7 +23,4 @@ void AttentionPropagateElemTypeFromInputToOutput(InferenceContext& ctx);
 /** Implements CausalMask for Attention. */
 bool AttentionAppendFunctionCausalMask(const FunctionBodyBuildContext& ctx, FunctionBuilder& builder, bool padding);
 
-} // namespace utils
-} // namespace nn
-} // namespace defs
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::defs::nn::utils

--- a/onnx/defs/sequence/utils.cc
+++ b/onnx/defs/sequence/utils.cc
@@ -11,10 +11,7 @@
 
 #include "onnx/defs/type_builders.h"
 
-namespace ONNX_NAMESPACE {
-namespace defs {
-namespace sequence {
-namespace utils {
+namespace ONNX_NAMESPACE::defs::sequence::utils {
 
 // Common documentation for SplitToSequence operator, versions 11 and 24
 static constexpr const char* SplitToSequence_ver11_doc =
@@ -188,7 +185,4 @@ std::function<void(OpSchema&)> SplitToSequenceOpGenerator(
   };
 }
 
-} // namespace utils
-} // namespace sequence
-} // namespace defs
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::defs::sequence::utils

--- a/onnx/defs/sequence/utils.h
+++ b/onnx/defs/sequence/utils.h
@@ -12,16 +12,10 @@
 #include "onnx/defs/tensor_proto_util.h"
 #include "onnx/onnx_pb.h"
 
-namespace ONNX_NAMESPACE {
-namespace defs {
-namespace sequence {
-namespace utils {
+namespace ONNX_NAMESPACE::defs::sequence::utils {
 
 std::function<void(OpSchema&)> SplitToSequenceOpGenerator(
     std::vector<std::string> input_types,
     std::vector<std::string> output_types);
 
-}
-} // namespace sequence
-} // namespace defs
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::defs::sequence::utils

--- a/onnx/inliner/inliner.cc
+++ b/onnx/inliner/inliner.cc
@@ -22,8 +22,7 @@
 #include "onnx/shape_inference/implementation.h"
 #include "onnx/version_converter/convert.h"
 
-namespace ONNX_NAMESPACE {
-namespace inliner {
+namespace ONNX_NAMESPACE::inliner {
 
 namespace { // internal/private API
 
@@ -802,5 +801,4 @@ std::string Renamer::BindToUniqueName(const std::string& original_name) {
   return pImpl_->GetRenamer().BindToUniqueName(original_name);
 }
 
-} // namespace inliner
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::inliner

--- a/onnx/inliner/inliner.h
+++ b/onnx/inliner/inliner.h
@@ -13,8 +13,7 @@
 #include "onnx/defs/schema.h"
 #include "onnx/onnx_pb.h"
 
-namespace ONNX_NAMESPACE {
-namespace inliner {
+namespace ONNX_NAMESPACE::inliner {
 
 // IR version 10 introduces overloaded function names. The following APIs to specify
 // functions to be inlined currently allow only specifying (domain, name). Thus,
@@ -142,7 +141,6 @@ class Renamer {
   std::unique_ptr<Impl> pImpl_;
 };
 
-} // namespace inliner
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::inliner
 
 #endif // ONNX_INLINER_INLINER_H_

--- a/onnx/shape_inference/attribute_binder.h
+++ b/onnx/shape_inference/attribute_binder.h
@@ -9,8 +9,7 @@
 
 #include "onnx/common/visitor.h"
 
-namespace ONNX_NAMESPACE {
-namespace internal { // internal/private API
+namespace ONNX_NAMESPACE::internal { // internal/private API
 
 using AttributeMap = std::unordered_map<std::string, const AttributeProto*>;
 
@@ -65,5 +64,4 @@ class AttributeBinder : public MutableVisitor {
   const AttributeMap& attr_map_;
 };
 
-} // namespace internal
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::internal

--- a/onnx/shape_inference/implementation.cc
+++ b/onnx/shape_inference/implementation.cc
@@ -21,8 +21,7 @@
 #include "onnx/defs/data_type_utils.h"
 #include "onnx/shape_inference/attribute_binder.h"
 
-namespace ONNX_NAMESPACE {
-namespace shape_inference {
+namespace ONNX_NAMESPACE::shape_inference {
 namespace {
 
 std::string GetValueCaseString(const TypeProto& type) {
@@ -1164,5 +1163,4 @@ void TraverseGraphsToAddExistingSymbols(const GraphProto& g, SymbolTable& symbol
   }
 }
 
-} // namespace shape_inference
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::shape_inference

--- a/onnx/shape_inference/implementation.h
+++ b/onnx/shape_inference/implementation.h
@@ -15,8 +15,7 @@
 #include "onnx/defs/tensor_proto_util.h"
 #include "onnx/string_utils.h"
 
-namespace ONNX_NAMESPACE {
-namespace shape_inference {
+namespace ONNX_NAMESPACE::shape_inference {
 
 using ModelLocalFunctionsMap = std::unordered_map<std::string, const FunctionProto*>;
 
@@ -534,5 +533,4 @@ std::string GetErrorWithNodeInfo(const NodeProto& n, const std::runtime_error& e
 
 void TraverseGraphsToAddExistingSymbols(const GraphProto& g, SymbolTable& symbol_table);
 
-} // namespace shape_inference
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::shape_inference

--- a/onnx/test/cpp/checker_test.cc
+++ b/onnx/test/cpp/checker_test.cc
@@ -19,8 +19,7 @@ namespace fs = std::filesystem;
 
 using ONNX_NAMESPACE::ScopedFd;
 
-namespace ONNX_NAMESPACE {
-namespace Test {
+namespace ONNX_NAMESPACE::Test {
 
 TEST(CHECKER, ValidDataLocationTest) {
 #ifndef ONNX_NO_EXCEPTIONS
@@ -182,5 +181,4 @@ TEST(CHECKER, OpenExternalDataTest) {
 #endif
 }
 
-} // namespace Test
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::Test

--- a/onnx/test/cpp/data_propagation_test.cc
+++ b/onnx/test/cpp/data_propagation_test.cc
@@ -10,8 +10,7 @@
 #include "onnx/defs/schema.h"
 #include "onnx/shape_inference/implementation.h"
 
-namespace ONNX_NAMESPACE {
-namespace Test {
+namespace ONNX_NAMESPACE::Test {
 
 static bool CompareShape(
     const TensorShapeProto& inferredShape,
@@ -408,5 +407,4 @@ agraph (int32[1,2,3,4,5,6,7,8] x) => (int32[3] w)
   EXPECT_TRUE(CompareShape(propagated_tsp, expected_tsp));
 }
 
-} // namespace Test
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::Test

--- a/onnx/test/cpp/function_context_test.cc
+++ b/onnx/test/cpp/function_context_test.cc
@@ -13,8 +13,7 @@
 #include "onnx/defs/function.h"
 #include "onnx/defs/schema.h"
 
-namespace ONNX_NAMESPACE {
-namespace Test {
+namespace ONNX_NAMESPACE::Test {
 
 // Utilities. TODO: Turn them into reusable ONNX utilities for use by
 
@@ -277,5 +276,4 @@ TEST(FunctionAPITest, TypeContextTest) {
   checker::check_function(fnProto, checkerCtx, lexicalScope);
 }
 
-} // namespace Test
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::Test

--- a/onnx/test/cpp/function_get_test.cc
+++ b/onnx/test/cpp/function_get_test.cc
@@ -5,8 +5,7 @@
 #include "gtest/gtest.h"
 #include "onnx/defs/schema.h"
 
-namespace ONNX_NAMESPACE {
-namespace Test {
+namespace ONNX_NAMESPACE::Test {
 
 TEST(FunctionAPITest, GetFunctionOpWithVersion) {
   const auto* const schema = OpSchemaRegistry::Schema("MeanVarianceNormalization", 9, "");
@@ -40,5 +39,4 @@ TEST(FunctionAPITest, GetMeanVarianceNormalizationFunctionWithVersion) {
   }
 }
 
-} // namespace Test
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::Test

--- a/onnx/test/cpp/function_verify_test.cc
+++ b/onnx/test/cpp/function_verify_test.cc
@@ -19,8 +19,7 @@
 #include "onnx/defs/schema.h"
 #include "onnx/shape_inference/implementation.h"
 
-namespace ONNX_NAMESPACE {
-namespace Test {
+namespace ONNX_NAMESPACE::Test {
 using TENSOR_TYPES_MAP = std::unordered_map<std::string, std::vector<std::string>>;
 
 static void GetFunctionProtoOpsetImport(
@@ -564,5 +563,4 @@ foo (x) => (y) {
   ONNX_NAMESPACE::shape_inference::InferShapes(model, OpSchemaRegistry::Instance(), options);
 }
 
-} // namespace Test
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::Test

--- a/onnx/test/cpp/inliner_test.cc
+++ b/onnx/test/cpp/inliner_test.cc
@@ -13,8 +13,7 @@
 #include "onnx/inliner/inliner.h"
 #include "onnx/shape_inference/implementation.h"
 
-namespace ONNX_NAMESPACE {
-namespace Test {
+namespace ONNX_NAMESPACE::Test {
 
 static void InlineFunctions(
     ModelProto& model,
@@ -498,5 +497,4 @@ TEST(Renamer, BasicFunctionality) {
   ASSERT_TRUE(node.output(0).find("test") != std::string::npos); // Should have prefix
 }
 
-} // namespace Test
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::Test

--- a/onnx/test/cpp/ir_test.cc
+++ b/onnx/test/cpp/ir_test.cc
@@ -10,8 +10,7 @@
 #include "onnx/common/ir_pb_converter.h"
 #include "onnx/defs/parser.h"
 
-namespace ONNX_NAMESPACE {
-namespace Test {
+namespace ONNX_NAMESPACE::Test {
 
 static bool IsValidIdentifier(const std::string& name) {
   if (name.empty()) {
@@ -69,5 +68,4 @@ TEST(Tensor, ElemNumLargeTensorNoOverflow) {
   EXPECT_EQ(t.size_from_dim(1), int64_t{50000});
 }
 
-} // namespace Test
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::Test

--- a/onnx/test/cpp/op_reg_test.cc
+++ b/onnx/test/cpp/op_reg_test.cc
@@ -5,8 +5,7 @@
 #include "gtest/gtest.h"
 #include "onnx/defs/schema.h"
 
-namespace ONNX_NAMESPACE {
-namespace Test {
+namespace ONNX_NAMESPACE::Test {
 TEST(OpRegistrationTest, GemmOp) {
   const auto* const opSchema = OpSchemaRegistry::Schema("Gemm");
   EXPECT_TRUE(nullptr != opSchema);
@@ -20,5 +19,4 @@ TEST(OpRegistrationTest, GemmOp) {
   EXPECT_NE(opSchema->attributes().count("beta"), 0);
   EXPECT_EQ(opSchema->attributes().at("beta").type, AttributeProto_AttributeType_FLOAT);
 }
-} // namespace Test
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::Test

--- a/onnx/test/cpp/parser_test.cc
+++ b/onnx/test/cpp/parser_test.cc
@@ -12,8 +12,7 @@
 #include "onnx/defs/parser.h"
 #include "onnx/defs/printer.h"
 
-namespace ONNX_NAMESPACE {
-namespace Test {
+namespace ONNX_NAMESPACE::Test {
 
 template <typename T>
 static void Parse(T& parsedData, std::string_view input) {
@@ -854,5 +853,4 @@ TEST(ParserTest, LocaleIndependentFloatParsing) {
   EXPECT_NEAR(alpha, 0.123f, 1e-6f) << "Float attribute misparsed under non-US locale";
 }
 
-} // namespace Test
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::Test

--- a/onnx/test/cpp/schema_registration_test.cc
+++ b/onnx/test/cpp/schema_registration_test.cc
@@ -6,8 +6,7 @@
 #include "onnx/defs/operator_sets.h"
 #include "onnx/defs/schema.h"
 
-namespace ONNX_NAMESPACE {
-namespace Test {
+namespace ONNX_NAMESPACE::Test {
 
 TEST(SchemaRegistrationTest, DisabledOnnxStaticRegistrationAPICall) {
 #ifdef __ONNX_DISABLE_STATIC_REGISTRATION
@@ -265,5 +264,4 @@ TEST(SchemaRegistrationTest, RegisterAllThenSpecificVersion) {
 #endif
 }
 
-} // namespace Test
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::Test

--- a/onnx/test/cpp/tensor_test.cc
+++ b/onnx/test/cpp/tensor_test.cc
@@ -12,8 +12,7 @@
 #include "onnx/common/tensor.h"
 #include "onnx/defs/tensor_util.h"
 
-namespace ONNX_NAMESPACE {
-namespace Test {
+namespace ONNX_NAMESPACE::Test {
 
 constexpr int64_t kLargeDim = int64_t{1} << 62;
 
@@ -74,5 +73,4 @@ TEST(TensorTest, ParseDataAcceptsAlignedRawData) {
 #endif
 }
 
-} // namespace Test
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::Test

--- a/onnx/version_converter/BaseConverter.h
+++ b/onnx/version_converter/BaseConverter.h
@@ -17,8 +17,7 @@
 #include "onnx/defs/schema.h"
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 // TODO(ONNX): Consider creating interface for this class.
 class BaseVersionConverter {
@@ -86,5 +85,4 @@ class BaseVersionConverter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/Attention_24_23.h
+++ b/onnx/version_converter/adapters/Attention_24_23.h
@@ -12,8 +12,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Attention_24_23 final : public Adapter {
  public:
@@ -41,5 +40,4 @@ class Attention_24_23 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/adapter.h
+++ b/onnx/version_converter/adapters/adapter.h
@@ -14,8 +14,7 @@
 #include "onnx/onnx_pb.h"
 #include "onnx/version_converter/helper.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Adapter {
  private:
@@ -65,5 +64,4 @@ class GenericAdapter final : public Adapter {
   NodeTransformerFunction transformer_;
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/axes_attribute_to_input.h
+++ b/onnx/version_converter/adapters/axes_attribute_to_input.h
@@ -12,8 +12,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class AxesAttributeToInput : public Adapter {
  public:
@@ -44,5 +43,4 @@ class AxesAttributeToInput : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/axes_input_to_attribute.h
+++ b/onnx/version_converter/adapters/axes_input_to_attribute.h
@@ -13,8 +13,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class AxesInputToAttribute : public Adapter {
  public:
@@ -58,5 +57,4 @@ class AxesInputToAttribute : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/axis_attribute_to_input.h
+++ b/onnx/version_converter/adapters/axis_attribute_to_input.h
@@ -10,8 +10,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class AxisAttributeToInput : public Adapter {
  public:
@@ -68,5 +67,4 @@ class AxisAttributeToInput : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/axis_input_to_attribute.h
+++ b/onnx/version_converter/adapters/axis_input_to_attribute.h
@@ -10,8 +10,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 class AxisInputToAttribute : public Adapter {
  public:
   explicit AxisInputToAttribute(
@@ -86,5 +85,4 @@ class AxisInputToAttribute : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/batch_normalization_13_14.h
+++ b/onnx/version_converter/adapters/batch_normalization_13_14.h
@@ -8,8 +8,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class BatchNormalization_13_14 final : public Adapter {
  public:
@@ -28,5 +27,4 @@ class BatchNormalization_13_14 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/broadcast_backward_compatibility.h
+++ b/onnx/version_converter/adapters/broadcast_backward_compatibility.h
@@ -14,8 +14,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class BroadcastBackwardCompatibility final : public Adapter {
  public:
@@ -57,5 +56,4 @@ class BroadcastBackwardCompatibility final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/broadcast_forward_compatibility.h
+++ b/onnx/version_converter/adapters/broadcast_forward_compatibility.h
@@ -13,8 +13,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class BroadcastForwardCompatibility final : public Adapter {
  public:
@@ -82,5 +81,4 @@ class BroadcastForwardCompatibility final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/cast_9_8.h
+++ b/onnx/version_converter/adapters/cast_9_8.h
@@ -10,8 +10,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Cast_9_8 final : public Adapter {
  public:
@@ -29,5 +28,4 @@ class Cast_9_8 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/clip_10_11.h
+++ b/onnx/version_converter/adapters/clip_10_11.h
@@ -10,8 +10,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Clip_10_11 final : public Adapter {
  public:
@@ -52,5 +51,4 @@ class Clip_10_11 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/compatible.h
+++ b/onnx/version_converter/adapters/compatible.h
@@ -12,8 +12,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 struct CompatibleAdapter final : public Adapter {
   explicit CompatibleAdapter(const std::string& op_name, const OpSetID& initial, const OpSetID& target)
@@ -24,5 +23,4 @@ struct CompatibleAdapter final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/dropout_11_12.h
+++ b/onnx/version_converter/adapters/dropout_11_12.h
@@ -11,8 +11,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Dropout_11_12 final : public Adapter {
  public:
@@ -43,5 +42,4 @@ class Dropout_11_12 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/extend_supported_types.h
+++ b/onnx/version_converter/adapters/extend_supported_types.h
@@ -14,8 +14,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 struct ExtendSupportedTypes final : public Adapter {
   explicit ExtendSupportedTypes(const std::string& op_name, const OpSetID& initial, const OpSetID& target)
@@ -100,5 +99,4 @@ struct ExtendSupportedTypes final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/gemm_6_7.h
+++ b/onnx/version_converter/adapters/gemm_6_7.h
@@ -11,8 +11,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Gemm_6_7 final : public Adapter {
  public:
@@ -53,5 +52,4 @@ class Gemm_6_7 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/gemm_7_6.h
+++ b/onnx/version_converter/adapters/gemm_7_6.h
@@ -13,8 +13,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Gemm_7_6 final : public Adapter {
  public:
@@ -62,5 +61,4 @@ class Gemm_7_6 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/gridsample_19_20.h
+++ b/onnx/version_converter/adapters/gridsample_19_20.h
@@ -10,8 +10,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class GridSample_19_20 final : public Adapter {
  public:
@@ -32,5 +31,4 @@ class GridSample_19_20 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/group_normalization_20_21.h
+++ b/onnx/version_converter/adapters/group_normalization_20_21.h
@@ -10,8 +10,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class GroupNormalization_20_21 final : public Adapter {
  public:
@@ -123,5 +122,4 @@ class GroupNormalization_20_21 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/maxpool_8_7.h
+++ b/onnx/version_converter/adapters/maxpool_8_7.h
@@ -10,8 +10,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class MaxPool_8_7 final : public Adapter {
  public:
@@ -30,5 +29,4 @@ class MaxPool_8_7 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/no_previous_version.h
+++ b/onnx/version_converter/adapters/no_previous_version.h
@@ -12,8 +12,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class NoPreviousVersionAdapter final : public Adapter {
  public:
@@ -26,5 +25,4 @@ class NoPreviousVersionAdapter final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/pad_10_11.h
+++ b/onnx/version_converter/adapters/pad_10_11.h
@@ -11,8 +11,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Pad_10_11 final : public Adapter {
  public:
@@ -52,5 +51,4 @@ class Pad_10_11 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/q_dq_21_20.h
+++ b/onnx/version_converter/adapters/q_dq_21_20.h
@@ -14,8 +14,7 @@
 #include "onnx/common/assertions.h"
 #include "onnx/version_converter/adapters/type_restriction.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 static const std::vector<TensorProto_DataType> q_dq_20_unallowed_types = {
     TensorProto_DataType_UINT16,
@@ -83,5 +82,4 @@ class DequantizeLinear_21_20 final : public TypeRestriction {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/range_27_26.h
+++ b/onnx/version_converter/adapters/range_27_26.h
@@ -14,8 +14,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Range_27_26 final : public Adapter {
  public:
@@ -57,5 +56,4 @@ class Range_27_26 final : public Adapter {
   std::vector<TensorProto_DataType> unallowed_types_;
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/remove_consumed_inputs.h
+++ b/onnx/version_converter/adapters/remove_consumed_inputs.h
@@ -11,8 +11,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class RemoveConsumedInputs : public Adapter {
  public:
@@ -26,5 +25,4 @@ class RemoveConsumedInputs : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/reshape_4_5.h
+++ b/onnx/version_converter/adapters/reshape_4_5.h
@@ -11,8 +11,7 @@
 
 #include "onnx/version_converter/adapters/remove_consumed_inputs.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Reshape_4_5 final : public RemoveConsumedInputs {
  public:
@@ -45,5 +44,4 @@ class Reshape_4_5 final : public RemoveConsumedInputs {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/reshape_5_4.h
+++ b/onnx/version_converter/adapters/reshape_5_4.h
@@ -13,8 +13,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Reshape_5_4 final : public Adapter {
  public:
@@ -61,5 +60,4 @@ class Reshape_5_4 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/resize_10_11.h
+++ b/onnx/version_converter/adapters/resize_10_11.h
@@ -11,8 +11,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Resize_10_11 final : public Adapter {
  public:
@@ -49,5 +48,4 @@ class Resize_10_11 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/scan_8_9.h
+++ b/onnx/version_converter/adapters/scan_8_9.h
@@ -12,8 +12,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 struct Scan_8_9 final : public Adapter {
   explicit Scan_8_9() : Adapter("Scan", OpSetID(8), OpSetID(9)) {}
 
@@ -67,5 +66,4 @@ struct Scan_8_9 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/scan_9_8.h
+++ b/onnx/version_converter/adapters/scan_9_8.h
@@ -12,8 +12,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 struct Scan_9_8 final : public Adapter {
   explicit Scan_9_8() : Adapter("Scan", OpSetID(9), OpSetID(8)) {}
@@ -89,5 +88,4 @@ struct Scan_9_8 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/scatter_10_11.h
+++ b/onnx/version_converter/adapters/scatter_10_11.h
@@ -10,8 +10,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Scatter_10_11 final : public Adapter {
  public:
@@ -42,5 +41,4 @@ class Scatter_10_11 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/scatter_16_15.h
+++ b/onnx/version_converter/adapters/scatter_16_15.h
@@ -18,8 +18,7 @@
 #include "onnx/version_converter/adapters/adapter.h"
 #include "onnx/version_converter/adapters/transformers.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Scatter_16_15 : public Adapter {
  public:
@@ -62,5 +61,4 @@ class Scatter_16_15 : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/scatter_18_17.h
+++ b/onnx/version_converter/adapters/scatter_18_17.h
@@ -12,8 +12,7 @@
 #include "onnx/common/interned_strings.h"
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Scatter_18_17 : public Adapter {
  public:
@@ -29,5 +28,4 @@ class Scatter_18_17 : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/slice_9_10.h
+++ b/onnx/version_converter/adapters/slice_9_10.h
@@ -11,8 +11,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Slice_9_10 final : public Adapter {
  public:
@@ -50,5 +49,4 @@ class Slice_9_10 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/softmax_12_13.h
+++ b/onnx/version_converter/adapters/softmax_12_13.h
@@ -11,8 +11,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Softmax_12_13 final : public Adapter {
  public:
@@ -82,5 +81,4 @@ class Softmax_12_13 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/softmax_13_12.h
+++ b/onnx/version_converter/adapters/softmax_13_12.h
@@ -11,8 +11,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Softmax_13_12 final : public Adapter {
  public:
@@ -62,5 +61,4 @@ class Softmax_13_12 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/split_12_13.h
+++ b/onnx/version_converter/adapters/split_12_13.h
@@ -11,8 +11,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Split_12_13 : public Adapter {
  public:
@@ -41,5 +40,4 @@ class Split_12_13 : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/split_13_12.h
+++ b/onnx/version_converter/adapters/split_13_12.h
@@ -13,8 +13,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Split_13_12 : public Adapter {
  public:
@@ -57,5 +56,4 @@ class Split_13_12 : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/split_17_18.h
+++ b/onnx/version_converter/adapters/split_17_18.h
@@ -11,8 +11,7 @@
 #include "onnx/version_converter/adapters/adapter.h"
 #include "onnx/version_converter/adapters/transformers.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Split_17_18 : public Adapter {
  public:
@@ -32,5 +31,4 @@ class Split_17_18 : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/sum_8_7.h
+++ b/onnx/version_converter/adapters/sum_8_7.h
@@ -11,8 +11,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Sum_8_7 final : public Adapter {
  public:
@@ -35,5 +34,4 @@ class Sum_8_7 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/topk_9_10.h
+++ b/onnx/version_converter/adapters/topk_9_10.h
@@ -11,8 +11,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class TopK_9_10 final : public Adapter {
  public:
@@ -39,5 +38,4 @@ class TopK_9_10 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/transformers.h
+++ b/onnx/version_converter/adapters/transformers.h
@@ -18,8 +18,7 @@
 // NOLINTNEXTLINE(bugprone-macro-parentheses)
 #define NODE_TRANSFORMER(node) [=](const std::shared_ptr<Graph>&, Node* node)
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 inline NodeTransformerFunction RemoveAttribute(Symbol attr) {
   return NODE_TRANSFORMER(node) {
@@ -96,5 +95,4 @@ inline NodeTransformerFunction SetAttributeIfAbsent(Symbol attr, int64_t value) 
   };
 }
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/type_restriction.h
+++ b/onnx/version_converter/adapters/type_restriction.h
@@ -14,8 +14,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class TypeRestriction : public Adapter {
  public:
@@ -59,5 +58,4 @@ class TypeRestriction : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/upsample_6_7.h
+++ b/onnx/version_converter/adapters/upsample_6_7.h
@@ -12,8 +12,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 struct Upsample_6_7 final : public Adapter {
   explicit Upsample_6_7() : Adapter("Upsample", OpSetID(6), OpSetID(7)) {}
@@ -44,5 +43,4 @@ struct Upsample_6_7 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/upsample_8_9.h
+++ b/onnx/version_converter/adapters/upsample_8_9.h
@@ -11,8 +11,7 @@
 
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 struct Upsample_8_9 final : public Adapter {
   explicit Upsample_8_9() : Adapter("Upsample", OpSetID(8), OpSetID(9)) {}
@@ -44,5 +43,4 @@ struct Upsample_8_9 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/upsample_9_10.h
+++ b/onnx/version_converter/adapters/upsample_9_10.h
@@ -11,8 +11,7 @@
 
 #include "onnx/common/ir.h"
 #include "onnx/version_converter/adapters/adapter.h"
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Upsample_9_10 final : public Adapter {
  public:
@@ -40,5 +39,4 @@ class Upsample_9_10 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/adapters/upsample_9_8.h
+++ b/onnx/version_converter/adapters/upsample_9_8.h
@@ -15,8 +15,7 @@
 #include "onnx/defs/tensor_util.h"
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 struct Upsample_9_8 final : public Adapter {
   explicit Upsample_9_8() : Adapter("Upsample", OpSetID(9), OpSetID(8)) {}
@@ -75,5 +74,4 @@ struct Upsample_9_8 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/convert.cc
+++ b/onnx/version_converter/convert.cc
@@ -10,8 +10,7 @@
 
 #include "onnx/common/ir_pb_converter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 ModelProto ConvertVersion(const ModelProto& mp_in, int target_version) {
   // Get initial_opsetid from mp_in
@@ -157,5 +156,4 @@ ModelProto DefaultVersionConverter::convert_version(
   return mp_out;
 }
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/convert.h
+++ b/onnx/version_converter/convert.h
@@ -62,8 +62,7 @@
 #include "onnx/version_converter/adapters/upsample_9_10.h"
 #include "onnx/version_converter/adapters/upsample_9_8.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class DefaultVersionConverter : public BaseVersionConverter {
  private:
@@ -994,5 +993,4 @@ class DefaultVersionConverter : public BaseVersionConverter {
 };
 
 ONNX_API ModelProto ConvertVersion(const ModelProto& mp_in, int target_version);
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/helper.cc
+++ b/onnx/version_converter/helper.cc
@@ -8,8 +8,7 @@
 
 #include <vector>
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 int check_numpy_unibroadcastable_and_require_broadcast(
     const std::vector<Dimension>& input1_sizes,
     const std::vector<Dimension>& input2_sizes) {
@@ -78,5 +77,4 @@ void assertInputsAvailable(const ArrayRef<Value*>& inputs, const char* name, uin
     assertNotParams(inputs[i]->sizes());
   }
 }
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion

--- a/onnx/version_converter/helper.h
+++ b/onnx/version_converter/helper.h
@@ -13,8 +13,7 @@
 #include "onnx/common/ir.h"
 #include "onnx/defs/tensor_util.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 int check_numpy_unibroadcastable_and_require_broadcast(
     const std::vector<Dimension>& input1_sizes,
     const std::vector<Dimension>& input2_sizes);
@@ -46,5 +45,4 @@ inline std::vector<int64_t> ReadInt64Tensor(const Tensor& tensor) {
   }
   return ParseData<int64_t>(&tensor);
 }
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion


### PR DESCRIPTION
### Motivation and Context

Enables `modernize-concat-nested-namespaces` and converts the codebase's nested namespace blocks to the C++17 concatenated form:

```cpp
namespace ONNX_NAMESPACE {
namespace defs {
namespace math {
...
} // namespace math
} // namespace defs
} // namespace ONNX_NAMESPACE
```
→
```cpp
namespace ONNX_NAMESPACE::defs::math {
...
} // namespace ONNX_NAMESPACE::defs::math
```

The `ONNX_NAMESPACE` macro is preserved. 