### PR TITLE
docs: update experimental and preview operator documentation

### DIFF
--- a/docs/AddNewOp.md
+++ b/docs/AddNewOp.md
@@ -20,6 +20,7 @@ Or updating an existing operator to a new Opset version.
     - [Step 3: PR Review by Operators SIG](#step-3-pr-review-by-operators-sig)
       - [Sign-off](#sign-off)
     - [Step 4: ONNX release](#step-4-onnx-release)
+  - [Preview Domain Path](#preview-domain-path)
   - [Updating an existing operator](#updating-an-existing-operator)
     - [Checklist](#checklist)
   - [Removing operator or function](#removing-operator-or-function)
@@ -75,7 +76,7 @@ Once the criteria of proposing new operator/function has been satisfied, you wil
 | Shape inference tests | `onnx/test/shape_inference_test.py` |
 | Upgrade/downgrade tests | `onnx/test/version_converter/automatic_upgrade_test.py` and `automatic_downgrade_test.py` |
 
-Domain subdirectories under `onnx/defs/`: `math/`, `nn/`, `tensor/`, `logical/`, `reduction/`, `rnn/`, `sequence/`, `image/`, `text/`, `quantization/`, `controlflow/`, `optional/`, `traditionalml/`, `training/`
+Domain subdirectories under `onnx/defs/`: `math/`, `nn/`, `tensor/`, `logical/`, `reduction/`, `rnn/`, `sequence/`, `image/`, `text/`, `quantization/`, `controlflow/`, `optional/`, `traditionalml/`, `training/`, `preview/`
 
 1. Description:
     1. Write a detailed description about the operator, and its expected behavior. Pretty much, the description should be clear enough to avoid confusion between implementors.
@@ -122,6 +123,32 @@ At least two sign-off from the Operators SIG [contributors](https://github.com/o
 ### Step 4: ONNX release
 
 Once the PR is reviewed and signed off by the Operators SIG, it will be merged. Your new operator/function will be part of the main branch and available to anyone building from source. These are not official releases. ONNX periodically releases official new versions that are a snapshot of the main branch. Your new operator/function will be part of that release.
+
+## Preview Domain Path
+
+For operators that are not yet ready for the standard namespace, ONNX provides the preview domains: `ai.onnx.preview` (for standard ops) and `ai.onnx.preview.training` (for training ops). The preview domain is designed to enable active experimentation and collect early feedback before formal standardization.
+
+### Proposing a Preview Operator
+Proposing a preview operator follows a similar path to Step 1 and Step 2 above:
+1. Submit an Issue with a proposal explaining the motivation, use cases, and design.
+2. The proposal must be reviewed and approved by the Operators SIG.
+
+### Implementation and Domain Mapping
+- **Schema Definition**: Place schemas in `onnx/defs/preview/defs.cc` (or `onnx/defs/training/defs.cc` for training ops).
+- **Subdirectory**: The C++ schemas are defined under the `preview/` subdirectory of `onnx/defs/`.
+- **Registration**: Define preview schemas using `ONNX_PREVIEW_OPERATOR_SET_SCHEMA` or `ONNX_PREVIEW_TRAINING_OPERATOR_SET_SCHEMA` macros, and register them in `onnx/defs/operator_sets_preview.h`.
+- **Reference Implementation**: Implement in Python under `onnx/reference/ops/aionnx_preview/`.
+
+### Stability Guarantees
+- **None**: Preview operators carry no backward compatibility guarantees.
+- **Single Version**: Preview domains do not increment their opset versions. They are fixed at version 1. If changes are needed, the existing version 1 specification is modified in-place.
+- **Deprecation/Removal**: A preview operator can be modified or removed at any time if experimentation shows a better design or if it is no longer needed.
+
+### Graduation to Standard Namespace
+Once a preview operator has stabilized and there is community consensus:
+1. Propose promoting the operator to the standard `ai.onnx` or `ai.onnx.training` namespace.
+2. The operator will graduate at a new opset version under the standard namespace.
+3. Once graduated, the preview operator schema under `ai.onnx.preview` (or `ai.onnx.preview.training`) is removed, and users are expected to transition to the standard namespace.
 
 ## Updating an existing operator
 

--- a/docs/ManagingExperimentalOps.md
+++ b/docs/ManagingExperimentalOps.md
@@ -4,7 +4,7 @@ Copyright (c) ONNX Project Contributors
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# Managing Experimental Operators
+# Managing Experimental and Preview Operators
 
 ## Deprecated Experimental Operators
 
@@ -23,20 +23,27 @@ Old operator        |New Operator
 `ParametricSoftplus`|`Mul(alpha, Softplus(Mul(beta, X)))`
 `Scale`             |`Mul(X, scale)`
 `ScaledTanh`        |`Mul(Tanh(Mul(X, beta)), alpha)`
+`Upsample-1`        |`Resize-10`
 
 ## Adding Experimental Operators [Deprecated - as of v1.5 experimental ops are no longer supported]
 
-The experimental flag in ONNX operator definitions indicates that a customer of ONNX may not be able to take a long term dependency on that op. Ops in the ONNX namespace (ai.onnx) in the _main_ branch, whether experimental or not, go through the regular review process.
+The old mechanism of marking standard operators as experimental using the experimental flag (via `SetSupportLevel(OpSchema::SupportType::EXPERIMENTAL)`) has been deprecated and is no longer supported for new operators. 
 
-Experimental ops that are being worked on that do not have consensus yet can be managed in one of 2 ways:
+For historical operators (like `Upsample-1`), this flag has been kept or the operators have been documented as deprecated/removed. For all new experimental features, contributors should follow the **Preview Operator Domains** path described below.
 
-1. Use a fork or branch – what you do in the fork or branch is entirely up to you. When you are ready, you can submit a PR using the normal process. This is the recommended way.
-2. If a fork/branch is not workable (for example due to complexity of mapping different branches between multiple repos), put the experimental ops in a custom namespace in the main branch.
-The specific process for this is:
+## Preview Operator Domains (`ai.onnx.preview` & `ai.onnx.preview.training`)
 
-* Submit an Issue with a proposal explaining the motivation and plan. It does not need to include detailed technical design. Issues will be tagged as "experimental op".
-* Reviewers will generally approve by default unless the proposal directly conflicts with existing ops or somehow goes against general ONNX strategy. Approval is indicated by adding the "experiment approved" tag.
-* The approval is good for 3 months, but can be renewed if needed.
-* Experimental ops should be submitted in a PR in a custom namespace that is the name of the proposal, i.e. “proposal.controlflow”. The name should be descriptive rather than a company or entity name. These PRs will be approved by default as long as the parent proposal is approved and active.
-* Once experimentation is done, the ops can be submitted for addition to the ONNX namespace via the regular process. The owner can also choose to end the experiment without promoting the ops.
-* Either way, the custom namespace is deleted once experimentation is complete or when the approval expires.
+To enable experimentation, research, and community feedback without cluttering the stable standard namespace, ONNX provides two preview domains:
+- `ai.onnx.preview` (for standard operators under development)
+- `ai.onnx.preview.training` (for training-specific operators under development)
+
+These domains function as the successor to the deprecated experimental flag mechanism.
+
+### Key Rules and Characteristics of Preview Domains
+
+1. **No Versioning Guarantees**: Preview operators are registered with a fixed version (version 1) within their respective preview domains (e.g., `ai.onnx.preview` version 1). 
+2. **In-place Modifications**: If changes are needed for a specific preview operator during the experimentation phase, its specification and schema should be modified directly in the repository without increasing its opset version.
+3. **No Stability or Compatibility Guarantees**: Operators in the preview domains can have breaking changes introduced, or can even be completely removed at any time, based on feedback and review.
+4. **Graduation to Standard Namespace**: Once a preview operator is mature and has consensus, it can graduate to the standard namespace (`ai.onnx` or `ai.onnx.training`). At that point, a new version of the operator is defined under the standard namespace, and the old version under the preview domain is eventually removed.
+
+For the step-by-step process on proposing and implementing preview operators, please see [AddNewOp.md](AddNewOp.md#preview-domain-path).

--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -201,5 +201,11 @@ ONNX version|IR version|Opset version ai.onnx|Opset version ai.onnx.ml|Opset ver
 1.20.1|13|25|5|1
 1.21.0|13|26|5|1
 
+### Preview Domains Versioning
+
+The preview domains `ai.onnx.preview` and `ai.onnx.preview.training` do not follow the standard incrementing opset versioning scheme shown in the table above. Instead, they are fixed at version `1`.
+
+Any new operator or update to an operator in these domains is made in-place on version `1` without incrementing the version number. They do not have backward compatibility or stability guarantees. Once a preview operator graduates, it is added to the standard namespace (`ai.onnx` or `ai.onnx.training`) at a new opset version.
+
 The version number is centrally defined in [VERSION_NUMBER](../VERSION_NUMBER).
 Programmatically accessible version information is available from [onnx/helper.py](../onnx/helper.py), `onnx/common/version.h` (auto-generated) and [onnx/defs/schema.h](../onnx/defs/schema.h).

--- a/onnx/defs/preview/defs.cc
+++ b/onnx/defs/preview/defs.cc
@@ -504,7 +504,6 @@ ONNX_PREVIEW_OPERATOR_SET_SCHEMA(
             OPTIONAL_VALUE)
         .TypeConstraint("T1", OpSchema::all_float_types_ir4(), "Constrain Q, K, V to float tensors.")
         .TypeAndShapeInferenceFunction(FlexAttentionShapeInference)
-        .SetSupportLevel(OpSchema::SupportType::EXPERIMENTAL)
         .SetNodeDeterminism(OpSchema::NodeDeterminism::Deterministic)
         .SetContextDependentFunctionBodyBuilder(BuildFlexAttentionFunctionBody));
 


### PR DESCRIPTION
### Summary of Changes

This PR addresses issue #8128 by documenting the <code>ai.onnx.preview</code> and <code>ai.onnx.preview.training</code> domains, which act as the modern successors to the legacy <code>EXPERIMENTAL</code> support level flag. It also cleans up some leftovers and ensures consistency.

#### Key Changes:
<ul>
<li><strong>Document Preview Domains (ai.onnx.preview & ai.onnx.preview.training)</strong>:
Update docs/ManagingExperimentalOps.md to specify that the legacy SetSupportLevel(OpSchema::SupportType::EXPERIMENTAL) mechanism is deprecated and has been superseded by the ai.onnx.preview and ai.onnx.preview.training domains.</li>
<li><strong>Document Deprecation of Upsample-1</strong>:
Document Upsample-1 in the Deprecated Experimental Operators removal table with Resize-10 as its replacement.</li>
<li><strong>Add Preview Operator Guidelines</strong>:
Add a comprehensive section to docs/AddNewOp.md detailing the proposal, implementation mapping, lack of stability/versioning guarantees, and graduation/promotion process for preview operators.</li>
<li><strong>Clarify Versioning for Preview Domains</strong>:
Update docs/Versioning.md to note the versioning characteristics of the preview domains (fixed at version 1 and modified in-place).</li>
<li><strong>Standardize Preview Signalling</strong>:
Standardize preview operator schemas by removing the redundant SetSupportLevel(EXPERIMENTAL) flag from FlexAttention in onnx/defs/preview/defs.cc.</li>
</ul>

### Related Issues
Fixes #8128