### PR TITLE
Set PLR0913/PLR0917 thresholds and fix RUF036

### DIFF
--- a/onnx/reference/ops/_op_list.py
+++ b/onnx/reference/ops/_op_list.py
@@ -509,10 +509,10 @@ def _build_registered_operators() -> dict[str, dict[int | None, type[OpRun]]]:
 def load_op(
     domain: str,
     op_type: str,
-    version: None | int = None,
+    version: int | None = None,
     custom: Any = None,
-    node: None | NodeProto = None,
-    input_types: None | list[TypeProto] = None,
+    node: NodeProto | None = None,
+    input_types: list[TypeProto] | None = None,
     expand: bool = False,
     evaluator_cls: type | None = None,
 ) -> Any:

--- a/onnx/reference/ops/aionnx_preview/_op_list.py
+++ b/onnx/reference/ops/aionnx_preview/_op_list.py
@@ -23,7 +23,7 @@ def _build_registered_operators() -> dict[str, dict[int | None, type[OpRun]]]:
 def load_op(
     domain: str,
     op_type: str,
-    version: None | int,
+    version: int | None,
     custom: Any = None,
 ) -> Any:
     """Loads the implemented for a specified operator.

--- a/onnx/reference/ops/aionnx_preview_training/_op_list.py
+++ b/onnx/reference/ops/aionnx_preview_training/_op_list.py
@@ -27,7 +27,7 @@ def _build_registered_operators() -> dict[str, dict[int | None, type[OpRun]]]:
 def load_op(
     domain: str,
     op_type: str,
-    version: None | int,
+    version: int | None,
     custom: Any = None,
 ) -> Any:
     """Loads the implemented for a specified operator.

--- a/onnx/reference/ops/aionnxml/_op_list.py
+++ b/onnx/reference/ops/aionnxml/_op_list.py
@@ -59,7 +59,7 @@ def _build_registered_operators() -> dict[str, dict[int | None, type[OpRun]]]:
 def load_op(
     domain: str,
     op_type: str,
-    version: None | int,
+    version: int | None,
     custom: Any = None,
 ) -> Any:
     """Loads the implemented for a specified operator.

--- a/onnx/reference/ops/experimental/_op_list.py
+++ b/onnx/reference/ops/experimental/_op_list.py
@@ -18,7 +18,7 @@ def _build_registered_operators() -> dict[str, dict[int | None, type[OpRun]]]:
 def load_op(
     domain: str,
     op_type: str,
-    version: None | int,
+    version: int | None,
     custom: Any = None,
 ) -> Any:
     """Loads the implemented for a specified operator.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,7 +224,6 @@ lint.ignore = [
     "N999", # Module names
     "NPY002", # np.random.Generator may not be preferred in all cases
     "PLR0912", # Too many branches
-    "PLR0913", # Too many arguments to function call
     "PLR0915", # Too many statements
     "PYI011", # Allow protobuf enums as defaults to function arguments
     "PYI021", # Allow docstrings in pyi files
@@ -247,6 +246,11 @@ builtins-ignorelist = ["id", "input"]
 # Disallow all relative imports.
 ban-relative-imports = "all"
 
+[tool.ruff.lint.pylint]
+# 13 is the widest public signature we keep for backward compatibility (compose.merge_models).
+max-args = 13
+max-positional-args = 13
+
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
@@ -264,8 +268,17 @@ required-imports = ["from __future__ import annotations"]
     "N801", # Class casing
     "PLR2004", # Magic numbers
 ]
+# Op implementations take one parameter per input and attribute, fixed by the schema.
+"onnx/backend/test/case/node/**" = ["PLR0913", "PLR0917"]
+"onnx/reference/ops*/**" = ["PLR0913", "PLR0917"]
 "onnx/test/reference_evaluator_test.py" = ["C408"]  # dict(...) -> { ... }
-"onnx/test/**" = ["PLR2004", "S311", "T20"] # Magic numbers, non-crypto random, print allowed in tests
+"onnx/test/**" = [
+    "PLR2004", # Magic numbers
+    "S311", # Non-crypto random
+    "T20", # print
+    "PLR0913", # Parametrized tests take one parameter per parametrize column
+    "PLR0917", # Ditto
+]
 "onnx/onnx_cpp2py_export/defs.pyi" = ["N802"]
 "onnx/fuzz/**" = [
     "N802",     # TestOneInput is the required atheris entry-point name


### PR DESCRIPTION
Ruff 0.16 stabilizes `PLR0917` (too-many-positional-arguments) and `RUF036` (none-not-at-end-of-union), which currently fail the style job on #8239.

- Drop `PLR0913` from the ignore list and set `max-args`/`max-positional-args` to 13, the widest public signature we keep for backward compatibility (`compose.merge_models`).
- Exempt op implementations (parameters follow the op schema) and parametrized tests via per-file-ignores.
- Move `None` to the end of unions in the reference op registries.

Verified clean with both ruff 0.15.19 (currently pinned) and 0.16.0.