### PR TITLE
fix(common): route tensor dim errors through throw_tensor_error

### DIFF
--- a/onnx/common/tensor.h
+++ b/onnx/common/tensor.h
@@ -51,14 +51,14 @@ struct Tensor final {
   /// if tensor is a scalar, the sizes is empty, but the element number is actually 1.
   /// size_from_dim() cannot handle this case, while elem_num() handles it correctly
   int64_t elem_num() const {
-    return safe_dim_product(sizes_, [](const char* msg) { throw tensor_error(msg); });
+    return safe_dim_product(sizes_, [](const char* msg) { throw_tensor_error(msg); });
   }
   int64_t size_from_dim(int dim) const {
     if (dim < 0) {
       dim += static_cast<int>(sizes_.size());
     }
     ONNX_ASSERT(dim >= 0 && static_cast<size_t>(dim) < sizes_.size())
-    return safe_dim_product(sizes_.begin() + dim, sizes_.end(), [](const char* msg) { throw tensor_error(msg); });
+    return safe_dim_product(sizes_.begin() + dim, sizes_.end(), [](const char* msg) { throw_tensor_error(msg); });
   }
 
   int32_t elem_type() const {


### PR DESCRIPTION
Fixes #8219.

`Tensor::elem_num()` and `Tensor::size_from_dim()` pass an error-handling lambda to `safe_dim_product()` that uses a raw `throw`, bypassing `ONNX_THROW_EX`. That breaks builds configured with `ONNX_DISABLE_EXCEPTIONS=ON`:

```
onnx/common/tensor.h:54:59: error: cannot use 'throw' with exceptions disabled
onnx/common/tensor.h:61:87: error: cannot use 'throw' with exceptions disabled
```

Any translation unit that includes `tensor.h` fails, so in practice this also takes out `onnx/common/ir_pb_converter.cc` and `onnx/defs/tensor_util.cc`.

Both call sites now go through the existing `[[noreturn]] throw_tensor_error()` helper, which honours `ONNX_NO_EXCEPTIONS`. This is the simplified form suggested in https://github.com/onnx/onnx/issues/8219#issuecomment-5094758402: since `throw_tensor_error()` takes `const std::string&`, the `const char*` binds directly to a temporary and no intermediate local is needed.

Behaviour is unchanged when exceptions are enabled (`ONNX_THROW_EX(tensor_error(msg))` expands to `throw tensor_error(msg)`), and the helper satisfies the contract documented in `safe_math.h` that `on_error` must not return.

### Verification

The construct was syntax-checked against the real `safe_math.h` and `assertions.h`, both with and without exceptions:

```sh
clang++ -fsyntax-only -std=c++20 -fno-exceptions -DONNX_NO_EXCEPTIONS ...   # was an error, now clean
clang++ -fsyntax-only -std=c++20 ...                                        # unchanged
```

### Note on CI

As observed in the issue, `win_no_exception_ci.yml` builds with `-DONNX_DISABLE_EXCEPTIONS=ON` only on MSVC, where a bare `throw` under `/EHs-c-` is warning C4530 rather than a hard error, which is why this was not caught. I hit it on Linux/clang while updating the ONNX Runtime toolchain used by Firefox, which builds onnx with exceptions disabled. A Linux GCC or clang `-fno-exceptions` job would catch this class of bug going forward but is out of scope here.
