### PR TITLE
Preserve inputs with no shape in Scan 8 -> 9

### DIFF
--- a/onnx/test/version_converter_test.py
+++ b/onnx/test/version_converter_test.py
@@ -1536,6 +1536,59 @@ class TestVersionConverter:
         assert converted_model.graph.node[0].op_type == "Scan"
         assert converted_model.opset_import[0].version == to_opset
 
+    def test_scan_8_9_preserves_unshaped_input(self) -> None:
+        """Scan 8 -> 9 removes the batch axis from each input. An input whose shape
+        is unknown must still be kept (only the shape strip is skipped), not dropped
+        together with the removed optional sequence_lens.
+        """
+        data_type = TensorProto.FLOAT
+        body = helper.make_graph(
+            [
+                helper.make_node("Add", ["sum_in", "next_in"], ["sum_out"]),
+                helper.make_node("Identity", ["sum_out"], ["scan_out"]),
+            ],
+            "scan_body",
+            [
+                helper.make_tensor_value_info("sum_in", data_type, [2]),
+                helper.make_tensor_value_info("next_in", data_type, [2]),
+            ],
+            [
+                helper.make_tensor_value_info("sum_out", data_type, [2]),
+                helper.make_tensor_value_info("scan_out", data_type, [2]),
+            ],
+        )
+        # A custom op produces `x` with no inferable shape, so it reaches the
+        # Scan 8 -> 9 adapter unshaped.
+        my_op = helper.make_node("MyOp", ["raw"], ["x"], domain="my.domain")
+        scan = helper.make_node(
+            "Scan", ["", "initial", "x"], ["y", "z"], body=body, num_scan_inputs=1
+        )
+        graph = helper.make_graph(
+            [my_op, scan],
+            "test_scan_8_9_unshaped_input",
+            [
+                helper.make_tensor_value_info("initial", data_type, [1, 2]),
+                helper.make_tensor_value_info("raw", data_type, [1, 3, 2]),
+            ],
+            [
+                helper.make_tensor_value_info("y", data_type, [1, 2]),
+                helper.make_tensor_value_info("z", data_type, [1, 3, 2]),
+            ],
+        )
+        model = helper.make_model(
+            graph,
+            opset_imports=[
+                helper.make_operatorsetid("", 8),
+                helper.make_operatorsetid("my.domain", 1),
+            ],
+        )
+        checker.check_model(model)
+
+        converted = onnx.version_converter.convert_version(model, 9)
+        scan_node = next(n for n in converted.graph.node if n.op_type == "Scan")
+        # The empty sequence_lens is removed, but the unshaped scan input is kept.
+        assert list(scan_node.input) == ["initial", "x"]
+
     # Test Cast Adapter: 8 -> 9
     def test_cast_8_9(self) -> None:
         from_opset = 8

--- a/onnx/test/version_converter_test.py
+++ b/onnx/test/version_converter_test.py
@@ -1536,61 +1536,6 @@ class TestVersionConverter:
         assert converted_model.graph.node[0].op_type == "Scan"
         assert converted_model.opset_import[0].version == to_opset
 
-    def test_scan_8_9_preserves_unshaped_input(self) -> None:
-        """Scan 8 -> 9 removes the batch axis from each input. An input whose shape
-        is unknown must still be kept (only the shape strip is skipped), not dropped
-        together with the removed optional sequence_lens.
-        """
-        data_type = TensorProto.FLOAT
-        body = helper.make_graph(
-            [
-                helper.make_node("Add", ["sum_in", "next_in"], ["sum_out"]),
-                helper.make_node("Identity", ["sum_out"], ["scan_out"]),
-            ],
-            "scan_body",
-            [
-                helper.make_tensor_value_info("sum_in", data_type, [2]),
-                helper.make_tensor_value_info("next_in", data_type, [2]),
-            ],
-            [
-                helper.make_tensor_value_info("sum_out", data_type, [2]),
-                helper.make_tensor_value_info("scan_out", data_type, [2]),
-            ],
-        )
-        # A custom op produces `x` with no inferable shape, so it reaches the
-        # Scan 8 -> 9 adapter unshaped.
-        my_op = helper.make_node("MyOp", ["raw"], ["x"], domain="my.domain")
-        scan = helper.make_node(
-            "Scan", ["", "initial", "x"], ["y", "z"], body=body, num_scan_inputs=1
-        )
-        graph = helper.make_graph(
-            [my_op, scan],
-            "test_scan_8_9_unshaped_input",
-            [
-                helper.make_tensor_value_info("initial", data_type, [1, 2]),
-                helper.make_tensor_value_info("raw", data_type, [1, 3, 2]),
-            ],
-            [
-                helper.make_tensor_value_info("y", data_type, [1, 2]),
-                helper.make_tensor_value_info("z", data_type, [1, 3, 2]),
-            ],
-        )
-        model = helper.make_model(
-            graph,
-            opset_imports=[
-                helper.make_operatorsetid("", 8),
-                helper.make_operatorsetid("my.domain", 1),
-            ],
-        )
-        checker.check_model(model)
-
-        converted = onnx.version_converter.convert_version(model, 9)
-        checker.check_model(converted, full_check=True)
-
-        scan_node = next(n for n in converted.graph.node if n.op_type == "Scan")
-        # The empty sequence_lens is removed, but the unshaped scan input is kept.
-        assert list(scan_node.input) == ["initial", "x"]
-
     # Test Cast Adapter: 8 -> 9
     def test_cast_8_9(self) -> None:
         from_opset = 8
