### PR TITLE
Make the text parser and printer locale-independent and float round-trip exact

### DIFF
--- a/onnx/defs/data_type_utils.cc
+++ b/onnx/defs/data_type_utils.cc
@@ -4,7 +4,6 @@
 
 #include "onnx/defs/data_type_utils.h"
 
-#include <cctype>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -13,6 +12,11 @@
 namespace ONNX_NAMESPACE {
 namespace Utils {
 namespace {
+
+// ASCII-only whitespace check; isspace is locale-dependent.
+constexpr bool IsAsciiSpace(char c) {
+  return c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' || c == '\r';
+}
 
 // Singleton wrapper around allowed data types.
 // This implements construct on first use which is needed to ensure
@@ -232,9 +236,8 @@ bool DataTypeUtils::IsValidDataTypeString(const std::string& type_str) {
 
 int32_t DataTypeUtils::FromDataTypeString(const std::string& type_str) {
   if (!IsValidDataTypeString(type_str)) {
-    ONNX_THROW_EX(
-        std::invalid_argument(
-            "DataTypeUtils::FromDataTypeString - Received invalid data type string '" + type_str + "'."));
+    ONNX_THROW_EX(std::invalid_argument(
+        "DataTypeUtils::FromDataTypeString - Received invalid data type string '" + type_str + "'."));
   }
 
   TypesWrapper& t = TypesWrapper::GetTypesWrapper();
@@ -279,7 +282,7 @@ bool StringRange::EndsWith(const StringRange& str) const {
 
 bool StringRange::LStrip() {
   size_t count = 0;
-  while (count < view_.size() && isspace(static_cast<unsigned char>(view_[count]))) {
+  while (count < view_.size() && IsAsciiSpace(view_[count])) {
     ++count;
   }
   if (count > 0) {
@@ -305,7 +308,7 @@ bool StringRange::LStrip(StringRange str) {
 
 bool StringRange::RStrip() {
   size_t count = 0;
-  while (count < view_.size() && isspace(static_cast<unsigned char>(view_[view_.size() - 1 - count]))) {
+  while (count < view_.size() && IsAsciiSpace(view_[view_.size() - 1 - count])) {
     ++count;
   }
   if (count > 0) {

--- a/onnx/defs/data_type_utils.cc
+++ b/onnx/defs/data_type_utils.cc
@@ -236,8 +236,9 @@ bool DataTypeUtils::IsValidDataTypeString(const std::string& type_str) {
 
 int32_t DataTypeUtils::FromDataTypeString(const std::string& type_str) {
   if (!IsValidDataTypeString(type_str)) {
-    ONNX_THROW_EX(std::invalid_argument(
-        "DataTypeUtils::FromDataTypeString - Received invalid data type string '" + type_str + "'."));
+    ONNX_THROW_EX(
+        std::invalid_argument(
+            "DataTypeUtils::FromDataTypeString - Received invalid data type string '" + type_str + "'."));
   }
 
   TypesWrapper& t = TypesWrapper::GetTypesWrapper();

--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -13,7 +13,6 @@
 #include <locale.h> // NOLINT(modernize-deprecated-headers)
 #endif
 
-#include <cctype>
 #include <cerrno>
 #include <charconv>
 #include <cstdlib>
@@ -183,7 +182,7 @@ Common::Status ParserBase::Parse(Literal& result) {
   }
 
   // Check for float literals that start with alphabet characters.
-  if (isalpha(nextch)) {
+  if (IsAlpha(nextch)) {
     // Has to be a special float literal now: (-)*(nan|inf|infinity).
     if (NextIsValidFloatString()) {
       while (!AtEnd() && IsAlpha(Cur())) {
@@ -204,7 +203,7 @@ Common::Status ParserBase::Parse(Literal& result) {
   }
 
   // Checking for numeric ints or float literal.
-  if (isdigit(nextch)) {
+  if (IsDigit(nextch)) {
     ++pos_;
 
     while (!AtEnd() && (IsDigit(Cur()) || (Cur() == '.'))) {
@@ -240,7 +239,7 @@ bool ParserBase::NextIsValidFloatString() {
   const size_t from = pos_;
   constexpr int INFINITY_LENGTH = 8;
 
-  if (isalpha(nextch)) {
+  if (IsAlpha(nextch)) {
     while (!AtEnd() && IsAlpha(Cur()) && (pos_ - from) <= INFINITY_LENGTH) {
       ++pos_;
     }
@@ -255,8 +254,10 @@ bool ParserBase::NextIsValidFloatString() {
     // Reset parser location before continuing.
     pos_ = from;
 
-    std::transform(
-        candidate.begin(), candidate.end(), candidate.begin(), [](unsigned char c) { return std::tolower(c); });
+    std::transform(candidate.begin(), candidate.end(), candidate.begin(), [](char c) {
+      // ASCII-only lowercasing; std::tolower is locale-dependent.
+      return (c >= 'A' && c <= 'Z') ? static_cast<char>(c - 'A' + 'a') : c;
+    });
     if (candidate == std::string_view("inf") || candidate == std::string_view("infinity") ||
         candidate == std::string_view("nan")) {
       return true;
@@ -683,7 +684,7 @@ bool OnnxParser::NextIsType() {
 Common::Status OnnxParser::ParseSingleAttributeValue(AttributeProto& attr, AttributeProto_AttributeType expected) {
   // Parse a single-value
   auto next = NextChar();
-  if (isalpha(next) || next == '_') {
+  if (IsAlpha(next) || next == '_') {
     if (NextIsType()) {
       TypeProto typeProto;
       CHECK_PARSER_STATUS(Parse(typeProto));

--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -7,14 +7,13 @@
 
 #include "onnx/defs/parser.h"
 
-// POSIX locale extensions (newlocale, freelocale, strtof_l, strtod_l) are needed
-// for the fallback path on platforms without floating-point std::from_chars.
-#if !defined(__cpp_lib_to_chars) || __cpp_lib_to_chars < 201611L
+// POSIX locale extensions (newlocale, freelocale, strtof_l, strtod_l) are used
+// to parse floating-point literals independently of the global locale.
 #include <locale.h> // NOLINT(modernize-deprecated-headers)
-#endif
 
 #include <cerrno>
 #include <charconv>
+#include <cmath>
 #include <cstdlib>
 #include <limits>
 #include <string>
@@ -26,37 +25,9 @@
 
 // Locale-independent float/double parsing implementation.
 // Uses std::from_chars when the stdlib supports it (__cpp_lib_to_chars >= 201611L),
-// otherwise falls back to strtof_l/strtod_l with an explicit "C" locale.
-
-#if defined(__cpp_lib_to_chars) && __cpp_lib_to_chars >= 201611L
-
-namespace ONNX_NAMESPACE {
-
-float LocaleIndependentStof(const std::string& s) {
-  float val = 0.0f;
-  const char* const begin = s.data();
-  const char* const end = begin + s.size();
-  auto result = std::from_chars(begin, end, val);
-  if (result.ec != std::errc{} || result.ptr != end) {
-    ONNX_THROW("Failed to parse float from string: " + s);
-  }
-  return val;
-}
-
-double LocaleIndependentStod(const std::string& s) {
-  double val = 0.0;
-  const char* const begin = s.data();
-  const char* const end = begin + s.size();
-  auto result = std::from_chars(begin, end, val);
-  if (result.ec != std::errc{} || result.ptr != end) {
-    ONNX_THROW("Failed to parse double from string: " + s);
-  }
-  return val;
-}
-
-} // namespace ONNX_NAMESPACE
-
-#else // Fallback for platforms without floating-point from_chars (e.g. Apple Clang)
+// otherwise strtof_l/strtod_l with an explicit "C" locale. The strto*_l helpers
+// also resolve from_chars range errors: underflow rounds to zero or a subnormal
+// and is accepted; only overflow is an error.
 
 namespace {
 
@@ -89,11 +60,7 @@ const CLocale& GetCLocale() {
   return instance;
 }
 
-} // anonymous namespace
-
-namespace ONNX_NAMESPACE {
-
-float LocaleIndependentStof(const std::string& s) {
+float StrtofC(const std::string& s) {
   const auto& cloc = GetCLocale();
   if (!cloc.loc) {
     ONNX_THROW("Failed to create C locale for float parsing");
@@ -101,17 +68,19 @@ float LocaleIndependentStof(const std::string& s) {
   char* end = nullptr;
   errno = 0;
 #ifdef _WIN32
-  float val = _strtof_l(s.c_str(), &end, cloc.loc);
+  const float val = _strtof_l(s.c_str(), &end, cloc.loc);
 #else
-  float val = strtof_l(s.c_str(), &end, cloc.loc);
+  const float val = strtof_l(s.c_str(), &end, cloc.loc);
 #endif
-  if (end == s.c_str() || end != s.c_str() + s.size() || errno == ERANGE) {
+  // ERANGE with a finite result is underflow: the value is still the correctly
+  // rounded zero or subnormal. Only overflow (±inf) is an error.
+  if (end == s.c_str() || end != s.c_str() + s.size() || (errno == ERANGE && std::isinf(val))) {
     ONNX_THROW("Failed to parse float from string: " + s);
   }
   return val;
 }
 
-double LocaleIndependentStod(const std::string& s) {
+double StrtodC(const std::string& s) {
   const auto& cloc = GetCLocale();
   if (!cloc.loc) {
     ONNX_THROW("Failed to create C locale for double parsing");
@@ -119,19 +88,65 @@ double LocaleIndependentStod(const std::string& s) {
   char* end = nullptr;
   errno = 0;
 #ifdef _WIN32
-  double val = _strtod_l(s.c_str(), &end, cloc.loc);
+  const double val = _strtod_l(s.c_str(), &end, cloc.loc);
 #else
-  double val = strtod_l(s.c_str(), &end, cloc.loc);
+  const double val = strtod_l(s.c_str(), &end, cloc.loc);
 #endif
-  if (end == s.c_str() || end != s.c_str() + s.size() || errno == ERANGE) {
+  if (end == s.c_str() || end != s.c_str() + s.size() || (errno == ERANGE && std::isinf(val))) {
     ONNX_THROW("Failed to parse double from string: " + s);
   }
   return val;
 }
 
-} // namespace ONNX_NAMESPACE
+} // anonymous namespace
+
+namespace ONNX_NAMESPACE {
+
+#if defined(__cpp_lib_to_chars) && __cpp_lib_to_chars >= 201611L
+
+float LocaleIndependentStof(const std::string& s) {
+  float val = 0.0f;
+  const char* const begin = s.data();
+  const char* const end = begin + s.size();
+  const auto result = std::from_chars(begin, end, val);
+  if (result.ec == std::errc::result_out_of_range && result.ptr == end) {
+    // from_chars leaves val unspecified on range errors; re-parse to accept
+    // underflow (rounds to zero/subnormal) and reject only overflow.
+    return StrtofC(s);
+  }
+  if (result.ec != std::errc{} || result.ptr != end) {
+    ONNX_THROW("Failed to parse float from string: " + s);
+  }
+  return val;
+}
+
+double LocaleIndependentStod(const std::string& s) {
+  double val = 0.0;
+  const char* const begin = s.data();
+  const char* const end = begin + s.size();
+  const auto result = std::from_chars(begin, end, val);
+  if (result.ec == std::errc::result_out_of_range && result.ptr == end) {
+    return StrtodC(s);
+  }
+  if (result.ec != std::errc{} || result.ptr != end) {
+    ONNX_THROW("Failed to parse double from string: " + s);
+  }
+  return val;
+}
+
+#else // No floating-point from_chars (e.g. Apple Clang)
+
+float LocaleIndependentStof(const std::string& s) {
+  return StrtofC(s);
+}
+
+double LocaleIndependentStod(const std::string& s) {
+  return StrtodC(s);
+}
 
 #endif // __cpp_lib_to_chars
+
+} // namespace ONNX_NAMESPACE
 
 #define PARSE_TOKEN(x) CHECK_PARSER_STATUS(ParserBase::Parse(x))
 #define PARSE(...) CHECK_PARSER_STATUS(Parse(__VA_ARGS__))
@@ -721,8 +736,14 @@ Common::Status OnnxParser::ParseSingleAttributeValue(AttributeProto& attr, Attri
       case LiteralType::UNDEFINED:
         return ParseError("Internal error");
       case LiteralType::INT_LITERAL:
-        attr.set_type(AttributeProto_AttributeType_INT);
-        attr.set_i(std::stoll(literal.value));
+        if (expected == AttributeProto_AttributeType_FLOAT) {
+          // Implicit INT->FLOAT cast; parse the text as float to preserve "-0".
+          attr.set_type(AttributeProto_AttributeType_FLOAT);
+          attr.set_f(LocaleIndependentStof(literal.value));
+        } else {
+          attr.set_type(AttributeProto_AttributeType_INT);
+          attr.set_i(std::stoll(literal.value));
+        }
         break;
       case LiteralType::FLOAT_LITERAL:
         attr.set_type(AttributeProto_AttributeType_FLOAT);
@@ -735,19 +756,11 @@ Common::Status OnnxParser::ParseSingleAttributeValue(AttributeProto& attr, Attri
     }
   }
   if ((expected != AttributeProto_AttributeType_UNDEFINED) && (expected != attr.type())) {
-    // Mismatch between type-annotation and attribute-value. We do an implicit cast
-    // only in the special case of FLOAT type and integral value like 2
-    if ((expected == AttributeProto_AttributeType_FLOAT) && (attr.type() == AttributeProto_AttributeType_INT)) {
-      attr.set_type(AttributeProto_AttributeType_FLOAT);
-      attr.set_f(static_cast<float>(attr.i()));
-      attr.clear_i();
-    } else {
-      return ParseError(
-          "Mismatch between expected type ",
-          AttributeProto_AttributeType_Name(expected),
-          " and specified value's type",
-          AttributeProto_AttributeType_Name(attr.type()));
-    }
+    return ParseError(
+        "Mismatch between expected type ",
+        AttributeProto_AttributeType_Name(expected),
+        " and specified value's type",
+        AttributeProto_AttributeType_Name(attr.type()));
   }
   return Common::Status::OK();
 }

--- a/onnx/defs/parser.h
+++ b/onnx/defs/parser.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <algorithm>
-#include <cctype>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -180,6 +179,25 @@ class KeyWordMap {
   std::unordered_map<std::string, KeyWord> map_;
 };
 
+// Locale-independent ASCII classification, so that the text format does not
+// vary with the process locale. Accepts char or the int returned by
+// ParserBase::NextChar; non-ASCII bytes classify as false either way.
+constexpr bool IsSpace(int c) {
+  return c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' || c == '\r';
+}
+
+constexpr bool IsAlpha(int c) {
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+
+constexpr bool IsDigit(int c) {
+  return c >= '0' && c <= '9';
+}
+
+constexpr bool IsAlnum(int c) {
+  return IsAlpha(c) || IsDigit(c);
+}
+
 class ParserBase {
  public:
   explicit ParserBase(std::string_view input) : input_(input) {}
@@ -247,7 +265,7 @@ class ParserBase {
   int NextChar(bool skipspace = true) {
     if (skipspace)
       SkipWhiteSpace();
-    // Return as unsigned char so the value is safe to pass to ctype functions.
+    // Return as unsigned char so byte values are non-negative.
     return AtEnd() ? 0 : static_cast<unsigned char>(Cur());
   }
 
@@ -418,20 +436,6 @@ class ParserBase {
   char Cur() const {
     return input_[pos_];
   }
-  // ctype wrappers that pass the character as unsigned char (UB otherwise for bytes > 127).
-  static bool IsSpace(char c) {
-    return std::isspace(static_cast<unsigned char>(c));
-  }
-  static bool IsAlpha(char c) {
-    return std::isalpha(static_cast<unsigned char>(c));
-  }
-  static bool IsAlnum(char c) {
-    return std::isalnum(static_cast<unsigned char>(c));
-  }
-  static bool IsDigit(char c) {
-    return std::isdigit(static_cast<unsigned char>(c));
-  }
-
   std::string_view input_;
   size_t pos_ = 0;
   size_t saved_pos_ = 0;

--- a/onnx/defs/printer.cc
+++ b/onnx/defs/printer.cc
@@ -30,7 +30,7 @@ void PrintNumber(std::ostream& os, T value) {
       return;
     }
   }
-  std::array<char, 32> buf;
+  std::array<char, 32> buf{};
   const auto res = std::to_chars(buf.data(), buf.data() + buf.size(), value);
   os.write(buf.data(), res.ptr - buf.data());
 }

--- a/onnx/defs/printer.cc
+++ b/onnx/defs/printer.cc
@@ -4,8 +4,12 @@
 
 #include "onnx/defs/printer.h"
 
+#include <array>
+#include <charconv>
+#include <cmath>
 #include <iomanip>
 #include <string>
+#include <type_traits>
 
 #include "onnx/defs/tensor_proto_util.h"
 
@@ -13,6 +17,23 @@ namespace ONNX_NAMESPACE {
 namespace {
 
 using StringStringEntryProtos = google::protobuf::RepeatedPtrField<StringStringEntryProto>;
+
+// Format numbers with std::to_chars: locale-independent and, for floating
+// point, the shortest form that round-trips through the parser.
+template <typename T>
+void PrintNumber(std::ostream& os, T value) {
+  if constexpr (std::is_floating_point_v<T>) {
+    // Normalize NaN: MSVC's to_chars emits payload forms like "nan(ind)"
+    // that the parser does not accept.
+    if (std::isnan(value)) {
+      os << (std::signbit(value) ? "-nan" : "nan");
+      return;
+    }
+  }
+  std::array<char, 32> buf;
+  const auto res = std::to_chars(buf.data(), buf.data() + buf.size(), value);
+  os.write(buf.data(), res.ptr - buf.data());
+}
 
 bool IsValidIdentifier(const std::string& str) {
   // Check if str is a valid identifier
@@ -92,7 +113,11 @@ class ProtoPrinter {
 
   template <typename T>
   void print(const T& prim) {
-    output_ << prim;
+    if constexpr (std::is_arithmetic_v<T>) {
+      PrintNumber(output_, prim);
+    } else {
+      output_ << prim;
+    }
   }
 
   void printQuoted(const std::string& str) {
@@ -157,7 +182,7 @@ class ProtoPrinter {
 
 void ProtoPrinter::print(const TensorShapeProto_Dimension& dim) {
   if (dim.has_dim_value()) {
-    output_ << dim.dim_value();
+    print(dim.dim_value());
   } else if (dim.has_dim_param()) {
     if (IsValidIdentifier(dim.dim_param()))
       output_ << dim.dim_param();
@@ -319,13 +344,13 @@ void ProtoPrinter::print(const AttributeProto& attr) {
   output_ << attr.name() << ": " << AttributeTypeNameMap::ToString(attr.type()) << " = ";
   switch (attr.type()) {
     case AttributeProto_AttributeType_INT:
-      output_ << attr.i();
+      print(attr.i());
       break;
     case AttributeProto_AttributeType_INTS:
       printSet("[", ", ", "]", attr.ints());
       break;
     case AttributeProto_AttributeType_FLOAT:
-      output_ << attr.f();
+      print(attr.f());
       break;
     case AttributeProto_AttributeType_FLOATS:
       printSet("[", ", ", "]", attr.floats());
@@ -458,7 +483,8 @@ void ProtoPrinter::print(const ModelProto& model) {
 
 void ProtoPrinter::print(const OperatorSetIdProto& opset) {
   printQuoted(opset.domain());
-  output_ << " : " << opset.version();
+  output_ << " : ";
+  print(opset.version());
 }
 
 void ProtoPrinter::print(const OpsetIdList& opsets) {

--- a/onnx/defs/printer.cc
+++ b/onnx/defs/printer.cc
@@ -20,10 +20,10 @@ bool IsValidIdentifier(const std::string& str) {
   const char* end_ = next_ + str.size();
   if (next_ == end_)
     return false; // empty string is not a valid identifier
-  if (!isalpha(*next_) && (*next_ != '_'))
+  if (!IsAlpha(*next_) && (*next_ != '_'))
     return false; // first character must be a letter or '_'
   ++next_;
-  while ((next_ < end_) && (isalnum(*next_) || (*next_ == '_')))
+  while ((next_ < end_) && (IsAlnum(*next_) || (*next_ == '_')))
     ++next_;
   return next_ == end_;
 }
@@ -467,19 +467,16 @@ void ProtoPrinter::print(const OpsetIdList& opsets) {
 
 void ProtoPrinter::print(const FunctionProto& fn) {
   output_ << "<\n";
-  output_ << "  "
-          << "domain: ";
+  output_ << "  " << "domain: ";
   printQuoted(fn.domain());
   output_ << ",\n";
   if (!fn.overload().empty()) {
-    output_ << "  "
-            << "overload: ";
+    output_ << "  " << "overload: ";
     printQuoted(fn.overload());
     output_ << ",\n";
   }
 
-  output_ << "  "
-          << "opset_import: ";
+  output_ << "  " << "opset_import: ";
   printSet("[", ",", "]", fn.opset_import());
   output_ << "\n>\n";
   printId(fn.name());

--- a/onnx/test/cpp/ir_test.cc
+++ b/onnx/test/cpp/ir_test.cc
@@ -8,6 +8,7 @@
 #include "gtest/gtest.h"
 #include "onnx/common/ir.h"
 #include "onnx/common/ir_pb_converter.h"
+#include "onnx/defs/parser.h"
 
 namespace ONNX_NAMESPACE {
 namespace Test {
@@ -16,11 +17,11 @@ static bool IsValidIdentifier(const std::string& name) {
   if (name.empty()) {
     return false;
   }
-  if (!isalpha(name[0]) && name[0] != '_') {
+  if (!IsAlpha(name[0]) && name[0] != '_') {
     return false;
   }
   for (size_t i = 1; i < name.size(); ++i) {
-    if (!isalnum(name[i]) && name[i] != '_') {
+    if (!IsAlnum(name[i]) && name[i] != '_') {
       return false;
     }
   }


### PR DESCRIPTION

### Motivation and Context
The parser and printer implicitly assumes the C locale. However, **Locale-independent ASCII classification.** `<cctype>` results vary with the process `LC_CTYPE` (e.g. `tolower('I')` in a Turkish locale breaks `INF` parsing) and calling them on negative `char` is UB.

Specifically, we made the following fixes:
1. Replaced with shared `constexpr` ASCII helpers in `parser.h`.
2. **Parser: accept float underflow, preserve `-0`.** Underflow still yields the correctly rounded subnormal or zero, so only reject overflow; `1e-45` used to fail to parse. `alpha: float = -0` keeps its sign.
3. **Printer: emit numbers with `std::to_chars`.** Shortest round-trip form; the previous 6-significant-digit output was lossy. NaN normalized to `nan`/`-nan` for MSVC.
4. **Data-type strings: ASCII whitespace trimming.** `StringRange::LStrip`/`RStrip` used locale-dependent `isspace`.

`C` locale is forced whenever the C++17 ``std::from_char`` feature is not supported by the compiler.
