### PR TITLE
Fix Python test bugs

### DIFF
--- a/onnx/test/reference_evaluator_ml_test.py
+++ b/onnx/test/reference_evaluator_ml_test.py
@@ -2165,7 +2165,7 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
                     )
                 ],
                 "tfidf",
-                [make_tensor_value_info("tokens", TensorProto.INT64, [None, None])],
+                [make_tensor_value_info("tokens", TensorProto.STRING, [None, None])],
                 [make_tensor_value_info("out", TensorProto.FLOAT, [None, None])],
             ),
             opset_imports=OPSETS,

--- a/onnx/test/reference_evaluator_test.py
+++ b/onnx/test/reference_evaluator_test.py
@@ -1866,6 +1866,58 @@ class TestReferenceEvaluator(unittest.TestCase):
             ):
                 sess.run(None, feeds)[0]
 
+    def _run_qlinear_int8(self, op_type, feeds, operand_shapes, output_shape, opset):
+        """Build and run a single-node int8 QLinear{Conv,MatMul} graph.
+
+        ``feeds`` supplies the eight quantized inputs in operator order
+        (a/x, a_scale, a_zero_point, b/w, b_scale, b_zero_point, y_scale,
+        y_zero_point); the operands and output are int8, the scales float.
+        """
+        names = list(feeds)
+        a_shape, b_shape = operand_shapes
+        i8, flt = TensorProto.INT8, TensorProto.FLOAT
+        graph = make_graph(
+            [make_node(op_type, names, ["y"])],
+            "g",
+            [
+                make_tensor_value_info(names[0], i8, a_shape),
+                make_tensor_value_info(names[1], flt, [1]),
+                make_tensor_value_info(names[2], i8, [1]),
+                make_tensor_value_info(names[3], i8, b_shape),
+                make_tensor_value_info(names[4], flt, [1]),
+                make_tensor_value_info(names[5], i8, [1]),
+                make_tensor_value_info(names[6], flt, [1]),
+                make_tensor_value_info(names[7], i8, [1]),
+            ],
+            [make_tensor_value_info("y", i8, output_shape)],
+        )
+        onnx_model = make_model_gen_version(
+            graph, opset_imports=[make_opsetid("", opset)]
+        )
+        return ReferenceEvaluator(onnx_model).run(None, feeds)[0]
+
+    def test_qlinearconv_int8(self):
+        # Self-contained int8 QLinearConv (no onnxruntime needed): a negative
+        # zero point and negative output exercise the signed int8 path that the
+        # uint8 tests above never reach.
+        feeds = {
+            "x": np.array([[[[10, 20], [30, 40]]]], dtype=np.int8),
+            "x_scale": np.array([0.1], dtype=np.float32),
+            "x_zero_point": np.array([5], dtype=np.int8),
+            "w": np.array([[[[1, 1], [1, 1]]]], dtype=np.int8),
+            "w_scale": np.array([1.0], dtype=np.float32),
+            "w_zero_point": np.array([0], dtype=np.int8),
+            "y_scale": np.array([1.0], dtype=np.float32),
+            "y_zero_point": np.array([-10], dtype=np.int8),
+        }
+        # dequantize(x) = (x - 5) * 0.1 = [[0.5, 1.5], [2.5, 3.5]]; dequantize(w) = 1.0
+        # valid conv (2x2 input, 2x2 kernel) = 0.5 + 1.5 + 2.5 + 3.5 = 8.0
+        # quantize(8.0, scale=1, zero_point=-10) = round(8.0) + (-10) = -2
+        got = self._run_qlinear_int8(
+            "QLinearConv", feeds, ([1, 1, 2, 2], [1, 1, 2, 2]), [1, 1, 1, 1], opset=16
+        )
+        np.testing.assert_array_equal(np.array([[[[-2]]]], dtype=np.int8), got)
+
     def common_test_im2col(self, kernel_shape, pads, strides, dilations):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None, None, None])
         Y1 = make_tensor_value_info("Y1", TensorProto.FLOAT, [None, None, None, None])
@@ -5492,74 +5544,27 @@ class TestReferenceEvaluator(unittest.TestCase):
             num_splits, np.array(expected_num_splits, dtype=np.int64)
         )
 
