### PR TITLE
docs: add structured PR description fields (agentic PR templates)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,6 +16,18 @@ When a change could fit more than one type, prefer `ci` for anything under `.git
 
 Individual commits within the PR do not need to follow this format, but each must still carry a DCO sign-off.
 
+## PR descriptions
+
+As a starting point, agent-authored PRs should structure their description with the following, filling in whatever applies (this isn't yet a project-wide requirement for human contributors). These fields are optional and not currently enforced by a checker. For trivial cleanup PRs, brief content (or N/A where appropriate) is fine.
+
+- **Root cause** (bug fixes) / **What changed** (features): what was actually wrong, or what this adds.
+- **Fix approach**: what was done, and any alternatives considered.
+- **Spec/compatibility impact**: does this change operator schemas, opset versions, the IR spec, or a public API in a way that could be backward-incompatible?
+- **Security impact**: does this touch model loading, external data handling, or parsing of untrusted input? See [SECURITY.md](../SECURITY.md).
+- **Tests**: what was added, modified, or removed.
+- **Auto-generated files**: were `docs/Operators.md`, `docs/Changelog.md`, protobuf files, or test data regenerated where applicable? See CLAUDE.md's Auto-Generated Files table.
+- **Backport**: does this need to land in an already-released version? If so, note the minimum affected version — see [RELEASE-MANAGEMENT.md](../RELEASE-MANAGEMENT.md)'s Long-Term Support section for the case-by-case backport policy.
+
 We use lintrunner as the linter:
 
 ```sh

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,3 +3,24 @@
 ### Motivation and Context
 
 Fixes #
+
+### Root cause / what changed
+<!-- Optional section. For bug fixes: what was actually wrong. For features: what this adds. -->
+
+### Fix approach
+<!-- Optional section. What was done, and any alternatives considered, if applicable. -->
+
+### Spec/compatibility impact
+<!-- Optional section. Does this change operator schemas, opset versions, the IR spec, or a public API in a way that could be backward-incompatible? -->
+
+### Security impact
+<!-- Optional section. Does this touch model loading, external data handling, or parsing of untrusted input? See SECURITY.md. -->
+
+### Tests
+<!-- Optional section. What tests were added, modified, or removed. -->
+
+### Auto-generated files
+<!-- Optional section. Were docs/Operators.md, docs/Changelog.md, protobuf files, or test data regenerated where applicable? See CLAUDE.md's Auto-Generated Files table. -->
+
+### Backport
+<!-- Optional section. Does this need to land in an already-released version? If so, what is the minimum affected version? See RELEASE-MANAGEMENT.md's Long-Term Support section for the case-by-case backport policy. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -272,6 +272,7 @@ Every PR needs to pass CIs before merge. CI pipelines are described in [CIPipeli
 - [Project roadmap](ROADMAP.md)
 - [How to implement ONNX backend (ONNX to something converter)](docs/ImplementingAnOnnxBackend.md)
 - [Backend test infrastructure and how to add tests](docs/OnnxBackendTest.md)
+- [Backport policy](RELEASE-MANAGEMENT.md#long-term-support-lts) — ONNX has no LTS branches; backporting a fix to an already-released version is assessed case by case.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,7 @@ Reports describing expected behavior, unrealistic preconditions, or issues outsi
 3. **Fix.** A patch is developed in a private fork or Security Advisory draft and reviewed by a second maintainer.
 4. **Disclose.** Merge the fix and release the patched version, then publish the GitHub Security Advisory — this requests a CVE if applicable and serves as the public announcement.
 
-Out-of-cycle releases are triggered for confirmed Critical/High vulnerabilities or active exploitation.
+Out-of-cycle releases are triggered for confirmed Critical/High vulnerabilities or active exploitation. ONNX has no LTS branches; backporting a fix to an already-released version beyond the current out-of-cycle release is assessed case by case — see [RELEASE-MANAGEMENT.md](RELEASE-MANAGEMENT.md#long-term-support-lts).
 
 ## Security announcements
 


### PR DESCRIPTION
## Summary

Addresses the "Agentic PR templates" item from an internal agent-readiness rubric: structured PR-description fields instead of a bare "describe your changes," to reduce reviewer back-and-forth.

- `.github/pull_request_template.md`: adds optional `###` sections — root cause/what changed, fix approach, spec/compatibility impact, security impact, tests, auto-generated files, backport — matching the existing low-friction style already used in `.github/ISSUE_TEMPLATE/bug.md` (optional headers, hint text in HTML comments, nothing required).
- `.github/copilot-instructions.md`: mirrors the same fields as a starting point for agent-authored PR descriptions (same "starting point for agents, not yet a human-contributor requirement" framing as the existing PR-titles section from #8188).
- `CONTRIBUTING.md` / `SECURITY.md`: both gained a one-line cross-link to `RELEASE-MANAGEMENT.md`'s Long-Term Support / backport section, since the new template's Backport field asks about a policy that wasn't previously linked from either doc.

## Notes for reviewers

- Fields chosen are scoped to ONNX's actual risk surface rather than a generic list: "spec/compatibility impact" (operator schemas/opset/IR spec/public API) is ONNX-specific and probably the highest-value field here, given how much of this repo's review burden is backward-compatibility related. "Auto-generated files" maps directly to CLAUDE.md's existing Auto-Generated Files table.
- Backport field is deliberately scoped to ONNX's real policy (case-by-case, no LTS branches) rather than implying a formal backport branch process that doesn't exist.
- All fields are optional/skippable — a one-line typo fix PR doesn't need to fill in seven sections.

## Test plan
- [x] N/A — documentation-only change