### PR TITLE
Strip PYTHONHOME/PYTHONPATH before delegating to pixi in pixi-shim.py

### DIFF
--- a/tools/pixi-shim.py
+++ b/tools/pixi-shim.py
@@ -14,6 +14,7 @@ The 'default' environment is used if Pixi is available.
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import sys
@@ -22,7 +23,15 @@ import warnings
 args = sys.argv[1:]
 
 if shutil.which("pixi"):
-    raise SystemExit(subprocess.call(["pixi", "run", "--", *args]))  # noqa: S603, S607
+    # Some Python distributions (e.g. standalone builds managed by uv) set
+    # PYTHONHOME/PYTHONPATH for themselves. Inherited by this subprocess, those
+    # variables leak into whichever interpreter pixi activates for the target
+    # environment and make it look for packages in the wrong place, so strip
+    # them and let pixi fully manage the environment.
+    env = os.environ.copy()
+    env.pop("PYTHONHOME", None)
+    env.pop("PYTHONPATH", None)
+    raise SystemExit(subprocess.call(["pixi", "run", "--", *args], env=env))  # noqa: S603, S607
 
 warnings.warn(
     "pixi not found. Running tools directly from PATH. "


### PR DESCRIPTION
python3 -m tools.pixi-shim invokes pixi as a subprocess, inheriting the calling interpreter's environment. Some Python distributions (e.g. standalone builds managed by uv) set PYTHONHOME for themselves; left in place, it leaks into whichever interpreter pixi activates for the target environment and makes it resolve the standard library location instead of that environment's site-packages, so tools like reuse fail with ModuleNotFoundError even though the environment is set up correctly.



### Motivation and Context

Fixes #
