### PR TITLE
ci: add Linux GCC/Clang build with exceptions disabled

### DIFF
--- a/.github/workflows/linux_no_exception_ci.yml
+++ b/.github/workflows/linux_no_exception_ci.yml
@@ -38,19 +38,15 @@ jobs:
       with:
          persist-credentials: false
 
-    - name: Set up Python
-      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-      with:
-        python-version: '3.10'
-
     - name: Build and test ONNX binaries with exceptions disabled
       env:
         CC: ${{ matrix.cc }}
         CXX: ${{ matrix.cxx }}
       run: |
         echo "Build ONNX with -DONNX_DISABLE_EXCEPTIONS=ON"
-        cmake -DONNX_WERROR=ON -DONNX_DISABLE_EXCEPTIONS=ON -DCMAKE_BUILD_TYPE=Release -DONNX_ML=1 -DONNX_BUILD_TESTS=ON -S . -B .setuptools-cmake-build
+        cmake -DONNX_WERROR=ON -DONNX_DISABLE_EXCEPTIONS=ON -DONNX_USE_LITE_PROTO=ON -DCMAKE_BUILD_TYPE=Release -DONNX_ML=1 -DONNX_BUILD_TESTS=ON -S . -B .setuptools-cmake-build
         cmake --build .setuptools-cmake-build --parallel "$(nproc)"
 
         echo "Run gtests"
-        LD_LIBRARY_PATH=./.setuptools-cmake-build/ .setuptools-cmake-build/onnx_gtests
+        export LD_LIBRARY_PATH="./.setuptools-cmake-build/:$LD_LIBRARY_PATH"
+        .setuptools-cmake-build/onnx_gtests

--- a/.github/workflows/linux_no_exception_ci.yml
+++ b/.github/workflows/linux_no_exception_ci.yml
@@ -1,0 +1,56 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Linux_No_Exception_CI
+
+on:
+   push:
+    branches: [ main, rel-* ]
+   pull_request:
+    branches: [ main, rel-* ]
+
+permissions:  # set top-level default permissions as security best practice
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build and test (${{ matrix.compiler }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc, clang]
+        include:
+          - compiler: gcc
+            cc: gcc
+            cxx: g++
+          - compiler: clang
+            cc: clang
+            cxx: clang++
+    steps:
+    - name: Checkout ONNX
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+         persist-credentials: false
+
+    - name: Set up Python
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      with:
+        python-version: '3.10'
+
+    - name: Build and test ONNX binaries with exceptions disabled
+      env:
+        CC: ${{ matrix.cc }}
+        CXX: ${{ matrix.cxx }}
+      run: |
+        echo "Build ONNX with -DONNX_DISABLE_EXCEPTIONS=ON"
+        cmake -DONNX_WERROR=ON -DONNX_DISABLE_EXCEPTIONS=ON -DCMAKE_BUILD_TYPE=Release -DONNX_ML=1 -DONNX_BUILD_TESTS=ON -S . -B .setuptools-cmake-build
+        cmake --build .setuptools-cmake-build --parallel "$(nproc)"
+
+        echo "Run gtests"
+        LD_LIBRARY_PATH=./.setuptools-cmake-build/ .setuptools-cmake-build/onnx_gtests


### PR DESCRIPTION
## Summary

`win_no_exception_ci.yml` is the only CI job that builds with `-DONNX_DISABLE_EXCEPTIONS=ON`, and it only runs on MSVC. Under MSVC's `/EHs-c-`, a bare `throw` is warning C4530, not a hard error — which is exactly why the regression fixed in #8220 (raw `throw tensor_error(msg)` in `tensor.h`, see #8219) shipped in `main`/v1.22.0 undetected. GCC and Clang treat `throw` under `-fno-exceptions` as a compile error, but no Linux job exercised `ONNX_DISABLE_EXCEPTIONS=ON` to catch it.

This adds a Linux job that builds with `-DONNX_DISABLE_EXCEPTIONS=ON` on both GCC and Clang and runs `onnx_gtests`, so this class of bug is caught as a hard compiler error going forward instead of relying on a downstream consumer hitting it (as happened here, via the ONNX Runtime/Firefox toolchain).

## Design notes

- Modeled on `win_no_exception_ci.yml`'s structure (same triggers, concurrency group, permissions).
- Invokes `cmake`/`cmake --build` directly rather than `pip install -e .`, since `CMakeLists.txt` documents `ONNX_DISABLE_EXCEPTIONS=ON` as incompatible with `ONNX_BUILD_PYTHON=ON` (the Python binding requires exceptions). `ONNX_BUILD_PYTHON` defaults `OFF` for a raw `cmake` invocation, so this isn't an issue.
- Protobuf needs no separate build step here (unlike `win_no_exception_ci.yml`, which builds it from source): when no system `protoc` is found, `CMakeLists.txt` already `FetchContent`s protobuf/abseil from the URLs pinned in `sbom.cdx.json` — the same path the `Internal` protobuf leg of `main.yml`'s Linux matrix relies on.
- `fail-fast: false` and a `[gcc, clang]` matrix so a failure on one compiler doesn't hide a failure on the other.
- Verified locally with `pixi run -- zizmor .github/workflows/linux_no_exception_ci.yml` (no findings) and `pixi run -- reuse lint` (already covered by the existing `.github/**/**.yml` wildcard annotation in `REUSE.toml`).


Related: #8219, #8220

🤖 Generated with [Claude Code](https://claude.com/claude-code)