### PR TITLE
Add Pad shape inference coverage for value_ints

### DIFF
--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -9310,6 +9310,23 @@ class TestShapeInference(TestShapeInferenceHelper):
             graph, [make_tensor_value_info("y", TensorProto.FLOAT, (3, None, 4))]
         )
 
+    def test_pad_with_constant_value_ints(self) -> None:
+        graph = self._make_graph(
+            [("x", TensorProto.FLOAT, (1, 2))],
+            [
+                make_node("Constant", [], ["pads"], value_ints=[0, 1, 0, 1]),
+                make_node("Pad", ["x", "pads"], ["y"]),
+            ],
+            [],
+        )
+        self._assert_inferred(
+            graph,
+            [
+                make_tensor_value_info("pads", TensorProto.INT64, (4,)),
+                make_tensor_value_info("y", TensorProto.FLOAT, (1, 4)),
+            ],
+        )
+
     def test_gatherelements_basic(self) -> None:
         graph = self._make_graph(
             [("x", TensorProto.FLOAT, (6,)), ("indices", TensorProto.INT64, (2,))],


### PR DESCRIPTION
### Motivation and Context

`Pad` shape inference previously failed when its `pads` input came from a `Constant` using `value_ints`. Current shape inference materializes list-valued constants with their one-dimensional shape, but this path lacked regression coverage.

Add a focused test that verifies both the Constant output shape and the inferred padded output shape.

Fixes onnx/onnx#6697

### Testing

- `.venv/bin/python -m pytest onnx/test/shape_inference_test.py::TestShapeInference::test_pad_opset10 onnx/test/shape_inference_test.py::TestShapeInference::test_constant_pad_2d_opset10 onnx/test/shape_inference_test.py::TestShapeInference::test_pad onnx/test/shape_inference_test.py::TestShapeInference::test_pad_with_constant_value_ints -q` (4 passed)
- `lintrunner onnx/test/shape_inference_test.py` (no lint issues)