### PR TITLE
Build Pyodide wheel for Python 3.14

### DIFF
--- a/.github/workflows/release_pyodide_cibw.yml
+++ b/.github/workflows/release_pyodide_cibw.yml
@@ -74,7 +74,7 @@ jobs:
             -DONNX_PYODIDE_BUILD=ON
             -DONNX_USE_LITE_PROTO=ON
             -DONNX_WERROR=ON
-            -DCMAKE_CXX_FLAGS='-Wno-error=deprecated-builtins'
+            -DCMAKE_CXX_FLAGS='-Wno-error=deprecated-builtins -Wno-error=deprecated-pragma'
             "
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ cmake.build-type = "Debug"
 cmake.define.ONNX_COVERAGE = "ON"
 
 [tool.cibuildwheel.pyodide]
-build = "cp313-pyodide_wasm32"
+build = "cp314-pyodide_wasm32"
 
 [tool.cibuildwheel]
 test-command = "pytest {project}/onnx/test"


### PR DESCRIPTION
## Summary

- target the Python 3.14 Pyodide cross-build environment
- produce a `pyemscripten_2026_0_wasm32` wheel instead of the current 2025 ABI wheel
- allow the Emscripten deprecated-macro pragmas emitted by protobuf's bundled Abseil while retaining `ONNX_WERROR=ON` for other warnings

The additional warning exception is needed because the newer Emscripten headers deprecate `__EMSCRIPTEN_major__`, `__EMSCRIPTEN_minor__`, and `__EMSCRIPTEN_tiny__`, which the bundled Abseil headers still reference.

## Validation

The repository's official `Pyodide Build` workflow was run on this branch:

https://github.com/metalmancode/onnx-pyodide-abi/actions/runs/29329430629

It completed successfully, including the cibuildwheel runtime test in a Python 3.14 Pyodide virtual environment. The produced artifact is:

```text
onnx_weekly-1.23.0.dev20260714-cp312-abi3-pyemscripten_2026_0_wasm32.whl
SHA-256: ab20c140cbe5dfa63068ae476fcf9eb5b76d9fc4ce94b8fb2badbd391364bc37
```

`lintrunner` also completed with no lint issues.

## Context

This follows the Pyodide maintainers' recommendation in pyodide/pyodide-recipes#620 to publish the 2026 ABI wheel from the ONNX repository rather than add a separate recipe. The current stable and weekly ONNX Pyodide wheels are published with the 2025 ABI.

A stable browser distribution for the Python 3.14 Pyodide environment is not yet available, so the validation uses cibuildwheel's official Python 3.14 Pyodide runtime test.