### PR TITLE
Replace setUp tearDown methods with pytest fixtures

### DIFF
--- a/onnx/test/schema_test.py
+++ b/onnx/test/schema_test.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import contextlib
-import unittest
 from typing import TYPE_CHECKING
 
 import parameterized
@@ -414,36 +413,31 @@ class TestAttribute:
         assert attribute.description == "attr1 description"
 
 
-@parameterized.parameterized_class(
+@pytest.mark.parametrize(
+    ("op_type", "op_version", "op_domain", "trap_op_version"),
     [
         # register to exist domain
-        {
-            "op_type": "CustomOp",
-            "op_version": 5,
-            "op_domain": "",
-            "trap_op_version": [1, 2, 6, 7],
-        },
+        ("CustomOp", 5, "", [1, 2, 6, 7]),
         # register to new domain
-        {
-            "op_type": "CustomOp",
-            "op_version": 5,
-            "op_domain": "test",
-            "trap_op_version": [1, 2, 6, 7],
-        },
-    ]
+        ("CustomOp", 5, "test", [1, 2, 6, 7]),
+    ],
 )
-class TestOpSchemaRegister(unittest.TestCase):
+class TestOpSchemaRegister:
     op_type: str
     op_version: int
     op_domain: str
     # register some fake schema to check behavior
     trap_op_version: list[int]
 
-    def setUp(self) -> None:
+    @pytest.fixture(autouse=True)
+    def _register_schema(self, op_type, op_version, op_domain, trap_op_version):
+        self.op_type = op_type
+        self.op_version = op_version
+        self.op_domain = op_domain
+        self.trap_op_version = trap_op_version
         # Ensure the schema is unregistered
         assert not onnx.defs.has(self.op_type, self.op_domain)
-
-    def tearDown(self) -> None:
+        yield
         # Clean up the registered schema
         for version in [*self.trap_op_version, self.op_version]:
             with contextlib.suppress(onnx.defs.SchemaError):

--- a/onnx/test/serialization_test.py
+++ b/onnx/test/serialization_test.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import os
 import tempfile
-import unittest
 
 import pytest
 
@@ -55,9 +54,11 @@ class _OnnxTestTextualSerializer(onnx.serialization.ProtoSerializer):
         raise ValueError(f"Unsupported proto type: {type(proto)}")
 
 
-class TestRegistry(unittest.TestCase):
-    def setUp(self) -> None:
+class TestRegistry:
+    @pytest.fixture(autouse=True)
+    def register_serializer(self):
         self.serializer = _OnnxTestTextualSerializer()
+        # FIXME: There is no API to unregister
         onnx.serialization.registry.register(self.serializer)
 
     def test_get_returns_the_registered_instance(self) -> None:

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -13230,12 +13230,13 @@ class TestCustomSchemaShapeInference(TestShapeInferenceHelper):
     op_version: int = 1
     op_domain: str = ""
 
-    def setUp(self) -> None:
+    @pytest.fixture(autouse=True)
+    def schema_cleanup(self):
         # Ensure the schema is unregistered
         assert not onnx.defs.has(self.custom_op_type, self.op_domain)
         assert not onnx.defs.has(self.dummy_graph_op_type, self.op_domain)
+        yield
 
