### PR TITLE
Replace `unittest.TestCase.subTest` with `pytest.mark.parametrize`

### DIFF
--- a/onnx/test/reference_evaluator_ml_test.py
+++ b/onnx/test/reference_evaluator_ml_test.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 import importlib
 import itertools
 import os
-import unittest
 
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 from parameterized import parameterized
 
@@ -49,11 +49,11 @@ def has_onnxruntime():
     return importlib.util.find_spec("onnxruntime") is not None
 
 
-class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
+class TestReferenceEvaluatorAiOnnxMl:
     @staticmethod
     def _check_ort(model, feeds, atol=0, rtol=0, equal=False, rev=False):
         if not has_onnxruntime():
-            raise unittest.SkipTest("onnxruntime not installed")
+            pytest.skip("onnxruntime not installed")
 
         from onnxruntime import InferenceSession  # noqa: PLC0415
 
@@ -112,7 +112,7 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
                     err_msg=f"Discrepancies for output {i} expected[0]={e.ravel()[0]}.",
                 )
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_binarizer(self):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None])
         Y = make_tensor_value_info("Y", TensorProto.FLOAT, [None, None])
@@ -129,7 +129,7 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         got = sess.run(None, {"X": x})[0]
         assert_allclose(got, expected)
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_scaler(self):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None])
         Y = make_tensor_value_info("Y", TensorProto.FLOAT, [None, None])
@@ -153,7 +153,7 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         got = sess.run(None, {"X": x})[0]
         assert_allclose(got, expected)
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_array_feature_extractor(self):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None])
         A = make_tensor_value_info("A", TensorProto.INT64, [None])
@@ -190,33 +190,46 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         got = sess.run(None, feeds)[0]
         assert_allclose(got, expected)
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
-    def test_normalizer(self):
+    @pytest.mark.parametrize(
+        "norm, compute",
+        [
+            ("MAX", lambda x: x / x.max(axis=1, keepdims=1)),
+            ("L1", lambda x: x / np.abs(x).sum(axis=1, keepdims=1)),
+            ("L2", lambda x: x / (x**2).sum(axis=1, keepdims=1) ** 0.5),
+        ],
+    )
+    def test_normalizer(self, norm, compute):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None])
         Y = make_tensor_value_info("Y", TensorProto.FLOAT, [None, None])
         x = np.arange(12).reshape((3, 4)).astype(np.float32)
-        expected = {
-            "MAX": x / x.max(axis=1, keepdims=1),
-            "L1": x / np.abs(x).sum(axis=1, keepdims=1),
-            "L2": x / (x**2).sum(axis=1, keepdims=1) ** 0.5,
-        }
-        for norm, value in expected.items():
-            with self.subTest(norm=norm):
-                node1 = make_node(
-                    "Normalizer", ["X"], ["Y"], norm=norm, domain="ai.onnx.ml"
-                )
-                graph = make_graph([node1], "ml", [X], [Y])
-                model = make_model_gen_version(graph, opset_imports=OPSETS)
-                onnx.checker.check_model(model)
 
-                feeds = {"X": x}
-                self._check_ort(model, feeds, atol=1e-6)
-                sess = ReferenceEvaluator(model)
-                got = sess.run(None, feeds)[0]
-                assert_allclose(got, value, atol=1e-6)
+        node1 = make_node("Normalizer", ["X"], ["Y"], norm=norm, domain="ai.onnx.ml")
+        graph = make_graph([node1], "ml", [X], [Y])
+        model = make_model_gen_version(graph, opset_imports=OPSETS)
+        onnx.checker.check_model(model)
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
-    def test_feature_vectorizer(self):
+        feeds = {"X": x}
+        expected = compute(x)
+        self._check_ort(model, feeds, atol=1e-6)
+        sess = ReferenceEvaluator(model)
+        got = sess.run(None, feeds)[0]
+        assert_allclose(got, expected, atol=1e-6)
+
+    @pytest.mark.parametrize(
+        "inputdimensions, expected_value",
+        [
+            ((1,), np.array([[0], [3], [6]], dtype=np.float32)),
+            ((2,), np.array([[0, 1], [3, 4], [6, 7]], dtype=np.float32)),
+            (
+                (4,),
+                np.array([[0, 1, 2, 0], [3, 4, 5, 0], [6, 7, 8, 0]], dtype=np.float32),
+            ),
+            ((1, 1), np.array([[0, 0.5], [3, 3.5], [6, 6.5]], dtype=np.float32)),
+            ((0, 1), np.array([[0.5], [3.5], [6.5]], dtype=np.float32)),
+        ],
+    )
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    def test_feature_vectorizer(self, inputdimensions, expected_value):
         X = [
             make_tensor_value_info("X0", TensorProto.FLOAT, [None, None]),
             make_tensor_value_info("X1", TensorProto.FLOAT, [None, None]),
@@ -226,40 +239,29 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
             np.arange(9).reshape((3, 3)).astype(np.float32),
             np.arange(9).reshape((3, 3)).astype(np.float32) + 0.5,
         ]
-        expected = {
-            (1,): np.array([[0], [3], [6]], dtype=np.float32),
-            (2,): np.array([[0, 1], [3, 4], [6, 7]], dtype=np.float32),
-            (4,): np.array(
-                [[0, 1, 2, 0], [3, 4, 5, 0], [6, 7, 8, 0]], dtype=np.float32
-            ),
-            (1, 1): np.array([[0, 0.5], [3, 3.5], [6, 6.5]], dtype=np.float32),
-            (0, 1): np.array([[0.5], [3.5], [6.5]], dtype=np.float32),
-        }
-        for inputdimensions, value in expected.items():
-            att = (
-                list(inputdimensions)
-                if isinstance(inputdimensions, tuple)
-                else inputdimensions
-            )
-            with self.subTest(inputdimensions=att):
-                node1 = make_node(
-                    "FeatureVectorizer",
-                    [f"X{i}" for i in range(len(att))],
-                    ["Y"],
-                    inputdimensions=att,
-                    domain="ai.onnx.ml",
-                )
-                graph = make_graph([node1], "ml", X[: len(att)], [Y])
-                model = make_model_gen_version(graph, opset_imports=OPSETS)
-                onnx.checker.check_model(model)
+        att = (
+            list(inputdimensions)
+            if isinstance(inputdimensions, tuple)
+            else inputdimensions
+        )
+        node1 = make_node(
+            "FeatureVectorizer",
+            [f"X{i}" for i in range(len(att))],
+            ["Y"],
+            inputdimensions=att,
+            domain="ai.onnx.ml",
+        )
+        graph = make_graph([node1], "ml", X[: len(att)], [Y])
+        model = make_model_gen_version(graph, opset_imports=OPSETS)
+        onnx.checker.check_model(model)
 
-                feeds = {f"X{i}": v for i, v in enumerate(x[: len(att)])}
-                self._check_ort(model, feeds, atol=1e-6)
-                sess = ReferenceEvaluator(model)
-                got = sess.run(None, feeds)[0]
-                assert_allclose(got, value, atol=1e-6)
+        feeds = {f"X{i}": v for i, v in enumerate(x[: len(att)])}
+        self._check_ort(model, feeds, atol=1e-6)
+        sess = ReferenceEvaluator(model)
+        got = sess.run(None, feeds)[0]
+        assert_allclose(got, expected_value, atol=1e-6)
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_imputer_float(self):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None])
         Y = make_tensor_value_info("Y", TensorProto.FLOAT, [None, None])
@@ -281,7 +283,7 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         got = sess.run(None, {"X": x})[0]
         assert_allclose(got, expected)
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_imputer_float_2d(self):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None])
         Y = make_tensor_value_info("Y", TensorProto.FLOAT, [None, None])
@@ -303,7 +305,7 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         got = sess.run(None, {"X": x})[0]
         assert_allclose(got, expected)
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_imputer_int(self):
         X = make_tensor_value_info("X", TensorProto.INT64, [None, None])
         Y = make_tensor_value_info("Y", TensorProto.INT64, [None, None])
@@ -325,7 +327,7 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         got = sess.run(None, {"X": x})[0]
         assert_allclose(got, expected)
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_label_encoder_float_int(self):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None])
         Y = make_tensor_value_info("Y", TensorProto.INT64, [None, None])
@@ -348,7 +350,7 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         got = sess.run(None, {"X": x})[0]
         assert_allclose(got, expected)
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_label_encoder_int_string(self):
         X = make_tensor_value_info("X", TensorProto.INT64, [None, None])
         Y = make_tensor_value_info("Y", TensorProto.STRING, [None, None])
@@ -371,7 +373,7 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         got = sess.run(None, {"X": x})[0]
         assert expected.tolist() == got.tolist()
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_label_encoder_int_string_tensor_attributes(self):
         X = make_tensor_value_info("X", TensorProto.INT64, [None, None])
         Y = make_tensor_value_info("Y", TensorProto.STRING, [None, None])
@@ -400,7 +402,7 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         got = sess.run(None, {"X": x})[0]
         assert expected.tolist() == got.tolist()
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_dict_vectorizer(self):
         value_type = TypeProto()
         value_type.tensor_type.elem_type = TensorProto.INT64
@@ -431,7 +433,7 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         got = sess.run(None, {"X": x})[0]
         assert expected.tolist() == got.tolist()
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_one_hot_encoder_int(self):
         X = make_tensor_value_info("X", TensorProto.INT64, [None, None])
         Y = make_tensor_value_info("Y", TensorProto.FLOAT, [None, None, None])
@@ -456,7 +458,7 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         got = sess.run(None, {"X": x})[0]
         assert expected.tolist() == got.tolist()
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_one_hot_encoder_string(self):
         X = make_tensor_value_info("X", TensorProto.STRING, [None, None])
         Y = make_tensor_value_info("Y", TensorProto.FLOAT, [None, None, None])
@@ -481,7 +483,7 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         got = sess.run(None, {"X": x})[0]
         assert expected.tolist() == got.tolist()
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_one_hot_encoder_zeros(self):
         X = make_tensor_value_info("X", TensorProto.INT64, [None, None])
         Y = make_tensor_value_info("Y", TensorProto.FLOAT, [None, None, None])
@@ -506,7 +508,7 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         got = sess.run(None, {"X": x})[0]
         assert expected.tolist() == got.tolist()
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_linear_regressor(self):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None])
         Y = make_tensor_value_info("Y", TensorProto.FLOAT, [None, None])
@@ -530,7 +532,7 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         got = sess.run(None, {"X": x})
         assert_allclose(got[0], expected, atol=1e-6)
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_linear_regressor_2(self):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None])
         Y = make_tensor_value_info("Y", TensorProto.FLOAT, [None, None])
@@ -556,8 +558,11 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         got = sess.run(None, {"X": x})
         assert_allclose(got[0], expected, atol=1e-6)
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
-    def test_linear_classifier_multi(self):
+    @pytest.mark.parametrize(
+        "post", ["SOFTMAX", "NONE", "LOGISTIC", "SOFTMAX_ZERO", "PROBIT"]
+    )
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    def test_linear_classifier_multi(self, post):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None])
         In = make_tensor_value_info("I", TensorProto.INT64, [None])
         Y = make_tensor_value_info("Y", TensorProto.FLOAT, [None, None])
@@ -614,38 +619,37 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
                 ),
             ],
         }
-        for post in ("SOFTMAX", "NONE", "LOGISTIC", "SOFTMAX_ZERO", "PROBIT"):
-            if post == "PROBIT":
-                coefficients = [0.058, 0.029, 0.09, 0.058, 0.029, 0.09]
-                intercepts = [0.27, 0.27, 0.05]
-            else:
-                coefficients = [-0.58, -0.29, -0.09, 0.58, 0.29, 0.09]
-                intercepts = [2.7, -2.7, 0.5]
-            with self.subTest(post_transform=post):
-                node1 = make_node(
-                    "LinearClassifier",
-                    ["X"],
-                    ["I", "Y"],
-                    domain="ai.onnx.ml",
-                    classlabels_ints=[0, 1, 2],
-                    coefficients=coefficients,
-                    intercepts=intercepts,
-                    multi_class=0,
-                    post_transform=post,
-                )
-                graph = make_graph([node1], "ml", [X], [In, Y])
-                model = make_model_gen_version(graph, opset_imports=OPSETS)
-                onnx.checker.check_model(model)
-                x = np.arange(6).reshape((-1, 2)).astype(np.float32)
-                self._check_ort(model, {"X": x}, rev=True, atol=1e-4)
-                sess = ReferenceEvaluator(model)
-                got = sess.run(None, {"X": x})
-                expected = expected_post[post]
-                assert_allclose(got[1], expected[1], atol=1e-4)
-                assert_allclose(got[0], expected[0])
+        if post == "PROBIT":
+            coefficients = [0.058, 0.029, 0.09, 0.058, 0.029, 0.09]
+            intercepts = [0.27, 0.27, 0.05]
+        else:
+            coefficients = [-0.58, -0.29, -0.09, 0.58, 0.29, 0.09]
+            intercepts = [2.7, -2.7, 0.5]
+        node1 = make_node(
+            "LinearClassifier",
+            ["X"],
+            ["I", "Y"],
+            domain="ai.onnx.ml",
+            classlabels_ints=[0, 1, 2],
+            coefficients=coefficients,
+            intercepts=intercepts,
+            multi_class=0,
+            post_transform=post,
+        )
+        graph = make_graph([node1], "ml", [X], [In, Y])
+        model = make_model_gen_version(graph, opset_imports=OPSETS)
+        onnx.checker.check_model(model)
+        x = np.arange(6).reshape((-1, 2)).astype(np.float32)
+        self._check_ort(model, {"X": x}, rev=True, atol=1e-4)
+        sess = ReferenceEvaluator(model)
+        got = sess.run(None, {"X": x})
+        expected = expected_post[post]
+        assert_allclose(got[1], expected[1], atol=1e-4)
+        assert_allclose(got[0], expected[0])
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
-    def test_linear_classifier_binary(self):
+    @pytest.mark.parametrize("post", ["SOFTMAX", "NONE", "LOGISTIC", "SOFTMAX_ZERO"])
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    def test_linear_classifier_binary(self, post):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None])
         In = make_tensor_value_info("I", TensorProto.INT64, [None])
         Y = make_tensor_value_info("Y", TensorProto.FLOAT, [None, None])
@@ -677,77 +681,87 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
             ],
         }
         x = np.arange(6).reshape((-1, 3)).astype(np.float32)
-        for post in ("SOFTMAX", "NONE", "LOGISTIC", "SOFTMAX_ZERO"):
-            expected = expected_post[post]
-            with self.subTest(post_transform=post):
-                node1 = make_node(
-                    "LinearClassifier",
-                    ["X"],
-                    ["I", "Y"],
-                    domain="ai.onnx.ml",
-                    classlabels_ints=[0, 1],
-                    coefficients=[-0.58, -0.29, -0.09],
-                    intercepts=[10.0],
-                    multi_class=0,
-                    post_transform=post,
-                )
-                graph = make_graph([node1], "ml", [X], [In, Y])
-                model = make_model_gen_version(graph, opset_imports=OPSETS)
-                onnx.checker.check_model(model)
-                # onnxruntime answer seems odd.
-                # self._check_ort(model, {"X": x}, rev=True)
-                sess = ReferenceEvaluator(model)
-                got = sess.run(None, {"X": x})
-                assert_allclose(got[1], expected[1], atol=1e-6)
-                assert_allclose(got[0], expected[0])
+        expected = expected_post[post]
+        node1 = make_node(
+            "LinearClassifier",
+            ["X"],
+            ["I", "Y"],
+            domain="ai.onnx.ml",
+            classlabels_ints=[0, 1],
+            coefficients=[-0.58, -0.29, -0.09],
+            intercepts=[10.0],
+            multi_class=0,
+            post_transform=post,
+        )
+        graph = make_graph([node1], "ml", [X], [In, Y])
+        model = make_model_gen_version(graph, opset_imports=OPSETS)
+        onnx.checker.check_model(model)
+        # onnxruntime answer seems odd.
+        # self._check_ort(model, {"X": x}, rev=True)
+        sess = ReferenceEvaluator(model)
+        got = sess.run(None, {"X": x})
+        assert_allclose(got[1], expected[1], atol=1e-6)
+        assert_allclose(got[0], expected[0])
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
-    def test_linear_classifier_unary(self):
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.parametrize(
+        "post, expected",
+        [
+            (
+                "NONE",
+                (
+                    np.array([1, 0], dtype=np.int64),
+                    np.array([[2.23], [-0.65]], dtype=np.float32),
+                ),
+            ),
+            (
+                "LOGISTIC",
+                (
+                    np.array([1, 0], dtype=np.int64),
+                    np.array([[0.902911], [0.34299]], dtype=np.float32),
+                ),
+            ),
+            (
+                "SOFTMAX",
+                (
+                    np.array([1, 1], dtype=np.int64),
+                    np.array([[1.0], [1.0]], dtype=np.float32),
+                ),
+            ),
+            (
+                "SOFTMAX_ZERO",
+                (
+                    np.array([1, 1], dtype=np.int64),
+                    np.array([[1.0], [1.0]], dtype=np.float32),
+                ),
+            ),
+        ],
+    )
+    def test_linear_classifier_unary(self, post, expected):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None])
         In = make_tensor_value_info("I", TensorProto.INT64, [None])
         Y = make_tensor_value_info("Y", TensorProto.FLOAT, [None, None])
-        expected_post = {
-            "NONE": [
-                np.array([1, 0], dtype=np.int64),
-                np.array([[2.23], [-0.65]], dtype=np.float32),
-            ],
-            "LOGISTIC": [
-                np.array([1, 0], dtype=np.int64),
-                np.array([[0.902911], [0.34299]], dtype=np.float32),
-            ],
-            "SOFTMAX": [
-                np.array([1, 1], dtype=np.int64),
-                np.array([[1.0], [1.0]], dtype=np.float32),
-            ],
-            "SOFTMAX_ZERO": [
-                np.array([1, 1], dtype=np.int64),
-                np.array([[1.0], [1.0]], dtype=np.float32),
-            ],
-        }
         x = np.arange(6).reshape((-1, 3)).astype(np.float32)
-        for post in ("NONE", "LOGISTIC", "SOFTMAX_ZERO", "SOFTMAX"):
-            expected = expected_post[post]
-            with self.subTest(post_transform=post):
-                node1 = make_node(
-                    "LinearClassifier",
-                    ["X"],
-                    ["I", "Y"],
-                    domain="ai.onnx.ml",
-                    classlabels_ints=[1],
-                    coefficients=[-0.58, -0.29, -0.09],
-                    intercepts=[2.7],
-                    multi_class=0,
-                    post_transform=post,
-                )
-                graph = make_graph([node1], "ml", [X], [In, Y])
-                model = make_model_gen_version(graph, opset_imports=OPSETS)
-                onnx.checker.check_model(model)
-                # onnxruntime answer seems odd.
-                # self._check_ort(model, {"X": x}, rev=True)
-                sess = ReferenceEvaluator(model)
-                got = sess.run(None, {"X": x})
-                assert_allclose(got[1], expected[1], atol=1e-6)
-                assert_allclose(got[0], expected[0])
+        node1 = make_node(
+            "LinearClassifier",
+            ["X"],
+            ["I", "Y"],
+            domain="ai.onnx.ml",
+            classlabels_ints=[1],
+            coefficients=[-0.58, -0.29, -0.09],
+            intercepts=[2.7],
+            multi_class=0,
+            post_transform=post,
+        )
+        graph = make_graph([node1], "ml", [X], [In, Y])
+        model = make_model_gen_version(graph, opset_imports=OPSETS)
+        onnx.checker.check_model(model)
+        # onnxruntime answer seems odd.
+        # self._check_ort(model, {"X": x}, rev=True)
+        sess = ReferenceEvaluator(model)
+        got = sess.run(None, {"X": x})
+        assert_allclose(got[1], expected[1], atol=1e-6)
+        assert_allclose(got[0], expected[0])
 
     @staticmethod
     def _get_test_tree_ensemble_opset_latest(
@@ -928,7 +942,7 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
             )
         )
     )
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_tree_ensemble_regressor_aggregation_functions(
         self, aggregate_function, expected_result, opset5
     ):