@@ -3019,6 +2964,61 @@ class TestVersionConverter:
         converted_model = self._converted(graph, helper.make_operatorsetid("", 9), 8)
         assert converted_model.graph.node[0].op_type == "Scan"
         assert converted_model.opset_import[0].version == 8
+
+    def test_scan_8_9_preserves_unshaped_input(self) -> None:
+        """Scan 8 -> 9 removes the batch axis from each input. An input whose shape
+        is unknown must still be kept (only the shape strip is skipped), not dropped
+        together with the removed optional sequence_lens.
+        """
+        data_type = TensorProto.FLOAT
+        body = helper.make_graph(
+            [
+                helper.make_node("Add", ["sum_in", "next_in"], ["sum_out"]),
+                helper.make_node("Identity", ["sum_out"], ["scan_out"]),
+            ],
+            "scan_body",
+            [
+                helper.make_tensor_value_info("sum_in", data_type, [2]),
+                helper.make_tensor_value_info("next_in", data_type, [2]),
+            ],
+            [
+                helper.make_tensor_value_info("sum_out", data_type, [2]),
+                helper.make_tensor_value_info("scan_out", data_type, [2]),
+            ],
+        )
+        # A custom op produces `x` with no inferable shape, so it reaches the
+        # Scan 8 -> 9 adapter unshaped.
+        my_op = helper.make_node("MyOp", ["raw"], ["x"], domain="my.domain")
+        scan = helper.make_node(
+            "Scan", ["", "initial", "x"], ["y", "z"], body=body, num_scan_inputs=1
+        )
+        graph = helper.make_graph(
+            [my_op, scan],
+            "test_scan_8_9_unshaped_input",
+            [
+                helper.make_tensor_value_info("initial", data_type, [1, 2]),
+                helper.make_tensor_value_info("raw", data_type, [1, 3, 2]),
+            ],
+            [
+                helper.make_tensor_value_info("y", data_type, [1, 2]),
+                helper.make_tensor_value_info("z", data_type, [1, 3, 2]),
+            ],
+        )
+        model = helper.make_model(
+            graph,
+            opset_imports=[
+                helper.make_operatorsetid("", 8),
+                helper.make_operatorsetid("my.domain", 1),
+            ],
+        )
+        checker.check_model(model)
+
+        converted = onnx.version_converter.convert_version(model, 9)
+        checker.check_model(converted, full_check=True)
+
+        scan_node = next(n for n in converted.graph.node if n.op_type == "Scan")
+        # The empty sequence_lens is removed, but the unshaped scan input is kept.
+        assert list(scan_node.input) == ["initial", "x"]
 
     def test_convert_version_ai_onnx_domain_spelling_preserves_custom_domain(
         self,

--- a/onnx/test/version_converter_test.py
+++ b/onnx/test/version_converter_test.py
@@ -2966,9 +2966,11 @@ class TestVersionConverter:
         assert converted_model.opset_import[0].version == 8
 
     def test_scan_8_9_preserves_unshaped_input(self) -> None:
-        """Scan 8 -> 9 removes the batch axis from each input. An input whose shape
-        is unknown must still be kept (only the shape strip is skipped), not dropped
-        together with the removed optional sequence_lens.
+        """Scan 8 -> 9 removes the batch axis from each input.
+        
+        An input whose shape is unknown must still be kept, and will be
+        unedited (the shape is unknown with or without batch axis). Only the
+        sequence_lens input should be removed.
         """
         data_type = TensorProto.FLOAT
         body = helper.make_graph(
@@ -2987,7 +2989,7 @@ class TestVersionConverter:
             ],
         )
         # A custom op produces `x` with no inferable shape, so it reaches the
-        # Scan 8 -> 9 adapter unshaped.
+        # Scan 8 -> 9 with no shape.
         my_op = helper.make_node("MyOp", ["raw"], ["x"], domain="my.domain")
         scan = helper.make_node(
             "Scan", ["", "initial", "x"], ["y", "z"], body=body, num_scan_inputs=1

--- a/onnx/test/version_converter_test.py
+++ b/onnx/test/version_converter_test.py
@@ -1585,6 +1585,8 @@ class TestVersionConverter:
         checker.check_model(model)
 
         converted = onnx.version_converter.convert_version(model, 9)
+        checker.check_model(converted, full_check=True)
+
         scan_node = next(n for n in converted.graph.node if n.op_type == "Scan")
         # The empty sequence_lens is removed, but the unshaped scan input is kept.
         assert list(scan_node.input) == ["initial", "x"]

--- a/onnx/test/version_converter_test.py
+++ b/onnx/test/version_converter_test.py
@@ -2967,7 +2967,7 @@ class TestVersionConverter:
 
     def test_scan_8_9_preserves_unshaped_input(self) -> None:
         """Scan 8 -> 9 removes the batch axis from each input.
-        
+
         An input whose shape is unknown must still be kept, and will be
         unedited (the shape is unknown with or without batch axis). Only the
         sequence_lens input should be removed.

--- a/onnx/version_converter/adapters/scan_8_9.h
+++ b/onnx/version_converter/adapters/scan_8_9.h
@@ -39,12 +39,17 @@ struct Scan_8_9 final : public Adapter {
 
     node->removeAllInputs();
 
-    for (Value* input : inputs) {
+    // inputs[0] is the optional sequence_lens (asserted empty above), which opset-9 Scan does
+    // not have, so it is dropped. Every remaining input is kept: opset 9 has no batch dimension,
+    // so strip the leading axis when the shape is known, but preserve an input whose shape is
+    // unknown rather than dropping it.
+    for (size_t i = 1; i < inputs.size(); ++i) {
+      Value* input = inputs[i];
       if (!input->sizes().empty()) {
         std::vector<Dimension> new_sizes(input->sizes().begin() + 1, input->sizes().end());
         input->setSizes(new_sizes);
-        node->addInput(input);
       }
+      node->addInput(input);
     }
 
     for (Value* output : outputs) {

--- a/onnx/version_converter/adapters/scan_8_9.h
+++ b/onnx/version_converter/adapters/scan_8_9.h
@@ -39,10 +39,11 @@ struct Scan_8_9 final : public Adapter {
 
     node->removeAllInputs();
 
-    // inputs[0] is the optional sequence_lens (asserted empty above), which opset-9 Scan does
-    // not have, so it is dropped. Every remaining input is kept: opset 9 has no batch dimension,
-    // so strip the leading axis when the shape is known, but preserve an input whose shape is
-    // unknown rather than dropping it.
+    // inputs[0] is the optional sequence_lens (asserted to be empty).
+    // Scan does not have it as optset 9, so it is intentionally dropped.
+    // All other inputs are kept. But opset 9 has no batch dimension, so strip
+    // the leading axis when the shape is known, skipping inputs with unknown
+    // shape.
     for (size_t i = 1; i < inputs.size(); ++i) {
       Value* input = inputs[i];
       if (!input->sizes().empty()) {

--- a/onnx/version_converter/adapters/scan_8_9.h
+++ b/onnx/version_converter/adapters/scan_8_9.h
@@ -42,8 +42,8 @@ struct Scan_8_9 final : public Adapter {
     // inputs[0] is the optional sequence_lens (asserted to be empty).
     // Scan does not have it as opset 9, so it is intentionally dropped.
     // All other inputs are kept. But opset 9 has no batch dimension, so strip
-    // the leading axis when the shape is known, skipping inputs with unknown
-    // shape.
+    // the leading axis when the shape is known, leaving alone inputs with
+    // unknown shape.
     for (size_t i = 1; i < inputs.size(); ++i) {
       Value* input = inputs[i];
       if (!input->sizes().empty()) {

--- a/onnx/version_converter/adapters/scan_8_9.h
+++ b/onnx/version_converter/adapters/scan_8_9.h
@@ -40,7 +40,7 @@ struct Scan_8_9 final : public Adapter {
     node->removeAllInputs();
 
     // inputs[0] is the optional sequence_lens (asserted to be empty).
-    // Scan does not have it as optset 9, so it is intentionally dropped.
+    // Scan does not have it as opset 9, so it is intentionally dropped.
     // All other inputs are kept. But opset 9 has no batch dimension, so strip
     // the leading axis when the shape is known, skipping inputs with unknown
     // shape.


### PR DESCRIPTION
### Motivation and Context

The definition of Scan 8 -> 9:

<https://onnx.ai/onnx/operators/onnx__Scan.html#l-onnx-op-scan-8> \
<https://onnx.ai/onnx/operators/onnx__Scan.html#l-onnx-op-scan-9>

1. Drops the `sequence_lens` input
2. Uses scan_input_axes instead of the batch axis 0

The version converter adapter's current behavior is to drop all inputs that don't have a defined shape, and remove the first axis from the rest. This produces an incorrect result when shape inference fails to produce a shape for one of the inputs for any reason (e.g. it comes from a custom op in a non-default domain).

https://gist.github.com/mcollinswisc/7102269a92dc92b240915316e1c584e9

Input at v8:

<img width="878" height="542" alt="image" src="https://github.com/user-attachments/assets/c11d5a39-28e1-4b1f-aa41-dd75d08f9c8f" />

Converter output at v9:

<img width="883" height="542" alt="image" src="https://github.com/user-attachments/assets/0356e707-69fb-42c9-b45d-316a13d811b3" />

This change fixes it & adds a unit test alongside the other Scan 8 -> 9 special cases.

We happened upon this as a secondary issue when investigating https://github.com/onnx/onnx/issues/4370.