### PR TITLE
Fix pyodide/emscripten CMake configure after nanobind 2.13.0 bump

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,19 @@ if(CMAKE_CROSSCOMPILING)
   endif()
   find_package(Python REQUIRED COMPONENTS Interpreter)
   set(ONNX_PYTHON_INTERPRETER Python::Interpreter)
+  if(ONNX_BUILD_PYTHON)
+    # nanobind >= 2.13 only auto-runs its own find_package(Python ...) when
+    # neither Python::Interpreter nor Python::Module exist yet. Since
+    # Python::Interpreter is already provided above (host interpreter, while
+    # Python3::Module above is the cross-compilation target's dev libs),
+    # nanobind would otherwise skip that step and fail to find Python::Module.
+    if(NOT TARGET Python::Module)
+      add_library(Python::Module ALIAS Python3::Module)
+    endif()
+    if(TARGET Python3::SABIModule AND NOT TARGET Python::SABIModule)
+      add_library(Python::SABIModule ALIAS Python3::SABIModule)
+    endif()
+  endif()
 else()
   find_package(Python3 REQUIRED COMPONENTS Interpreter ${python_dev_component})
   # Find Python for nanobind


### PR DESCRIPTION
## Summary
- The pyodide (`cp313-pyodide_wasm32`) release build has been failing on `main` since #8151 (nanobind 2.12.0 → 2.13.0).
- Root cause: nanobind 2.13.0 changed its own CMake guard from `NOT TARGET Python::Module OR NOT TARGET Python::Interpreter` to an `AND`, so it now only self-configures Python when *both* targets are missing. In our `CMAKE_CROSSCOMPILING` branch (`CMakeLists.txt`), `Python::Interpreter` is already provided (host interpreter), but `Python::Module` never was — only `Python3::Module` (target/wasm dev libs), since interpreter and dev-library lookups must use separate packages when cross-compiling (see https://gitlab.kitware.com/cmake/cmake/-/issues/25145). nanobind's own strict check then fails with `You must invoke find_package(Python COMPONENTS Interpreter Development REQUIRED) prior to including nanobind`.
- Fix: alias `Python::Module` (and `Python::SABIModule`, if present) to the already-resolved `Python3` targets in the cross-compiling branch, so nanobind 2.13.0 finds what it expects.
- Confirmed via CI history: the commit right before the nanobind bump (`29f3349de`) built pyodide successfully on the same cibuildwheel 4.1.0; the bump commit (`a5934724a`) is the first to fail, with this exact error.

## Test plan
- [ ] `call-pyodide / build` check passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)