-    def test_qlinearconv_int8(self):
-        node = make_node(
-            "QLinearMatMul",
-            inputs=[
-                "a",
-                "a_scale",
-                "a_zero_point",
-                "b",
-                "b_scale",
-                "b_zero_point",
-                "y_scale",
-                "y_zero_point",
-            ],
-            outputs=["y"],
+    def test_qlinearmatmul_int8(self):
+        a = (np.array([[208, 236, 0, 238], [3, 214, 255, 29]]) - 127).astype(np.int8)
+        b = (
+            np.array([[152, 51, 244], [60, 26, 255], [0, 127, 246], [127, 254, 247]])
+            - 127
+        ).astype(np.int8)
+        feeds = {
+            "a": a,
+            "a_scale": np.array([0.0066], dtype=np.float32),
+            "a_zero_point": np.array([113 - 127], dtype=np.int8),
+            "b": b,
+            "b_scale": np.array([0.00705], dtype=np.float32),
+            "b_zero_point": np.array([114 - 127], dtype=np.int8),
+            "y_scale": np.array([0.0107], dtype=np.float32),
+            "y_zero_point": np.array([118 - 127], dtype=np.int8),
+        }
+        got = self._run_qlinear_int8(
+            "QLinearMatMul", feeds, ([2, 4], [4, 3]), [2, 3], opset=20
         )
-        graph = make_graph(
-            [node],
-            "g",
-            [
-                make_tensor_value_info("a", TensorProto.FLOAT, [None, None]),
-                make_tensor_value_info("a_scale", TensorProto.FLOAT, [1]),
-                make_tensor_value_info("a_zero_point", TensorProto.INT8, [1]),
-                make_tensor_value_info("b", TensorProto.FLOAT, [None, None]),
-                make_tensor_value_info("b_scale", TensorProto.FLOAT, [1]),
-                make_tensor_value_info("b_zero_point", TensorProto.INT8, [1]),
-                make_tensor_value_info("y_scale", TensorProto.FLOAT, [1]),
-                make_tensor_value_info("y_zero_point", TensorProto.INT8, [1]),
-            ],
-            [make_tensor_value_info("y", TensorProto.FLOAT, [None, None])],
-        )
-        onnx_model = make_model(
-            graph, opset_imports=[make_opsetid("", 20)], ir_version=9
-        )
-        sess = ReferenceEvaluator(onnx_model)
-
-        a = np.array([[208, 236, 0, 238], [3, 214, 255, 29]])
-        a -= 127
-        a = a.astype(np.int8)
-
-        a_scale = np.array([0.0066], dtype=np.float32)
-        a_zero_point = np.array([113 - 127], dtype=np.int8)
-
-        b = np.array([[152, 51, 244], [60, 26, 255], [0, 127, 246], [127, 254, 247]])
-        b -= 127
-        b = b.astype(np.int8)
-
-        b_scale = np.array([0.00705], dtype=np.float32)
-        b_zero_point = np.array([114 - 127], dtype=np.int8)
-
-        y_scale = np.array([0.0107], dtype=np.float32)
-        y_zero_point = np.array([118 - 127], dtype=np.int8)
-
-        got = sess.run(
-            None,
-            dict(
-                a=a,
-                a_scale=a_scale,
-                a_zero_point=a_zero_point,
-                b=b,
-                b_scale=b_scale,
-                b_zero_point=b_zero_point,
-                y_scale=y_scale,
-                y_zero_point=y_zero_point,
-            ),
-        )
-
         np.testing.assert_array_equal(
-            np.array([[41, -12, -9], [1, -75, -128]], dtype=np.int8), got[0]
+            np.array([[41, -12, -9], [1, -75, -128]], dtype=np.int8), got
         )
 
     @parameterized.parameterized.expand(

--- a/onnx/test/reference_evaluator_test.py
+++ b/onnx/test/reference_evaluator_test.py
@@ -1873,7 +1873,32 @@ class TestReferenceEvaluator(unittest.TestCase):
         (a/x, a_scale, a_zero_point, b/w, b_scale, b_zero_point, y_scale,
         y_zero_point); the operands and output are int8, the scales float.
         """
-        names = list(feeds)
+        if op_type == "QLinearConv":
+            names = [
+                "x",
+                "x_scale",
+                "x_zero_point",
+                "w",
+                "w_scale",
+                "w_zero_point",
+                "y_scale",
+                "y_zero_point",
+            ]
+        elif op_type == "QLinearMatMul":
+            names = [
+                "a",
+                "a_scale",
+                "a_zero_point",
+                "b",
+                "b_scale",
+                "b_zero_point",
+                "y_scale",
+                "y_zero_point",
+            ]
+        else:
+            raise ValueError(f"Unsupported op_type: {op_type!r}")
+        if set(names) != set(feeds):
+            raise ValueError(f"feeds must contain exactly these keys: {names}")
         a_shape, b_shape = operand_shapes
         i8, flt = TensorProto.INT8, TensorProto.FLOAT
         graph = make_graph(

--- a/onnx/test/version_converter/automatic_upgrade_test.py
+++ b/onnx/test/version_converter/automatic_upgrade_test.py
@@ -305,8 +305,13 @@ class TestAutomaticUpgrade(automatic_conversion_test_base.TestAutomaticConversio
         )
 
     def test_Conv_2(self) -> None:
+        # strided Conv: floor((5 - 2) / 2) + 1 = 2 in each spatial dim
         self._test_op_upgrade(
-            "Conv", 1, [[1, 3, 5, 5], [4, 3, 2, 2], [4]], [[1, 4, 4, 4]]
+            "Conv",
+            1,
+            [[1, 3, 5, 5], [4, 3, 2, 2], [4]],
+            [[1, 4, 2, 2]],
+            attrs={"strides": [2, 2]},
         )
 
     def test_Conv_3(self) -> None:

--- a/onnx/test/version_converter_test.py
+++ b/onnx/test/version_converter_test.py
@@ -616,10 +616,10 @@ class TestVersionConverter(unittest.TestCase):
             ],
             [helper.make_tensor_value_info("sum", TensorProto.FLOAT, (5,))],
         )
-        converted_model = self._converted(graph, helper.make_operatorsetid("", 5), 7)
+        converted_model = self._converted(graph, helper.make_operatorsetid("", 5), 8)
         # Assert equality of graph and converted_model
         assert converted_model.graph.node[0].op_type == "Sum"
-        assert converted_model.opset_import[0].version == 7
+        assert converted_model.opset_import[0].version == 8
 
     # Test Sum Adapter: 8 -> 5
     def test_sum_8_5(self) -> None:


### PR DESCRIPTION
### Motivation and Context

A handful of Python tests were silently testing the wrong thing — asserting the wrong opset, duplicating another test, running the wrong op, or declaring an input type that contradicts its data. Each is a latent coverage hole that masks real regressions. This PR fixes them.

### Changes

- **`version_converter_test.test_sum_5_8`** — converted 5→7 and asserted opset 7, so it never crossed the opset-8 boundary where Sum's multidirectional-broadcasting adapter lives (the path its name and `# Sum Adapter: 5 -> 8` comment target). Now converts 5→8 and asserts opset 8.
- **`automatic_upgrade_test.test_Conv_2`** — had been byte-identical to `test_Conv_1` since 2021, adding no coverage. Now a distinct case that isolates strides (`strides=[2, 2]`, output `floor((5 - 2) / 2) + 1 = 2` per spatial dim → `[1, 4, 2, 2]`), matching the distinct-per-number convention of `test_Add_1/_2/_3`.
- **`reference_evaluator_test.test_qlinearconv_int8`** — built a `QLinearMatMul` node, not a `QLinearConv`; renamed to `test_qlinearmatmul_int8` to match its body. Added a real, self-contained int8 `QLinearConv` test (negative zero point / negative output) covering the signed path the uint8 tests never reach, and factored the shared 8-input QLinear scaffolding into a `_run_qlinear_int8` helper — which also corrects the matmul test's `value_info` that wrongly declared its int8 operands and output as `FLOAT`.
- **`reference_evaluator_ml_test`** tfidf "strings" test — fed string data and `pool_strings` but declared its token input `INT64` (copied from the `ints` sibling); an int-typed input fed strings, which would fail `check_model`. Declared `STRING`.
