### PR TITLE
Fix clang-tidy CI issue

### DIFF
--- a/onnx/version_converter/adapters/resize_18_17.h
+++ b/onnx/version_converter/adapters/resize_18_17.h
@@ -12,8 +12,7 @@
 #include "onnx/common/interned_strings.h"
 #include "onnx/version_converter/adapters/adapter.h"
 
-namespace ONNX_NAMESPACE {
-namespace version_conversion {
+namespace ONNX_NAMESPACE::version_conversion {
 
 class Resize_18_17 final : public Adapter {
  public:
@@ -74,5 +73,4 @@ class Resize_18_17 final : public Adapter {
   }
 };
 
-} // namespace version_conversion
-} // namespace ONNX_NAMESPACE
+} // namespace ONNX_NAMESPACE::version_conversion


### PR DESCRIPTION
I think we had a little race condition between PRs, leading to clang-tidy failing on main. This should fix it.

