### PR TITLE
reference: accept sorted=0 in TopK

### DIFF
--- a/onnx/reference/ops/op_topk.py
+++ b/onnx/reference/ops/op_topk.py
@@ -92,7 +92,7 @@ class TopK_11(_CommonTopK):
         ink,
         axis=None,
         largest=None,
-        sorted=None,  # noqa: A002
+        sorted=None,  # noqa: A002, ARG002
     ):
         """Runtime for operator *TopK*.
 
@@ -106,6 +106,5 @@ class TopK_11(_CommonTopK):
             does in `top_k.cc
             <https://github.com/Microsoft/onnxruntime/blob/main/onnxruntime/core/providers/cpu/math/top_k.cc#L63>`_.
         """
-        if sorted not in (True, 1):
-            raise RuntimeError("TopK does not implement anything for sorted=0.")
+        # sorted=0 means undefined order, so returning sorted output is conformant.
         return _CommonTopK._common_run(self, data, ink, axis=axis, largest=largest)


### PR DESCRIPTION
### Motivation and Context

The TopK spec states that when sorted=0 the order of the returned Values and Indices is undefined; it does not permit the operator to fail. The reference impl raised RuntimeError for sorted=0. Drop the guard and return the top-k set (sorted output is a conformant result since the order is undefined).

For comparison, onnxruntime's CPU kernel ([top_k.cc](https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/providers/cpu/math/top_k.cc)) treats sorted=0 purely as a performance hint: it selects the top-k via `std::nth_element` (or a k-sized heap for small k) and only runs the final O(k log k) sort when sorted=1, so with sorted=0 the output order is simply whatever the selection leaves. PyTorch's `torch.topk(sorted=False)` likewise makes no ordering promise, and its CPU path often returns sorted results anyway. Always returning sorted output from the reference implementation is consistent with both.
