### PR TITLE
docs: add REUSE annotation for AGENTS.md symlink

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -234,3 +234,9 @@ path = "sbom.cdx.json"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "Copyright (c) ONNX Project Contributors"
 SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "AGENTS.md"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "Copyright (c) ONNX Project Contributors"
+SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
## Summary

`AGENTS.md` is a symlink to `CLAUDE.md` (added in #8187) so that Codex-style tooling that looks for the `AGENTS.md` convention picks up the same guidance without duplicating content. A symlink has no content of its own, so it can't carry an embedded SPDX header — this left it flagged by `reuse lint` as missing copyright/license information, which currently fails the `reuse` pre-commit hook on the tip of `main`.

## Fix

Follows the existing `REUSE.toml` pattern already used for other files that can't carry an embedded header (e.g. `sbom.cdx.json`, `pixi.lock`): declare the copyright via a `[[annotations]]` entry instead of editing the file.

## Test plan

- [x] `pixi run -- reuse lint` no longer flags `AGENTS.md` (verified locally: compliant file count went from 27115/27119 to 27116/27119, with `AGENTS.md` no longer in the "missing copyright" list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)