### PR TITLE
test: fix two copy-paste bugs that left code paths untested

### DIFF
--- a/onnx/test/numpy_helper_test.py
+++ b/onnx/test/numpy_helper_test.py
@@ -66,7 +66,7 @@ class TestNumpyHelper(unittest.TestCase):
         np.testing.assert_equal(a, a_recover)
 
     def test_float16(self) -> None:
-        self._test_numpy_helper_float_type(np.float32)
+        self._test_numpy_helper_float_type(np.float16)
 
     def test_complex64(self) -> None:
         self._test_numpy_helper_float_type(np.complex64)

--- a/onnx/test/version_converter_test.py
+++ b/onnx/test/version_converter_test.py
@@ -1469,7 +1469,7 @@ class TestVersionConverter(unittest.TestCase):
 
     # Test Upsample Adapter: 9 -> 8
     def test_upsample_with_raw_initializer_9_8(self) -> None:
-        self.helper_upsample_with_constant(raw_scale=True)
+        self.helper_upsample_with_initializer(raw_scale=True)
 
     # Test Upsample Adapter: 9 -> 8
     def test_upsample_with_raw_constant_node_9_8(self) -> None:


### PR DESCRIPTION
### Motivation and Context

- numpy_helper test_float16 tested np.float32 (same as test_float); use np.float16.
- version_converter test_upsample_with_raw_initializer_9_8 called helper_upsample_with_constant (same as the raw_constant_node test); call helper_upsample_with_initializer.




 