### PR TITLE
QuantizeLinear reference implementation turns -0.0 into +0.0 for no-Inf/NaN low-precision float type

### DIFF
--- a/onnx/reference/ops/op_quantize_linear.py
+++ b/onnx/reference/ops/op_quantize_linear.py
@@ -75,11 +75,8 @@ class _CommonQuantizeLinear(OpRun):
             )
 
         # Compute
-        zero_point = (
-            _reshape_input(zero_point, x.shape, axis, block_size)
-            if zero_point is not None
-            else 0
-        )
+        if zero_point is not None:
+            zero_point = _reshape_input(zero_point, x.shape, axis, block_size)
         if precision:
             precision_np = tensor_dtype_to_np_dtype(precision)
             x = x.astype(precision_np) / y_scale.astype(precision_np)
@@ -88,7 +85,8 @@ class _CommonQuantizeLinear(OpRun):
 
         if tensor_type in _QUANT_INTEGER_RANGES:
             xi = np.rint(x).astype(np.int32)
-            xi += zero_point
+            if zero_point is not None:
+                xi += zero_point
             dtype = tensor_dtype_to_np_dtype(tensor_type)
             quant_range = _QUANT_INTEGER_RANGES[tensor_type]
             return (np.clip(xi, quant_range[0], quant_range[1]).astype(dtype),)
@@ -108,7 +106,8 @@ class _CommonQuantizeLinear(OpRun):
             return (x.astype(tensor_dtype_to_np_dtype(tensor_type)),)
 
         if tensor_type == TensorProto.FLOAT4E2M1:
-            x += zero_point
+            if zero_point is not None:
+                x = x + zero_point
             return (x.astype(tensor_dtype_to_np_dtype(tensor_type)),)
 
         raise ValueError(

--- a/onnx/test/reference_evaluator_test.py
+++ b/onnx/test/reference_evaluator_test.py
@@ -5793,6 +5793,30 @@ class TestReferenceEvaluator:
         got = ref.run(None, {"X": np.asarray(data)})
         assert_allclose(got[0], expected)
 
+    def test_quantize_linear_float4e2m1_signed_zero(self):
+        X = make_tensor_value_info("X", TensorProto.FLOAT, [None])
+        Y = make_tensor_value_info("Y", TensorProto.FLOAT4E2M1, [None])
+        model = make_model(
+            make_graph(
+                [
+                    make_node(
+                        "QuantizeLinear",
+                        ["X", "scale"],
+                        ["Y"],
+                        output_dtype=TensorProto.FLOAT4E2M1,
+                    ),
+                ],
+                "g",
+                [X],
+                [Y],
+                [make_tensor("scale", TensorProto.FLOAT, [1], [1.0])],
+            )
+        )
+        ref = ReferenceEvaluator(model)
+        data = np.array([-0.0, 0.0], dtype=np.float32)
+        got = ref.run(None, {"X": data})
+        assert np.signbit(got[0].astype(np.float32)).tolist() == [True, False]
+
     @pytest.mark.parametrize("cast_from", (TensorProto.FLOAT, TensorProto.FLOAT16))
     @pytest.mark.parametrize("cast_to", (TensorProto.UINT4, TensorProto.INT4))
     def test_cast_int4_output(self, cast_from, cast_to):


### PR DESCRIPTION
The functional fix (skip the `+ zero_point` addition when the optional zero-point input is absent, so `-0.0` keeps its sign bit before the FLOAT4E2M1 downcast) and its regression test are unchanged from the reviewed commits. A third commit adds `# noqa: PLR0917` to the five pre-existing too-many-positional-arguments sites in the two touched files, which ruff reports whenever either file is edited. That clears exactly what the linter flagged without altering any signature or behaviour.

Fixes #8227

### Testing
[targeted; 3 commit(s) checked individually] $ /Users/m2/Documents/PW/github-bot/work/onnx__onnx/8227/.contrib-venv/bin/python -m pytest -q --no-header onnx/test/reference_evaluator_test.py

