### PR TITLE
Mark Range operator as deterministic

### DIFF
--- a/onnx/defs/generator/defs.cc
+++ b/onnx/defs/generator/defs.cc
@@ -404,6 +404,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "T",
             {types::Float, types::Double, types::Int16, types::Int32, types::Int64, types::Float16, types::BFloat16},
             "Constrain input types to common numeric type tensors.")
+        .SetNodeDeterminism(OpSchema::NodeDeterminism::Deterministic)
         .SetContextDependentFunctionBodyBuilder(BuildFunctionBodyRange27)
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
           // Type inference

--- a/onnx/defs/generator/old.cc
+++ b/onnx/defs/generator/old.cc
@@ -969,6 +969,7 @@ ONNX_OPERATOR_SET_SCHEMA(
             "T",
             {"tensor(float)", "tensor(double)", "tensor(int16)", "tensor(int32)", "tensor(int64)"},
             "Constrain input types to common numeric type tensors.")
+        .SetNodeDeterminism(OpSchema::NodeDeterminism::Deterministic)
         .FunctionBody(R"ONNX(
           {
             sub_result = Sub (limit, start)

--- a/onnx/test/schema_test.py
+++ b/onnx/test/schema_test.py
@@ -53,6 +53,11 @@ class TestSchema:
             == defs.OpSchema.NodeDeterminism.Deterministic
         )
         assert not cast_like_schema.non_deterministic
+        range_schema = defs.get_schema("Range")
+        assert (
+            range_schema.node_determinism == defs.OpSchema.NodeDeterminism.Deterministic
+        )
+        assert not range_schema.non_deterministic
         if_schema = defs.get_schema("If")
         assert (
             if_schema.node_determinism == defs.OpSchema.NodeDeterminism.NonDeterministic


### PR DESCRIPTION
### Motivation and Context

The Range operator is defined via a function body: opset 11 uses a plain FunctionBody containing a Loop (whose graph attribute makes it look non-deterministic to the auto-detection in GetNodeDeterminism), and opset 27 uses a context-dependent function body (which resolves to Unknown). As a result, Range was reported as non-deterministic, causing constant-folding passes to skip it even though its output is fully determined by its inputs.

Explicitly mark both Range schema versions as Deterministic, mirroring how CastLike (also backed by a context-dependent function body) is handled. Add a determinism assertion for Range to schema_test.py.


Claude-Session: https://claude.ai/code/session_01KhxWeAaSGL4RrnU6ALDgzM

Ref https://github.com/onnxsim/onnxsim/pull/525



Fixes #
