### PR TITLE
Preserve doc_string on Value in IR pb converter

### DIFF
--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -299,6 +299,8 @@ struct Value final {
   use_list uses_in_current_graph_;
   bool has_unique_name_{false};
   std::string unique_name_;
+  bool has_doc_string_{false};
+  std::string doc_string_;
   int32_t elem_type_{ONNX_NAMESPACE::TensorProto_DataType_UNDEFINED};
   bool has_sizes_{false};
   std::vector<Dimension> sizes_;
@@ -340,6 +342,17 @@ struct Value final {
     return toVarName(unique());
   }
   Value* setUniqueName(const std::string& name, bool update_related_names = true);
+  bool has_doc_string() const {
+    return has_doc_string_;
+  }
+  const std::string& docString() const {
+    return doc_string_;
+  }
+  Value* setDocString(std::string doc_string) {
+    has_doc_string_ = true;
+    doc_string_ = std::move(doc_string);
+    return this;
+  }
   Value* setStage(size_t s) {
     stage_ = s;
     return this;
@@ -376,6 +389,9 @@ struct Value final {
     setSizes(from->sizes());
     if (from->has_unique_name()) {
       setUniqueName(from->uniqueName());
+    }
+    if (from->has_doc_string()) {
+      setDocString(from->docString());
     }
     return this;
   }

--- a/onnx/common/ir_pb_converter.cc
+++ b/onnx/common/ir_pb_converter.cc
@@ -295,6 +295,9 @@ std::unique_ptr<Graph> graphProtoToGraph(const ONNX_NAMESPACE::GraphProto& gp, b
     if (!vip.type().has_tensor_type()) {
       v->type() = std::make_unique<TypeProto>(vip.type());
     }
+    if (vip.has_doc_string()) {
+      v->setDocString(vip.doc_string());
+    }
     v->setUniqueName(vip.name());
     value_by_name_of[vip.name()] = v;
   }
@@ -390,6 +393,9 @@ std::unique_ptr<Graph> graphProtoToGraph(const ONNX_NAMESPACE::GraphProto& gp, b
     if (!output.type().has_tensor_type()) {
       output_value->type() = std::make_unique<TypeProto>(output.type());
     }
+    if (output.has_doc_string()) {
+      output_value->setDocString(output.doc_string());
+    }
     g->registerOutput(output_value);
   }
 
@@ -409,6 +415,9 @@ std::unique_ptr<Graph> graphProtoToGraph(const ONNX_NAMESPACE::GraphProto& gp, b
     }
     if (!gp.value_info(i).type().has_tensor_type()) {
       v->type() = std::make_unique<TypeProto>(gp.value_info(i).type());
+    }
+    if (gp.value_info(i).has_doc_string()) {
+      v->setDocString(gp.value_info(i).doc_string());
     }
   }
 
@@ -627,6 +636,9 @@ static void encodeValueInfo(ONNX_NAMESPACE::ValueInfoProto& v, Value& n) {
     encodeTypeProtoTensorType(*tensor_type, n);
   } else if (n.type()) {
     v.mutable_type()->CopyFrom(*n.type());
+  }
+  if (n.has_doc_string()) {
+    v.set_doc_string(n.docString());
   }
 }
 


### PR DESCRIPTION
The IR Value type had no doc_string field, so the doc_string on graph inputs, outputs and value_info was dropped when a ModelProto was converted to the internal IR and back (e.g. during onnxoptimizer passes). Add doc_string storage to Value and read/write it in graphProtoToGraph and encodeValueInfo, and carry it in Value::copyMetadata. Node and Graph doc_strings were already preserved.


Claude-Session: https://claude.ai/code/session_01AhuZK9rLE3HKdn3Dgxi1Vu



### Motivation and Context

Relates to https://github.com/onnxsim/onnxsim/issues/428