-    def tearDown(self) -> None:
         # Clean up the registered schema
         with contextlib.suppress(onnx.defs.SchemaError):
             onnx.defs.deregister_schema(

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -52,7 +52,6 @@ class TestLoadExternalDataBase:
 
     @pytest.fixture(autouse=True)
     def setup(self, tmp_path: Path):
-        self._temp_path = tmp_path
         self.temp_dir = str(tmp_path)
         self.initializer_value = np.arange(6).reshape(3, 2).astype(np.float32) + 512
         self.attribute_value = np.arange(6).reshape(2, 3).astype(np.float32) + 256
@@ -265,17 +264,11 @@ class TestLoadExternalDataSingleFile(TestLoadExternalDataBase):
             onnx.save_model(model, new_model_filepath, self.serialization_format)
 
 
-@parameterized.parameterized_class(
-    [
-        {"serialization_format": "protobuf"},
-        {"serialization_format": "textproto"},
-    ]
-)
+@pytest.mark.parametrize("serialization_format", ["protobuf", "textproto"])
 class TestSaveAllTensorsAsExternalData:
-    serialization_format: str = "protobuf"
-
     @pytest.fixture(autouse=True)
-    def setup(self, tmp_path):
+    def setup(self, tmp_path, serialization_format: str):
+        self.serialization_format = serialization_format
         self.temp_dir: str = str(tmp_path)
         self.initializer_value = np.arange(6).reshape(3, 2).astype(np.float32) + 512
         self.attribute_value = np.arange(6).reshape(2, 3).astype(np.float32) + 256
@@ -322,11 +315,9 @@ class TestSaveAllTensorsAsExternalData:
         )
         return helper.make_model(graph)
 
-    @pytest.mark.skipif(
-        serialization_format != "protobuf",
-        reason="check_model supports protobuf only when provided as a path",
-    )
     def test_check_model(self) -> None:
+        if self.serialization_format != "protobuf":
+            pytest.skip("check_model supports protobuf only when provided as a path")
         checker.check_model(self.model)
 
     def test_convert_model_to_external_data_with_size_threshold(self) -> None:
@@ -567,17 +558,11 @@ class TestSaveAllTensorsAsExternalData:
         assert initializer_tensor.raw_data == original_raw_data
 
 
-@parameterized.parameterized_class(
-    [
-        {"serialization_format": "protobuf"},
-        {"serialization_format": "textproto"},
-    ]
-)
+@pytest.mark.parametrize("serialization_format", ["protobuf", "textproto"])
 class TestExternalDataToArray:
-    serialization_format: str = "protobuf"
-
     @pytest.fixture(autouse=True)
-    def setup(self, tmp_path) -> None:
+    def setup(self, tmp_path, serialization_format: str) -> None:
+        self.serialization_format = serialization_format
         self.temp_dir = str(tmp_path)
         self._model_file_path: str = os.path.join(self.temp_dir, "model.onnx")
         self.large_data = np.random.rand(10, 60, 100).astype(np.float32)
@@ -626,11 +611,10 @@ class TestExternalDataToArray:
         )
         return helper.make_model(graph_def, producer_name="onnx-example")
 
-    @pytest.mark.skipif(
-        serialization_format != "protobuf",
-        reason="check_model supports protobuf only when provided as a path",
-    )
     def test_check_model(self) -> None:
+        if self.serialization_format != "protobuf":
+            pytest.skip("check_model supports protobuf only when provided as a path")
+
         checker.check_model(self.model)
 
     def test_reshape_inference_with_external_data_fail(self) -> None:

--- a/onnx/test/test_external_data.py
+++ b/onnx/test/test_external_data.py
@@ -7,8 +7,6 @@ import itertools
 import os
 import pathlib
 import shutil
-import tempfile
-import unittest
 import uuid
 import warnings
 from typing import TYPE_CHECKING, Any
