### PR TITLE
Bump nanobind to v2.13.0 and fix Renovate tracking

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -26,7 +26,7 @@
   // Add a note to every Renovate PR body explaining the update context
   "prBodyNotes": [
     "This PR was automatically created by [Renovate Bot](https://docs.renovatebot.com/) to keep build dependencies up to date.",
-    "Renovate manages dependencies **not** handled by Dependabot: manylinux Docker images, nanobind (via CMake FetchContent), googletest (release tarball + SHA256), and the Pixi lockfile.",
+    "Renovate manages dependencies **not** handled by Dependabot: manylinux Docker images, nanobind (via sbom.cdx.json), googletest (release tarball + SHA256), and the Pixi lockfile.",
     "Please review the linked changelog/release notes before merging. A one-week stabilization period (`minimumReleaseAge`) has already elapsed since the new version was published."
   ],
   // Custom managers for dependencies not auto-detected by Renovate
@@ -44,23 +44,28 @@
       "versioningTemplate": "loose"
     },
     {
-      // Detect nanobind version in CMakeLists.txt
+      // Detect nanobind version in sbom.cdx.json. CMakeLists.txt reads the version and
+      // GIT_REPOSITORY URL from this file via sbom_get_dep() (see cmake/Utils.cmake) rather
+      // than hardcoding them, so this is the only place the pin needs to be bumped.
       // Example:
-      //   FetchContent_Declare(
-      //     nanobind
-      //     GIT_REPOSITORY https://github.com/wjakob/nanobind.git
-      //     GIT_TAG v2.10.2
+      //   {
+      //     "type": "library",
+      //     "name": "nanobind",
+      //     "version": "2.12.0",
+      //     "bom-ref": "nanobind",
+      //     "purl": "pkg:github/wjakob/nanobind@v2.12.0",
       // nanobind is fetched via GIT_TAG (git clone), not as a release tarball, so no
-      // URL_HASH is available. If nanobind switches to publishing release tarballs,
-      // this should be migrated to github-releases with a URL + SHA256 hash (like googletest).
+      // hash is recorded here (see the "hashes" field on other sbom.cdx.json entries).
+      // If nanobind switches to publishing release tarballs, this should be migrated to
+      // github-releases with a URL + SHA256 hash (like googletest / protobuf / abseil-cpp).
       "customType": "regex",
-      "fileMatch": ["^CMakeLists\\.txt$"],
+      "fileMatch": ["^sbom\\.cdx\\.json$"],
       "matchStrings": [
-        "FetchContent_Declare\\(\\s*nanobind\\s+GIT_REPOSITORY\\s+https://github\\.com/(?<depName>[^/]+/[^.]+)\\.git\\s+GIT_TAG\\s+(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
+        "\"name\":\\s*\"nanobind\",\\s*\"version\":\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\",\\s*\"bom-ref\":\\s*\"nanobind\",\\s*\"purl\":\\s*\"pkg:github/(?<depName>[^/]+/[^@]+)@v[0-9]+\\.[0-9]+\\.[0-9]+\""
       ],
+      "autoReplaceStringTemplate": "\"name\": \"nanobind\",\n      \"version\": \"{{{newValue}}}\",\n      \"bom-ref\": \"nanobind\",\n      \"purl\": \"pkg:github/{{{depName}}}@v{{{newValue}}}\"",
       // github-tags is used because nanobind publishes tags (e.g. v2.12.0) but not GitHub releases
-      "datasourceTemplate": "github-tags",
-      "extractVersionTemplate": "^v(?<version>.*)$"
+      "datasourceTemplate": "github-tags"
     },
     {
       // Detect googletest release tarball and SHA256 hash in cmake/external/googletest.cmake

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -51,9 +51,9 @@
     {
       "type": "library",
       "name": "nanobind",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "bom-ref": "nanobind",
-      "purl": "pkg:github/wjakob/nanobind@v2.12.0",
+      "purl": "pkg:github/wjakob/nanobind@v2.13.0",
       "externalReferences": [
         {
           "type": "vcs",


### PR DESCRIPTION
## Summary
- Bump the nanobind pin in `sbom.cdx.json` from 2.12.0 to 2.13.0 (`CMakeLists.txt` reads this via `sbom_get_dep()`, so no other file needs a version edit).
- Repoint the Renovate `custom.regex` manager for nanobind at `sbom.cdx.json`. It previously matched a `FetchContent_Declare(...GIT_TAG...)` pattern in `CMakeLists.txt` that no longer exists since the SBOM-based dependency refactor (#7995), so Renovate has never actually opened a nanobind update PR — all prior bumps (2.8.0 → 2.10.2 → 2.12.0) were manual.
- `pixi.toml` / `pixi.lock` are intentionally left untouched (nanobind there is a loose `>=2.8.0` constraint managed separately).

## Test plan
- [x] Verified the new regex matches the current `sbom.cdx.json` nanobind block and captures `currentValue`/`depName` correctly (tested locally with Python's `re`).
- [x] Verified `renovate.json5` still parses as valid JSON5 after the edit.
- [ ] CI build/tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)