### PR TITLE
feat(fuzz): add missing fuzz_compose harness and CI smoke test

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -19,12 +19,14 @@ on:
     paths:
       - 'onnx/**'
       - 'pyproject.toml'
+      - '.github/workflows/fuzz.yml'
   push:
     branches:
       - main
     paths:
       - 'onnx/**'
       - 'pyproject.toml'
+      - '.github/workflows/fuzz.yml'
   schedule:
     - cron: '0 6 * * *'  # nightly: run each harness for longer than the PR smoke test
   workflow_dispatch:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -88,22 +88,34 @@ jobs:
           fi
 
       - name: Run fuzz_checker.py
-        run: python onnx/fuzz/fuzz_checker.py -max_total_time=${{ steps.duration.outputs.seconds }} -timeout=20 corpus/checker
+        run: python onnx/fuzz/fuzz_checker.py -max_total_time="$FUZZ_SECONDS" -timeout=20 corpus/checker
+        env:
+          FUZZ_SECONDS: ${{ steps.duration.outputs.seconds }}
 
       - name: Run fuzz_model_loader.py
-        run: python onnx/fuzz/fuzz_model_loader.py -max_total_time=${{ steps.duration.outputs.seconds }} -timeout=20 corpus/model_loader
+        run: python onnx/fuzz/fuzz_model_loader.py -max_total_time="$FUZZ_SECONDS" -timeout=20 corpus/model_loader
+        env:
+          FUZZ_SECONDS: ${{ steps.duration.outputs.seconds }}
 
       - name: Run fuzz_parser.py
-        run: python onnx/fuzz/fuzz_parser.py -max_total_time=${{ steps.duration.outputs.seconds }} -timeout=20 corpus/parser
+        run: python onnx/fuzz/fuzz_parser.py -max_total_time="$FUZZ_SECONDS" -timeout=20 corpus/parser
+        env:
+          FUZZ_SECONDS: ${{ steps.duration.outputs.seconds }}
 
       - name: Run fuzz_shape_inference.py
-        run: python onnx/fuzz/fuzz_shape_inference.py -max_total_time=${{ steps.duration.outputs.seconds }} -timeout=20 corpus/shape_inference
+        run: python onnx/fuzz/fuzz_shape_inference.py -max_total_time="$FUZZ_SECONDS" -timeout=20 corpus/shape_inference
+        env:
+          FUZZ_SECONDS: ${{ steps.duration.outputs.seconds }}
 
       - name: Run fuzz_version_converter.py
-        run: python onnx/fuzz/fuzz_version_converter.py -max_total_time=${{ steps.duration.outputs.seconds }} -timeout=20 corpus/version_converter
+        run: python onnx/fuzz/fuzz_version_converter.py -max_total_time="$FUZZ_SECONDS" -timeout=20 corpus/version_converter
+        env:
+          FUZZ_SECONDS: ${{ steps.duration.outputs.seconds }}
 
       - name: Run fuzz_compose.py