@@ -41,9 +39,10 @@ from onnx.numpy_helper import from_array, to_array
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from pathlib import Path
 
 
-class TestLoadExternalDataBase(unittest.TestCase):
+class TestLoadExternalDataBase:
     """Base class for testing external data related behaviors.
 
     Subclasses should be parameterized with a serialization format.
@@ -51,15 +50,13 @@ class TestLoadExternalDataBase(unittest.TestCase):
 
     serialization_format: str = "protobuf"
 
-    def setUp(self) -> None:
-        self._temp_dir_obj = tempfile.TemporaryDirectory()
-        self.temp_dir: str = self._temp_dir_obj.name
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_path: Path):
+        self._temp_path = tmp_path
+        self.temp_dir = str(tmp_path)
         self.initializer_value = np.arange(6).reshape(3, 2).astype(np.float32) + 512
         self.attribute_value = np.arange(6).reshape(2, 3).astype(np.float32) + 256
         self.model_filename = self.create_test_model()
-
-    def tearDown(self) -> None:
-        self._temp_dir_obj.cleanup()
 
     def get_temp_model_filename(self) -> str:
         return os.path.join(self.temp_dir, str(uuid.uuid4()) + ".onnx")
@@ -118,7 +115,7 @@ class TestLoadExternalDataBase(unittest.TestCase):
 
     def test_check_model(self) -> None:
         if self.serialization_format != "protobuf":
-            self.skipTest(
+            pytest.skip(
                 "check_model supports protobuf only as binary when provided as a path"
             )
         checker.check_model(self.model_filename)
@@ -274,12 +271,12 @@ class TestLoadExternalDataSingleFile(TestLoadExternalDataBase):
         {"serialization_format": "textproto"},
     ]
 )
-class TestSaveAllTensorsAsExternalData(unittest.TestCase):
+class TestSaveAllTensorsAsExternalData:
     serialization_format: str = "protobuf"
 
-    def setUp(self) -> None:
-        self._temp_dir_obj = tempfile.TemporaryDirectory()
-        self.temp_dir: str = self._temp_dir_obj.name
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_path):
+        self.temp_dir: str = str(tmp_path)
         self.initializer_value = np.arange(6).reshape(3, 2).astype(np.float32) + 512
         self.attribute_value = np.arange(6).reshape(2, 3).astype(np.float32) + 256
         self.model = self.create_test_model_proto()
@@ -325,9 +322,9 @@ class TestSaveAllTensorsAsExternalData(unittest.TestCase):
         )
         return helper.make_model(graph)
 
-    @unittest.skipIf(
+    @pytest.mark.skipif(
         serialization_format != "protobuf",
-        "check_model supports protobuf only when provided as a path",
+        reason="check_model supports protobuf only when provided as a path",
     )
     def test_check_model(self) -> None:
         checker.check_model(self.model)
@@ -576,12 +573,12 @@ class TestSaveAllTensorsAsExternalData(unittest.TestCase):
         {"serialization_format": "textproto"},
     ]
 )
-class TestExternalDataToArray(unittest.TestCase):
+class TestExternalDataToArray:
     serialization_format: str = "protobuf"
 
-    def setUp(self) -> None:
-        self._temp_dir_obj = tempfile.TemporaryDirectory()
-        self.temp_dir: str = self._temp_dir_obj.name
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_path) -> None:
+        self.temp_dir = str(tmp_path)
         self._model_file_path: str = os.path.join(self.temp_dir, "model.onnx")
         self.large_data = np.random.rand(10, 60, 100).astype(np.float32)
         self.small_data = (200, 300)
@@ -590,9 +587,6 @@ class TestExternalDataToArray(unittest.TestCase):
     @property
     def model_file_path(self):
         return self._model_file_path
-
-    def tearDown(self) -> None:
-        self._temp_dir_obj.cleanup()
 
     def create_test_model(self) -> ModelProto:
         X = helper.make_tensor_value_info("X", TensorProto.FLOAT, self.large_data.shape)
@@ -632,9 +626,9 @@ class TestExternalDataToArray(unittest.TestCase):
         )
         return helper.make_model(graph_def, producer_name="onnx-example")
 
-    @unittest.skipIf(
+    @pytest.mark.skipif(
         serialization_format != "protobuf",
-        "check_model supports protobuf only when provided as a path",
+        reason="check_model supports protobuf only when provided as a path",
     )
     def test_check_model(self) -> None:
         checker.check_model(self.model)
@@ -770,7 +764,7 @@ class TestNotAllowToLoadExternalDataOutsideModelDirectory(TestLoadExternalDataBa
             checker.check_model(self.model_filename)
 
 
-@unittest.skipIf(os.name != "nt", reason="Skip Windows test")
+@pytest.mark.skipif(os.name != "nt", reason="Skip Windows test")
 class TestNotAllowToLoadExternalDataOutsideModelDirectoryOnWindows(
     TestNotAllowToLoadExternalDataOutsideModelDirectory
 ):
@@ -808,16 +802,13 @@ class TestExternalDataToArrayWithPath(TestExternalDataToArray):
         return pathlib.Path(self._model_file_path)
 
 
-class TestFunctionsAndSubGraphs(unittest.TestCase):
-    def setUp(self) -> None:
-        self._temp_dir_obj = tempfile.TemporaryDirectory()
-        temp_dir = self._temp_dir_obj.name
+class TestFunctionsAndSubGraphs:
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_path) -> None:
+        temp_dir = str(tmp_path)
         self._model_file_path: str = os.path.join(temp_dir, "model.onnx")
         array = np.arange(4096).astype(np.float32)
         self._tensor = from_array(array, "tensor")
-
-    def tearDown(self) -> None:
-        self._temp_dir_obj.cleanup()
 
     def _check_is_internal(self, tensor: TensorProto) -> None:
         assert tensor.data_location == TensorProto.DEFAULT
@@ -904,7 +895,7 @@ def _make_external_data_test_model() -> tuple[ModelProto, np.ndarray]:
     return model, array
 
 
-@unittest.skipIf(
+@pytest.mark.skipif(
     os.name == "nt", reason="Symlinks require elevated privileges on Windows"
 )
 class TestSaveExternalDataSymlinkProtection(TestLoadExternalDataBase):
@@ -951,7 +942,7 @@ class TestSaveExternalDataSymlinkProtection(TestLoadExternalDataBase):
             assert f.read() == "SENSITIVE DATA"
 
 
-@unittest.skipIf(
+@pytest.mark.skipif(
     os.name == "nt", reason="Symlinks require elevated privileges on Windows"
 )
 class TestLoadExternalDataSymlinkProtection(TestLoadExternalDataBase):
@@ -1049,7 +1040,7 @@ class TestLoadExternalDataSymlinkProtection(TestLoadExternalDataBase):
             load_external_data_for_model(loaded_model, model_dir)
 
 
-@unittest.skipIf(os.name == "nt", reason="Hardlinks behave differently on Windows")
+@pytest.mark.skipif(os.name == "nt", reason="Hardlinks behave differently on Windows")
 class TestLoadExternalDataHardlinkProtection(TestLoadExternalDataBase):
     """Test that loading external data rejects files with multiple hardlinks."""
 

--- a/onnx/test/version_converter/automatic_conversion_test_base.py
+++ b/onnx/test/version_converter/automatic_conversion_test_base.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import string
-import unittest
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
@@ -18,7 +17,7 @@ if TYPE_CHECKING:
 LATEST_OPSET = onnx.defs.onnx_opset_version()
 
 
-class TestAutomaticConversion(unittest.TestCase):
+class TestAutomaticConversion:
     def _test_model_conversion(
         self, to_opset: int, model: str | onnx.ModelProto
     ) -> None:

--- a/onnx/test/version_converter/automatic_upgrade_test.py
+++ b/onnx/test/version_converter/automatic_upgrade_test.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+from typing import ClassVar
+
 import automatic_conversion_test_base
 import numpy as np
 
@@ -16,9 +18,7 @@ from onnx import TensorProto, helper
 
 
 class TestAutomaticUpgrade(automatic_conversion_test_base.TestAutomaticConversion):
-    @classmethod
-    def setUpClass(cls):
-        cls.tested_ops = []
+    tested_ops: ClassVar[list] = []
 
     def _test_op_upgrade(self, op, *args, **kwargs):
         self.tested_ops.append(op)


### PR DESCRIPTION
### Motivation and Context

Another step in reducing the dependency on `unittest.TestCase` with the goal of replacing `parameterized` with `pytest.mark.parametrize` in the test suite. `pytest.fixtures` are more powerful than `setUp` and `tearDown` and thus used as a replacement here. The tests are not particularly idiomatic for pytest even after these changes, but I wanted to keep the diff clean.

Related to #8104 