@@ -990,7 +1004,7 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
             )
         )
     )
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_tree_ensemble_regressor_rule(self, rule, expected, opset5):
         x = np.arange(9).reshape((-1, 3)).astype(np.float32) / 10 - 0.5
         model_factory = (
@@ -1005,7 +1019,7 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         (actual,) = sess.run(None, {"X": x})
         assert_allclose(actual, expected, atol=1e-6)
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_tree_ensemble_regressor_2_targets_opset3(self):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None])
         Y = make_tensor_value_info("Y", TensorProto.FLOAT, [None, None])
@@ -1105,7 +1119,7 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         got = sess.run(None, {"X": x})
         assert_allclose(got[0], expected, atol=1e-6)
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_tree_ensemble_regressor_missing_opset3(self):
         x = np.arange(9).reshape((-1, 3)).astype(np.float32) / 10 - 0.5
         x[2, 0] = 5
@@ -1118,10 +1132,8 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         assert_allclose(got[0], expected, atol=1e-6)
         assert "op_type=TreeEnsembleRegressor" in str(sess.rt_nodes_[0])
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
-    @parameterized.expand(
-        [(input_type,) for input_type in [TensorProto.FLOAT, TensorProto.DOUBLE]]
-    )
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.parametrize("input_type", [TensorProto.FLOAT, TensorProto.DOUBLE])
     def test_tree_ensemble_missing_opset5(self, input_type):
         model = self._get_test_tree_ensemble_opset_latest(
             AggregationFunction.SUM, Mode.LEQ, True, input_type
@@ -1135,7 +1147,7 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         (actual,) = session.run(None, {"X": x})
         assert_allclose(actual, expected, atol=1e-6)
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_tree_ensemble_regressor_missing_opset5_float16(self):
         model = self._get_test_tree_ensemble_opset_latest(
             AggregationFunction.SUM, Mode.LEQ, False, TensorProto.FLOAT16
@@ -1149,7 +1161,7 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         (actual,) = session.run(None, {"X": x})
         assert_allclose(actual, expected, atol=1e-6)
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_single_tree_ensemble(self):
         X = make_tensor_value_info("X", TensorProto.DOUBLE, [None, None])
         Y = make_tensor_value_info("Y", TensorProto.DOUBLE, [None, None])
@@ -1212,7 +1224,7 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
             output, np.array([[5.23, 0], [5.23, 0], [0, 12.12]], dtype=np.float64)
         )
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_tree_ensemble_regressor_set_membership_opset5(self):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None])
         Y = make_tensor_value_info("Y", TensorProto.FLOAT, [None, None])
