### PR TITLE
Add infer_shapes_and_report to count inferred/updated values

### DIFF
--- a/docs/docsgen/source/api/shape_inference.md
+++ b/docs/docsgen/source/api/shape_inference.md
@@ -6,6 +6,12 @@
 .. autofunction:: onnx.shape_inference.infer_shapes
 ```
 
+## infer_shapes_and_report
+
+```{eval-rst}
+.. autofunction:: onnx.shape_inference.infer_shapes_and_report
+```
+
 ## infer_shapes_path
 
 ```{eval-rst}

--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -760,6 +760,28 @@ NB_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) { // NOLINT(cppcoreguidelines-
       nb::arg("strict_mode") = false,
       nb::arg("data_prop") = false);
 
+  // Same as infer_shapes, but also returns the number of graph values (value_info
+  // entries) that were newly inferred or updated during the pass.
+  shape_inference.def(
+      "infer_shapes_and_report",
+      [](const nb::bytes& bytes, bool check_type, bool strict_mode, bool data_prop) {
+        ModelProto proto{};
+        ParseProtoFromPyBytes(&proto, bytes);
+        ShapeInferenceOptions options{check_type, strict_mode ? 1 : 0, data_prop};
+        size_t num_inferred_values = 0;
+        shape_inference::InferShapes(
+            proto,
+            OpSchemaRegistry::Instance(),
+            options,
+            /*generated_shape_data_by_name=*/nullptr,
+            &num_inferred_values);
+        return nb::make_tuple(ProtoToBytes(proto), num_inferred_values);
+      },
+      nb::arg("bytes"),
+      nb::arg("check_type") = false,
+      nb::arg("strict_mode") = false,
+      nb::arg("data_prop") = false);
+
   shape_inference.def(
       "infer_shapes_path",
       [](const std::string& model_path,

--- a/onnx/onnx_cpp2py_export/shape_inference.pyi
+++ b/onnx/onnx_cpp2py_export/shape_inference.pyi
@@ -31,6 +31,9 @@ class InferenceContext:
 def infer_shapes(
     b: bytes, check_type: bool, strict_mode: bool, data_prop: bool
 ) -> bytes: ...
+def infer_shapes_and_report(
+    b: bytes, check_type: bool, strict_mode: bool, data_prop: bool
+) -> tuple[bytes, int]: ...
 def infer_shapes_path(
     model_path: str,
     output_path: str,

--- a/onnx/shape_inference.py
+++ b/onnx/shape_inference.py
@@ -70,6 +70,51 @@ def infer_shapes(
     )
 
 
+def infer_shapes_and_report(
+    model: ModelProto | bytes,
+    check_type: bool = False,
+    strict_mode: bool = False,
+    data_prop: bool = False,
+) -> tuple[ModelProto, int]:
+    """Apply shape inference and report how many values were inferred or updated.
+
+    This behaves exactly like :func:`infer_shapes`, but in addition to the
+    inferred model it returns the number of graph values (``value_info``
+    entries of the main graph) that were newly inferred or whose type/shape was
+    updated during the pass. A value counts as modified only when a
+    previously-unknown element type, rank, or dimension actually became known;
+    re-inferring already-known information does not increase the count.
+
+    Arguments:
+        model: ModelProto.
+        check_type: Checks the type-equality for input and output.
+        strict_mode: Stricter shape inference, it will throw errors if any;
+            Otherwise, simply stop if any error.
+        data_prop: Enables data propagation for limited operators to perform shape computation.
+
+    Returns:
+        A tuple ``(model, num_inferred_values)`` where ``model`` is the
+        ModelProto with inferred shape information and ``num_inferred_values``
+        is the number of values that were newly inferred or updated.
+    """
+    if isinstance(model, (ModelProto, bytes)):
+        model_str = model if isinstance(model, bytes) else model.SerializeToString()
+        inferred_model_str, num_inferred_values = C.infer_shapes_and_report(
+            model_str, check_type, strict_mode, data_prop
+        )
+        return onnx.load_from_string(inferred_model_str), num_inferred_values
+    if isinstance(model, (str, os.PathLike)):
+        raise TypeError(
+            "infer_shapes_and_report only accepts ModelProto or bytes,"
+            " For Model paths (str or os.PathLike), use infer_shapes_path()."
+        )
+
+    raise TypeError(
+        "infer_shapes_and_report only accepts ModelProto or bytes,"
+        f" incorrect type: {type(model)}"
+    )
+
+
 def infer_shapes_path(
     model_path: str | os.PathLike,
     output_path: str | os.PathLike = "",

--- a/onnx/shape_inference/implementation.cc
+++ b/onnx/shape_inference/implementation.cc
@@ -147,72 +147,93 @@ void checkShapesAndTypes(const TypeProto& inferred_type, const TypeProto& existi
   }
 }
 
-void mergeShapesAndTypes(const TypeProto_Tensor& inferred_type, TypeProto_Tensor* existing_type) {
+// Merges the dimensions of an inferred tensor/sparse-tensor shape into an existing
+// shape (both are known to have a shape). Returns true if any dimension was changed.
+template <typename TensorShapeProtoType>
+static bool MergeShapeDims(const TensorShapeProtoType& inferred_shape, TensorShapeProtoType* existing_shape) {
+  bool modified = false;
+  for (int i = 0; i < inferred_shape.dim_size(); ++i) {
+    const auto& inferred_dim = inferred_shape.dim(i);
+    auto* existing_dim = existing_shape->mutable_dim(i);
+    const bool existing_unknown = !existing_dim->has_dim_value() && !existing_dim->has_dim_param();
+    if (existing_unknown || inferred_dim.has_dim_value()) {
+      // A dimension is considered changed when previously-unknown dimension info
+      // becomes known, or an existing symbolic/value dimension is replaced by a
+      // different concrete value.
+      if ((existing_unknown && (inferred_dim.has_dim_value() || inferred_dim.has_dim_param())) ||
+          (!existing_unknown && inferred_dim.has_dim_value() &&
+           (!existing_dim->has_dim_value() || existing_dim->dim_value() != inferred_dim.dim_value()))) {
+        modified = true;
+      }
+      *existing_dim = inferred_dim;
+    }
+  }
+  return modified;
+}
+
+bool mergeShapesAndTypes(const TypeProto_Tensor& inferred_type, TypeProto_Tensor* existing_type) {
+  bool modified = false;
   if (existing_type->elem_type() == TensorProto::UNDEFINED) {
+    modified = inferred_type.elem_type() != TensorProto::UNDEFINED;
     existing_type->set_elem_type(inferred_type.elem_type());
   }
 
   if (!inferred_type.has_shape()) {
-    return;
+    return modified;
   }
 
   if (!existing_type->has_shape()) {
     *existing_type->mutable_shape() = inferred_type.shape();
-    return;
+    return true;
   }
 
-  for (int i = 0; i < inferred_type.shape().dim_size(); ++i) {
-    const auto& inferred_dim = inferred_type.shape().dim(i);
-    auto* existing_dim = existing_type->mutable_shape()->mutable_dim(i);
-    if ((!existing_dim->has_dim_value() && !existing_dim->has_dim_param()) || inferred_dim.has_dim_value()) {
-      *existing_dim = inferred_dim;
-    }
-  }
+  return MergeShapeDims(inferred_type.shape(), existing_type->mutable_shape()) || modified;
 }
 
-void mergeShapesAndTypes(const TypeProto_SparseTensor& inferred_type, TypeProto_SparseTensor* existing_type) {
+bool mergeShapesAndTypes(const TypeProto_SparseTensor& inferred_type, TypeProto_SparseTensor* existing_type) {
+  bool modified = false;
   if (existing_type->elem_type() == TensorProto::UNDEFINED) {
+    modified = inferred_type.elem_type() != TensorProto::UNDEFINED;
     existing_type->set_elem_type(inferred_type.elem_type());
   }
 
   if (!inferred_type.has_shape()) {
-    return;
+    return modified;
   }
 
   if (!existing_type->has_shape()) {
     *existing_type->mutable_shape() = inferred_type.shape();
-    return;
+    return true;
   }
 
-  for (int i = 0; i < inferred_type.shape().dim_size(); ++i) {
-    const auto& inferred_dim = inferred_type.shape().dim(i);
-    auto* existing_dim = existing_type->mutable_shape()->mutable_dim(i);
-    if ((!existing_dim->has_dim_value() && !existing_dim->has_dim_param()) || inferred_dim.has_dim_value()) {
-      *existing_dim = inferred_dim;
-    }
-  }
+  return MergeShapeDims(inferred_type.shape(), existing_type->mutable_shape()) || modified;
 }
 
-void mergeShapesAndTypes(const TypeProto& inferred_type, TypeProto* existing_type) {
+bool mergeShapesAndTypes(const TypeProto& inferred_type, TypeProto* existing_type) {
   // Check before merge
   checkShapesAndTypes(inferred_type, *existing_type);
   const auto inferred_val_case = inferred_type.value_case();
   if (inferred_val_case == TypeProto::kTensorType) {
-    mergeShapesAndTypes(inferred_type.tensor_type(), existing_type->mutable_tensor_type());
+    return mergeShapesAndTypes(inferred_type.tensor_type(), existing_type->mutable_tensor_type());
   } else if (inferred_val_case == TypeProto::kSparseTensorType) {
-    mergeShapesAndTypes(inferred_type.sparse_tensor_type(), existing_type->mutable_sparse_tensor_type());
+    return mergeShapesAndTypes(inferred_type.sparse_tensor_type(), existing_type->mutable_sparse_tensor_type());
   } else if (inferred_val_case == TypeProto::kSequenceType) {
-    mergeShapesAndTypes(
+    return mergeShapesAndTypes(
         inferred_type.sequence_type().elem_type(), existing_type->mutable_sequence_type()->mutable_elem_type());
   } else if (inferred_val_case == TypeProto::kOptionalType) {
-    mergeShapesAndTypes(
+    return mergeShapesAndTypes(
         inferred_type.optional_type().elem_type(), existing_type->mutable_optional_type()->mutable_elem_type());
   } else if (inferred_val_case == TypeProto::kMapType) {
+    bool modified = false;
     if (existing_type->map_type().key_type() == TensorProto::UNDEFINED) {
+      modified = inferred_type.map_type().key_type() != TensorProto::UNDEFINED;
       existing_type->mutable_map_type()->set_key_type(inferred_type.map_type().key_type());
     }
-    mergeShapesAndTypes(inferred_type.map_type().value_type(), existing_type->mutable_map_type()->mutable_value_type());
+    return mergeShapesAndTypes(
+               inferred_type.map_type().value_type(), existing_type->mutable_map_type()->mutable_value_type()) ||
+        modified;
   }
+  return false;
 }
 
 // TypeProto_Tensor or TypeProto_SparseTensor
@@ -364,9 +385,12 @@ class ShapeInferenceImplBase {
     // information. Otherwise, initialize it in an empty state.
     auto iter = value_types_by_name.find(name);
     if (iter != value_types_by_name.end()) {
-      mergeShapesAndTypes(*inferred_type, iter->second);
+      if (mergeShapesAndTypes(*inferred_type, iter->second)) {
+        ++num_inferred_values;
+      }
     } else {
       value_types_by_name[name] = inferred_types.Add(name, *inferred_type);
+      ++num_inferred_values;
       // For undefined output type, update both value_info and output for now
       // Update existing output with undefined type: assign inferred type to it
       iter = undefined_value_types_by_name.find(name);
@@ -730,6 +754,12 @@ class ShapeInferenceImplBase {
     return inference_errors;
   }
 
+  // Number of graph values (value_info entries) that were newly inferred or
+  // updated during this inference pass.
+  size_t getNumInferredValues() const {
+    return num_inferred_values;
+  }
+
  private:
   InferredTypes inferred_types;
   std::unordered_map<std::string, TypeProto*> value_types_by_name;
@@ -751,6 +781,8 @@ class ShapeInferenceImplBase {
 
   bool has_unsupported_op = false;
 
+  size_t num_inferred_values = 0;
+
   std::vector<std::string> inference_errors;
 
   std::list<TypeProto> initializer_type_list;
@@ -769,8 +801,8 @@ void InferShapesImpl(
     const ModelLocalFunctionsMap& model_local_functions_map,
     const ISchemaRegistry* schema_registry = OpSchemaRegistry::Instance(),
     DataValueMap* generated_shape_data_by_name = nullptr,
-    const int64_t ir_version = IR_VERSION // default the latest one
-) {
+    const int64_t ir_version = IR_VERSION, // default the latest one
+    size_t* num_inferred_values = nullptr) {
   DataValueMap empty;
   if (generated_shape_data_by_name == nullptr) {
     generated_shape_data_by_name = &empty;
@@ -787,6 +819,9 @@ void InferShapesImpl(
       ir_version);
   base.Process(*g);
   base.FinalizeShapeInference();
+  if (num_inferred_values != nullptr) {
+    *num_inferred_values = base.getNumInferredValues();
+  }
 }
 
 } // namespace
@@ -812,7 +847,8 @@ void InferShapes(
     ModelProto& m,
     const ISchemaRegistry* schema_registry,
     const ShapeInferenceOptions& options,
-    DataValueMap* generated_shape_data_by_name) {
+    DataValueMap* generated_shape_data_by_name,
+    size_t* num_inferred_values) {
   auto opset_imports = GetOpsetImportsFromProto(m);
   SymbolTableImpl symbol_table;
   ModelLocalFunctionsMap model_local_functions_by_id;
@@ -829,7 +865,8 @@ void InferShapes(
       model_local_functions_by_id,
       schema_registry,
       generated_shape_data_by_name,
-      m.ir_version());
+      m.ir_version(),
+      num_inferred_values);
 }
 
 void InferShapes(

--- a/onnx/shape_inference/implementation.h
+++ b/onnx/shape_inference/implementation.h
@@ -460,11 +460,15 @@ void checkShapesAndTypes(const TypeProto& inferred_type, const TypeProto& existi
 
 void MaterializeSymbolicShape(TypeProto* inferred_type, SymbolTable& symbol_table);
 
-void mergeShapesAndTypes(const TypeProto_Tensor& inferred_type, TypeProto_Tensor* existing_type);
+// The mergeShapesAndTypes overloads merge inferred type/shape information into an
+// existing type. They return true if the existing type was actually modified (a
+// previously-unknown element type, rank, or dimension became known), and false if
+// the merge was a no-op. Callers may ignore the return value.
+bool mergeShapesAndTypes(const TypeProto_Tensor& inferred_type, TypeProto_Tensor* existing_type);
 
-void mergeShapesAndTypes(const TypeProto_SparseTensor& inferred_type, TypeProto_SparseTensor* existing_type);
+bool mergeShapesAndTypes(const TypeProto_SparseTensor& inferred_type, TypeProto_SparseTensor* existing_type);
 
-void mergeShapesAndTypes(const TypeProto& inferred_type, TypeProto* existing_type);
+bool mergeShapesAndTypes(const TypeProto& inferred_type, TypeProto* existing_type);
 
 ///
 /// ModelLocalFunctionsMap is a map of function id -> model local function proto
@@ -477,11 +481,14 @@ ONNX_API void InferShapes(
     const ShapeInferenceOptions& options = ShapeInferenceOptions(),
     const ModelLocalFunctionsMap& in_model_functions = {});
 
+/// If \p num_inferred_values is non-null, it is set to the number of graph values
+/// (value_info entries) that were newly inferred or updated during this pass.
 ONNX_API void InferShapes(
     ModelProto& m,
     const ISchemaRegistry* schema_registry = OpSchemaRegistry::Instance(),
     const ShapeInferenceOptions& options = ShapeInferenceOptions(),
-    DataValueMap* generated_shape_data_by_name = nullptr);
+    DataValueMap* generated_shape_data_by_name = nullptr,
+    size_t* num_inferred_values = nullptr);
 
 ONNX_API void InferShapes(
     const std::string& model_path,

--- a/onnx/test/shape_inference_test.py
+++ b/onnx/test/shape_inference_test.py
@@ -12995,6 +12995,73 @@ class TestShapeInference(TestShapeInferenceHelper):
         ):
             onnx.shape_inference.infer_shapes(Path("model.onnx"))
 
+    def test_infer_shapes_and_report_counts_inferred_values(self) -> None:
+        # Two chained Adds: "t" is a brand-new value_info and "out" is a graph
+        # output whose shape is unknown before inference. Both are inferred.
+        model = onnx.parser.parse_model(
+            """
+            <ir_version: 8, opset_import: [ "" : 18 ]>
+            g (float[3,4] X, float[3,4] Y) => (out) {
+                t = Add(X, Y)
+                out = Add(t, Y)
+            }
+            """
+        )
+        inferred, num_inferred_values = onnx.shape_inference.infer_shapes_and_report(
+            model, strict_mode=True
+        )
+        assert num_inferred_values == 2
+        # The reported model matches plain infer_shapes exactly.
+        assert (
+            inferred.SerializeToString()
+            == onnx.shape_inference.infer_shapes(
+                model, strict_mode=True
+            ).SerializeToString()
+        )
+
+    def test_infer_shapes_and_report_is_idempotent(self) -> None:
+        # Re-running inference on an already-inferred model reports zero changes,
+        # because no previously-unknown type/shape actually becomes known.
+        model = onnx.parser.parse_model(
+            """
+            <ir_version: 8, opset_import: [ "" : 18 ]>
+            g (float[3,4] X, float[3,4] Y) => (out) {
+                t = Add(X, Y)
+                out = Add(t, Y)
+            }
+            """
+        )
+        inferred, first_count = onnx.shape_inference.infer_shapes_and_report(
+            model, strict_mode=True
+        )
+        assert first_count > 0
+        _, second_count = onnx.shape_inference.infer_shapes_and_report(
+            inferred, strict_mode=True
+        )
+        assert second_count == 0
+
+    def test_infer_shapes_and_report_accepts_bytes(self) -> None:
+        model = onnx.parser.parse_model(
+            """
+            <ir_version: 8, opset_import: [ "" : 18 ]>
+            g (float[3,4] X, float[3,4] Y) => (out) {
+                out = Add(X, Y)
+            }
+            """
+        )
+        inferred, num_inferred_values = onnx.shape_inference.infer_shapes_and_report(
+            model.SerializeToString(), strict_mode=True
+        )
+        assert isinstance(inferred, ModelProto)
+        assert num_inferred_values == 1
+
+    def test_infer_shapes_and_report_pathlike_error(self) -> None:
+        with pytest.raises(
+            TypeError,
+            match=r"For Model paths \(str or os.PathLike\), use infer_shapes_path\(\)\.",
+        ):
+            onnx.shape_inference.infer_shapes_and_report(Path("model.onnx"))
+
 
 class TestCustomSchemaShapeInference(TestShapeInferenceHelper):
     custom_op_type: str = "CustomOp"


### PR DESCRIPTION
### Motivation and Context

Fixes #

Shape inference had no way to report how many graph values it actually changed during a pass. This adds an opt-in reporting path that returns the number of graph values (value_info entries of the main graph) that were newly inferred or whose type/shape was updated.

A value is counted only when a previously-unknown element type, rank, or dimension actually becomes known; re-inferring already-known information does not increase the count (running inference on an already-inferred model reports zero changes).

Implementation:
- mergeShapesAndTypes overloads now return whether the existing type was actually modified. Existing callers may ignore the return value.
- ShapeInferenceImplBase tracks a per-pass counter, incremented in UpdateType for newly-added and actually-changed values.
- InferShapesImpl and InferShapes(ModelProto&, ...) gain an optional trailing out-parameter, keeping existing signatures backward compatible.
- New Python binding infer_shapes_and_report and wrapper returning (ModelProto, int). The existing infer_shapes API is unchanged.


Claude-Session: https://claude.ai/code/session_01AwSCH6MvnGruXDxPP1dY7N
