### PR TITLE
Bump protobuf/abseil-cpp versions used to build protobuf from source in CI

### DIFF
--- a/workflow_scripts/protobuf/build_protobuf_unix.sh
+++ b/workflow_scripts/protobuf/build_protobuf_unix.sh
@@ -24,14 +24,14 @@ fi
 # Build protobuf from source with -fPIC on Unix-like system
 ORIGINAL_PATH=$(pwd)
 cd ..
-wget https://github.com/abseil/abseil-cpp/releases/download/20230802.2/abseil-cpp-20230802.2.tar.gz
-tar -xvf abseil-cpp-20230802.2.tar.gz
+wget https://github.com/abseil/abseil-cpp/releases/download/20250127.0/abseil-cpp-20250127.0.tar.gz
+tar -xvf abseil-cpp-20250127.0.tar.gz
 
-wget https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protobuf-25.1.tar.gz
-tar -xvf protobuf-25.1.tar.gz
-cd protobuf-25.1
+wget https://github.com/protocolbuffers/protobuf/releases/download/v31.1/protobuf-31.1.tar.gz
+tar -xvf protobuf-31.1.tar.gz
+cd protobuf-31.1
 mkdir build_source && cd build_source
-cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=$INSTALL_PROTOBUF_PATH -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DABSL_ROOT_DIR="${ORIGINAL_PATH}/../abseil-cpp-20230802.2" -DCMAKE_CXX_STANDARD=17 -DABSL_PROPAGATE_CXX_STD=on ..
+cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=$INSTALL_PROTOBUF_PATH -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DABSL_ROOT_DIR="${ORIGINAL_PATH}/../abseil-cpp-20250127.0" -DCMAKE_CXX_STANDARD=17 -DABSL_PROPAGATE_CXX_STD=on ..
 if [ "$INSTALL_PROTOBUF_PATH" == "/usr" ]; then
     # Don't use sudo for root
     if [[ "$(id -u)" == "0" ]]; then

--- a/workflow_scripts/protobuf/build_protobuf_win.ps1
+++ b/workflow_scripts/protobuf/build_protobuf_win.ps1
@@ -11,20 +11,20 @@ param(
 )
 
 echo "Build ABSL-cpp from source on Windows."
-Invoke-WebRequest -Uri https://github.com/abseil/abseil-cpp/releases/download/20230802.2/abseil-cpp-20230802.2.tar.gz -OutFile abseil-cpp.tar.gz -Verbose
+Invoke-WebRequest -Uri https://github.com/abseil/abseil-cpp/releases/download/20250127.0/abseil-cpp-20250127.0.tar.gz -OutFile abseil-cpp.tar.gz -Verbose
 tar -xvf abseil-cpp.tar.gz
 
 echo "Build protobuf from source on Windows."
-Invoke-WebRequest -Uri https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protobuf-25.1.tar.gz -OutFile protobuf.tar.gz -Verbose
+Invoke-WebRequest -Uri https://github.com/protocolbuffers/protobuf/releases/download/v31.1/protobuf-31.1.tar.gz -OutFile protobuf.tar.gz -Verbose
 tar -xvf protobuf.tar.gz
-cd protobuf-25.1
+cd protobuf-31.1
 mkdir protobuf_install
 $protobuf_install_dir = Get-Location
 mkdir build
 cd build
 $protobuf_root_dir = Get-Location
 
-cmake -G "Visual Studio 17 2022" -A $cmake_arch -Dprotobuf_MSVC_STATIC_RUNTIME=OFF -DABSL_MSVC_STATIC_RUNTIME=OFF -DBUILD_SHARED_LIBS=OFF -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_EXAMPLES=OFF -DABSL_ROOT_DIR="$protobuf_root_dir/../../abseil-cpp-20230802.2" -DCMAKE_CXX_STANDARD=17 -DABSL_PROPAGATE_CXX_STD=on -DCMAKE_INSTALL_PREFIX="$protobuf_install_dir" ..
+cmake -G "Visual Studio 17 2022" -A $cmake_arch -Dprotobuf_MSVC_STATIC_RUNTIME=OFF -DABSL_MSVC_STATIC_RUNTIME=OFF -DBUILD_SHARED_LIBS=OFF -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_EXAMPLES=OFF -DABSL_ROOT_DIR="$protobuf_root_dir/../../abseil-cpp-20250127.0" -DCMAKE_CXX_STANDARD=17 -DABSL_PROPAGATE_CXX_STD=on -DCMAKE_INSTALL_PREFIX="$protobuf_install_dir" ..
 cmake --build . --config $build_type --target install
 echo "Protobuf installation complete."
 echo "Set paths"


### PR DESCRIPTION
### Motivation and Context

#8153 bumped the minimum required protobuf version from `4.25.1` to `6.31.1` in `pyproject.toml`, `pixi.toml`, and `sbom.cdx.json`, but `workflow_scripts/protobuf/build_protobuf_unix.sh` and `build_protobuf_win.ps1` were left pinned to the old `protobuf-25.1` / `abseil-cpp-20230802.2` sources. These scripts are used by `main.yml`, `lint.yml`, and `win_no_exception_ci.yml` to build protobuf from source (with `-fPIC` / static runtime) for the C++ test and lint jobs, so CI was still building against an EOL protobuf release even after the minimum version bump.

This PR updates both scripts to build `protobuf v31.1` (package version `6.31.1`) with `abseil-cpp 20250127.0`, matching the versions already pinned in `sbom.cdx.json`.