### PR TITLE
Raise macOS wheel deployment target to 13.3 for better C++17 support

### DIFF
--- a/.github/workflows/release_macos_cibw.yml
+++ b/.github/workflows/release_macos_cibw.yml
@@ -73,7 +73,7 @@ jobs:
           only: ${{ matrix.build }}
         env:
           CIBW_ENVIRONMENT: >-
-            MACOSX_DEPLOYMENT_TARGET=12.0
+            MACOSX_DEPLOYMENT_TARGET=13.3
             CMAKE_ARGS="
             -DFETCHCONTENT_SOURCE_DIR_PROTOBUF=${{ github.workspace }}/protobuf-${{ env.PROTOBUF_VERSION }}
             -DONNX_CUSTOM_PROTOC_EXECUTABLE=${{ github.workspace }}/protoc-host/bin/protoc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ manylinux-aarch64-image = "manylinux_2_28"
 
 [tool.cibuildwheel.macos]
 archs = ["universal2"]
-environment = { MACOSX_DEPLOYMENT_TARGET = "12.0" }
+environment = { MACOSX_DEPLOYMENT_TARGET = "13.3" }
 
 [tool.check-wheel-contents]
 ignore = ["W002"]


### PR DESCRIPTION


### Motivation and Context
Release wheel builds on macOS fail since #8195: floating-point `std::to_chars` in Apple's libc++ requires macOS 13.3+, but wheels target 12.0 ([failing run](https://github.com/onnx/onnx/actions/runs/29526369275)).

macOS 12 has been EOL since September 2024, and 13.0–13.2 users can update to 13.7 for free, so this effectively drops only unsupported systems. Wheel tags change from `macosx_12_0` to `macosx_13_3`.


Raise `MACOSX_DEPLOYMENT_TARGET` to 13.3 in `pyproject.toml` and the release workflow.


🤖 Generated with [Claude Code](https://claude.com/claude-code)