-        run: python onnx/fuzz/fuzz_compose.py -max_total_time=${{ steps.duration.outputs.seconds }} -timeout=20 corpus/compose
+        run: python onnx/fuzz/fuzz_compose.py -max_total_time="$FUZZ_SECONDS" -timeout=20 corpus/compose
+        env:
+          FUZZ_SECONDS: ${{ steps.duration.outputs.seconds }}
 
       - name: Upload crash artifacts
         if: failure()

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,114 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Runs the OSS-Fuzz harnesses under onnx/fuzz/ directly (not via OSS-Fuzz
+# infrastructure) as a regression check. This is deliberately not a
+# replacement for OSS-Fuzz's own continuous, long-running campaigns
+# (see google/oss-fuzz#15382) — it exists to catch harness regressions
+# (import errors, API drift, a harness file going missing) at PR time
+# instead of silently, since OSS-Fuzz failures are not surfaced here.
+#
+# atheris only ships wheels for Linux and macOS, so this does not run on
+# Windows. See onnx/fuzz/README.md for the harness/toggle-byte details.
+
+name: Fuzz
+
+on:
+  pull_request:
+    paths:
+      - 'onnx/**'
+      - 'pyproject.toml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'onnx/**'
+      - 'pyproject.toml'
+  schedule:
+    - cron: '0 6 * * *'  # nightly: run each harness for longer than the PR smoke test
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    name: Run fuzz harnesses (${{ github.event_name == 'schedule' && 'nightly' || 'smoke' }})
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+
+      - name: Build and install ONNX
+        run: pip install -e ".[reference]" -v
+        env:
+          ONNX_ML: 1
+
+      - name: Install atheris
+        run: pip install atheris
+
+      - name: Generate seed corpora
+        run: |
+          mkdir -p corpus
+          python onnx/fuzz/make_seed_corpus.py \
+            corpus/version_converter.zip corpus/parser.zip \
+            corpus/checker.zip corpus/shape_inference.zip corpus/compose.zip
+          for name in version_converter parser checker shape_inference compose; do
+            mkdir -p "corpus/$name"
+            python -m zipfile -e "corpus/$name.zip" "corpus/$name/"
+          done
+          # fuzz_model_loader.py has no dedicated seeds; it exercises the same
+          # load+check path as fuzz_checker.py, so reuse that corpus.
+          mkdir -p corpus/model_loader
+          cp corpus/checker/* corpus/model_loader/
+
+      - name: Set fuzz duration
+        id: duration
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "seconds=300" >> "$GITHUB_OUTPUT"
+          else
+            echo "seconds=60" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run fuzz_checker.py
+        run: python onnx/fuzz/fuzz_checker.py -max_total_time=${{ steps.duration.outputs.seconds }} -timeout=20 corpus/checker
+
+      - name: Run fuzz_model_loader.py
+        run: python onnx/fuzz/fuzz_model_loader.py -max_total_time=${{ steps.duration.outputs.seconds }} -timeout=20 corpus/model_loader
+
+      - name: Run fuzz_parser.py
+        run: python onnx/fuzz/fuzz_parser.py -max_total_time=${{ steps.duration.outputs.seconds }} -timeout=20 corpus/parser
+
+      - name: Run fuzz_shape_inference.py
+        run: python onnx/fuzz/fuzz_shape_inference.py -max_total_time=${{ steps.duration.outputs.seconds }} -timeout=20 corpus/shape_inference
+
+      - name: Run fuzz_version_converter.py
+        run: python onnx/fuzz/fuzz_version_converter.py -max_total_time=${{ steps.duration.outputs.seconds }} -timeout=20 corpus/version_converter
+
+      - name: Run fuzz_compose.py
+        run: python onnx/fuzz/fuzz_compose.py -max_total_time=${{ steps.duration.outputs.seconds }} -timeout=20 corpus/compose
+
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-crashes
+          path: |
+            crash-*
+            timeout-*
+            oom-*
+          if-no-files-found: ignore

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -17,6 +17,7 @@ name: Fuzz
 on:
   pull_request:
     paths:
+      - '.github/workflows/fuzz.yml'
       - 'onnx/**'
       - 'pyproject.toml'
       - '.github/workflows/fuzz.yml'
@@ -24,13 +25,13 @@ on:
     branches:
       - main
     paths:
+      - '.github/workflows/fuzz.yml'
       - 'onnx/**'
       - 'pyproject.toml'
       - '.github/workflows/fuzz.yml'
   schedule:
     - cron: '0 6 * * *'  # nightly: run each harness for longer than the PR smoke test
   workflow_dispatch:
-
 permissions:
   contents: read
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,7 +10,8 @@
 # instead of silently, since OSS-Fuzz failures are not surfaced here.
 #
 # atheris only ships wheels for Linux and macOS, so this does not run on
-# Windows. See onnx/fuzz/README.md for the harness/toggle-byte details.
+# Windows. See https://github.com/onnx/onnx/blob/main/onnx/fuzz/README.md 
+# for the harness/toggle-byte details.
 
 name: Fuzz
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,7 +10,7 @@
 # instead of silently, since OSS-Fuzz failures are not surfaced here.
 #
 # atheris only ships wheels for Linux and macOS, so this does not run on
-# Windows. See https://github.com/onnx/onnx/blob/main/onnx/fuzz/README.md 
+# Windows. See https://github.com/onnx/onnx/blob/main/onnx/fuzz/README.md
 # for the harness/toggle-byte details.
 
 name: Fuzz

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -17,7 +17,6 @@ name: Fuzz
 on:
   pull_request:
     paths:
-      - '.github/workflows/fuzz.yml'
       - 'onnx/**'
       - 'pyproject.toml'
       - '.github/workflows/fuzz.yml'
@@ -25,13 +24,13 @@ on:
     branches:
       - main
     paths:
-      - '.github/workflows/fuzz.yml'
       - 'onnx/**'
       - 'pyproject.toml'
       - '.github/workflows/fuzz.yml'
   schedule:
     - cron: '0 6 * * *'  # nightly: run each harness for longer than the PR smoke test
   workflow_dispatch:
+
 permissions:
   contents: read
 

--- a/docs/AssuranceCase.md
+++ b/docs/AssuranceCase.md
@@ -81,7 +81,7 @@ A malicious model references external tensor data via attacker-controlled file p
 |--------|---------|
 | Static analysis | CodeQL (GitHub Advanced Security), Clang Static Analyzer, sonarcloud |
 | Dynamic analysis | ASan, MSan, UBSan, TSan in CI build matrix |
-| Fuzzing | not yet |
+| Fuzzing | Early stage — OSS-Fuzz harnesses ([onnx/fuzz](https://github.com/onnx/onnx/tree/main/onnx/fuzz)) cover the checker, model loader, text parser, shape inference, version converter, and compose; reference evaluator and external-data parsing are not yet covered. A short smoke run of these harnesses is part of this repo's CI ([fuzz.yml](https://github.com/onnx/onnx/blob/main/.github/workflows/fuzz.yml)); the full OSS-Fuzz continuous campaigns run separately and are not surfaced here |
 | Dependency scanning | Dependabot, OpenSSF Scorecard |
 
 

--- a/onnx/fuzz/README.md
+++ b/onnx/fuzz/README.md
@@ -19,6 +19,14 @@ for crashes, hangs, and sanitizer violations.
 | `fuzz_version_converter.py` | `version_converter.convert_version` | Raw bytes → protobuf parser |
 | `make_seed_corpus.py` | *(seed generator, not a fuzzer)* | Produces seed zips for OSS-Fuzz |
 
+## CI regression check
+
+[`.github/workflows/fuzz.yml`](../../.github/workflows/fuzz.yml) runs each harness in this
+repo's own CI (a short smoke run on PRs/pushes that touch `onnx/`, a longer nightly run) as
+a regression check — e.g. to catch a harness failing to import or a documented harness file
+going missing. This is separate from, and much shallower than, OSS-Fuzz's own continuous
+fuzzing campaigns; OSS-Fuzz findings are not surfaced in this repo's CI.
+
 ## How OSS-Fuzz uses these files
 
 The companion OSS-Fuzz project ([google/oss-fuzz#15382](https://github.com/google/oss-fuzz/pull/15382))

--- a/onnx/fuzz/fuzz_compose.py
+++ b/onnx/fuzz/fuzz_compose.py
@@ -30,8 +30,14 @@ import sys
 import atheris
 
 with atheris.instrument_imports():
-    import onnx
-    from onnx import TensorProto, checker, compose, helper
+    from onnx import (
+        TensorProto,
+        checker,
+        compose,
+        defs,
+        helper,
+        load_model_from_string,
+    )
 
 _UNARY = ("Relu", "Sigmoid", "Tanh", "Abs", "Neg", "Identity")
 
@@ -40,13 +46,16 @@ def _value_info(name):
     return helper.make_tensor_value_info(name, TensorProto.FLOAT, ["N"])
 
 
-def _build_model(fdp, tag):
+def _build_model(fdp, tag, opset):
     """Build a small linear graph with predictable input/output names.
 
     Naming the sole input/output `In<tag>`/`Out<tag>` lets the derived
     io_map (m1's outputs -> m2's inputs) connect on most iterations, so
     merge_models' rewrite logic is reached without relying on the raw
-    protobuf parser to produce compatible names.
+    protobuf parser to produce compatible names. `opset` is shared between
+    both models: merge_models rejects mismatched opset_import up front, so
+    picking it independently per model would make the structured path
+    rarely reach the merge/connect logic it exists to exercise.
     """
     n_ops = fdp.ConsumeIntInRange(0, 4)
     last = f"In{tag}"
@@ -61,7 +70,6 @@ def _build_model(fdp, tag):
     graph = helper.make_graph(
         nodes, f"g{tag}", [_value_info(f"In{tag}")], [_value_info(out_name)]
     )
-    opset = fdp.ConsumeIntInRange(7, onnx.defs.onnx_opset_version())
     return helper.make_model(graph, opset_imports=[helper.make_opsetid("", opset)])
 
 
@@ -99,8 +107,9 @@ def TestOneInput(data):
     try:
         if use_structured:
             fdp = atheris.FuzzedDataProvider(body)
-            m1 = _build_model(fdp, 1)
-            m2 = _build_model(fdp, 2)
+            opset = fdp.ConsumeIntInRange(7, defs.onnx_opset_version())
+            m1 = _build_model(fdp, 1, opset)
+            m2 = _build_model(fdp, 2, opset)
         else:
             if len(body) < 4:
                 return
@@ -108,8 +117,8 @@ def TestOneInput(data):
             rest = body[4:]
             if n1 > len(rest):
                 return
-            m1 = onnx.load_model_from_string(rest[:n1])
-            m2 = onnx.load_model_from_string(rest[n1:])
+            m1 = load_model_from_string(rest[:n1])
+            m2 = load_model_from_string(rest[n1:])
 
         io_map = (
             _random_io_map(body, m1, m2)
@@ -117,12 +126,9 @@ def TestOneInput(data):
             else _derived_io_map(m1, m2)
         )
 
-        kwargs = {}
-        if use_prefix:
-            kwargs["prefix1"] = "g1_"
-            kwargs["prefix2"] = "g2_"
-
-        merged = compose.merge_models(m1, m2, io_map, **kwargs)
+        prefix1 = "g1_" if use_prefix else None
+        prefix2 = "g2_" if use_prefix else None
+        merged = compose.merge_models(m1, m2, io_map, prefix1=prefix1, prefix2=prefix2)
         checker.check_model(merged, full_check=True)
     except Exception:
         # Malformed fuzz inputs raise a broad set of expected exceptions

--- a/onnx/fuzz/fuzz_compose.py
+++ b/onnx/fuzz/fuzz_compose.py
@@ -1,0 +1,141 @@
+# Copyright (c) ONNX Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Atheris fuzz harness for onnx.compose.
+
+Two input paths are exercised per iteration, selected by a fuzzer-controlled
+toggle byte read from the *tail* of the input:
+
+* Raw    -> a 4-byte big-endian length prefix splits the remaining bytes
+  into m1 | m2, each parsed via onnx.load_model_from_string. Catches
+  protobuf parser bugs and bugs reachable only through crafted serialized
+  models the structured builder will not produce.
+
+* Structured -> helper.make_model from FuzzedDataProvider builds two small
+  linear graphs with predictable input/output names, so merge_models
+  reaches its connect_io/add_prefix logic on most iterations rather than
+  only when the parser happens to accept a random byte string.
+
+Further bits of the toggle byte select prefix1/prefix2 (add_prefix
+collision-resolution path) and a randomized (vs. derived) io_map, so a
+single harness covers merge_models, merge_graphs, check_overlapping_names,
+the recursive connect_io subgraph rewrite, and add_prefix.
+"""
+
+from __future__ import annotations
+
+import random
+import struct
+import sys
+
+import atheris
+
+with atheris.instrument_imports():
+    import onnx
+    from onnx import TensorProto, checker, compose, helper
+
+_UNARY = ("Relu", "Sigmoid", "Tanh", "Abs", "Neg", "Identity")
+
+
+def _value_info(name):
+    return helper.make_tensor_value_info(name, TensorProto.FLOAT, ["N"])
+
+
+def _build_model(fdp, tag):
+    """Build a small linear graph with predictable input/output names.
+
+    Naming the sole input/output `In<tag>`/`Out<tag>` lets the derived
+    io_map (m1's outputs -> m2's inputs) connect on most iterations, so
+    merge_models' rewrite logic is reached without relying on the raw
+    protobuf parser to produce compatible names.
+    """
+    n_ops = fdp.ConsumeIntInRange(0, 4)
+    last = f"In{tag}"
+    nodes = []
+    for i in range(n_ops):
+        op = _UNARY[fdp.ConsumeIntInRange(0, len(_UNARY) - 1)]
+        nxt = f"v{tag}_{i}"
+        nodes.append(helper.make_node(op, [last], [nxt]))
+        last = nxt
+    out_name = f"Out{tag}"
+    nodes.append(helper.make_node("Identity", [last], [out_name]))
+    graph = helper.make_graph(
+        nodes, f"g{tag}", [_value_info(f"In{tag}")], [_value_info(out_name)]
+    )
+    opset = fdp.ConsumeIntInRange(7, onnx.defs.onnx_opset_version())
+    return helper.make_model(graph, opset_imports=[helper.make_opsetid("", opset)])
+
+
+def _derived_io_map(m1, m2):
+    outs = [o.name for o in m1.graph.output]
+    ins = [i.name for i in m2.graph.input]
+    return list(zip(outs, ins, strict=False))
+
+
+def _random_io_map(data, m1, m2):
+    outs = [o.name for o in m1.graph.output]
+    ins = [i.name for i in m2.graph.input]
+    if not outs or not ins:
+        return []
+    rng = random.Random(data)
+    rng.shuffle(outs)
+    rng.shuffle(ins)
+    n = rng.randint(0, min(len(outs), len(ins)))
+    return list(zip(outs[:n], ins[:n], strict=True))
+
+
+def TestOneInput(data):
+    # Toggles live in the trailing byte; see module docstring and
+    # onnx/fuzz/README.md's "fuzz_compose.py toggle byte" table.
+    if len(data) < 2:
+        return
+    toggles = data[-1]
+    body = data[:-1]
+    use_prefix = bool(toggles & 0x01)
+    use_structured = bool(toggles & 0x04)
+    use_random_io_map = bool(toggles & 0x08)
+    # bits 0x02, 0x10..0x80 are reserved for future toggles; mutations
+    # against them are harmless until claimed.
+
+    try:
+        if use_structured:
+            fdp = atheris.FuzzedDataProvider(body)
+            m1 = _build_model(fdp, 1)
+            m2 = _build_model(fdp, 2)
+        else:
+            if len(body) < 4:
+                return
+            (n1,) = struct.unpack(">I", body[:4])
+            rest = body[4:]
+            if n1 > len(rest):
+                return
+            m1 = onnx.load_model_from_string(rest[:n1])
+            m2 = onnx.load_model_from_string(rest[n1:])
+
+        io_map = (
+            _random_io_map(body, m1, m2)
+            if use_random_io_map
+            else _derived_io_map(m1, m2)
+        )
+
+        kwargs = {}
+        if use_prefix:
+            kwargs["prefix1"] = "g1_"
+            kwargs["prefix2"] = "g2_"
+
+        merged = compose.merge_models(m1, m2, io_map, **kwargs)
+        checker.check_model(merged, full_check=True)
+    except Exception:
+        # Malformed fuzz inputs raise a broad set of expected exceptions
+        # (ValidationError, TypeError, ValueError, DecodeError, ...).
+        # Real bugs surface as crashes, hangs, or sanitizer reports.
+        return
+
+
+def main():
+    atheris.instrument_all()
+    atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -273,6 +273,7 @@ required-imports = ["from __future__ import annotations"]
     "PLR2004",  # Magic numbers are fine in low-level fuzz scaffolding
     "S112",     # try-except-continue is the correct pattern for per-version fuzzing
     "PERF203",  # try-except in loop is unavoidable in the version-converter harness
+    "S311",     # Non-crypto random is fine for fuzz input shuffling
 ]
 "onnx/gen_proto.py" = ["T20"] # Build script uses print for progress
 "onnx/defs/gen_*.py" = ["T20"] # Code generators use print for output


### PR DESCRIPTION
onnx/fuzz/README.md and make_seed_corpus.py already documented and seeded a fuzz_compose.py harness for onnx.compose.merge_models, but the harness file itself was never committed, leaving compose entirely unfuzzed despite looking covered on paper. This adds the harness per the existing README spec (raw and structured input paths, prefix and random-io_map toggles).

Also adds .github/workflows/fuzz.yml, a short smoke run of all fuzz harnesses on PRs/pushes (and a longer nightly run) so a regression like the missing harness file is caught by this repo's own CI instead of silently, since OSS-Fuzz results aren't surfaced here. Updates docs/AssuranceCase.md and onnx/fuzz/README.md to reflect current coverage and the new CI check.



### Motivation and Context

Fixes #
