### PR TITLE
Fix CI failures on main after the sanitizer PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,10 @@
 name: CI
 
 env:
-  ASAN_OPTIONS: detect_leaks=0:symbolize=1:detect_stack_use_after_return=true:strict_init_order=true:detect_odr_violation=1:detect_container_overflow=1:check_initialization_order=true:debug=true:fast_unwind_on_malloc=1:verify_asan_link_order=0:alloc_dealloc_mismatch=1:abort_on_error=1
+  # detect_container_overflow is off: CPython, protobuf and googletest are built
+  # without instrumentation, so their containers lack the annotations ASan expects
+  # and the check reports false positives.
+  ASAN_OPTIONS: detect_leaks=0:symbolize=1:detect_stack_use_after_return=true:strict_init_order=true:detect_odr_violation=1:detect_container_overflow=0:check_initialization_order=true:debug=true:fast_unwind_on_malloc=1:verify_asan_link_order=0:alloc_dealloc_mismatch=1:abort_on_error=1
   UBSAN_OPTIONS: print_stacktrace=1
   TSAN_OPTIONS: suppressions=./tsan.supp
 
@@ -223,8 +226,6 @@ jobs:
         # Prohibitively slow for Windows debug builds
         if: ${{ !(startsWith(matrix.os, 'windows') && matrix.debug_build == 1) }}
         run: |
-          # LD_PRELOAD'd ASan trips a protobuf RepeatedField false positive (protobuf #13115); keep the check on for gtests, disable it only here.
-          if [ -n "$LD_PRELOAD" ]; then export ASAN_OPTIONS="${ASAN_OPTIONS//detect_container_overflow=1/detect_container_overflow=0}"; fi
           pytest -sv --cov=onnx --cov-report=xml --cov-append --cov-branch --junitxml junit.xml -n auto --dist loadscope
       - name: Run C++ tests
         if: startsWith(matrix.os,'ubuntu') || matrix.os == 'macos-latest'

--- a/onnx/defs/tensor_proto_util.cc
+++ b/onnx/defs/tensor_proto_util.cc
@@ -125,7 +125,10 @@ namespace ONNX_NAMESPACE {
     /* copying as the underlying type, otherwise we may hit memory   */                                              \
     /* misalignment issues on certain platforms, such as arm32-v7a */                                                \
     res.resize(required_bytes_sz / element_size);                                                                    \
-    memcpy(reinterpret_cast<char*>(res.data()), bytes, required_bytes_sz);                                           \
+    /* memcpy requires a non-null destination even for a zero-length copy */                                         \
+    if (required_bytes_sz != 0) {                                                                                    \
+      memcpy(reinterpret_cast<char*>(res.data()), bytes, required_bytes_sz);                                         \
+    }                                                                                                                \
     return res;                                                                                                      \
   }
 


### PR DESCRIPTION
`main` has been red since #7471.

- **Windows test jobs (all four)** — the `Run Python tests` step gained a bash guard, but that step runs under pwsh on Windows (`Missing '(' after 'if'`). Windows builds pass no `ONNX_USE_ASAN`, so the guard was pointless there; removed.
- **`ubuntu-24.04, 3.14, debug=1`** — `onnx_gtests` aborted (exit 134) with `container-overflow` inside googletest's `UnitTestFilter`. This job builds with `-DONNX_USE_ASAN=ON` for the first time, but googletest, internal protobuf and CPython stay uninstrumented, so the check misfires. `detect_container_overflow` is now off in the workflow-level `ASAN_OPTIONS`; that job is the only ASan consumer here, and it covers both the pytest and C++ steps.
- **UBSan** — the same job logged `tensor_proto_util.cc:149:1: null pointer passed as argument 1`. A zero-element tensor resizes the result vector to 0, whose `data()` is null, so even a 0-byte `memcpy` is UB. Guarded on a non-zero size.

 