### PR TITLE
improve checker which fails on a particular mismatch between type and shape

### DIFF
--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -238,6 +238,23 @@ void check_tensor(const TensorProto& tensor, const CheckerContext& ctx) {
       case TensorProto::FLOAT8E5M2:
       case TensorProto::FLOAT8E5M2FNUZ:
       case TensorProto::FLOAT8E8M0:
+        check_field(int32_data);
+        if (nelem > 0) {
+          // These types are not packed: each element occupies one int32_data entry.
+          const int64_t expected_int32s = nelem;
+          if (static_cast<int64_t>(tensor.int32_data().size()) < expected_int32s) {
+            fail_check(
+                "TensorProto (tensor name: ",
+                tensor.name(),
+                ") int32_data size (",
+                tensor.int32_data().size(),
+                ") is too small for the declared shape (",
+                expected_int32s,
+                " int32 values required).");
+          }
+        }
+        break;
+
       case TensorProto::UINT4:
       case TensorProto::INT4:
       case TensorProto::FLOAT4E2M1:

--- a/onnx/test/checker_test.py
+++ b/onnx/test/checker_test.py
@@ -1495,6 +1495,46 @@ class TestChecker:
             tensor2.int32_data.extend([0, 0])  # ceil(20/16) = 2
             checker.check_tensor(tensor2)
 
+    def test_check_tensor_unpacked_int32_data(self) -> None:
+        """Reject non-packed int32_data-stored tensors whose payload is too small.
+
+        BOOL, INT8, UINT8, INT16, UINT16, FLOAT16, BFLOAT16, and FLOAT8* types are
+        stored one element per int32_data entry (they are not bit-packed), unlike
+        INT4/UINT4/FLOAT4E2M1. Regression test for a checker/runtime discrepancy
+        where check_model() incorrectly accepted these types using the packed
+        ceil(nelem/8) formula instead of requiring nelem entries.
+        """
+        for dtype in (
+            TensorProto.BOOL,
+            TensorProto.INT8,
+            TensorProto.UINT8,
+            TensorProto.INT16,
+            TensorProto.UINT16,
+            TensorProto.FLOAT16,
+            TensorProto.BFLOAT16,
+            TensorProto.FLOAT8E4M3FN,
+            TensorProto.FLOAT8E4M3FNUZ,
+            TensorProto.FLOAT8E5M2,
+            TensorProto.FLOAT8E5M2FNUZ,
+            TensorProto.FLOAT8E8M0,
+        ):
+            tensor = TensorProto()
+            tensor.data_type = dtype
+            tensor.dims.extend([32])
+            tensor.name = "t"
+            # Only 4 int32_data entries; the packed formula ceil(32/8) = 4 would
+            # incorrectly accept this, but 32 entries (one per element) are needed.
+            tensor.int32_data.extend([0] * 4)
+            with pytest.raises(checker.ValidationError):
+                checker.check_tensor(tensor)
+            # Exactly enough (unpacked) int32 values must pass.
+            tensor2 = TensorProto()
+            tensor2.data_type = dtype
+            tensor2.dims.extend([32])
+            tensor2.name = "t"
+            tensor2.int32_data.extend([0] * 32)
+            checker.check_tensor(tensor2)
+
     def test_check_tensor_packed_subbyte_zero_elems(self) -> None:
         """Zero-element packed tensors with empty payload must be valid."""
         for dtype in (


### PR DESCRIPTION
Vulnerability:  onnx.checker.check_model()  incorrectly validated non-packed tensor data types (BOOL, INT8, UINT8, INT16, UINT16, FLOAT16, BFLOAT16, FLOAT8*), applying a bit-packed formula  (nelem+7)/8  to types that actually store one element per  int32_data  entry. This let under-sized tensors pass ONNX validation while crashing ONNX Runtime (and risking OOB reads in other consumers).

Fix —  onnx/checker.cc  ( check_tensor() ):

• Split the switch-case that previously merged non-packed types with truly packed 4-bit types (UINT4/INT4/FLOAT4E2M1).
• Non-packed types now require  expected_int32s = nelem .
• Packed 4-bit types still correctly use  expected_int32s = (nelem+7)/8 .

Test —  onnx/test/checker_test.py :

• Added  test_check_tensor_unpacked_int32_data , covering all 12 affected dtypes: verifies an under-sized  int32_data  payload (4 entries for a 32-element tensor) is now rejected, and the correct count (32 entries) passes.