@@ -1329,34 +1341,40 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         onnx.checker.check_model(model)
         return model
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
-    def test_svm_regressor(self):
-        x = np.arange(9).reshape((-1, 3)).astype(np.float32) / 10 - 0.5
-        expected_kernel = {
-            "LINEAR": (
+    @pytest.mark.parametrize(
+        "kernel, params, expected",
+        [
+            (
+                "LINEAR",
                 [0.42438405752182007, 0.0, 3.0],
                 np.array([[-0.468206], [0.227487], [0.92318]], dtype=np.float32),
             ),
-            "POLY": (
+            (
+                "POLY",
                 [0.3426632285118103, 0.0, 3.0],
                 np.array([[0.527084], [0.543578], [0.546506]], dtype=np.float32),
             ),
-            "RBF": (
+            (
+                "RBF",
                 [0.30286383628845215, 0.0, 3.0],
                 np.array([[0.295655], [0.477876], [0.695292]], dtype=np.float32),
             ),
-            "SIGMOID": (
+            (
+                "SIGMOID",
                 [0.30682486295700073, 0.0, 3.0],
                 np.array([[0.239304], [0.448929], [0.661689]], dtype=np.float32),
             ),
-        }
-        for kernel, (params, expected) in expected_kernel.items():
-            with self.subTest(kernel=kernel):
-                model = self._get_test_svm_regressor(kernel, params)
-                self._check_ort(model, {"X": x}, atol=1e-6)
-                sess = ReferenceEvaluator(model)
-                got = sess.run(None, {"X": x})
-                assert_allclose(got[0], expected, atol=1e-6)
+        ],
+    )
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    def test_svm_regressor(self, kernel, params, expected):
+        x = np.arange(9).reshape((-1, 3)).astype(np.float32) / 10 - 0.5
+
+        model = self._get_test_svm_regressor(kernel, params)
+        self._check_ort(model, {"X": x}, atol=1e-6)
+        sess = ReferenceEvaluator(model)
+        (got,) = sess.run(None, {"X": x})
+        assert_allclose(got, expected, atol=1e-6)
 
     @staticmethod
     def _get_test_tree_ensemble_classifier_binary(post_transform):
@@ -1429,55 +1447,71 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         onnx.checker.check_model(model)
         return model
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
-    def test_tree_ensemble_classifier_binary(self):
+    @pytest.mark.parametrize(
+        "post, expected",
+        [
+            (
+                "NONE",
+                (
+                    np.array([0, 1, 1], dtype=np.int64),
+                    np.array(
+                        [[1.0, 0.0], [0.394958, 0.605042], [0.394958, 0.605042]],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "LOGISTIC",
+                (
+                    np.array([0, 1, 1], dtype=np.int64),
+                    np.array(
+                        [[0.5, 0.5], [0.353191, 0.646809], [0.353191, 0.646809]],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "SOFTMAX",
+                (
+                    np.array([0, 1, 1], dtype=np.int64),
+                    np.array(
+                        [[0.5, 0.5], [0.229686, 0.770314], [0.229686, 0.770314]],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "SOFTMAX_ZERO",
+                (
+                    np.array([0, 1, 1], dtype=np.int64),
+                    np.array(
+                        [[0.5, 0.5], [0.229686, 0.770314], [0.229686, 0.770314]],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "PROBIT",
+                (
+                    np.array([0, 1, 1], dtype=np.int64),
+                    np.array(
+                        [[0.0, 0.0], [-0.266426, 0.266426], [-0.266426, 0.266426]],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+        ],
+    )
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    def test_tree_ensemble_classifier_binary(self, post, expected):
         x = (np.arange(9).reshape((-1, 3)) - 5).astype(np.float32) / 5
-        expected_post = {
-            "NONE": (
-                np.array([0, 1, 1], dtype=np.int64),
-                np.array(
-                    [[1.0, 0.0], [0.394958, 0.605042], [0.394958, 0.605042]],
-                    dtype=np.float32,
-                ),
-            ),
-            "LOGISTIC": (
-                np.array([0, 1, 1], dtype=np.int64),
-                np.array(
-                    [[0.5, 0.5], [0.353191, 0.646809], [0.353191, 0.646809]],
-                    dtype=np.float32,
-                ),
-            ),
-            "SOFTMAX": (
-                np.array([0, 1, 1], dtype=np.int64),
-                np.array(
-                    [[0.5, 0.5], [0.229686, 0.770314], [0.229686, 0.770314]],
-                    dtype=np.float32,
-                ),
-            ),
-            "SOFTMAX_ZERO": (
-                np.array([0, 1, 1], dtype=np.int64),
-                np.array(
-                    [[0.5, 0.5], [0.229686, 0.770314], [0.229686, 0.770314]],
-                    dtype=np.float32,
-                ),
-            ),
-            "PROBIT": (
-                np.array([0, 1, 1], dtype=np.int64),
-                np.array(
-                    [[0.0, 0.0], [-0.266426, 0.266426], [-0.266426, 0.266426]],
-                    dtype=np.float32,
-                ),
-            ),
-        }
-        for post, expected in expected_post.items():
-            with self.subTest(post_transform=post):
-                model = self._get_test_tree_ensemble_classifier_binary(post)
-                if post == "NONE":
-                    self._check_ort(model, {"X": x})
-                sess = ReferenceEvaluator(model)
-                got = sess.run(None, {"X": x})
-                assert_allclose(got[1], expected[1], atol=1e-6)
-                assert_allclose(got[0], expected[0])
+        model = self._get_test_tree_ensemble_classifier_binary(post)
+        if post == "NONE":
+            self._check_ort(model, {"X": x})
+        sess = ReferenceEvaluator(model)
+        got = sess.run(None, {"X": x})
+        assert_allclose(got[1], expected[1], atol=1e-6)
+        assert_allclose(got[0], expected[0])
 
     @staticmethod
     def _get_test_tree_ensemble_classifier_multi(post_transform):
@@ -1557,75 +1591,91 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         onnx.checker.check_model(model)
         return model
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
-    def test_tree_ensemble_classifier_multi(self):
+    @pytest.mark.parametrize(
+        "post, expected",
+        [
+            (
+                "NONE",
+                (
+                    np.array([0, 0, 1], dtype=np.int64),
+                    np.array(
+                        [
+                            [0.916667, 0.0, 0.083333],
+                            [0.569608, 0.191176, 0.239216],
+                            [0.302941, 0.431176, 0.265882],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "LOGISTIC",
+                (
+                    np.array([0, 0, 1], dtype=np.int64),
+                    np.array(
+                        [
+                            [0.714362, 0.5, 0.520821],
+                            [0.638673, 0.547649, 0.55952],
+                            [0.575161, 0.606155, 0.566082],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "SOFTMAX",
+                (
+                    np.array([0, 0, 1], dtype=np.int64),
+                    np.array(
+                        [
+                            [0.545123, 0.217967, 0.23691],
+                            [0.416047, 0.284965, 0.298988],
+                            [0.322535, 0.366664, 0.310801],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "SOFTMAX_ZERO",
+                (
+                    np.array([0, 0, 1], dtype=np.int64),
+                    np.array(
+                        [
+                            [0.697059, 0.0, 0.302941],
+                            [0.416047, 0.284965, 0.298988],
+                            [0.322535, 0.366664, 0.310801],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "PROBIT",
+                (
+                    np.array([0, 0, 1], dtype=np.int64),
+                    np.array(
+                        [
+                            [1.383104, 0, -1.383105],
+                            [0.175378, -0.873713, -0.708922],
+                            [-0.516003, -0.173382, -0.625385],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+        ],
+    )
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    def test_tree_ensemble_classifier_multi(self, post, expected):
         x = (np.arange(9).reshape((-1, 3)) - 5).astype(np.float32) / 5
-        expected_post = {
-            "NONE": (
-                np.array([0, 0, 1], dtype=np.int64),
-                np.array(
-                    [
-                        [0.916667, 0.0, 0.083333],
-                        [0.569608, 0.191176, 0.239216],
-                        [0.302941, 0.431176, 0.265882],
-                    ],
-                    dtype=np.float32,
-                ),
-            ),
-            "LOGISTIC": (
-                np.array([0, 0, 1], dtype=np.int64),
-                np.array(
-                    [
-                        [0.714362, 0.5, 0.520821],
-                        [0.638673, 0.547649, 0.55952],
-                        [0.575161, 0.606155, 0.566082],
-                    ],
-                    dtype=np.float32,
-                ),
-            ),
-            "SOFTMAX": (
-                np.array([0, 0, 1], dtype=np.int64),
-                np.array(
-                    [
-                        [0.545123, 0.217967, 0.23691],
-                        [0.416047, 0.284965, 0.298988],
-                        [0.322535, 0.366664, 0.310801],
-                    ],
-                    dtype=np.float32,
-                ),
-            ),
-            "SOFTMAX_ZERO": (
-                np.array([0, 0, 1], dtype=np.int64),
-                np.array(
-                    [
-                        [0.697059, 0.0, 0.302941],
-                        [0.416047, 0.284965, 0.298988],
-                        [0.322535, 0.366664, 0.310801],
-                    ],
-                    dtype=np.float32,
-                ),
-            ),
-            "PROBIT": (
-                np.array([0, 0, 1], dtype=np.int64),
-                np.array(
-                    [
-                        [1.383104, 0, -1.383105],
-                        [0.175378, -0.873713, -0.708922],
-                        [-0.516003, -0.173382, -0.625385],
-                    ],
-                    dtype=np.float32,
-                ),
-            ),
-        }
-        for post, expected in expected_post.items():
-            with self.subTest(post_transform=post):
-                model = self._get_test_tree_ensemble_classifier_multi(post)
-                if post != "PROBIT":
-                    self._check_ort(model, {"X": x}, atol=1e-5)
-                sess = ReferenceEvaluator(model)
-                got = sess.run(None, {"X": x})
-                assert_allclose(got[1], expected[1], atol=1e-6)
-                assert_allclose(got[0], expected[0])
+        model = self._get_test_tree_ensemble_classifier_multi(post)
+        if post != "PROBIT":
+            self._check_ort(model, {"X": x}, atol=1e-5)
+        sess = ReferenceEvaluator(model)
+        got = sess.run(None, {"X": x})
+        assert_allclose(got[1], expected[1], atol=1e-6)
+        assert_allclose(got[0], expected[0])
 
     @staticmethod
     def _get_test_svm_classifier_binary(post_transform, probability=True, linear=False):
@@ -1706,246 +1756,337 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         onnx.checker.check_model(model)
         return model
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
-    def test_svm_classifier_binary(self):
+    @pytest.mark.parametrize(
+        "post, expected",
+        [
+            (
+                "NONE",
+                (
+                    np.array([0, 1, 1], dtype=np.int64),
+                    np.array(
+                        [
+                            [0.993287, 0.006713],
+                            [0.469401, 0.530599],
+                            [0.014997, 0.985003],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "LOGISTIC",
+                (
+                    np.array([0, 1, 1], dtype=np.int64),
+                    np.array(
+                        [
+                            [0.729737, 0.501678],
+                            [0.615242, 0.629623],
+                            [0.503749, 0.7281],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "SOFTMAX",
+                (
+                    np.array([0, 1, 1], dtype=np.int64),
+                    np.array(
+                        [
+                            [0.728411, 0.271589],
+                            [0.484705, 0.515295],
+                            [0.274879, 0.725121],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "SOFTMAX_ZERO",
+                (
+                    np.array([0, 1, 1], dtype=np.int64),
+                    np.array(
+                        [
+                            [0.728411, 0.271589],
+                            [0.484705, 0.515295],
+                            [0.274879, 0.725121],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "PROBIT",
+                (
+                    np.array([0, 1, 1], dtype=np.int64),
+                    np.array(
+                        [
+                            [2.469393, -2.469391],
+                            [-0.076776, 0.076776],
+                            [-2.16853, 2.16853],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+        ],
+    )
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    def test_svm_classifier_binary(self, post, expected):
         x = (np.arange(9).reshape((-1, 3)) - 5).astype(np.float32) / 5
-        expected_post = {
-            "NONE": (
-                np.array([0, 1, 1], dtype=np.int64),
-                np.array(
-                    [[0.993287, 0.006713], [0.469401, 0.530599], [0.014997, 0.985003]],
-                    dtype=np.float32,
-                ),
-            ),
-            "LOGISTIC": (
-                np.array([0, 1, 1], dtype=np.int64),
-                np.array(
-                    [[0.729737, 0.501678], [0.615242, 0.629623], [0.503749, 0.7281]],
-                    dtype=np.float32,
-                ),
-            ),
-            "SOFTMAX": (
-                np.array([0, 1, 1], dtype=np.int64),
-                np.array(
-                    [[0.728411, 0.271589], [0.484705, 0.515295], [0.274879, 0.725121]],
-                    dtype=np.float32,
-                ),
-            ),
-            "SOFTMAX_ZERO": (
-                np.array([0, 1, 1], dtype=np.int64),
-                np.array(
-                    [[0.728411, 0.271589], [0.484705, 0.515295], [0.274879, 0.725121]],
-                    dtype=np.float32,
-                ),
-            ),
-            "PROBIT": (
-                np.array([0, 1, 1], dtype=np.int64),
-                np.array(
-                    [[2.469393, -2.469391], [-0.076776, 0.076776], [-2.16853, 2.16853]],
-                    dtype=np.float32,
-                ),
-            ),
-        }
-        for post, expected in expected_post.items():
-            with self.subTest(post_transform=post):
-                model = self._get_test_svm_classifier_binary(post)
-                self._check_ort(model, {"X": x}, rev=True, atol=1e-5)
-                sess = ReferenceEvaluator(model)
-                got = sess.run(None, {"X": x})
-                assert_allclose(got[1], expected[1], atol=1e-5)
-                assert_allclose(got[0], expected[0])
+        model = self._get_test_svm_classifier_binary(post)
+        self._check_ort(model, {"X": x}, rev=True, atol=1e-5)
+        sess = ReferenceEvaluator(model)
+        got = sess.run(None, {"X": x})
+        assert_allclose(got[1], expected[1], atol=1e-5)
+        assert_allclose(got[0], expected[0])
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
-    def test_svm_classifier_binary_noprob(self):
+    @pytest.mark.parametrize(
+        "post, expected",
+        [
+            (
+                "NONE",
+                (
+                    np.array([0, 1, 1], dtype=np.int64),
+                    np.array(
+                        [
+                            [-0.986073, 0.986073],
+                            [0.011387, -0.011387],
+                            [0.801808, -0.801808],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "LOGISTIC",
+                (
+                    np.array([0, 1, 1], dtype=np.int64),
+                    np.array(
+                        [
+                            [0.271688, 0.728312],
+                            [0.502847, 0.497153],
+                            [0.690361, 0.309639],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "SOFTMAX",
+                (
+                    np.array([0, 1, 1], dtype=np.int64),
+                    np.array(
+                        [
+                            [0.122158, 0.877842],
+                            [0.505693, 0.494307],
+                            [0.832523, 0.167477],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "SOFTMAX_ZERO",
+                (
+                    np.array([0, 1, 1], dtype=np.int64),
+                    np.array(
+                        [
+                            [0.122158, 0.877842],
+                            [0.505693, 0.494307],
+                            [0.832523, 0.167477],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+        ],
+    )
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    def test_svm_classifier_binary_noprob(self, post, expected):
         x = (np.arange(9).reshape((-1, 3)) - 5).astype(np.float32) / 5
-        expected_post = {
-            "NONE": (
-                np.array([0, 1, 1], dtype=np.int64),
-                np.array(
-                    [
-                        [-0.986073, 0.986073],
-                        [0.011387, -0.011387],
-                        [0.801808, -0.801808],
-                    ],
-                    dtype=np.float32,
-                ),
-            ),
-            "LOGISTIC": (
-                np.array([0, 1, 1], dtype=np.int64),
-                np.array(
-                    [[0.271688, 0.728312], [0.502847, 0.497153], [0.690361, 0.309639]],
-                    dtype=np.float32,
-                ),
-            ),
-            "SOFTMAX": (
-                np.array([0, 1, 1], dtype=np.int64),
-                np.array(
-                    [[0.122158, 0.877842], [0.505693, 0.494307], [0.832523, 0.167477]],
-                    dtype=np.float32,
-                ),
-            ),
-            "SOFTMAX_ZERO": (
-                np.array([0, 1, 1], dtype=np.int64),
-                np.array(
-                    [[0.122158, 0.877842], [0.505693, 0.494307], [0.832523, 0.167477]],
-                    dtype=np.float32,
-                ),
-            ),
-        }
-        for post, expected in expected_post.items():
-            with self.subTest(post_transform=post):
-                model = self._get_test_svm_classifier_binary(post, probability=False)
-                if post not in {"LOGISTIC", "SOFTMAX", "SOFTMAX_ZERO", "PROBIT"}:
-                    self._check_ort(model, {"X": x}, rev=True, atol=1e-5)
-                sess = ReferenceEvaluator(model)
-                got = sess.run(None, {"X": x})
-                assert_allclose(got[1], expected[1], atol=1e-6)
-                assert_allclose(got[0], expected[0])
+        model = self._get_test_svm_classifier_binary(post, probability=False)
+        if post not in {"LOGISTIC", "SOFTMAX", "SOFTMAX_ZERO", "PROBIT"}:
+            self._check_ort(model, {"X": x}, rev=True, atol=1e-5)
+        sess = ReferenceEvaluator(model)
+        got = sess.run(None, {"X": x})
+        assert_allclose(got[1], expected[1], atol=1e-6)
+        assert_allclose(got[0], expected[0])
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
-    def test_svm_classifier_noprob_linear(self):
+    @pytest.mark.parametrize(
+        "post, expected",
+        [
+            (
+                "NONE",
+                (
+                    np.array([2, 3, 0], dtype=np.int64),
+                    np.array(
+                        [
+                            [-0.118086, -0.456685, 0.415783, 0.334506],
+                            [-0.061364, -0.231444, 0.073899, 0.091242],
+                            [-0.004642, -0.006203, -0.267985, -0.152023],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "LOGISTIC",
+                (
+                    np.array([2, 3, 0], dtype=np.int64),
+                    np.array(
+                        [
+                            [0.470513, 0.387773, 0.602474, 0.582855],
+                            [0.484664, 0.442396, 0.518466, 0.522795],
+                            [0.498839, 0.498449, 0.433402, 0.462067],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "SOFTMAX",
+                (
+                    np.array([2, 3, 0], dtype=np.int64),
+                    np.array(
+                        [
+                            [0.200374, 0.14282, 0.341741, 0.315065],
+                            [0.240772, 0.203115, 0.275645, 0.280467],
+                            [0.275491, 0.275061, 0.211709, 0.237739],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "SOFTMAX_ZERO",
+                (
+                    np.array([2, 3, 0], dtype=np.int64),
+                    np.array(
+                        [
+                            [0.200374, 0.14282, 0.341741, 0.315065],
+                            [0.240772, 0.203115, 0.275645, 0.280467],
+                            [0.275491, 0.275061, 0.211709, 0.237739],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "PROBIT",
+                (
+                    np.array([2, 3, 0], dtype=np.int64),
+                    np.array(
+                        [
+                            [np.nan, np.nan, -0.212698, -0.427529],
+                            [np.nan, np.nan, -1.447414, -1.333286],
+                            [np.nan, np.nan, np.nan, np.nan],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+        ],
+    )
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    def test_svm_classifier_noprob_linear(self, post, expected):
         x = (np.arange(9).reshape((-1, 3)) - 5).astype(np.float32) / 5
-        nan = np.nan
-        expected_post = {
-            "NONE": (
-                np.array([2, 3, 0], dtype=np.int64),
-                np.array(
-                    [
-                        [-0.118086, -0.456685, 0.415783, 0.334506],
-                        [-0.061364, -0.231444, 0.073899, 0.091242],
-                        [-0.004642, -0.006203, -0.267985, -0.152023],
-                    ],
-                    dtype=np.float32,
-                ),
-            ),
-            "LOGISTIC": (
-                np.array([2, 3, 0], dtype=np.int64),
-                np.array(
-                    [
-                        [0.470513, 0.387773, 0.602474, 0.582855],
-                        [0.484664, 0.442396, 0.518466, 0.522795],
-                        [0.498839, 0.498449, 0.433402, 0.462067],
-                    ],
-                    dtype=np.float32,
-                ),
-            ),
-            "SOFTMAX": (
-                np.array([2, 3, 0], dtype=np.int64),
-                np.array(
-                    [
-                        [0.200374, 0.14282, 0.341741, 0.315065],
-                        [0.240772, 0.203115, 0.275645, 0.280467],
-                        [0.275491, 0.275061, 0.211709, 0.237739],
-                    ],
-                    dtype=np.float32,
-                ),
-            ),
-            "SOFTMAX_ZERO": (
-                np.array([2, 3, 0], dtype=np.int64),
-                np.array(
-                    [
-                        [0.200374, 0.14282, 0.341741, 0.315065],
-                        [0.240772, 0.203115, 0.275645, 0.280467],
-                        [0.275491, 0.275061, 0.211709, 0.237739],
-                    ],
-                    dtype=np.float32,
-                ),
-            ),
-            "PROBIT": (
-                np.array([2, 3, 0], dtype=np.int64),
-                np.array(
-                    [
-                        [nan, nan, -0.212698, -0.427529],
-                        [nan, nan, -1.447414, -1.333286],
-                        [nan, nan, nan, nan],
-                    ],
-                    dtype=np.float32,
-                ),
-            ),
-        }
-        for post, expected in expected_post.items():
-            with self.subTest(post_transform=post):
-                model = self._get_test_svm_classifier_binary(
-                    post, probability=False, linear=True
-                )
-                self._check_ort(model, {"X": x}, rev=True, atol=1e-5)
-                sess = ReferenceEvaluator(model)
-                got = sess.run(None, {"X": x})
-                assert_allclose(got[1], expected[1], atol=1e-6)
-                assert_allclose(got[0], expected[0])
+        model = self._get_test_svm_classifier_binary(
+            post, probability=False, linear=True
+        )
+        self._check_ort(model, {"X": x}, rev=True, atol=1e-5)
+        sess = ReferenceEvaluator(model)
+        got = sess.run(None, {"X": x})
+        assert_allclose(got[1], expected[1], atol=1e-6)
+        assert_allclose(got[0], expected[0])
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
-    def test_svm_classifier_linear(self):
+    @pytest.mark.parametrize(
+        "post, expected",
+        [
+            (
+                "NONE",
+                (
+                    np.array([2, 3, 0], dtype=np.int64),
+                    np.array(
+                        [
+                            [-0.118086, -0.456685, 0.415783, 0.334506],
+                            [-0.061364, -0.231444, 0.073899, 0.091242],
+                            [-0.004642, -0.006203, -0.267985, -0.152023],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "LOGISTIC",
+                (
+                    np.array([2, 3, 0], dtype=np.int64),
+                    np.array(
+                        [
+                            [0.470513, 0.387773, 0.602474, 0.582855],
+                            [0.484664, 0.442396, 0.518466, 0.522795],
+                            [0.498839, 0.498449, 0.433402, 0.462067],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "SOFTMAX",
+                (
+                    np.array([2, 3, 0], dtype=np.int64),
+                    np.array(
+                        [
+                            [0.200374, 0.14282, 0.341741, 0.315065],
+                            [0.240772, 0.203115, 0.275645, 0.280467],
+                            [0.275491, 0.275061, 0.211709, 0.237739],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "SOFTMAX_ZERO",
+                (
+                    np.array([2, 3, 0], dtype=np.int64),
+                    np.array(
+                        [
+                            [0.200374, 0.14282, 0.341741, 0.315065],
+                            [0.240772, 0.203115, 0.275645, 0.280467],
+                            [0.275491, 0.275061, 0.211709, 0.237739],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "PROBIT",
+                (
+                    np.array([2, 3, 0], dtype=np.int64),
+                    np.array(
+                        [
+                            [np.nan, np.nan, -0.212698, -0.427529],
+                            [np.nan, np.nan, -1.447414, -1.333286],
+                            [np.nan, np.nan, np.nan, np.nan],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+        ],
+    )
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    def test_svm_classifier_linear(self, post, expected):
         # prob_a, prob_b are not used in this case.
         x = (np.arange(9).reshape((-1, 3)) - 5).astype(np.float32) / 5
-        nan = np.nan
-        expected_post = {
-            "NONE": (
-                np.array([2, 3, 0], dtype=np.int64),
-                np.array(
-                    [
-                        [-0.118086, -0.456685, 0.415783, 0.334506],
-                        [-0.061364, -0.231444, 0.073899, 0.091242],
-                        [-0.004642, -0.006203, -0.267985, -0.152023],
-                    ],
-                    dtype=np.float32,
-                ),
-            ),
-            "LOGISTIC": (
-                np.array([2, 3, 0], dtype=np.int64),
-                np.array(
-                    [
-                        [0.470513, 0.387773, 0.602474, 0.582855],
-                        [0.484664, 0.442396, 0.518466, 0.522795],
-                        [0.498839, 0.498449, 0.433402, 0.462067],
-                    ],
-                    dtype=np.float32,
-                ),
-            ),
-            "SOFTMAX": (
-                np.array([2, 3, 0], dtype=np.int64),
-                np.array(
-                    [
-                        [0.200374, 0.14282, 0.341741, 0.315065],
-                        [0.240772, 0.203115, 0.275645, 0.280467],
-                        [0.275491, 0.275061, 0.211709, 0.237739],
-                    ],
-                    dtype=np.float32,
-                ),
-            ),
-            "SOFTMAX_ZERO": (
-                np.array([2, 3, 0], dtype=np.int64),
-                np.array(
-                    [
-                        [0.200374, 0.14282, 0.341741, 0.315065],
-                        [0.240772, 0.203115, 0.275645, 0.280467],
-                        [0.275491, 0.275061, 0.211709, 0.237739],
-                    ],
-                    dtype=np.float32,
-                ),
-            ),
-            "PROBIT": (
-                np.array([2, 3, 0], dtype=np.int64),
-                np.array(
-                    [
-                        [nan, nan, -0.212698, -0.427529],
-                        [nan, nan, -1.447414, -1.333286],
-                        [nan, nan, nan, nan],
-                    ],
-                    dtype=np.float32,
-                ),
-            ),
-        }
-        for post, expected in expected_post.items():
-            with self.subTest(post_transform=post):
-                model = self._get_test_svm_classifier_binary(
-                    post, probability=True, linear=True
-                )
-                self._check_ort(model, {"X": x}, rev=True, atol=1e-5)
-                sess = ReferenceEvaluator(model)
-                got = sess.run(None, {"X": x})
-                assert_allclose(got[1], expected[1], atol=1e-6)
-                assert_allclose(got[0], expected[0])
+        model = self._get_test_svm_classifier_binary(
+            post, probability=True, linear=True
+        )
+        self._check_ort(model, {"X": x}, rev=True, atol=1e-5)
+        sess = ReferenceEvaluator(model)
+        got = sess.run(None, {"X": x})
+        assert_allclose(got[1], expected[1], atol=1e-6)
+        assert_allclose(got[0], expected[0])
 
     @staticmethod
     def _get_test_svm_classifier_linear_sv(post_transform, probability=True):
@@ -1994,48 +2135,78 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         onnx.checker.check_model(model)
         return model
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
-    def test_svm_classifier_binary_noprob_linear_sv(self):
+    @pytest.mark.parametrize(
+        "post, expected",
+        [
+            (
+                "NONE",
+                (
+                    np.array([0, 0, 0], dtype=np.int64),
+                    np.array(
+                        [
+                            [-2.662655, 2.662655],
+                            [-2.21481, 2.21481],
+                            [-1.766964, 1.766964],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "LOGISTIC",
+                (
+                    np.array([0, 0, 0], dtype=np.int64),
+                    np.array(
+                        [
+                            [0.065213, 0.934787],
+                            [0.098428, 0.901572],
+                            [0.14592, 0.85408],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "SOFTMAX",
+                (
+                    np.array([0, 0, 0], dtype=np.int64),
+                    np.array(
+                        [
+                            [0.004843, 0.995157],
+                            [0.011779, 0.988221],
+                            [0.028362, 0.971638],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+            (
+                "SOFTMAX_ZERO",
+                (
+                    np.array([0, 0, 0], dtype=np.int64),
+                    np.array(
+                        [
+                            [0.004843, 0.995157],
+                            [0.011779, 0.988221],
+                            [0.028362, 0.971638],
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            ),
+        ],
+    )
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    def test_svm_classifier_binary_noprob_linear_sv(self, post, expected):
         x = (np.arange(9).reshape((-1, 3)) - 5).astype(np.float32) / 5
-        expected_post = {
-            "NONE": (
-                np.array([0, 0, 0], dtype=np.int64),
-                np.array(
-                    [[-2.662655, 2.662655], [-2.21481, 2.21481], [-1.766964, 1.766964]],
-                    dtype=np.float32,
-                ),
-            ),
-            "LOGISTIC": (
-                np.array([0, 0, 0], dtype=np.int64),
-                np.array(
-                    [[0.065213, 0.934787], [0.098428, 0.901572], [0.14592, 0.85408]],
-                    dtype=np.float32,
-                ),
-            ),
-            "SOFTMAX": (
-                np.array([0, 0, 0], dtype=np.int64),
-                np.array(
-                    [[0.004843, 0.995157], [0.011779, 0.988221], [0.028362, 0.971638]],
-                    dtype=np.float32,
-                ),
-            ),
-            "SOFTMAX_ZERO": (
-                np.array([0, 0, 0], dtype=np.int64),
-                np.array(
-                    [[0.004843, 0.995157], [0.011779, 0.988221], [0.028362, 0.971638]],
-                    dtype=np.float32,
-                ),
-            ),
-        }
-        for post, expected in expected_post.items():
-            with self.subTest(post_transform=post):
-                model = self._get_test_svm_classifier_linear_sv(post, probability=False)
-                if post not in {"LOGISTIC", "SOFTMAX", "SOFTMAX_ZERO"}:
-                    self._check_ort(model, {"X": x}, rev=True, atol=1e-5)
-                sess = ReferenceEvaluator(model)
-                got = sess.run(None, {"X": x})
-                assert_allclose(got[1], expected[1], atol=1e-6)
-                assert_allclose(got[0], expected[0])
+
+        model = self._get_test_svm_classifier_linear_sv(post, probability=False)
+        if post not in {"LOGISTIC", "SOFTMAX", "SOFTMAX_ZERO"}:
+            self._check_ort(model, {"X": x}, rev=True, atol=1e-5)
+        sess = ReferenceEvaluator(model)
+        got = sess.run(None, {"X": x})
+        assert_allclose(got[1], expected[1], atol=1e-6)
+        assert_allclose(got[0], expected[0])
 
     @staticmethod
     def _get_test_svm_regressor_linear(post_transform, one_class=0):
@@ -2057,43 +2228,47 @@ class TestReferenceEvaluatorAiOnnxMl(unittest.TestCase):
         onnx.checker.check_model(model)
         return model
 
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
-    def test_svm_regressor_linear(self):
-        x = (np.arange(9).reshape((-1, 3)) - 5).astype(np.float32) / 5
-        expected_post = {
-            "NONE": (
+    @pytest.mark.parametrize(
+        "post, expected",
+        [
+            (
+                "NONE",
                 np.array(
                     [[0.96869], [1.132491], [1.296293]],
                     dtype=np.float32,
                 ),
             ),
-        }
-        for post, expected in expected_post.items():
-            with self.subTest(post_transform=post):
-                model = self._get_test_svm_regressor_linear(post)
-                self._check_ort(model, {"X": x}, rev=True, atol=1e-5)
-                sess = ReferenceEvaluator(model)
-                got = sess.run(None, {"X": x})
-                assert_allclose(got[0], expected[0], atol=1e-6)
-
-    @unittest.skipIf(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
-    def test_svm_regressor_linear_one_class(self):
+        ],
+    )
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    def test_svm_regressor_linear(self, post, expected):
         x = (np.arange(9).reshape((-1, 3)) - 5).astype(np.float32) / 5
-        expected_post = {
-            "NONE": (
+        model = self._get_test_svm_regressor_linear(post)
+        self._check_ort(model, {"X": x}, rev=True, atol=1e-5)
+        sess = ReferenceEvaluator(model)
+        (got,) = sess.run(None, {"X": x})
+        assert_allclose(got, expected, atol=1e-6)
+
+    @pytest.mark.parametrize(
+        "post, expected",
+        [
+            (
+                "NONE",
                 np.array(
                     [[1.0], [1.0], [1.0]],
                     dtype=np.float32,
                 ),
-            ),
-        }
-        for post, expected in expected_post.items():
-            with self.subTest(post_transform=post):
-                model = self._get_test_svm_regressor_linear(post, one_class=1)
-                self._check_ort(model, {"X": x}, rev=True, atol=1e-5)
-                sess = ReferenceEvaluator(model)
-                got = sess.run(None, {"X": x})
-                assert_allclose(got[0], expected[0], atol=1e-6)
+            )
+        ],
+    )
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    def test_svm_regressor_linear_one_class(self, post, expected):
+        x = (np.arange(9).reshape((-1, 3)) - 5).astype(np.float32) / 5
+        model = self._get_test_svm_regressor_linear(post, one_class=1)
+        self._check_ort(model, {"X": x}, rev=True, atol=1e-5)
+        sess = ReferenceEvaluator(model)
+        (got,) = sess.run(None, {"X": x})
+        assert_allclose(got, expected, atol=1e-6)
 
     def test_onnxrt_tfidf_vectorizer_ints(self):
         inputi = np.array([[1, 1, 3, 3, 3, 7], [8, 6, 7, 5, 6, 8]]).astype(np.int64)

--- a/onnx/test/reference_evaluator_ml_test.py
+++ b/onnx/test/reference_evaluator_ml_test.py
@@ -198,6 +198,7 @@ class TestReferenceEvaluatorAiOnnxMl:
             ("L2", lambda x: x / (x**2).sum(axis=1, keepdims=1) ** 0.5),
         ],
     )
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
     def test_normalizer(self, norm, compute):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None])
         Y = make_tensor_value_info("Y", TensorProto.FLOAT, [None, None])

--- a/onnx/test/reference_evaluator_test.py
+++ b/onnx/test/reference_evaluator_test.py
@@ -12,14 +12,10 @@
 
 from __future__ import annotations
 
-import importlib
+import importlib.util
 import itertools
 import math
-import unittest
 import warnings
-from contextlib import redirect_stdout
-from functools import wraps
-from io import StringIO
 from os import getenv
 from textwrap import dedent
 from typing import TYPE_CHECKING
@@ -86,34 +82,15 @@ ORT_MAX_ONNX_OPSET_SUPPORTED_VERSION = int(
 )
 
 
-def skip_if_no_onnxruntime(fn):
-    @wraps(fn)
-    def wrapper(*args, **kwargs):
-        if importlib.util.find_spec("onnxruntime") is None:
-            raise unittest.SkipTest("onnxruntime not installed")
-        fn(*args, **kwargs)
-
-    return wrapper
-
-
-def skip_if_no_torch(fn):
-    @wraps(fn)
-    def wrapper(*args, **kwargs):
-        if importlib.util.find_spec("torch") is None:
-            raise unittest.SkipTest("torch not installed")
-        fn(*args, **kwargs)
-
-    return wrapper
-
-
-def skip_if_no_torchvision(fn):
-    @wraps(fn)
-    def wrapper(*args, **kwargs):
-        if importlib.util.find_spec("torchvision") is None:
-            raise unittest.SkipTest("torchvision not installed")
-        fn(*args, **kwargs)
-
-    return wrapper
+skip_if_no_onnxruntime = pytest.mark.skipif(
+    importlib.util.find_spec("onnxruntime") is None, reason="onnxruntime not installed"
+)
+skip_if_no_torch = pytest.mark.skipif(
+    importlib.util.find_spec("torch") is None, reason="torch not installed"
+)
+skip_if_no_torchvision = pytest.mark.skipif(
+    importlib.util.find_spec("torchvision") is None, reason="torchvision not installed"
+)
 
 
 def make_sequence_value_info(name, elem_type, shape):
@@ -212,7 +189,7 @@ def im2col(
     return res.reshape(new_shape)
 
 
-class TestReferenceEvaluator(unittest.TestCase):
+class TestReferenceEvaluator:
     m2_def = """
         <
             ir_version: 7,
@@ -340,50 +317,33 @@ class TestReferenceEvaluator(unittest.TestCase):
         expected = (x + y) * (y - z)
         assert_allclose(res, expected)
 
-    def test_reference_evaluator_no_attribute_verbose(self):
-        m = TestReferenceEvaluator._load_model(TestReferenceEvaluator.m2_def)
-        x = np.array([[0, 1], [2, 3]], dtype=np.float32)
-        y = np.array([[4, 5], [6, 7]], dtype=np.float32)
-        z = np.array([[-4, -5], [-6, -7]], dtype=np.float32)
-
-        with self.subTest(level=2):
-            sess = ReferenceEvaluator(m, verbose=2)
-            stdout = StringIO()
-            with redirect_stdout(stdout):
-                sess.run(None, {"B01": x, "B11": y, "B21": z})
-            out = stdout.getvalue()
-            log = "Add(B01, B11) -> C0\nSub(B11, B21) -> C1\nMul(C0, C1) -> D0\n"
-            assert log == out
-
-        with self.subTest(level=3):
-            sess = ReferenceEvaluator(m, verbose=3)
-            stdout = StringIO()
-            with redirect_stdout(stdout):
-                sess.run(None, {"B01": x, "B11": y, "B21": z})
-            out = stdout.getvalue()
-            log = dedent(
-                """
-                 +I B01: float32:(2, 2) in [0.0, 3.0]
-                 +I B11: float32:(2, 2) in [4.0, 7.0]
-                 +I B21: float32:(2, 2) in [-7.0, -4.0]
-                Add(B01, B11) -> C0
-                 + C0: float32:(2, 2) in [4.0, 10.0]
-                Sub(B11, B21) -> C1
-                 + C1: float32:(2, 2) in [8.0, 14.0]
-                Mul(C0, C1) -> D0
-                 + D0: float32:(2, 2) in [32.0, 140.0]
-                """
-            ).lstrip("\n")
-            assert log == out
-
-        with self.subTest(level=4):
-            sess = ReferenceEvaluator(m, verbose=4)
-            stdout = StringIO()
-            with redirect_stdout(stdout):
-                sess.run(None, {"B01": x, "B11": y, "B21": z})
-            out = stdout.getvalue()
-            log = dedent(
-                """
+    @pytest.mark.parametrize(
+        "level, expected",
+        [
+            (
+                2,
+                "Add(B01, B11) -> C0\nSub(B11, B21) -> C1\nMul(C0, C1) -> D0\n",
+            ),
+            (
+                3,
+                dedent(
+                    """
+                     +I B01: float32:(2, 2) in [0.0, 3.0]
+                     +I B11: float32:(2, 2) in [4.0, 7.0]
+                     +I B21: float32:(2, 2) in [-7.0, -4.0]
+                    Add(B01, B11) -> C0
+                     + C0: float32:(2, 2) in [4.0, 10.0]
+                    Sub(B11, B21) -> C1
+                     + C1: float32:(2, 2) in [8.0, 14.0]
+                    Mul(C0, C1) -> D0
+                     + D0: float32:(2, 2) in [32.0, 140.0]
+                    """
+                ).lstrip("\n"),
+            ),
+            (
+                4,
+                dedent(
+                    """
                  +I B01: float32:(2, 2):[0.0, 1.0, 2.0, 3.0]
                  +I B11: float32:(2, 2):[4.0, 5.0, 6.0, 7.0]
                  +I B21: float32:(2, 2):[-4.0, -5.0, -6.0, -7.0]
@@ -394,17 +354,12 @@ class TestReferenceEvaluator(unittest.TestCase):
                 Mul(C0, C1) -> D0
                  + D0: float32:(2, 2):[32.0, 60.0, 96.0, 140.0]
                 """
-            ).lstrip("\n")
-            assert log == out
-
-        with self.subTest(level=15):
-            sess = ReferenceEvaluator(m, verbose=15)
-            stdout = StringIO()
-            with redirect_stdout(stdout):
-                sess.run(None, {"B01": x, "B11": y, "B21": z})
-            out = stdout.getvalue()
-            log = dedent(
-                """
+                ).lstrip("\n"),
+            ),
+            (
+                15,
+                dedent(
+                    """
                  +I B01: float32:(2, 2):[0.0, 1.0, 2.0, 3.0]
                  +I B11: float32:(2, 2):[4.0, 5.0, 6.0, 7.0]
                  +I B21: float32:(2, 2):[-4.0, -5.0, -6.0, -7.0]
@@ -421,10 +376,27 @@ class TestReferenceEvaluator(unittest.TestCase):
                 -- done Mul.run -> 1 outputs
                  + D0: float32:(2, 2):[32.0, 60.0, 96.0, 140.0]
                 """
-            ).lstrip("\n")
-            assert log == out
+                ).lstrip("\n"),
+            ),
+        ],
+    )
+    def test_reference_evaluator_no_attribute_verbose(
+        self, level, expected, capsys: pytest.CaptureFixture
+    ):
+        m = TestReferenceEvaluator._load_model(TestReferenceEvaluator.m2_def)
+        x = np.array([[0, 1], [2, 3]], dtype=np.float32)
+        y = np.array([[4, 5], [6, 7]], dtype=np.float32)
+        z = np.array([[-4, -5], [-6, -7]], dtype=np.float32)
 
-    def test_reference_evaluator_empty_array_verbose(self):
+        sess = ReferenceEvaluator(m, verbose=level)
+        sess.run(None, {"B01": x, "B11": y, "B21": z})
+        out, _err = capsys.readouterr()
+        assert expected == out
+
+    @pytest.mark.parametrize("level", [2, 3, 4, 15])
+    def test_reference_evaluator_empty_array_verbose(
+        self, level, capsys: pytest.CaptureFixture
+    ):
         input_tensor = make_tensor_value_info("input", TensorProto.FLOAT, [None, 3])
         output_tensor = make_tensor_value_info("output", TensorProto.FLOAT, [None, 3])
 
@@ -432,22 +404,18 @@ class TestReferenceEvaluator(unittest.TestCase):
         graph = make_graph([node], "test_empty_array", [input_tensor], [output_tensor])
         model = make_model(graph)
 
-        for verbose_level in [2, 3, 4, 15]:
-            with self.subTest(level=verbose_level):
-                sess = ReferenceEvaluator(model, verbose=verbose_level)
+        sess = ReferenceEvaluator(model, verbose=level)
 
-                empty_input = np.array([], dtype=np.float32).reshape(0, 3)
+        empty_input = np.array([], dtype=np.float32).reshape(0, 3)
 
-                stdout = StringIO()
-                with redirect_stdout(stdout):
-                    result = sess.run(None, {"input": empty_input})
+        (result,) = sess.run(None, {"input": empty_input})
 
-                expected = empty_input
-                assert_allclose(result[0], expected)
-                assert result[0].shape == (0, 3)
+        expected = empty_input
+        assert_allclose(result, expected)
+        assert result.shape == (0, 3)
 
-                out = stdout.getvalue()
-                assert "Identity" in out
+        out, _err = capsys.readouterr()
+        assert "Identity" in out
 
     def test_reference_evaluator_lr(self):
         lr, f = TestReferenceEvaluator._linear_regression()
@@ -459,89 +427,42 @@ class TestReferenceEvaluator(unittest.TestCase):
         got = sess.run(None, {"X": a, "A": a, "B": b})[0]
         assert_allclose(got, expected)
 
-    def test_reference_evaluator_lr_clip(self):
-        with self.subTest(opt="min+max"):
-            lr, f = TestReferenceEvaluator._linear_regression(clip=True)
-            x = np.array([[0, 1], [2, 3]], dtype=np.float32)
-            a = np.array([1, 1], dtype=np.float32)
-            b = np.array([11], dtype=np.float32)
-            expected = f(x, a, b)
-            sess = ReferenceEvaluator(lr)
-            last_node = sess.rt_nodes_[-1]
-            assert last_node.__class__.__name__ == "Clip_11"
-            got = sess.run(None, {"X": a, "A": a, "B": b})[0]
-            assert_allclose(got, expected)
+    @pytest.mark.parametrize("kwargs", [{}, {"min_value": None}, {"max_value": None}])
+    def test_reference_evaluator_lr_clip(self, kwargs):
+        lr, f = TestReferenceEvaluator._linear_regression(clip=True, **kwargs)
+        x = np.array([[0, 1], [2, 3]], dtype=np.float32)
+        a = np.array([1, 1], dtype=np.float32)
+        b = np.array([11], dtype=np.float32)
+        expected = f(x, a, b)
+        sess = ReferenceEvaluator(lr)
+        last_node = sess.rt_nodes_[-1]
+        assert last_node.__class__.__name__ == "Clip_11"
+        (got,) = sess.run(None, {"X": a, "A": a, "B": b})
+        assert_allclose(got, expected)
 
-        with self.subTest(opt="max"):
-            lr, f = TestReferenceEvaluator._linear_regression(clip=True, min_value=None)
-            x = np.array([[0, 1], [2, 3]], dtype=np.float32)
-            a = np.array([1, 1], dtype=np.float32)
-            b = np.array([11], dtype=np.float32)
-            expected = f(x, a, b)
-            sess = ReferenceEvaluator(lr)
-            last_node = sess.rt_nodes_[-1]
-            assert last_node.__class__.__name__ == "Clip_11"
-            got = sess.run(None, {"X": a, "A": a, "B": b})[0]
-            assert_allclose(got, expected)
-
-        with self.subTest(opt="min"):
-            lr, f = TestReferenceEvaluator._linear_regression(clip=True, max_value=None)
-            x = np.array([[0, 1], [2, 3]], dtype=np.float32)
-            a = np.array([1, 1], dtype=np.float32)
-            b = np.array([11], dtype=np.float32)
-            expected = f(x, a, b)
-            sess = ReferenceEvaluator(lr)
-            last_node = sess.rt_nodes_[-1]
-            assert last_node.__class__.__name__ == "Clip_11"
-            got = sess.run(None, {"X": a, "A": a, "B": b})[0]
-            assert_allclose(got, expected)
-
-    def test_reference_evaluator_lr_clip_6(self):
-        with self.subTest(opt="min+max"):
-            lr, f = TestReferenceEvaluator._linear_regression(clip=True, opset=10)
-            x = np.array([[0, 1], [2, 3]], dtype=np.float32)
-            a = np.array([1, 1], dtype=np.float32)
-            b = np.array([11], dtype=np.float32)
-            expected = f(x, a, b)
-            sess = ReferenceEvaluator(lr)
-            last_node = sess.rt_nodes_[-1]
-            assert last_node.__class__.__name__ == "Clip_6"
-            assert last_node.min == -1
-            assert last_node.max == 1
-            got = sess.run(None, {"X": a, "A": a, "B": b})[0]
-            assert_allclose(got, expected)
-
-        with self.subTest(opt="max"):
-            lr, f = TestReferenceEvaluator._linear_regression(
-                clip=True, opset=10, min_value=None
-            )
-            x = np.array([[0, 1], [2, 3]], dtype=np.float32)
-            a = np.array([1, 1], dtype=np.float32)
-            b = np.array([11], dtype=np.float32)
-            expected = f(x, a, b)
-            sess = ReferenceEvaluator(lr)
-            last_node = sess.rt_nodes_[-1]
-            assert last_node.__class__.__name__ == "Clip_6"
-            assert last_node.max == 1
-            assert last_node.min == -3.4028234663852886e38
-            got = sess.run(None, {"X": a, "A": a, "B": b})[0]
-            assert_allclose(got, expected)
-
-        with self.subTest(opt="min"):
-            lr, f = TestReferenceEvaluator._linear_regression(
-                clip=True, opset=10, max_value=None
-            )
-            x = np.array([[0, 1], [2, 3]], dtype=np.float32)
-            a = np.array([1, 1], dtype=np.float32)
-            b = np.array([11], dtype=np.float32)
-            expected = f(x, a, b)
-            sess = ReferenceEvaluator(lr)
-            last_node = sess.rt_nodes_[-1]
-            assert last_node.__class__.__name__ == "Clip_6"
-            assert last_node.min == -1
-            assert last_node.max == 3.4028234663852886e38
-            got = sess.run(None, {"X": a, "A": a, "B": b})[0]
-            assert_allclose(got, expected)
+    @pytest.mark.parametrize(
+        "kwargs, min_expected, max_expected",
+        [
+            ({}, -1, 1),
+            ({"min_value": None}, -3.4028234663852886e38, 1),
+            ({"max_value": None}, -1, 3.4028234663852886e38),
+        ],
+    )
+    def test_reference_evaluator_lr_clip_6(self, kwargs, min_expected, max_expected):
+        # FIXME: This test reads as if it is a test for the
+        # implementation details of the TestReferenceEvaluator.
+        lr, f = TestReferenceEvaluator._linear_regression(clip=True, opset=10, **kwargs)
+        x = np.array([[0, 1], [2, 3]], dtype=np.float32)
+        a = np.array([1, 1], dtype=np.float32)
+        b = np.array([11], dtype=np.float32)
+        expected = f(x, a, b)
+        sess = ReferenceEvaluator(lr)
+        last_node = sess.rt_nodes_[-1]
+        assert last_node.__class__.__name__ == "Clip_6"
+        assert last_node.min == min_expected
+        assert last_node.max == max_expected
+        (got,) = sess.run(None, {"X": a, "A": a, "B": b})
+        assert_allclose(got, expected)
 
     def test_nested_local_functions(self):
         m = parser.parse_model(
@@ -1629,56 +1550,65 @@ class TestReferenceEvaluator(unittest.TestCase):
             for j in range(sW):
                 x = np.zeros((1, 1, sH, sW), dtype=np.uint8)
                 x[0, 0, i, j] = 1.0
-                with self.subTest(w="1x1", i=i, j=j):
-                    w = np.zeros((1, 1, 1, 1), dtype=np.uint8)
-                    w[0, 0, :, :] = 1
-                    feeds = {
-                        "x": x,
-                        "x_scale": np.array([1], dtype=np.float32),
-                        "x_zero_point": np.array([0], dtype=np.uint8),
-                        "w": w,
-                        "w_scale": np.array([1], dtype=np.float32),
-                        "w_zero_point": np.array([0], dtype=np.uint8),
-                        "y_scale": np.array([1], dtype=np.float32),
-                        "y_zero_point": np.array([0], np.uint8),
-                    }
-                    expected = sess1.run(None, feeds)[0]
-                    got = sess2.run(None, feeds)[0]
-                    assert_allclose(got, expected)
-                with self.subTest(w="3x3", i=i, j=j):
-                    w = np.zeros((1, 1, 3, 3), dtype=np.uint8)
-                    w[0, 0, :, :] = np.minimum(2 ** np.arange(9).reshape((3, -1)), 128)
-                    feeds = {
-                        "x": x,
-                        "x_scale": np.array([1], dtype=np.float32),
-                        "x_zero_point": np.array([0], dtype=np.uint8),
-                        "w": w,
-                        "w_scale": np.array([1], dtype=np.float32),
-                        "w_zero_point": np.array([0], dtype=np.uint8),
-                        "y_scale": np.array([1], dtype=np.float32),
-                        "y_zero_point": np.array([0], np.uint8),
-                    }
-                    expected = sess1.run(None, feeds)[0]
-                    got = sess2.run(None, feeds)[0]
-                    assert_allclose(got, expected)
-                with self.subTest(w="1x1", i=i, j=j):
-                    w = np.zeros((1, 1, 1, 1), dtype=np.uint8)
-                    w[0, 0, :, :] = 0
-                    feeds = {
-                        "x": x,
-                        "x_scale": np.array([0.00369204697], dtype=np.float32),
-                        "x_zero_point": np.array([132], dtype=np.uint8),
-                        "w": w,
-                        "w_scale": np.array([100.001727945750], dtype=np.float32),
-                        "w_zero_point": np.array([255], dtype=np.uint8),
-                        "y_scale": np.array([0.00162681262], dtype=np.float32),
-                        "y_zero_point": np.array([132], np.uint8),
-                    }
-                    expected = sess1.run(None, feeds)[0]
-                    got = sess2.run(None, feeds)[0]
-                    assert_allclose(got, expected)
+                #######
+                # 1x1 #
+                #######
+                w = np.zeros((1, 1, 1, 1), dtype=np.uint8)
+                w[0, 0, :, :] = 1
+                feeds = {
+                    "x": x,
+                    "x_scale": np.array([1], dtype=np.float32),
+                    "x_zero_point": np.array([0], dtype=np.uint8),
+                    "w": w,
+                    "w_scale": np.array([1], dtype=np.float32),
+                    "w_zero_point": np.array([0], dtype=np.uint8),
+                    "y_scale": np.array([1], dtype=np.float32),
+                    "y_zero_point": np.array([0], np.uint8),
+                }
+                expected = sess1.run(None, feeds)[0]
+                got = sess2.run(None, feeds)[0]
+                assert_allclose(got, expected)
 
-    def test_qlinearconv_w_scale_vector(self):
+                #######
+                # 3x3 #
+                #######
+                w = np.zeros((1, 1, 3, 3), dtype=np.uint8)
+                w[0, 0, :, :] = np.minimum(2 ** np.arange(9).reshape((3, -1)), 128)
+                feeds = {
+                    "x": x,
+                    "x_scale": np.array([1], dtype=np.float32),
+                    "x_zero_point": np.array([0], dtype=np.uint8),
+                    "w": w,
+                    "w_scale": np.array([1], dtype=np.float32),
+                    "w_zero_point": np.array([0], dtype=np.uint8),
+                    "y_scale": np.array([1], dtype=np.float32),
+                    "y_zero_point": np.array([0], np.uint8),
+                }
+                expected = sess1.run(None, feeds)[0]
+                got = sess2.run(None, feeds)[0]
+                assert_allclose(got, expected)
+
+                #######
+                # 1x1 #
+                #######
+                w = np.zeros((1, 1, 1, 1), dtype=np.uint8)
+                w[0, 0, :, :] = 0
+                feeds = {
+                    "x": x,
+                    "x_scale": np.array([0.00369204697], dtype=np.float32),
+                    "x_zero_point": np.array([132], dtype=np.uint8),
+                    "w": w,
+                    "w_scale": np.array([100.001727945750], dtype=np.float32),
+                    "w_zero_point": np.array([255], dtype=np.uint8),
+                    "y_scale": np.array([0.00162681262], dtype=np.float32),
+                    "y_zero_point": np.array([132], np.uint8),
+                }
+                expected = sess1.run(None, feeds)[0]
+                got = sess2.run(None, feeds)[0]
+                assert_allclose(got, expected)
+
+    @pytest.fixture
+    def qlinearconv_w_scale_vector_session(self) -> ReferenceEvaluator:
         x = make_tensor_value_info("x", TensorProto.UINT8, [None, None, None, None])
         w = make_tensor_value_info("w", TensorProto.UINT8, [None, None, None, None])
         y = make_tensor_value_info("y", TensorProto.UINT8, [None, None, None, None])
@@ -1710,160 +1640,168 @@ class TestReferenceEvaluator(unittest.TestCase):
             [y],
         )
         onnx_model = make_model_gen_version(graph, opset_imports=[make_opsetid("", 16)])
-        sess = ReferenceEvaluator(onnx_model)
+        return ReferenceEvaluator(onnx_model)
 
-        with self.subTest("single_channel"):
-            x = np.array(
-                [
-                    [255, 174, 162, 25, 203, 168, 58],
-                    [15, 59, 237, 95, 129, 0, 64],
-                    [56, 242, 153, 221, 168, 12, 166],
-                    [232, 178, 186, 195, 237, 162, 237],
-                    [188, 39, 124, 77, 80, 102, 43],
-                    [127, 230, 21, 83, 41, 40, 134],
-                    [255, 154, 92, 141, 42, 148, 247],
-                ],
-                dtype=np.uint8,
-            ).reshape((1, 1, 7, 7))
-            x_scale = np.array([0.00369204697], dtype=np.float32)
-            x_zero_point = np.array([132], dtype=np.uint8)
-            w = np.array([0], dtype=np.uint8).reshape((1, 1, 1, 1))
-            w_scale = np.array([0.00172794575], dtype=np.float32)
-            w_zero_point = np.array([255], dtype=np.uint8)
-            y_scale = np.array([0.00162681262], dtype=np.float32)
-            y_zero_point = np.array([123], dtype=np.uint8)
+    def test_qlinearconv_w_scale_vector_single_channel(
+        self, qlinearconv_w_scale_vector_session: ReferenceEvaluator
+    ):
+        x = np.array(
+            [
+                [255, 174, 162, 25, 203, 168, 58],
+                [15, 59, 237, 95, 129, 0, 64],
+                [56, 242, 153, 221, 168, 12, 166],
+                [232, 178, 186, 195, 237, 162, 237],
+                [188, 39, 124, 77, 80, 102, 43],
+                [127, 230, 21, 83, 41, 40, 134],
+                [255, 154, 92, 141, 42, 148, 247],
+            ],
+            dtype=np.uint8,
+        ).reshape((1, 1, 7, 7))
+        x_scale = np.array([0.00369204697], dtype=np.float32)
+        x_zero_point = np.array([132], dtype=np.uint8)
+        w = np.array([0], dtype=np.uint8).reshape((1, 1, 1, 1))
+        w_scale = np.array([0.00172794575], dtype=np.float32)
+        w_zero_point = np.array([255], dtype=np.uint8)
+        y_scale = np.array([0.00162681262], dtype=np.float32)
+        y_zero_point = np.array([123], dtype=np.uint8)
 
-            feeds = {
-                "x": x,
-                "x_scale": x_scale,
-                "x_zero_point": x_zero_point,
-                "w": w,
-                "w_scale": w_scale,
-                "w_zero_point": w_zero_point,
-                "y_scale": y_scale,
-                "y_zero_point": y_zero_point,
-            }
-            expected = [
+        feeds = {
+            "x": x,
+            "x_scale": x_scale,
+            "x_zero_point": x_zero_point,
+            "w": w,
+            "w_scale": w_scale,
+            "w_zero_point": w_zero_point,
+            "y_scale": y_scale,
+            "y_zero_point": y_zero_point,
+        }
+        expected = [
+            [
                 [
-                    [
-                        [0, 81, 93, 230, 52, 87, 197],
-                        [240, 196, 18, 160, 126, 255, 191],
-                        [199, 13, 102, 34, 87, 243, 89],
-                        [23, 77, 69, 60, 18, 93, 18],
-                        [67, 216, 131, 178, 175, 153, 212],
-                        [128, 25, 234, 172, 214, 215, 121],
-                        [0, 101, 163, 114, 213, 107, 8],
-                    ]
+                    [0, 81, 93, 230, 52, 87, 197],
+                    [240, 196, 18, 160, 126, 255, 191],
+                    [199, 13, 102, 34, 87, 243, 89],
+                    [23, 77, 69, 60, 18, 93, 18],
+                    [67, 216, 131, 178, 175, 153, 212],
+                    [128, 25, 234, 172, 214, 215, 121],
+                    [0, 101, 163, 114, 213, 107, 8],
                 ]
             ]
+        ]
 
-            got = sess.run(None, feeds)[0]
-            assert_allclose(got, expected)
+        (got,) = qlinearconv_w_scale_vector_session.run(None, feeds)
+        assert_allclose(got, expected)
 
-        with self.subTest("multiple_output_channels"):
-            x = np.array(
+    def test_qlinearconv_w_scale_vector_multiple_output_channels(
+        self, qlinearconv_w_scale_vector_session: ReferenceEvaluator
+    ):
+        x = np.array(
+            [
+                [255, 174, 162, 25, 203, 168, 58],
+                [15, 59, 237, 95, 129, 0, 64],
+                [56, 242, 153, 221, 168, 12, 166],
+                [232, 178, 186, 195, 237, 162, 237],
+                [188, 39, 124, 77, 80, 102, 43],
+                [127, 230, 21, 83, 41, 40, 134],
+                [255, 154, 92, 141, 42, 148, 247],
+            ],
+            dtype=np.uint8,
+        ).reshape((1, 1, 7, 7))
+        x_scale = np.array([0.00390625], dtype=np.float32)
+        x_zero_point = np.array([0], dtype=np.uint8)
+        w = np.full([2, 1, 3, 3], 128, dtype=np.uint8)
+        w[0, 0, 1, 2] = 200
+        w[1, 0, 1, 0] = 2
+        w_scale = np.array([0.00390625, 0.001953125], dtype=np.float32)
+        w_zero_point = np.array([128, 128], dtype=np.uint8)
+        y_scale = np.array([0.00162681262], dtype=np.float32)
+        y_zero_point = np.array([123], dtype=np.uint8)
+
+        feeds = {
+            "x": x,
+            "x_scale": x_scale,
+            "x_zero_point": x_zero_point,
+            "w": w,
+            "w_scale": w_scale,
+            "w_zero_point": w_zero_point,
+            "y_scale": y_scale,
+            "y_zero_point": y_zero_point,
+        }
+        expected = [
+            [
                 [
-                    [255, 174, 162, 25, 203, 168, 58],
-                    [15, 59, 237, 95, 129, 0, 64],
-                    [56, 242, 153, 221, 168, 12, 166],
-                    [232, 178, 186, 195, 237, 162, 237],
-                    [188, 39, 124, 77, 80, 102, 43],
-                    [127, 230, 21, 83, 41, 40, 134],
-                    [255, 154, 92, 141, 42, 148, 247],
+                    [255, 187, 210, 123, 166],
+                    [226, 255, 236, 131, 235],
+                    [249, 255, 255, 232, 255],
+                    [207, 175, 177, 192, 152],
+                    [137, 179, 151, 150, 213],
                 ],
-                dtype=np.uint8,
-            ).reshape((1, 1, 7, 7))
-            x_scale = np.array([0.00390625], dtype=np.float32)
-            x_zero_point = np.array([0], dtype=np.uint8)
-            w = np.full([2, 1, 3, 3], 128, dtype=np.uint8)
-            w[0, 0, 1, 2] = 200
-            w[1, 0, 1, 0] = 2
-            w_scale = np.array([0.00390625, 0.001953125], dtype=np.float32)
-            w_zero_point = np.array([128, 128], dtype=np.uint8)
-            y_scale = np.array([0.00162681262], dtype=np.float32)
-            y_zero_point = np.array([123], dtype=np.uint8)
-
-            feeds = {
-                "x": x,
-                "x_scale": x_scale,
-                "x_zero_point": x_zero_point,
-                "w": w,
-                "w_scale": w_scale,
-                "w_zero_point": w_zero_point,
-                "y_scale": y_scale,
-                "y_zero_point": y_zero_point,
-            }
-            expected = [
                 [
-                    [
-                        [255, 187, 210, 123, 166],
-                        [226, 255, 236, 131, 235],
-                        [249, 255, 255, 232, 255],
-                        [207, 175, 177, 192, 152],
-                        [137, 179, 151, 150, 213],
-                    ],
-                    [
-                        [114, 88, 0, 67, 47],
-                        [90, 0, 33, 0, 24],
-                        [0, 18, 13, 8, 0],
-                        [12, 100, 50, 77, 76],
-                        [48, 0, 111, 74, 99],
-                    ],
-                ]
+                    [114, 88, 0, 67, 47],
+                    [90, 0, 33, 0, 24],
+                    [0, 18, 13, 8, 0],
+                    [12, 100, 50, 77, 76],
+                    [48, 0, 111, 74, 99],
+                ],
             ]
+        ]
 
-            got = sess.run(None, feeds)[0]
-            assert_allclose(got, expected)
+        got = qlinearconv_w_scale_vector_session.run(None, feeds)[0]
+        assert_allclose(got, expected)
 
-        with self.subTest("fails_with_w_scale_2D"):
-            x = np.zeros((1, 1, 7, 7), dtype=np.uint8)
-            x_scale = np.array([0.00390625], dtype=np.float32)
-            x_zero_point = np.array([0], dtype=np.uint8)
-            w = np.full([2, 1, 3, 3], 128, dtype=np.uint8)
-            w_scale = np.array([[0.00390625, 0.001953125], [1, 1]], dtype=np.float32)
-            w_zero_point = np.array([128, 128], dtype=np.uint8)
-            y_scale = np.array([0.00162681262], dtype=np.float32)
-            y_zero_point = np.array([123], dtype=np.uint8)
+    def test_qlinearconv_w_scale_vector_fails_with_w_scale_2D(
+        self, qlinearconv_w_scale_vector_session: ReferenceEvaluator
+    ):
+        x = np.zeros((1, 1, 7, 7), dtype=np.uint8)
+        x_scale = np.array([0.00390625], dtype=np.float32)
+        x_zero_point = np.array([0], dtype=np.uint8)
+        w = np.full([2, 1, 3, 3], 128, dtype=np.uint8)
+        w_scale = np.array([[0.00390625, 0.001953125], [1, 1]], dtype=np.float32)
+        w_zero_point = np.array([128, 128], dtype=np.uint8)
+        y_scale = np.array([0.00162681262], dtype=np.float32)
+        y_zero_point = np.array([123], dtype=np.uint8)
 
-            feeds = {
-                "x": x,
-                "x_scale": x_scale,
-                "x_zero_point": x_zero_point,
-                "w": w,
-                "w_scale": w_scale,
-                "w_zero_point": w_zero_point,
-                "y_scale": y_scale,
-                "y_zero_point": y_zero_point,
-            }
-            with pytest.raises(
-                ValueError, match="w_scale must be a scalar or a 1-D tensor"
-            ):
-                sess.run(None, feeds)[0]
+        feeds = {
+            "x": x,
+            "x_scale": x_scale,
+            "x_zero_point": x_zero_point,
+            "w": w,
+            "w_scale": w_scale,
+            "w_zero_point": w_zero_point,
+            "y_scale": y_scale,
+            "y_zero_point": y_zero_point,
+        }
+        with pytest.raises(
+            ValueError, match="w_scale must be a scalar or a 1-D tensor"
+        ):
+            qlinearconv_w_scale_vector_session.run(None, feeds)
 
-        with self.subTest("fails_with_w_scale_wrong_length"):
-            x = np.zeros((1, 1, 7, 7), dtype=np.uint8)
-            x_scale = np.array([0.00390625], dtype=np.float32)
-            x_zero_point = np.array([0], dtype=np.uint8)
-            w = np.full([2, 1, 3, 3], 128, dtype=np.uint8)
-            w_scale = np.array([0.00390625, 0.001953125, 1], dtype=np.float32)
-            w_zero_point = np.array([128, 128], dtype=np.uint8)
-            y_scale = np.array([0.00162681262], dtype=np.float32)
-            y_zero_point = np.array([123], dtype=np.uint8)
+    def test_qlinearconv_w_scale_vector_fails_with_w_scale_wrong_length(
+        self, qlinearconv_w_scale_vector_session: ReferenceEvaluator
+    ):
+        x = np.zeros((1, 1, 7, 7), dtype=np.uint8)
+        x_scale = np.array([0.00390625], dtype=np.float32)
+        x_zero_point = np.array([0], dtype=np.uint8)
+        w = np.full([2, 1, 3, 3], 128, dtype=np.uint8)
+        w_scale = np.array([0.00390625, 0.001953125, 1], dtype=np.float32)
+        w_zero_point = np.array([128, 128], dtype=np.uint8)
+        y_scale = np.array([0.00162681262], dtype=np.float32)
+        y_zero_point = np.array([123], dtype=np.uint8)
 
-            feeds = {
-                "x": x,
-                "x_scale": x_scale,
-                "x_zero_point": x_zero_point,
-                "w": w,
-                "w_scale": w_scale,
-                "w_zero_point": w_zero_point,
-                "y_scale": y_scale,
-                "y_zero_point": y_zero_point,
-            }
-            with pytest.raises(
-                ValueError, match="w_scale elements must match output channels"
-            ):
-                sess.run(None, feeds)[0]
+        feeds = {
+            "x": x,
+            "x_scale": x_scale,
+            "x_zero_point": x_zero_point,
+            "w": w,
+            "w_scale": w_scale,
+            "w_zero_point": w_zero_point,
+            "y_scale": y_scale,
+            "y_zero_point": y_zero_point,
+        }
+        with pytest.raises(
+            ValueError, match="w_scale elements must match output channels"
+        ):
+            qlinearconv_w_scale_vector_session.run(None, feeds)
 
     def _run_qlinear_int8(self, op_type, feeds, operand_shapes, output_shape, opset):
         """Build and run a single-node int8 QLinear{Conv,MatMul} graph.
@@ -2683,13 +2621,10 @@ class TestReferenceEvaluator(unittest.TestCase):
         got = ref.run(None, feeds)
         assert_allclose(got[0], expected[0], atol=1e-5)
 
+    @pytest.mark.parametrize("mode", ["avg", "max"])
     @skip_if_no_onnxruntime
-    def test_roi_align(self):
-        with self.subTest(mode="avg"):
-            self.common_test_roi_align("avg")
-        # max does not have example in the backend
-        with self.subTest(mode="max"):
-            self.common_test_roi_align("max")
+    def test_roi_align(self, mode):
+        self.common_test_roi_align(mode)
 
     def common_test_roi_align_torch(self, mode):
         import torch  # noqa: PLC0415
@@ -2707,11 +2642,7 @@ class TestReferenceEvaluator(unittest.TestCase):
     @skip_if_no_torch
     @skip_if_no_torchvision
     def test_roi_align_torch(self):
-        with self.subTest(mode="avg"):
-            self.common_test_roi_align_torch("avg")
-        # not implemented in torch
-        # with self.subTest(mode="max"):
-        #     self.common_test_roi_align_torch("max")
+        self.common_test_roi_align_torch("avg")
 
     def test_split(self):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None])
@@ -3436,9 +3367,9 @@ class TestReferenceEvaluator(unittest.TestCase):
         assert_allclose(got[2], expected1)
         assert_allclose(got[3], expected2)
 
-    @unittest.skipIf(
+    @pytest.mark.skipif(
         version_utils.numpy_older_than("2.0"),
-        "assert_allclose does not support ml_dtypes in numpy < 2.0",
+        reason="assert_allclose does not support ml_dtypes in numpy < 2.0",
     )
     def test_cast_like_float8(self):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None])
@@ -3493,7 +3424,108 @@ class TestReferenceEvaluator(unittest.TestCase):
         assert got[0].tolist() == expected1.tolist()
         assert got[1].tolist() == expected2.tolist()
 
-    def test_float8_4_types(self):
+    @pytest.mark.parametrize(
+        "to, expected",
+        [
+            (
+                TensorProto.FLOAT8E4M3FN,
+                np.array(
+                    [
+                        0.40625,
+                        352.0,
+                        416.0,
+                        320.0,
+                        320.0,
+                        256.0,
+                        -256.0,
+                        -96.0,
+                        0.0,
+                        0.009765625,
+                        416.0,
+                        448.0,
+                        448.0,
+                        448.0,
+                        -448.0,
+                        np.nan,
+                    ],
+                    dtype=np.float32,
+                ),
+            ),
+            (
+                TensorProto.FLOAT8E4M3FNUZ,
+                np.array(
+                    [
+                        0.40625,
+                        240.0,
+                        240.0,
+                        240.0,
+                        240.0,
+                        240.0,
+                        -240.0,
+                        -96.0,
+                        0.0,
+                        0.009765625,
+                        240.0,
+                        240.0,
+                        240.0,
+                        240.0,
+                        -240.0,
+                        np.nan,
+                    ],
+                    dtype=np.float32,
+                ),
+            ),
+            (
+                TensorProto.FLOAT8E5M2,
+                np.array(
+                    [
+                        0.4375,
+                        384.0,
+                        384.0,
+                        320.0,
+                        320.0,
+                        256.0,
+                        -256.0,
+                        -96.0,
+                        0.0001068115234375,
+                        0.009765625,
+                        384.0,
+                        448.0,
+                        57344.0,
+                        57344.0,
+                        -57344.0,
+                        np.nan,
+                    ],
+                    dtype=np.float32,
+                ),
+            ),
+            (
+                TensorProto.FLOAT8E5M2FNUZ,
+                np.array(
+                    [
+                        4.3750000e-01,
+                        3.8400000e02,
+                        3.8400000e02,
+                        3.2000000e02,
+                        3.2000000e02,
+                        2.5600000e02,
+                        -2.5600000e02,
+                        -9.6000000e01,
+                        1.0681152e-04,
+                        9.7656250e-03,
+                        3.8400000e02,
+                        4.4800000e02,
+                        5.7344000e04,
+                        5.7344000e04,
+                        -5.7344000e04,
+                        np.nan,
+                    ],
+                    dtype=np.float32,
+                ),
+            ),
+        ],
+    )
+    def test_float8_4_types(self, to, expected):
         x = np.array(
             [
                 0.4068359375,
@@ -3515,92 +3547,6 @@ class TestReferenceEvaluator(unittest.TestCase):
             ],
             dtype=np.float32,
         )
-        expected = {
-            TensorProto.FLOAT8E4M3FN: np.array(
-                [
-                    0.40625,
-                    352.0,
-                    416.0,
-                    320.0,
-                    320.0,
-                    256.0,
-                    -256.0,
-                    -96.0,
-                    0.0,
-                    0.009765625,
-                    416.0,
-                    448.0,
-                    448.0,
-                    448.0,
-                    -448.0,
-                    np.nan,
-                ],
-                dtype=np.float32,
-            ),
-            TensorProto.FLOAT8E4M3FNUZ: np.array(
-                [
-                    0.40625,
-                    240.0,
-                    240.0,
-                    240.0,
-                    240.0,
-                    240.0,
-                    -240.0,
-                    -96.0,
-                    0.0,
-                    0.009765625,
-                    240.0,
-                    240.0,
-                    240.0,
-                    240.0,
-                    -240.0,
-                    np.nan,
-                ],
-                dtype=np.float32,
-            ),
-            TensorProto.FLOAT8E5M2: np.array(
-                [
-                    0.4375,
-                    384.0,
-                    384.0,
-                    320.0,
-                    320.0,
-                    256.0,
-                    -256.0,
-                    -96.0,
-                    0.0001068115234375,
-                    0.009765625,
-                    384.0,
-                    448.0,
-                    57344.0,
-                    57344.0,
-                    -57344.0,
-                    np.nan,
-                ],
-                dtype=np.float32,
-            ),
-            TensorProto.FLOAT8E5M2FNUZ: np.array(
-                [
-                    4.3750000e-01,
-                    3.8400000e02,
-                    3.8400000e02,
-                    3.2000000e02,
-                    3.2000000e02,
-                    2.5600000e02,
-                    -2.5600000e02,
-                    -9.6000000e01,
-                    1.0681152e-04,
-                    9.7656250e-03,
-                    3.8400000e02,
-                    4.4800000e02,
-                    5.7344000e04,
-                    5.7344000e04,
-                    -5.7344000e04,
-                    np.nan,
-                ],
-                dtype=np.float32,
-            ),
-        }
 
         def model_cast_cast(to):
             X = make_tensor_value_info("X", TensorProto.FLOAT, [None])
@@ -3612,14 +3558,12 @@ class TestReferenceEvaluator(unittest.TestCase):
             check_model(onnx_model)
             return onnx_model
 
-        for to, expect in expected.items():
-            with self.subTest(to=to):
-                onnx_model = model_cast_cast(to)
-                ref = ReferenceEvaluator(onnx_model)
-                y = ref.run(None, {"X": x})[0]
-                assert_allclose(y, expect)
-                assert y.shape == expect.shape
-                assert y.dtype == expect.dtype
+        onnx_model = model_cast_cast(to)
+        ref = ReferenceEvaluator(onnx_model)
+        (y,) = ref.run(None, {"X": x})
+        assert_allclose(y, expected)
+        assert y.shape == expected.shape
+        assert y.dtype == expected.dtype
 
     def test_cast_bfloat16_output(self):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None])

--- a/onnx/test/schema_test.py
+++ b/onnx/test/schema_test.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 
-class TestSchema(unittest.TestCase):
+class TestSchema:
     def test_get_schema(self) -> None:
         relu_schema = defs.get_schema("Relu")
         assert (
@@ -99,10 +99,9 @@ class TestSchema(unittest.TestCase):
         }
 
         for expected_type in expected_types:
-            with self.subTest(type=expected_type):
-                assert expected_type in supported_types, (
-                    f"Range should support {expected_type}"
-                )
+            assert expected_type in supported_types, (
+                f"Range should support {expected_type}"
+            )
 
         # Verify no unexpected types are supported (regression check)
         allowed_type_families = {

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -5,15 +5,12 @@
 from __future__ import annotations
 
 import contextlib
-import itertools
-import unittest
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pytest
 from google.protobuf import text_format
-from parameterized import parameterized
 
 import onnx.shape_inference
 from onnx import (
@@ -74,16 +71,13 @@ ALL_OP_VERSIONS: dict[str, tuple[str, frozenset[int]]] = {
 }
 
 
-def all_versions_for(op_name: str) -> list[tuple[str, int]]:
+def all_versions_for(op_name: str) -> list[int]:
     domain, versions_set = ALL_OP_VERSIONS[op_name]
     if not versions_set:
         raise ValueError(f"No versions available for operator {op_name}")
     versions = sorted(versions_set)
     return [
-        (
-            f"version{version}",
-            version,
-        )
+        version
         for version in versions
         # FIXME(#5289): Reshape errors in self._make_graph when version <= 5.
         # Issue reference: https://github.com/onnx/onnx/issues/5289.
@@ -249,8 +243,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             graph, [make_tensor_value_info("y", TensorProto.FLOAT, (30, 4, 5))]
         )
 
-    @parameterized.expand(all_versions_for("Transpose"))
-    def test_transpose(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Transpose"))
+    def test_transpose(self, version) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (2, 3, 4))],
             [make_node("Transpose", ["X"], ["Y"], perm=[1, 0, 2])],
@@ -262,8 +256,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Transpose"))
-    def test_transpose_preexisting(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Transpose"))
+    def test_transpose_preexisting(self, version) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (2, 3, 4))],
             [make_node("Transpose", ["X"], ["Y"], perm=[1, 0, 2])],
@@ -275,8 +269,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Transpose"))
-    def test_transpose_scalar(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Transpose"))
+    def test_transpose_scalar(self, version) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, ())],
             [make_node("Transpose", ["X"], ["Y"])],
@@ -289,8 +283,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Transpose"))
-    def test_transpose_partial(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Transpose"))
+    def test_transpose_partial(self, version) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (2, 3, 4))],
             [make_node("Transpose", ["X"], ["Y"], perm=[1, 0, 2])],
@@ -302,8 +296,7 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Transpose"))
-    def test_transpose_preexisting_incorrect_shape(self, *_) -> None:
+    def test_transpose_preexisting_incorrect_shape(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (2, 3, 4))],
             [make_node("Transpose", ["X"], ["Y"], perm=[1, 0, 2])],
@@ -312,8 +305,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         with pytest.raises(onnx.shape_inference.InferenceError):
             self._inferred(graph)
 
-    @parameterized.expand(all_versions_for("Transpose"))
-    def test_transpose_preexisting_incorrect_type(self, *_) -> None:
+    def test_transpose_preexisting_incorrect_type(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (2, 3, 4))],
             [make_node("Transpose", ["X"], ["Y"], perm=[1, 0, 2])],
@@ -322,8 +314,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         with pytest.raises(onnx.shape_inference.InferenceError):
             self._inferred(graph)
 
-    @parameterized.expand(all_versions_for("Transpose"))
-    def test_transpose_incorrect_repeated_perm(self, *_) -> None:
+    def test_transpose_incorrect_repeated_perm(self) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (2, 3, 4))],
             [make_node("Transpose", ["X"], ["Y"], perm=[1, 0, 1])],
@@ -350,8 +341,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("MatMul"))
-    def test_matmul_all_dims_known(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("MatMul"))
+    def test_matmul_all_dims_known(self, version) -> None:
         self._make_matmul_test_all_dims_known(version, (2,), (2,))
 
         self._make_matmul_test_all_dims_known(version, (4, 2), (2, 4))
@@ -379,8 +370,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("MatMul"))
-    def test_matmul_allow_unknown(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("MatMul"))
+    def test_matmul_allow_unknown(self, version) -> None:
         self._make_matmul_test_allow_unknown(version, (None,), (None,), ())
         self._make_matmul_test_allow_unknown(version, (3,), (None,), ())
         self._make_matmul_test_allow_unknown(version, (2,), (2, "a"), ("a",))
@@ -396,8 +387,8 @@ class TestShapeInference(TestShapeInferenceHelper):
         self._make_matmul_test_allow_unknown(version, (3,), None, None)
         self._make_matmul_test_allow_unknown(version, None, None, None)
 
-    @parameterized.expand(all_versions_for("Cast"))
-    def test_cast(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Cast"))
+    def test_cast(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 4, 3))],
             [make_node("Cast", ["x"], ["y"], to=TensorProto.UINT8)],
@@ -409,11 +400,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Cast"))
-    @unittest.skip(
-        "Issue #5960"
-    )  # FIXME(#5960) propagateElemTypeFromAttributeToOutput does not validate against output type constraints
-    def test_cast_to_complex(self, _, version) -> None:  # noqa: ARG002
+    @pytest.mark.xfail(reason="Issue #5960")
+    def test_cast_to_complex(self) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 4, 3))],
             [make_node("Cast", ["x"], ["y"], to=TensorProto.COMPLEX128)],
@@ -423,8 +411,8 @@ class TestShapeInference(TestShapeInferenceHelper):
         with pytest.raises(onnx.shape_inference.InferenceError):
             self._inferred(graph)
 
-    @parameterized.expand(all_versions_for("CastLike"))
-    def test_cast_like(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("CastLike"))
+    def test_cast_like(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 4, 3)), ("t", TensorProto.FLOAT16, ("N",))],
             [make_node("CastLike", ["x", "t"], ["y"])],
@@ -436,8 +424,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("BitCast"))
-    def test_bitcast_same_size(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("BitCast"))
+    def test_bitcast_same_size(self, version) -> None:
         # Test bitcast between types of same size (float32 -> int32)
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 4, 3))],
@@ -450,8 +438,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("BitCast"))
-    def test_bitcast_scalar(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("BitCast"))
+    def test_bitcast_scalar(self, version) -> None:
         # Test bitcast with scalar input (same size)
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, ())],
@@ -464,8 +452,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("BitCast"))
-    def test_bitcast_1d(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("BitCast"))
+    def test_bitcast_1d(self, version) -> None:
         # Test bitcast with 1D tensor (float32 -> uint32, same size)
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (8,))],
@@ -478,8 +466,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("BitCast"))
-    def test_bitcast_double_to_int64(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("BitCast"))
+    def test_bitcast_double_to_int64(self, version) -> None:
         # Test bitcast between 64-bit types (double -> int64)
         graph = self._make_graph(
             [("x", TensorProto.DOUBLE, (3, 5))],
@@ -492,8 +480,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("BitCast"))
-    def test_bitcast_int8_to_uint8(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("BitCast"))
+    def test_bitcast_int8_to_uint8(self, version) -> None:
         # Test bitcast between 8-bit types (int8 -> uint8)
         graph = self._make_graph(
             [("x", TensorProto.INT8, (4, 6))],
@@ -506,8 +494,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("BitCast"))
-    def test_bitcast_float16_to_int16(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("BitCast"))
+    def test_bitcast_float16_to_int16(self, version) -> None:
         # Test bitcast between 16-bit types (float16 -> int16)
         graph = self._make_graph(
             [("x", TensorProto.FLOAT16, (2, 3))],
@@ -520,8 +508,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Col2Im"))
-    def test_col2im(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Col2Im"))
+    def test_col2im(self, version) -> None:
         graph = self._make_graph(
             [
                 ("input", TensorProto.FLOAT, (1, 5, 5)),
@@ -545,8 +533,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Col2Im"))
-    def test_col2im_strides(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Col2Im"))
+    def test_col2im_strides(self, version) -> None:
         graph = self._make_graph(
             [
                 ("input", TensorProto.FLOAT, (1, 9, 4)),
@@ -573,8 +561,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Col2Im"))
-    def test_col2im_pads(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Col2Im"))
+    def test_col2im_pads(self, version) -> None:
         graph = self._make_graph(
             [
                 ("input", TensorProto.FLOAT, (1, 5, 15)),
@@ -601,8 +589,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Col2Im"))
-    def test_col2im_dilations(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Col2Im"))
+    def test_col2im_dilations(self, version) -> None:
         graph = self._make_graph(
             [
                 ("input", TensorProto.FLOAT, (1, 4, 5)),
@@ -629,8 +617,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Col2Im"))
-    def test_col2im_5d(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Col2Im"))
+    def test_col2im_5d(self, version) -> None:
         graph = self._make_graph(
             [
                 ("input", TensorProto.FLOAT, (1, 10, 12)),
@@ -654,8 +642,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Concat"))
-    def test_concat(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Concat"))
+    def test_concat(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 4, 3)), ("y", TensorProto.FLOAT, (7, 4, 3))],
             [make_node("Concat", ["x", "y"], ["z"], axis=0)],
@@ -667,8 +655,7 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Concat"))
-    def test_concat_missing_shape(self, *_) -> None:
+    def test_concat_missing_shape(self) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (2, 4, 3)),
@@ -681,8 +668,8 @@ class TestShapeInference(TestShapeInferenceHelper):
         with pytest.raises(onnx.shape_inference.InferenceError):
             self._inferred(graph)
 
-    @parameterized.expand(all_versions_for("Concat"))
-    def test_concat_3d_axis_2(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Concat"))
+    def test_concat_3d_axis_2(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 2, 2)), ("y", TensorProto.FLOAT, (2, 2, 2))],
             [make_node("Concat", ["x", "y"], ["z"], axis=2)],
@@ -694,8 +681,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Concat"))
-    def test_concat_param(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Concat"))
+    def test_concat_param(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, ("a", 2)), ("y", TensorProto.FLOAT, ("a", 3))],
             [make_node("Concat", ["x", "y"], ["z"], axis=1)],
@@ -707,8 +694,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Concat"))
-    def test_concat_param_single_input(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Concat"))
+    def test_concat_param_single_input(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, ("a", 2))],
             [make_node("Concat", ["x"], ["z"], axis=0)],
@@ -720,8 +707,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Reshape"))
-    def test_reshape_dynamic_shape_known_rank(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Reshape"))
+    def test_reshape_dynamic_shape_known_rank(self, version) -> None:
         self.skipIf(version < 14, "Rank inference is added from Version 14")
         graph = self._make_graph(
             [("x", TensorProto.UINT8, (2, 4, 3)), ("shape", TensorProto.INT64, (2,))],
@@ -734,8 +721,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Reshape"))
-    def test_reshape_dynamic_shape_symbolic(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Reshape"))
+    def test_reshape_dynamic_shape_symbolic(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.UINT8, (2, 4, 3)), ("shape", TensorProto.INT64, ("M",))],
             [make_node("Reshape", ["x", "shape"], ["y"])],
@@ -747,8 +734,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Reshape"))
-    def test_reshape_dynamic_unknown_shape(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Reshape"))
+    def test_reshape_dynamic_unknown_shape(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.UINT8, (2, 4, 3)), ("shape", TensorProto.INT64, None)],
             [make_node("Reshape", ["x", "shape"], ["y"])],
@@ -760,8 +747,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Reshape"))
-    def test_reshape_static_shape(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Reshape"))
+    def test_reshape_static_shape(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.UINT8, (2, 4, 3)), ("shape", TensorProto.INT64, (2,))],
             [make_node("Reshape", ["x", "shape"], ["y"])],
@@ -774,8 +761,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Reshape"))
-    def test_reshape_static_shape_inferred(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Reshape"))
+    def test_reshape_static_shape_inferred(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.UINT8, (2, 4, 3)), ("shape", TensorProto.INT64, (3,))],
             [make_node("Reshape", ["x", "shape"], ["y"])],
@@ -788,8 +775,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Reshape"))
-    def test_reshape_static_shape_zero(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Reshape"))
+    def test_reshape_static_shape_zero(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.UINT8, (1, 1, 1)), ("shape", TensorProto.INT64, (3,))],
             [make_node("Reshape", ["x", "shape"], ["y"])],
@@ -802,8 +789,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Reshape"))
-    def test_reshape_static_shape_allowzero(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Reshape"))
+    def test_reshape_static_shape_allowzero(self, version) -> None:
         self.skipIf(version < 14, "allowzero is added from Version 14")
         graph = self._make_graph(
             [
@@ -820,8 +807,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Reshape"))
-    def test_reshape_static_shape_constant(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Reshape"))
+    def test_reshape_static_shape_constant(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.UINT8, (2, 4, 3))],
             [
@@ -844,8 +831,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Upsample"))
-    def test_upsample(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Upsample"))
+    def test_upsample(self, version) -> None:
         if version == 7:
             graph = self._make_graph(
                 [("x", TensorProto.INT32, (2, 4, 3, 5))],
@@ -886,8 +873,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 ):
                     call_inference()
 
-    @parameterized.expand(all_versions_for("Upsample"))
-    def test_upsample_raw_data(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Upsample"))
+    def test_upsample_raw_data(self, version) -> None:
         if version == 7:
             graph = self._make_graph(
                 [("x", TensorProto.INT32, (1, 3, 4, 5))],
@@ -934,8 +921,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 ):
                     call_inference()
 
-    @parameterized.expand(all_versions_for("Expand"))
-    def test_expand(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Expand"))
+    def test_expand(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.INT32, (3, 1)), ("shape", TensorProto.INT64, (3,))],
             [make_node("Expand", ["x", "shape"], ["y"])],
@@ -948,8 +935,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Expand"))
-    def test_expand_scalar_input(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Expand"))
+    def test_expand_scalar_input(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.INT32, ()), ("shape", TensorProto.INT64, (2,))],
             [make_node("Expand", ["x", "shape"], ["y"])],
@@ -962,8 +949,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Expand"))
-    def test_expand_raw_data(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Expand"))
+    def test_expand_raw_data(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.INT32, (3, 1)), ("shape", TensorProto.INT64, (2,))],
             [make_node("Expand", ["x", "shape"], ["y"])],
@@ -984,8 +971,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Expand"))
-    def test_expand_dynamic_shape(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Expand"))
+    def test_expand_dynamic_shape(self, version) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.INT32, (1, 2, None)),
@@ -1001,8 +988,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Expand"))
-    def test_expand_symbolic_shape(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Expand"))
+    def test_expand_symbolic_shape(self, version) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.INT32, (1, 2, None)),
@@ -1019,8 +1006,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Resize"))
-    def test_resize_size(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Resize"))
+    def test_resize_size(self, version) -> None:
         if version == 10:
             graph = self._make_graph(
                 [
@@ -1076,8 +1063,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    @parameterized.expand(all_versions_for("RMSNormalization"))
-    def test_rms_normalization(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("RMSNormalization"))
+    def test_rms_normalization(self, version) -> None:
         graph = self._make_graph(
             [
                 ("X", TensorProto.FLOAT, ("N", "C", "H", "W")),
@@ -1092,8 +1079,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Resize"))
-    def test_resize_size_axes_2_3(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Resize"))
+    def test_resize_size_axes_2_3(self, version) -> None:
         self.skipIf(version < 18, "axes is from Version 18")
         graph = self._make_graph(
             [
@@ -1111,8 +1098,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Resize"))
-    def test_resize_size_axes_3_2(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Resize"))
+    def test_resize_size_axes_3_2(self, version) -> None:
         self.skipIf(version < 18, "axes is from Version 18")
         graph = self._make_graph(
             [
@@ -1130,8 +1117,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Resize"))
-    def test_resize_size_not_larger(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Resize"))
+    def test_resize_size_not_larger(self, version) -> None:
         self.skipIf(
             version < 18,
             "keep_aspect_ratio_policy is from Version 18",
@@ -1159,8 +1146,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Resize"))
-    def test_resize_size_axes_2_3_not_larger(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Resize"))
+    def test_resize_size_axes_2_3_not_larger(self, version) -> None:
         self.skipIf(
             version < 18,
             "axes & keep_aspect_ratio_policy are from Version 18",
@@ -1189,8 +1176,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Resize"))
-    def test_resize_size_not_smaller(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Resize"))
+    def test_resize_size_not_smaller(self, version) -> None:
         self.skipIf(
             version < 18,
             "keep_aspect_ratio_policy is from Version 18",
@@ -1218,8 +1205,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Resize"))
-    def test_resize_size_axes_2_3_not_smaller(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Resize"))
+    def test_resize_size_axes_2_3_not_smaller(self, version) -> None:
         self.skipIf(
             version < 18,
             "axes & keep_aspect_ratio_policy are from Version 18",
@@ -1282,8 +1269,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Resize"))
-    def test_resize_keep_aspect_ratio_precision_not_larger(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Resize"))
+    def test_resize_keep_aspect_ratio_precision_not_larger(self, version) -> None:
         # Regression: KeepAspectRatioHelper computed `sizes_data[i] /
         # static_cast<float>(dim_value)` and `roundf(scale * dim_value)`.
         # With float32, 2**24 + 1 = 16_777_217 is unrepresentable, so a 1:1
@@ -1297,8 +1284,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             expected=(16777217, 16777217),
         )
 
-    @parameterized.expand(all_versions_for("Resize"))
-    def test_resize_keep_aspect_ratio_precision_not_smaller(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Resize"))
+    def test_resize_keep_aspect_ratio_precision_not_smaller(self, version) -> None:
         # Same float32 mantissa boundary, NOT_SMALLER policy path.
         self.skipIf(version < 18, "keep_aspect_ratio_policy is from Version 18")
         self._check_keep_aspect_ratio_precision(
@@ -1309,10 +1296,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             expected=(16777217, 16777217),
         )
 
-    @parameterized.expand(all_versions_for("Resize"))
-    def test_resize_keep_aspect_ratio_precision_non_unit_scale(
-        self, _, version
-    ) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Resize"))
+    def test_resize_keep_aspect_ratio_precision_non_unit_scale(self, version) -> None:
         # Non-unit scale path: dim 16_777_217 scaled by 2 should produce
         # 33_554_434. With float32 the result collapses to 33_554_432.
         self.skipIf(version < 18, "keep_aspect_ratio_policy is from Version 18")
@@ -1324,8 +1309,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             expected=(33554434,),
         )
 
-    @parameterized.expand(all_versions_for("Resize"))
-    def test_resize_scale(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Resize"))
+    def test_resize_scale(self, version) -> None:
         self.skipIf(version < 11, "roi input is from Version 11")
         graph = self._make_graph(
             [
@@ -1345,8 +1330,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Resize"))
-    def test_resize_scale_axes_2_3(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Resize"))
+    def test_resize_scale_axes_2_3(self, version) -> None:
         self.skipIf(version < 18, "axes is from Version 18")
         graph = self._make_graph(
             [
@@ -1364,8 +1349,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Resize"))
-    def test_resize_scale_axes_3_2(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Resize"))
+    def test_resize_scale_axes_3_2(self, version) -> None:
         self.skipIf(version < 18, "axes is from Version 18")
         graph = self._make_graph(
             [
@@ -1383,8 +1368,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Resize"))
-    def test_resize_scale_raw_data(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Resize"))
+    def test_resize_scale_raw_data(self, version) -> None:
         self.skipIf(version < 11, "roi input is from Version 11")
         graph = self._make_graph(
             [
@@ -1448,16 +1433,16 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Resize"))
-    def test_resize_scale_precision_large_dim(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Resize"))
+    def test_resize_scale_precision_large_dim(self, version) -> None:
         # Regression for #4919, current-version helper
         for scale in [1, 2]:
             self._check_resize_scale_precision(
                 version, (1.0, 1.0, 1.0, float(scale)), 16777217 * scale
             )
 
-    @parameterized.expand(all_versions_for("Resize"))
-    def test_resize_scale_and_size_but_one_is_empty(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Resize"))
+    def test_resize_scale_and_size_but_one_is_empty(self, version) -> None:
         self.skipIf(version < 11, "roi input is from Version 11")
         graph = self._make_graph(
             [
@@ -1491,8 +1476,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Resize"))
-    def test_resize_opset11_scales_is_empty(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Resize"))
+    def test_resize_opset11_scales_is_empty(self, version) -> None:
         self.skipIf(version != 11, "This test only works for Version 11")
         # "scales" input in Resize in opset11 is not optional. It must be an empty tensor
         # if sizes is needed. Shape inference for Resize shall handle this case.
@@ -1524,8 +1509,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid("", version)],
         )
 
-    @parameterized.expand(all_versions_for("Shape"))
-    def test_shape(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Shape"))
+    def test_shape(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 4, 3))],
             [make_node("Shape", ["x"], ["y"])],
@@ -1537,8 +1522,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Shape"))
-    def test_shape_start_1(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Shape"))
+    def test_shape_start_1(self, version) -> None:
         self.skipIf(version < 15, "start and end are from Version 15")
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 4, 3))],
@@ -1551,8 +1536,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Shape"))
-    def test_shape_end_1(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Shape"))
+    def test_shape_end_1(self, version) -> None:
         self.skipIf(version < 15, "start and end are from Version 15")
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 4, 3))],
@@ -1565,8 +1550,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Shape"))
-    def test_shape_negative_start(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Shape"))
+    def test_shape_negative_start(self, version) -> None:
         self.skipIf(version < 15, "start and end are from Version 15")
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 4, 3))],
@@ -1579,8 +1564,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Shape"))
-    def test_shape_clip1(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Shape"))
+    def test_shape_clip1(self, version) -> None:
         self.skipIf(version < 15, "start and end are from Version 15")
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 4, 3))],
@@ -1593,8 +1578,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Shape"))
-    def test_shape_clip2(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Shape"))
+    def test_shape_clip2(self, version) -> None:
         self.skipIf(version < 15, "start and end are from Version 15")
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 4, 3))],
@@ -1607,8 +1592,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Size"))
-    def test_size(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Size"))
+    def test_size(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 4, 3))], [make_node("Size", ["x"], ["y"])], []
         )
@@ -1618,8 +1603,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Gather"))
-    def test_gather(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Gather"))
+    def test_gather(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (4, 3)), ("i", TensorProto.INT64, (2,))],
             [make_node("Gather", ["x", "i"], ["y"])],
@@ -1631,8 +1616,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Gather"))
-    def test_gather_axis1(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Gather"))
+    def test_gather_axis1(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (4, 3, 5)), ("i", TensorProto.INT64, (1, 2))],
             [make_node("Gather", ["x", "i"], ["y"], axis=1)],
@@ -1644,8 +1629,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Gather"))
-    def test_gather_into_scalar(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Gather"))
+    def test_gather_into_scalar(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3,)), ("i", TensorProto.INT64, ())],
             [make_node("Gather", ["x", "i"], ["y"])],
@@ -1657,8 +1642,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("GatherElements"))
-    def test_gather_elements(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("GatherElements"))
+    def test_gather_elements(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (2, 2)), ("i", TensorProto.INT64, (2, 2))],
             [make_node("GatherElements", ["x", "i"], ["y"], axis=1)],
@@ -1670,8 +1655,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("GatherElements"))
-    def test_gather_elements_axis0(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("GatherElements"))
+    def test_gather_elements_axis0(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3, 3)), ("i", TensorProto.INT64, (2, 3))],
             [make_node("GatherElements", ["x", "i"], ["y"], axis=0)],
@@ -1683,8 +1668,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Scatter"))
-    def test_scatter(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Scatter"))
+    def test_scatter(self, version) -> None:
         if version >= 11:
             # Scatter is deprecated in domain_version of 11.
             with pytest.raises(
@@ -1710,8 +1695,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("Scatter"))
-    def test_scatter_axis1(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Scatter"))
+    def test_scatter_axis1(self, version) -> None:
         if version >= 11:
             # Scatter is deprecated in domain_version of 11.
             with pytest.raises(
@@ -1737,8 +1722,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("ScatterElements"))
-    def test_scatter_elements(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("ScatterElements"))
+    def test_scatter_elements(self, version) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (3, 3)),
@@ -1754,8 +1739,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("ScatterElements"))
-    def test_scatter_elements_axis1(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("ScatterElements"))
+    def test_scatter_elements_axis1(self, version) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (1, 5)),
@@ -1771,8 +1756,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("ScatterND"))
-    def test_scatternd(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("ScatterND"))
+    def test_scatternd(self, version) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (4, 5, 6)),
@@ -1788,8 +1773,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("ScatterND"))
-    def test_scatternd_noshape(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("ScatterND"))
+    def test_scatternd_noshape(self, version) -> None:
         # The shape of 'x_reshaped' cannot be inferred, since it is the output of a dynamic reshape.
         # Thus the shape of 'y' is also None.
         graph = self._make_graph(
@@ -1841,8 +1826,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 24)],
         )
 
-    @parameterized.expand(all_versions_for("Squeeze"))
-    def test_squeeze(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Squeeze"))
+    def test_squeeze(self, version) -> None:
         if version == 11:
             graph = self._make_graph(
                 [("x", TensorProto.FLOAT, (1, 3, 1, 1, 2, 1))],
@@ -1872,8 +1857,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    @parameterized.expand(all_versions_for("StringConcat"))
-    def test_stringconcat(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("StringConcat"))
+    def test_stringconcat(self, version) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.STRING, (2, 3, 4)),
@@ -1888,8 +1873,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("StringConcat"))
-    def test_stringconcat_broadcasting(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("StringConcat"))
+    def test_stringconcat_broadcasting(self, version) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.STRING, (2, 3, 4)),
@@ -1904,8 +1889,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("RegexFullMatch"))
-    def test_regex_full_match(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("RegexFullMatch"))
+    def test_regex_full_match(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.STRING, (2, 4, 3, 9))],
             [make_node("RegexFullMatch", ["x"], ["y"], pattern=r"^[A-Z][a-z]*$")],
@@ -1917,8 +1902,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("RegexFullMatch"))
-    def test_regex_full_match_empty_shape(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("RegexFullMatch"))
+    def test_regex_full_match_empty_shape(self, version) -> None:
         graph = self._make_graph(
             [("x", TensorProto.STRING, ())],
             [make_node("RegexFullMatch", ["x"], ["y"], pattern=r"^[A-Z][a-z]*$")],
@@ -2411,8 +2396,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             graph, [make_tensor_value_info("z", TensorProto.FLOAT, (30, 50, 6, 3, 2))]
         )
 
-    @parameterized.expand(all_versions_for("Conv"))
-    def test_conv_zero_strides(self, _: str, version: int) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Conv"))
+    def test_conv_zero_strides(self, version: int) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (1, 1, 5, 5)),
@@ -2427,8 +2412,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    @parameterized.expand(all_versions_for("Conv"))
-    def test_conv_negative_strides(self, _: str, version: int) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Conv"))
+    def test_conv_negative_strides(self, version: int) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (1, 1, 5, 5)),
@@ -2557,18 +2542,19 @@ class TestShapeInference(TestShapeInferenceHelper):
             graph, [make_tensor_value_info("z", TensorProto.FLOAT, None)]
         )
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "version",
         [
             # opset 1-10 -> Conv-1 -> convPoolShapeInference_opset1_to_11
-            ("opset1_to_10", 10),
+            10,
             # opset 11-21 -> Conv-11 -> convPoolShapeInference_opset19
-            ("opset19", 19),
+            19,
             # opset 22+ -> Conv-22 -> convPoolShapeInference
-            ("latest", defs.get_schema("Conv").since_version),
-        ]
+            defs.get_schema("Conv").since_version,
+        ],
     )
     def test_conv_weight_more_spatial_dims_than_input_raises(
-        self, _: str, version: int
+        self, version: int
     ) -> None:
         # Weight has more spatial dims than input and no explicit kernel_shape
         # attribute, so kernel_shape is derived from the weight. This must fail
@@ -2587,18 +2573,19 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "version",
         [
             # opset 1-10 -> Conv-1 -> convPoolShapeInference_opset1_to_11
-            ("opset1_to_10", 10),
+            10,
             # opset 11-21 -> Conv-11 -> convPoolShapeInference_opset19
-            ("opset19", 19),
+            19,
             # opset 22+ -> Conv-22 -> convPoolShapeInference
-            ("latest", defs.get_schema("Conv").since_version),
-        ]
+            defs.get_schema("Conv").since_version,
+        ],
     )
     def test_conv_weight_fewer_spatial_dims_than_input_raises(
-        self, _: str, version: int
+        self, version: int
     ) -> None:
         # Weight has fewer spatial dims than input and no explicit kernel_shape
         # attribute, so kernel_shape is derived from the weight. This must fail
@@ -2617,8 +2604,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    @parameterized.expand(all_versions_for("Conv"))
-    def test_conv_zero_dilations(self, _: str, version: int) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Conv"))
+    def test_conv_zero_dilations(self, version: int) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (1, 1, 5, 5)),
@@ -2633,8 +2620,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    @parameterized.expand(all_versions_for("Conv"))
-    def test_conv_negative_dilations(self, _: str, version: int) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Conv"))
+    def test_conv_negative_dilations(self, version: int) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (1, 1, 5, 5)),
@@ -2649,8 +2636,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    @parameterized.expand(all_versions_for("Conv"))
-    def test_conv_negative_pads(self, _: str, version: int) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Conv"))
+    def test_conv_negative_pads(self, version: int) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (1, 1, 5, 5)),
@@ -2665,8 +2652,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    @parameterized.expand(all_versions_for("Conv"))
-    def test_conv_input_too_few_dims(self, _: str, version: int) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Conv"))
+    def test_conv_input_too_few_dims(self, version: int) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (1, 1)),
@@ -2681,8 +2668,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    @parameterized.expand(all_versions_for("Conv"))
-    def test_conv_zero_kernel_shape(self, _: str, version: int) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Conv"))
+    def test_conv_zero_kernel_shape(self, version: int) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (1, 1, 5, 5)),
@@ -2697,8 +2684,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    @parameterized.expand(all_versions_for("Conv"))
-    def test_conv_negative_kernel_shape(self, _: str, version: int) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("Conv"))
+    def test_conv_negative_kernel_shape(self, version: int) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (1, 1, 5, 5)),
@@ -2713,8 +2700,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    @parameterized.expand(all_versions_for("MaxPool"))
-    def test_maxpool_zero_kernel_shape(self, _: str, version: int) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("MaxPool"))
+    def test_maxpool_zero_kernel_shape(self, version: int) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (1, 1, 5, 5))],
             [make_node("MaxPool", ["X"], ["Y"], kernel_shape=[0, 3])],
@@ -2726,8 +2713,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    @parameterized.expand(all_versions_for("MaxPool"))
-    def test_maxpool_negative_dilations(self, _: str, version: int) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("MaxPool"))
+    def test_maxpool_negative_dilations(self, version: int) -> None:
         if version < 10:
             pytest.skip("dilations not supported before MaxPool-10")
         graph = self._make_graph(
@@ -2749,8 +2736,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    @parameterized.expand(all_versions_for("MaxPool"))
-    def test_maxpool_negative_pads(self, _: str, version: int) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("MaxPool"))
+    def test_maxpool_negative_pads(self, version: int) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (1, 1, 5, 5))],
             [
@@ -2770,10 +2757,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    @parameterized.expand(all_versions_for("ConvTranspose"))
-    def test_conv_transpose_weight_spatial_rank_mismatch(
-        self, _: str, version: int
-    ) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("ConvTranspose"))
+    def test_conv_transpose_weight_spatial_rank_mismatch(self, version: int) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (1, 1, 4, 4)),
@@ -2788,8 +2773,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    @parameterized.expand(all_versions_for("ConvTranspose"))
-    def test_conv_transpose_negative_dilations(self, _: str, version: int) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("ConvTranspose"))
+    def test_conv_transpose_negative_dilations(self, version: int) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (1, 1, 4, 4)),
@@ -2804,8 +2789,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    @parameterized.expand(all_versions_for("ConvTranspose"))
-    def test_conv_transpose_zero_strides(self, _: str, version: int) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("ConvTranspose"))
+    def test_conv_transpose_zero_strides(self, version: int) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (1, 1, 4, 4)),
@@ -2820,8 +2805,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    @parameterized.expand(all_versions_for("ConvTranspose"))
-    def test_conv_transpose_negative_pads(self, _: str, version: int) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("ConvTranspose"))
+    def test_conv_transpose_negative_pads(self, version: int) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (1, 1, 4, 4)),
@@ -2836,8 +2821,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    @parameterized.expand(all_versions_for("ConvTranspose"))
-    def test_conv_transpose_negative_output_padding(self, _: str, version: int) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("ConvTranspose"))
+    def test_conv_transpose_negative_output_padding(self, version: int) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (1, 1, 4, 4)),
@@ -2860,8 +2845,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    @parameterized.expand(all_versions_for("ConvTranspose"))
-    def test_conv_transpose_negative_output_shape(self, _: str, version: int) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("ConvTranspose"))
+    def test_conv_transpose_negative_output_shape(self, version: int) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (1, 1, 4, 4)),
@@ -2883,8 +2868,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    @parameterized.expand(all_versions_for("ConvTranspose"))
-    def test_conv_transpose_zero_kernel_shape(self, _: str, version: int) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("ConvTranspose"))
+    def test_conv_transpose_zero_kernel_shape(self, version: int) -> None:
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (1, 1, 4, 4)),
@@ -5443,8 +5428,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 3, 3))]
         )
 
-    @parameterized.expand(all_versions_for("MaxPool"))
-    def test_maxpool_zero_strides(self, _: str, version: int) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("MaxPool"))
+    def test_maxpool_zero_strides(self, version: int) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
             [
@@ -5464,8 +5449,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    @parameterized.expand(all_versions_for("MaxPool"))
-    def test_maxpool_negative_strides(self, _: str, version: int) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("MaxPool"))
+    def test_maxpool_negative_strides(self, version: int) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
             [
@@ -5721,8 +5706,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (5, 3, 3, 3))]
         )
 
-    @parameterized.expand(all_versions_for("AveragePool"))
-    def test_averagepool_zero_strides(self, _: str, version: int) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("AveragePool"))
+    def test_averagepool_zero_strides(self, version: int) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
             [
@@ -5742,8 +5727,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    @parameterized.expand(all_versions_for("AveragePool"))
-    def test_averagepool_negative_strides(self, _: str, version: int) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("AveragePool"))
+    def test_averagepool_negative_strides(self, version: int) -> None:
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (5, 3, 4, 4))],
             [
@@ -5874,8 +5859,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             graph, [make_tensor_value_info("Y", TensorProto.FLOAT, (2, 3, 2, 2))]
         )
 
-    @parameterized.expand(all_versions_for("MaxRoiPool"))
-    def test_roipool_negative_pooled_shape(self, _: str, version: int) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("MaxRoiPool"))
+    def test_roipool_negative_pooled_shape(self, version: int) -> None:
         graph = self._make_graph(
             [
                 ("X", TensorProto.FLOAT, (5, 3, 4, 4)),
@@ -7628,8 +7613,9 @@ class TestShapeInference(TestShapeInferenceHelper):
         self._make_matmulinteger_test((5, 1, 4, 2), (1, 3, 2, 3))
         self._make_matmulinteger_test((4, 2), (3, 2, 3))
 
-    @parameterized.expand(
-        [onnx.TensorProto.FLOAT, onnx.TensorProto.FLOAT16, onnx.TensorProto.BFLOAT16]
+    @pytest.mark.parametrize(
+        "elem_type",
+        [onnx.TensorProto.FLOAT, onnx.TensorProto.FLOAT16, onnx.TensorProto.BFLOAT16],
     )
     def test_quantizelinear(self, elem_type) -> None:
         graph = self._make_graph(
@@ -7726,9 +7712,7 @@ class TestShapeInference(TestShapeInferenceHelper):
                 graph,
             )
 
-    @unittest.skip(
-        "Issue #5960"
-    )  # FIXME(#5960) propagateElemTypeFromAttributeToOutput does not validate against output type constraints
+    @pytest.mark.xfail(reason="Issue #5960")
     def test_quantizelinear_invalid_output_dtype(self) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (3, 4, 5)), ("y_scale", TensorProto.FLOAT, ())],
@@ -7748,8 +7732,9 @@ class TestShapeInference(TestShapeInferenceHelper):
                 graph,
             )
 
-    @parameterized.expand(
-        [onnx.TensorProto.FLOAT, onnx.TensorProto.FLOAT16, onnx.TensorProto.BFLOAT16]
+    @pytest.mark.parametrize(
+        "elem_type",
+        [onnx.TensorProto.FLOAT, onnx.TensorProto.FLOAT16, onnx.TensorProto.BFLOAT16],
     )
     def test_dequantizelinear(self, elem_type) -> None:
         graph = self._make_graph(
@@ -7893,7 +7878,9 @@ class TestShapeInference(TestShapeInferenceHelper):
             graph, [make_tensor_value_info("y", TensorProto.FLOAT, (None, None, None))]
         )
 
-    @unittest.skipUnless(ONNX_ML, "ONNX_ML required to test ai.onnx.ml operators")
+    @pytest.mark.skipif(
+        not ONNX_ML, reason="ONNX_ML required to test ai.onnx.ml operators"
+    )
     def test_linearclassifier_1D_input(self) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (5,))],
@@ -7922,7 +7909,9 @@ class TestShapeInference(TestShapeInferenceHelper):
             ],
         )
 
-    @unittest.skipUnless(ONNX_ML, "ONNX_ML required to test ai.onnx.ml operators")
+    @pytest.mark.skipif(
+        not ONNX_ML, reason="ONNX_ML required to test ai.onnx.ml operators"
+    )
     def test_linearclassifier_2D_input(self) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (4, 5))],
@@ -8056,10 +8045,11 @@ class TestShapeInference(TestShapeInferenceHelper):
             ],
         )
 
-    @parameterized.expand(
-        all_versions_for("LabelEncoder") if ONNX_ML else [], skip_on_empty=True
+    @pytest.mark.parametrize(
+        "version",
+        all_versions_for("LabelEncoder") if ONNX_ML else [],
     )
-    def test_label_encoder_string_int64(self, _, version) -> None:
+    def test_label_encoder_string_int64(self, version) -> None:
         self.skipIf(
             version < 2, "keys_* attributes were introduced in ai.onnx.ml opset 2"
         )
@@ -8204,10 +8194,10 @@ class TestShapeInference(TestShapeInferenceHelper):
             ],
         )
 
-    @parameterized.expand(
-        all_versions_for("LabelEncoder") if ONNX_ML else [], skip_on_empty=True
+    @pytest.mark.parametrize(
+        "version", all_versions_for("LabelEncoder") if ONNX_ML else []
     )
-    def test_label_encoder_tensor_attributes(self, _, version) -> None:
+    def test_label_encoder_tensor_attributes(self, version) -> None:
         self.skipIf(
             version < 4, "tensor attributes were introduced in ai.onnx.ml opset 4"
         )
@@ -8243,11 +8233,11 @@ class TestShapeInference(TestShapeInferenceHelper):
             ],
         )
 
-    @parameterized.expand(
-        all_versions_for("LabelEncoder") if ONNX_ML else [], skip_on_empty=True
+    @pytest.mark.parametrize(
+        "version", all_versions_for("LabelEncoder") if ONNX_ML else []
     )
     def test_label_encoder_tensor_attributes_invalid_configurations(
-        self, _, version
+        self, version
     ) -> None:
         self.skipIf(version < 4, "tensor attributes introduced in ai.onnx.ml opset 4")
         key_tensor = make_tensor(
@@ -10831,8 +10821,8 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
         self._assert_inferred(graph, [output_tensor_val_info])
 
-    @parameterized.expand(all_versions_for("StringSplit"))
-    def test_string_split_basic(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("StringSplit"))
+    def test_string_split_basic(self, version) -> None:
         substrings = make_tensor_value_info(
             "substrings",
             TensorProto.STRING,
@@ -10852,8 +10842,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("StringSplit"))
-    def test_string_split_symbolic(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("StringSplit"))
+    def test_string_split_symbolic(self, version) -> None:
         substrings = make_tensor_value_info(
             "substrings",
             TensorProto.STRING,
@@ -10873,8 +10863,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("StringSplit"))
-    def test_string_split_nested(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("StringSplit"))
+    def test_string_split_nested(self, version) -> None:
         substrings = make_tensor_value_info(
             "substrings", TensorProto.STRING, (2, 4, 3, None)
         )
@@ -10892,8 +10882,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("StringSplit"))
-    def test_string_split_zero_dimensional_input(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("StringSplit"))
+    def test_string_split_zero_dimensional_input(self, version) -> None:
         substrings = make_tensor_value_info("substrings", TensorProto.STRING, (None,))
         length = make_tensor_value_info("length", TensorProto.INT64, ())
 
@@ -10910,8 +10900,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(all_versions_for("StringSplit"))
-    def test_string_split_empty_input(self, _, version) -> None:
+    @pytest.mark.parametrize("version", all_versions_for("StringSplit"))
+    def test_string_split_empty_input(self, version) -> None:
         substrings = make_tensor_value_info(
             "substrings", TensorProto.STRING, ("M", 3, 0, None)
         )
@@ -11602,53 +11592,31 @@ class TestShapeInference(TestShapeInferenceHelper):
             ],
         )
 
-    @parameterized.expand(
+    @pytest.mark.parametrize("version", all_versions_for("DFT"))
+    @pytest.mark.parametrize(
+        "input_shape, axis, onesided, inverse, expected_shape",
         [
-            (
-                name,
-                version,
-                test_aspect,
-                input_shape,
-                axis,
-                onesided,
-                inverse,
-                expected_shape,
-            )
-            for (name, version), (
-                test_aspect,
-                input_shape,
-                axis,
-                onesided,
-                inverse,
-                expected_shape,
-            ) in itertools.product(
-                all_versions_for("DFT"),
-                (
-                    ("reals_default_axis", (2, 5, 1), None, None, None, (2, 5, 2)),
-                    ("reals_axis_0", (3, 5, 10, 1), 0, 0, 0, (3, 5, 10, 2)),
-                    ("reals_axis_1", (3, 5, 10, 1), 1, 0, 0, (3, 5, 10, 2)),
-                    ("reals_axis_2", (3, 5, 10, 1), 2, 0, 0, (3, 5, 10, 2)),
-                    ("reals_axis_neg", (3, 5, 10, 1), -2, 0, 0, (3, 5, 10, 2)),
-                    ("reals_axis_0_onesided", (3, 5, 10, 1), 0, 1, 0, (2, 5, 10, 2)),
-                    ("reals_axis_1_onesided", (3, 5, 10, 1), 1, 1, 0, (3, 3, 10, 2)),
-                    ("reals_axis_2_onesided", (3, 5, 10, 1), 2, 1, 0, (3, 5, 6, 2)),
-                    ("reals_axis_neg_onesided", (3, 5, 10, 1), -2, 1, 0, (3, 5, 6, 2)),
-                    ("complex_default_axis", (2, 5, 2), None, None, None, (2, 5, 2)),
-                    ("real_inverse", (2, 5, 1), 1, None, 1, (2, 5, 2)),
-                    ("complex_inverse", (2, 5, 2), 1, None, 1, (2, 5, 2)),
-                    ("irfft_axis_0", (2, 5, 10, 2), 0, 1, 1, (2, 5, 10, 1)),
-                    ("irfft_axis_1", (3, 3, 10, 2), 1, 1, 1, (3, 4, 10, 1)),
-                    ("irfft_axis_2", (3, 5, 6, 2), 2, 1, 1, (3, 5, 10, 1)),
-                    ("irfft_axis_neg", (3, 5, 6, 2), -2, 1, 1, (3, 5, 10, 1)),
-                ),
-            )
-        ]
+            ((2, 5, 1), None, None, None, (2, 5, 2)),
+            ((3, 5, 10, 1), 0, 0, 0, (3, 5, 10, 2)),
+            ((3, 5, 10, 1), 1, 0, 0, (3, 5, 10, 2)),
+            ((3, 5, 10, 1), 2, 0, 0, (3, 5, 10, 2)),
+            ((3, 5, 10, 1), -2, 0, 0, (3, 5, 10, 2)),
+            ((3, 5, 10, 1), 0, 1, 0, (2, 5, 10, 2)),
+            ((3, 5, 10, 1), 1, 1, 0, (3, 3, 10, 2)),
+            ((3, 5, 10, 1), 2, 1, 0, (3, 5, 6, 2)),
+            ((3, 5, 10, 1), -2, 1, 0, (3, 5, 6, 2)),
+            ((2, 5, 2), None, None, None, (2, 5, 2)),
+            ((2, 5, 1), 1, None, 1, (2, 5, 2)),
+            ((2, 5, 2), 1, None, 1, (2, 5, 2)),
+            ((2, 5, 10, 2), 0, 1, 1, (2, 5, 10, 1)),
+            ((3, 3, 10, 2), 1, 1, 1, (3, 4, 10, 1)),
+            ((3, 5, 6, 2), 2, 1, 1, (3, 5, 10, 1)),
+            ((3, 5, 6, 2), -2, 1, 1, (3, 5, 10, 1)),
+        ],
     )
     def test_dft(
         self,
-        _: str,
         version: int,
-        _test_aspect: str,
         input_shape: tuple[int],
         axis: int | None,
         onesided: int | None,
@@ -11715,53 +11683,31 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(
+    @pytest.mark.parametrize("version", all_versions_for("DFT"))
+    @pytest.mark.parametrize(
+        "input_shape, axis, onesided, inverse, expected_shape",
         [
-            (
-                name,
-                version,
-                test_aspect,
-                input_shape,
-                axis,
-                onesided,
-                inverse,
-                expected_shape,
-            )
-            for (name, version), (
-                test_aspect,
-                input_shape,
-                axis,
-                onesided,
-                inverse,
-                expected_shape,
-            ) in itertools.product(
-                all_versions_for("DFT"),
-                (
-                    ("reals_default_axis", (2, 5, 1), None, None, None, (2, 42, 2)),
-                    ("reals_axis_0", (3, 5, 10, 1), 0, 0, 0, (42, 5, 10, 2)),
-                    ("reals_axis_1", (3, 5, 10, 1), 1, 0, 0, (3, 42, 10, 2)),
-                    ("reals_axis_2", (3, 5, 10, 1), 2, 0, 0, (3, 5, 42, 2)),
-                    ("reals_axis_neg", (3, 5, 10, 1), -2, 0, 0, (3, 5, 42, 2)),
-                    ("reals_axis_0_onesided", (3, 5, 10, 1), 0, 1, 0, (22, 5, 10, 2)),
-                    ("reals_axis_1_onesided", (3, 5, 10, 1), 1, 1, 0, (3, 22, 10, 2)),
-                    ("reals_axis_2_onesided", (3, 5, 10, 1), 2, 1, 0, (3, 5, 22, 2)),
-                    ("reals_axis_neg_onesided", (3, 5, 10, 1), -2, 1, 0, (3, 5, 22, 2)),
-                    ("complex_default_axis", (2, 5, 2), None, None, None, (2, 42, 2)),
-                    ("real_inverse", (2, 5, 1), 1, None, 1, (2, 42, 2)),
-                    ("complex_inverse", (2, 5, 2), 1, None, 1, (2, 42, 2)),
-                    ("irfft_axis_0", (2, 5, 10, 2), 0, 1, 1, (42, 5, 10, 1)),
-                    ("irfft_axis_1", (3, 3, 10, 2), 1, 1, 1, (3, 42, 10, 1)),
-                    ("irfft_axis_2", (3, 5, 6, 2), 2, 1, 1, (3, 5, 42, 1)),
-                    ("irfft_axis_neg", (3, 5, 6, 2), -2, 1, 1, (3, 5, 42, 1)),
-                ),
-            )
-        ]
+            ((2, 5, 1), None, None, None, (2, 42, 2)),
+            ((3, 5, 10, 1), 0, 0, 0, (42, 5, 10, 2)),
+            ((3, 5, 10, 1), 1, 0, 0, (3, 42, 10, 2)),
+            ((3, 5, 10, 1), 2, 0, 0, (3, 5, 42, 2)),
+            ((3, 5, 10, 1), -2, 0, 0, (3, 5, 42, 2)),
+            ((3, 5, 10, 1), 0, 1, 0, (22, 5, 10, 2)),
+            ((3, 5, 10, 1), 1, 1, 0, (3, 22, 10, 2)),
+            ((3, 5, 10, 1), 2, 1, 0, (3, 5, 22, 2)),
+            ((3, 5, 10, 1), -2, 1, 0, (3, 5, 22, 2)),
+            ((2, 5, 2), None, None, None, (2, 42, 2)),
+            ((2, 5, 1), 1, None, 1, (2, 42, 2)),
+            ((2, 5, 2), 1, None, 1, (2, 42, 2)),
+            ((2, 5, 10, 2), 0, 1, 1, (42, 5, 10, 1)),
+            ((3, 3, 10, 2), 1, 1, 1, (3, 42, 10, 1)),
+            ((3, 5, 6, 2), 2, 1, 1, (3, 5, 42, 1)),
+            ((3, 5, 6, 2), -2, 1, 1, (3, 5, 42, 1)),
+        ],
     )
     def test_dft_dft_length(
         self,
-        _: str,
         version: int,
-        _test_aspect: str,
         input_shape: tuple[int],
         axis: int | None,
         onesided: int | None,
@@ -11871,15 +11817,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    @parameterized.expand(
-        [
-            ("last", 3),
-            ("last_negative", -1),
-            ("out_of_range", 4),
-            ("out_of_range_negative", -5),
-        ]
-    )
-    def test_dft_invalid_axis_opset17(self, _: str, axis: int) -> None:
+    @pytest.mark.parametrize("axis", [3, -1, 4, -5])
+    def test_dft_invalid_axis_opset17(self, axis: int) -> None:
         graph = self._make_graph(
             [],
             [
@@ -11908,15 +11847,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 17)],
             )
 
-    @parameterized.expand(
-        [
-            ("last", 3),
-            ("last_negative", -1),
-            ("out_of_range", 4),
-            ("out_of_range_negative", -5),
-        ]
-    )
-    def test_dft_invalid_axis_opset20(self, _: str, axis: int) -> None:
+    @pytest.mark.parametrize("axis", [3, -1, 4, -5])
+    def test_dft_invalid_axis_opset20(self, axis: int) -> None:
         graph = self._make_graph(
             [],
             [
@@ -12090,13 +12022,8 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 20)],
             )
 
-    @parameterized.expand(
-        [
-            ("real", (2, 5, 5, 1)),
-            ("complex", (2, 5, 5, 2)),
-        ]
-    )
-    def test_dft_dynamic_axis_opset20(self, _: str, shape: tuple[int, ...]) -> None:
+    @pytest.mark.parametrize("shape", [(2, 5, 5, 1), (2, 5, 5, 2)])
+    def test_dft_dynamic_axis_opset20(self, shape: tuple[int, ...]) -> None:
         graph = self._make_graph(
             [("axis", TensorProto.INT64, ())],
             [
@@ -12124,13 +12051,9 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 20)],
         )
 
-    @parameterized.expand(
-        [
-            ("real", (2, 5, 5, 1)),
-        ]
-    )
+    @pytest.mark.parametrize("shape", [(2, 5, 5, 1)])
     def test_dft_dynamic_axis_onesided_dft_length_opset20(
-        self, _: str, shape: tuple[int, ...]
+        self, shape: tuple[int, ...]
     ) -> None:
         graph = self._make_graph(
             [("axis", TensorProto.INT64, ())],
@@ -12175,14 +12098,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 20)],
         )
 
-    @parameterized.expand(
-        [
-            ("real", (2, 5, 5, 1)),
-        ]
-    )
-    def test_dft_dynamic_axis_onesided_opset20(
-        self, _: str, shape: tuple[int, ...]
-    ) -> None:
+    @pytest.mark.parametrize("shape", [(2, 5, 5, 1)])
+    def test_dft_dynamic_axis_onesided_opset20(self, shape: tuple[int, ...]) -> None:
         graph = self._make_graph(
             [("axis", TensorProto.INT64, ())],
             [
@@ -12633,7 +12550,9 @@ class TestShapeInference(TestShapeInferenceHelper):
             opset_imports=[helper.make_opsetid(ONNX_DOMAIN, 18)],
         )
 
-    @unittest.skipUnless(ONNX_ML, "ONNX_ML required to test ai.onnx.ml operators")
+    @pytest.mark.skipif(
+        not ONNX_ML, reason="ONNX_ML required to test ai.onnx.ml operators"
+    )
     def test_category_mapper(self) -> None:
         cat = make_node(
             "CategoryMapper",
@@ -12670,15 +12589,18 @@ class TestShapeInference(TestShapeInferenceHelper):
             ],
         )
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "cats_int64s, cats_strings",
         [
             ([1, 2, 3], ["1", "2"]),
             ([1, 2, 3], None),
             (None, ["1", "2", "3"]),
             (None, None),
-        ]
+        ],
     )
-    @unittest.skipUnless(ONNX_ML, "ONNX_ML required to test ai.onnx.ml operators")
+    @pytest.mark.skipif(
+        not ONNX_ML, reason="ONNX_ML required to test ai.onnx.ml operators"
+    )
     def test_category_mapper_fails_if_invalid_attributes(
         self, cats_int64s, cats_strings
     ) -> None:
@@ -12704,7 +12626,9 @@ class TestShapeInference(TestShapeInferenceHelper):
                 ],
             )
 
-    @unittest.skipUnless(ONNX_ML, "ONNX_ML required to test ai.onnx.ml operators")
+    @pytest.mark.skipif(
+        not ONNX_ML, reason="ONNX_ML required to test ai.onnx.ml operators"
+    )
     def test_tree_ensemble_regressor(self) -> None:
         tree = make_node(
             "TreeEnsembleRegressor",
@@ -12727,8 +12651,12 @@ class TestShapeInference(TestShapeInferenceHelper):
             ],
         )
 
-    @parameterized.expand([TensorProto.FLOAT, TensorProto.DOUBLE, TensorProto.FLOAT16])
-    @unittest.skipUnless(ONNX_ML, "ONNX_ML required to test ai.onnx.ml operators")
+    @pytest.mark.parametrize(
+        "dtype", [TensorProto.FLOAT, TensorProto.DOUBLE, TensorProto.FLOAT16]
+    )
+    @pytest.mark.skipif(
+        not ONNX_ML, reason="ONNX_ML required to test ai.onnx.ml operators"
+    )
     def test_tree_ensemble(self, dtype) -> None:
         interior_nodes = 5
         leaves = 9
@@ -12781,7 +12709,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             ],
         )
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "nodes_truenodeids, leaf_weights, nodes_splits",
         [
             (
                 [0] * 6,
@@ -12803,9 +12732,11 @@ class TestShapeInference(TestShapeInferenceHelper):
                 make_tensor("leaf_weights", TensorProto.DOUBLE, (9,), [1] * 9),
                 make_tensor("nodes_splits", TensorProto.FLOAT, (5,), [1] * 5),
             ),
-        ]
+        ],
     )
-    @unittest.skipUnless(ONNX_ML, "ONNX_ML required to test ai.onnx.ml operators")
+    @pytest.mark.skipif(
+        not ONNX_ML, reason="ONNX_ML required to test ai.onnx.ml operators"
+    )
     def test_tree_ensemble_fails_if_invalid_attributes(
         self,
         nodes_truenodeids,
@@ -12851,7 +12782,9 @@ class TestShapeInference(TestShapeInferenceHelper):
                 ],
             )
 
-    @unittest.skipUnless(ONNX_ML, "ONNX_ML required to test ai.onnx.ml operators")
+    @pytest.mark.skipif(
+        not ONNX_ML, reason="ONNX_ML required to test ai.onnx.ml operators"
+    )
     def test_tree_ensemble_classifier(self) -> None:
         tree = make_node(
             "TreeEnsembleClassifier",
@@ -12877,7 +12810,9 @@ class TestShapeInference(TestShapeInferenceHelper):
             ],
         )
 
-    @unittest.skipUnless(ONNX_ML, "ONNX_ML required to test ai.onnx.ml operators")
+    @pytest.mark.skipif(
+        not ONNX_ML, reason="ONNX_ML required to test ai.onnx.ml operators"
+    )
     def test_array_feature_extractor(self) -> None:
         node = make_node(
             "ArrayFeatureExtractor",
@@ -12907,7 +12842,9 @@ class TestShapeInference(TestShapeInferenceHelper):
                 ],
             )
 
-    @unittest.skipUnless(ONNX_ML, "ONNX_ML required to test ai.onnx.ml operators")
+    @pytest.mark.skipif(
+        not ONNX_ML, reason="ONNX_ML required to test ai.onnx.ml operators"
+    )
     def test_binarizer(self) -> None:
         node = make_node(
             "Binarizer",
@@ -12931,7 +12868,9 @@ class TestShapeInference(TestShapeInferenceHelper):
             ],
         )
 
-    @unittest.skipUnless(ONNX_ML, "ONNX_ML required to test ai.onnx.ml operators")
+    @pytest.mark.skipif(
+        not ONNX_ML, reason="ONNX_ML required to test ai.onnx.ml operators"
+    )
     def test_one_hot_encoder(self) -> None:
         graph = self._make_graph(
             [("input", TensorProto.INT64, (2, "N", 3))],
@@ -12955,13 +12894,16 @@ class TestShapeInference(TestShapeInferenceHelper):
             ],
         )
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "cats_int64s, cats_strings",
         [
             ([1, 2, 3], ["1", "2", "3"]),
             (None, None),
-        ]
+        ],
     )
-    @unittest.skipUnless(ONNX_ML, "ONNX_ML required to test ai.onnx.ml operators")
+    @pytest.mark.skipif(
+        not ONNX_ML, reason="ONNX_ML required to test ai.onnx.ml operators"
+    )
     def test_one_hot_encoder_fails_if_invalid_attributes(
         self, cats_int64s, cats_strings
     ) -> None:
@@ -12988,9 +12930,6 @@ class TestShapeInference(TestShapeInferenceHelper):
                 ],
             )
 
-    @pytest.mark.skipif(
-        not ONNX_ML, reason="ONNX_ML required to test ai.onnx.ml operators"
-    )
     @pytest.mark.parametrize(
         "attrs, input_type",
         [
@@ -12998,10 +12937,10 @@ class TestShapeInference(TestShapeInferenceHelper):
             ({"classlabels_strings": ["a", "b", "c"]}, onnx.TensorProto.STRING),
         ],
     )
+    @pytest.mark.skipif(
+        not ONNX_ML, reason="ONNX_ML required to test ai.onnx.ml operators"
+    )
     def test_zip_map(self, attrs, input_type) -> None:
-        self.zip_map_test_case(attrs, input_type)
-
-    def zip_map_test_case(self, attrs, input_type) -> None:
         graph = self._make_graph(
             [("input", TensorProto.FLOAT, ("N", 3))],
             [
@@ -13145,8 +13084,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             onnx.checker.check_model(model, full_check=True)
             onnx.shape_inference.infer_shapes(model)
 
-    @parameterized.expand(all_versions_for("ConstantOfShape"))
-    def test_issue_constantofshape_6135(self, _, version):
+    @pytest.mark.parametrize("version", all_versions_for("ConstantOfShape"))
+    def test_issue_constantofshape_6135(self, version):
         graph = self._make_graph(
             [("std.constant", TensorProto.INT64, (1,)), "output"],
             [

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -91,7 +91,7 @@ def all_versions_for(op_name: str) -> list[tuple[str, int]]:
     ]
 
 
-class TestShapeInferenceHelper(unittest.TestCase):
+class TestShapeInferenceHelper:
     def _make_graph(
         self,
         seed_values: Sequence[str | tuple[str, TensorProto.DataType, Any]],
@@ -2729,7 +2729,7 @@ class TestShapeInference(TestShapeInferenceHelper):
     @parameterized.expand(all_versions_for("MaxPool"))
     def test_maxpool_negative_dilations(self, _: str, version: int) -> None:
         if version < 10:
-            self.skipTest("dilations not supported before MaxPool-10")
+            pytest.skip("dilations not supported before MaxPool-10")
         graph = self._make_graph(
             [("X", TensorProto.FLOAT, (1, 1, 5, 5))],
             [
@@ -12988,15 +12988,18 @@ class TestShapeInference(TestShapeInferenceHelper):
                 ],
             )
 
-    @unittest.skipUnless(ONNX_ML, "ONNX_ML required to test ai.onnx.ml operators")
-    def test_zip_map(self) -> None:
-        params = (
+    @pytest.mark.skipif(
+        not ONNX_ML, reason="ONNX_ML required to test ai.onnx.ml operators"
+    )
+    @pytest.mark.parametrize(
+        "attrs, input_type",
+        [
             ({"classlabels_int64s": [1, 2, 3]}, onnx.TensorProto.INT64),
             ({"classlabels_strings": ["a", "b", "c"]}, onnx.TensorProto.STRING),
-        )
-        for attrs, input_type in params:
-            with self.subTest(attrs=attrs, input_type=input_type):
-                self.zip_map_test_case(attrs, input_type)
+        ],
+    )
+    def test_zip_map(self, attrs, input_type) -> None:
+        self.zip_map_test_case(attrs, input_type)
 
     def zip_map_test_case(self, attrs, input_type) -> None:
         graph = self._make_graph(
@@ -13230,25 +13233,24 @@ class TestShapeInference(TestShapeInferenceHelper):
         with pytest.raises(onnx.checker.ValidationError):
             onnx.shape_inference.infer_shapes(model)
 
-    def test_scan_invalid_num_scan_inputs_does_not_crash(self):
+    @pytest.mark.parametrize("attrs", ["", "num_scan_inputs = -1, "])
+    def test_scan_invalid_num_scan_inputs_does_not_crash(self, attrs):
         # Missing required attribute would null-deref; negative value would
         # overflow narrow<size_t>. Both must raise InferenceError, not crash.
         scan_body = (
             "body = b (float[1] si, float[1] xi) => (float[1] so, float[1] xo) "
             "{ so = Identity(si) xo = Identity(xi) }"
         )
-        for attrs in ("", "num_scan_inputs = -1, "):
-            with self.subTest(attrs=attrs or "missing"):
-                model = onnx.parser.parse_model(
-                    f"""
-                    <ir_version: 8, opset_import: [ "" : 9 ]>
-                    g (float[1] s, float[3,1] x) => (float[1] so, float[3,1] xo) {{
-                        so, xo = Scan <{attrs}{scan_body}> (s, x)
-                    }}
-                    """
-                )
-                with pytest.raises(onnx.shape_inference.InferenceError):
-                    onnx.shape_inference.infer_shapes(model, strict_mode=True)
+        model = onnx.parser.parse_model(
+            f"""
+            <ir_version: 8, opset_import: [ "" : 9 ]>
+            g (float[1] s, float[3,1] x) => (float[1] so, float[3,1] xo) {{
+                so, xo = Scan <{attrs}{scan_body}> (s, x)
+            }}
+            """
+        )
+        with pytest.raises(onnx.shape_inference.InferenceError):
+            onnx.shape_inference.infer_shapes(model, strict_mode=True)
 
     def test_function_output_count_mismatch_does_not_crash(self):
         # Function declares 2 outputs; calling node declares 1.


### PR DESCRIPTION
Another PR towards modernizing our test suite. The primary goal remains to get rid of `parameterized` which means that we need to get rid of subclassing `unittest.TestCase`. This PR removes the usages of `subTest` to reduce the dependency. Most cases are replaced by `pytest.mark.parametrize`.

The changes are mechanical, but the diff is pretty large. `subTest` often relies on defining parametrization in the test function body, but pytest expects parametrization in the decorators. Some of the refactored tests are still not idiomatic pytest code, but I didn't want to inflate this PR further.

### Motivation and Context

Relates to #8104 
