### PR TITLE
fix: validate raw_data for segmented tensors

### DIFF
--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -175,66 +175,51 @@ void check_tensor(const TensorProto& tensor, const CheckerContext& ctx) {
     if (tensor.data_type() == TensorProto::STRING) {
       fail_check("STRING data (tensor name: ", tensor.name(), ") should not be stored in raw_data field");
     }
-    // Validate that raw_data is large enough for the declared shape and type: either a
-    // packed sub-byte type (2 or 4 elements per byte) or a regular, byte-aligned type.
-    int64_t expected_bytes = 0;
-    int64_t bytes_per_elem = 0;
-    switch (tensor.data_type()) {
-      case TensorProto::UINT4:
-      case TensorProto::INT4:
-      case TensorProto::FLOAT4E2M1:
-        expected_bytes = (nelem + 1) / 2; // 2 elements per byte, ceiling division
-        break;
-      case TensorProto::UINT2:
-      case TensorProto::INT2:
-        expected_bytes = (nelem + 3) / 4; // 4 elements per byte, ceiling division
-        break;
-      case TensorProto::UINT8:
-      case TensorProto::INT8:
-      case TensorProto::BOOL:
-      case TensorProto::FLOAT8E4M3FN:
-      case TensorProto::FLOAT8E4M3FNUZ:
-      case TensorProto::FLOAT8E5M2:
-      case TensorProto::FLOAT8E5M2FNUZ:
-      case TensorProto::FLOAT8E8M0:
-        bytes_per_elem = 1;
-        break;
-      case TensorProto::UINT16:
-      case TensorProto::INT16:
-      case TensorProto::FLOAT16:
-      case TensorProto::BFLOAT16:
-        bytes_per_elem = 2;
-        break;
-      case TensorProto::FLOAT:
-      case TensorProto::INT32:
-      case TensorProto::UINT32:
-        bytes_per_elem = 4;
-        break;
-      case TensorProto::DOUBLE:
-      case TensorProto::INT64:
-      case TensorProto::UINT64:
-      case TensorProto::COMPLEX64: // 2 x float32
-        bytes_per_elem = 8;
-        break;
-      case TensorProto::COMPLEX128: // 2 x float64
-        bytes_per_elem = 16;
-        break;
-      default:
-        break;
+    // For segmented tensors, dims describe the full tensor; segment describes the stored chunk.
+    int64_t described_elems = nelem;
+    if (tensor.has_segment()) {
+      const auto& seg = tensor.segment();
+      if (!seg.has_begin() || !seg.has_end()) {
+        fail_check("TensorProto segment must set begin and end (tensor name: ", tensor.name(), ")");
+      }
+      const int64_t begin = seg.begin();
+      const int64_t end = seg.end();
+      if (begin < 0 || end < begin || end > nelem) {
+        fail_check(
+            "Invalid TensorProto segment (tensor name: ",
+            tensor.name(),
+            "): [",
+            begin,
+            ", ",
+            end,
+            ") out of [0, ",
+            nelem,
+            ")");
+      }
+      described_elems = end - begin;
     }
-    if (bytes_per_elem > 0 && checked_mul_overflow(nelem, bytes_per_elem, &expected_bytes)) {
-      fail_check(
-          "TensorProto (tensor name: ", tensor.name(), ") has a shape too large to validate against its data type.");
+    const int64_t bit_width = ElementBitWidth(tensor.data_type());
+    if (bit_width < 0) {
+      fail_check("Unrecognized data_type (tensor name: ", tensor.name(), "): ", tensor.data_type());
     }
-    if (expected_bytes > 0 && static_cast<int64_t>(tensor.raw_data().size()) < expected_bytes) {
-      fail_check(
-          "TensorProto (tensor name: ",
-          tensor.name(),
-          ") raw_data size (",
-          tensor.raw_data().size(),
-          " bytes) is too small for the declared shape and type (",
-          expected_bytes,
-          " bytes required).");
+    if (described_elems > 0) {
+      int64_t total_bits = 0;
+      if (checked_mul_overflow(described_elems, bit_width, &total_bits) ||
+          checked_add_overflow(total_bits, 7, &total_bits)) {
+        fail_check("Tensor byte size overflow (tensor name: ", tensor.name(), ")");
+      }
+      const int64_t expected_bytes = total_bits / 8;
+      const int64_t actual_bytes = static_cast<int64_t>(tensor.raw_data().size());
+      if (actual_bytes < expected_bytes) {
+        fail_check(
+            "TensorProto (tensor name: ",
+            tensor.name(),
+            ") raw_data size (",
+            actual_bytes,
+            " bytes) is too small for the declared shape and type (",
+            expected_bytes,
+            " bytes required).");
+      }
     }
     return;
   } else {

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -178,45 +178,6 @@ ONNX_OPERATOR_SET_SCHEMA(
             OpSchema::all_non_string_tensor_types_ir13(),
             "Constrain output types. Bitcasting to string is not supported.")
         .TypeAndShapeInferenceFunction([](InferenceContext& ctx) {
-          auto get_bit_size = [](int element_type) -> int {
-            switch (element_type) {
-              case TensorProto::FLOAT:
-              case TensorProto::INT32:
-              case TensorProto::UINT32:
-                return 32;
-              case TensorProto::DOUBLE:
-              case TensorProto::INT64:
-              case TensorProto::UINT64:
-              case TensorProto::COMPLEX64:
-                return 64;
-              case TensorProto::COMPLEX128:
-                return 128;
-              case TensorProto::FLOAT16:
-              case TensorProto::BFLOAT16:
-              case TensorProto::INT16:
-              case TensorProto::UINT16:
-                return 16;
-              case TensorProto::INT8:
-              case TensorProto::UINT8:
-              case TensorProto::BOOL:
-              case TensorProto::FLOAT8E4M3FN:
-              case TensorProto::FLOAT8E4M3FNUZ:
-              case TensorProto::FLOAT8E5M2:
-              case TensorProto::FLOAT8E5M2FNUZ:
-              case TensorProto::FLOAT8E8M0:
-                return 8;
-              case TensorProto::INT4:
-              case TensorProto::UINT4:
-              case TensorProto::FLOAT4E2M1:
-                return 4;
-              case TensorProto::INT2:
-              case TensorProto::UINT2:
-                return 2;
-              default:
-                return 0;
-            }
-          };
-
           // Validate that input and output types have the same bit-width
           auto input_type = ctx.getInputType(0);
           if (input_type && input_type->has_tensor_type()) {
@@ -224,9 +185,9 @@ ONNX_OPERATOR_SET_SCHEMA(
             auto* to_attr = ctx.getAttribute("to");
             if (to_attr) {
               auto output_element_type = static_cast<int32_t>(to_attr->i());
-              int input_element_bit_size = get_bit_size(input_element_type);
-              int output_element_bit_size = get_bit_size(output_element_type);
-              if (input_element_bit_size != 0 && output_element_bit_size != 0 &&
+              int64_t input_element_bit_size = ElementBitWidth(input_element_type);
+              int64_t output_element_bit_size = ElementBitWidth(output_element_type);
+              if (input_element_bit_size > 0 && output_element_bit_size > 0 &&
                   input_element_bit_size != output_element_bit_size) {
                 fail_shape_inference(
                     "BitCast requires input and output types to have the same bit-width, but input type has ",

--- a/onnx/defs/tensor_proto_util.cc
+++ b/onnx/defs/tensor_proto_util.cc
@@ -13,6 +13,45 @@
 
 namespace ONNX_NAMESPACE {
 
+int64_t ElementBitWidth(int32_t data_type) {
+  switch (data_type) {
+    case TensorProto::COMPLEX128:
+      return 128;
+    case TensorProto::DOUBLE:
+    case TensorProto::COMPLEX64:
+    case TensorProto::INT64:
+    case TensorProto::UINT64:
+      return 64;
+    case TensorProto::FLOAT:
+    case TensorProto::INT32:
+    case TensorProto::UINT32:
+      return 32;
+    case TensorProto::INT16:
+    case TensorProto::UINT16:
+    case TensorProto::FLOAT16:
+    case TensorProto::BFLOAT16:
+      return 16;
+    case TensorProto::INT8:
+    case TensorProto::UINT8:
+    case TensorProto::BOOL:
+    case TensorProto::FLOAT8E4M3FN:
+    case TensorProto::FLOAT8E4M3FNUZ:
+    case TensorProto::FLOAT8E5M2:
+    case TensorProto::FLOAT8E5M2FNUZ:
+    case TensorProto::FLOAT8E8M0:
+      return 8;
+    case TensorProto::UINT4:
+    case TensorProto::INT4:
+    case TensorProto::FLOAT4E2M1:
+      return 4;
+    case TensorProto::UINT2:
+    case TensorProto::INT2:
+      return 2;
+    default:
+      return -1;
+  }
+}
+
 int64_t RawDataElementCount(const TensorProto& tensor, size_t element_size, bool exact_fit) {
   const int64_t num_elements = safe_dim_product(
       tensor.dims(), [&](const char* msg) { fail_shape_inference(msg, " for tensor: ", tensor.name()); });

--- a/onnx/defs/tensor_proto_util.h
+++ b/onnx/defs/tensor_proto_util.h
@@ -15,6 +15,9 @@
 
 namespace ONNX_NAMESPACE {
 
+// Returns bits per element of a tensor element type, or -1 if unknown.
+ONNX_API int64_t ElementBitWidth(int32_t data_type);
+
 template <typename T>
 ONNX_API TensorProto ToTensor(const T& value);
 

--- a/tests/python/checker_test.py
+++ b/tests/python/checker_test.py
@@ -1452,6 +1452,87 @@ class TestChecker:
         tensor3.name = "t"
         checker.check_tensor(tensor3)
 
+    @staticmethod
+    def _raw_data_tensor(dtype: int, dims: list[int], nbytes: int) -> TensorProto:
+        tensor = TensorProto()
+        tensor.data_type = dtype
+        tensor.dims.extend(dims)
+        tensor.name = "t"
+        tensor.raw_data = b"\x00" * nbytes
+        return tensor
+
+    def test_check_tensor_raw_data_size(self) -> None:
+        """Reject whole-byte tensors whose raw_data payload is too small."""
+        # (data type, bytes per element)
+        cases = [
+            (TensorProto.BOOL, 1),
+            (TensorProto.UINT8, 1),
+            (TensorProto.FLOAT8E4M3FN, 1),
+            (TensorProto.FLOAT16, 2),
+            (TensorProto.BFLOAT16, 2),
+            (TensorProto.FLOAT, 4),
+            (TensorProto.INT32, 4),
+            (TensorProto.DOUBLE, 8),
+            (TensorProto.INT64, 8),
+            (TensorProto.COMPLEX64, 8),
+            (TensorProto.COMPLEX128, 16),
+        ]
+        for dtype, elem_size in cases:
+            with pytest.raises(checker.ValidationError):
+                checker.check_tensor(
+                    self._raw_data_tensor(dtype, [4], 4 * elem_size - 1)
+                )
+            # Exactly enough bytes must pass.
+            checker.check_tensor(self._raw_data_tensor(dtype, [4], 4 * elem_size))
+
+        # Trailing bytes are accepted: external data loaded without a length key reads to EOF.
+        checker.check_tensor(self._raw_data_tensor(TensorProto.FLOAT, [4], 64))
+
+        # Segmented tensors use the segment range instead of dims; raw_data holds one
+        # chunk of length end - begin, and begin/end must lie in [0, nelem].
+        tensor = self._raw_data_tensor(TensorProto.FLOAT, [1000], 16)
+        tensor.segment.begin = 0
+        tensor.segment.end = 4
+        checker.check_tensor(tensor)
+
+        # Segment missing begin or end.
+        for kwargs in ({"begin": 0}, {"end": 4}):
+            bad = self._raw_data_tensor(TensorProto.FLOAT, [1000], 16)
+            for k, v in kwargs.items():
+                setattr(bad.segment, k, v)
+            with pytest.raises(checker.ValidationError):
+                checker.check_tensor(bad)
+
+        # Segment begin < 0.
+        bad = self._raw_data_tensor(TensorProto.FLOAT, [1000], 16)
+        bad.segment.begin = -1
+        bad.segment.end = 4
+        with pytest.raises(checker.ValidationError):
+            checker.check_tensor(bad)
+
+        # Segment end > nelem.
+        bad = self._raw_data_tensor(TensorProto.FLOAT, [1000], 16)
+        bad.segment.begin = 0
+        bad.segment.end = 1001
+        with pytest.raises(checker.ValidationError):
+            checker.check_tensor(bad)
+
+        # An unrecognized data_type has no known element size.
+        with pytest.raises(checker.ValidationError):
+            checker.check_tensor(self._raw_data_tensor(99, [4], 16))
+
+        # Byte-size overflow is reported instead of overflowing int64 internally.
+        # 2**63 - 1 elements overflow the multiplication; (2**63 - 2) // 2 two-bit
+        # elements fit it, and overflow the rounding-up addition instead.
+        with pytest.raises(checker.ValidationError):
+            checker.check_tensor(
+                self._raw_data_tensor(TensorProto.FLOAT, [2**63 - 1], 1)
+            )
+        with pytest.raises(checker.ValidationError):
+            checker.check_tensor(
+                self._raw_data_tensor(TensorProto.INT2, [(2**63 - 2) // 2], 1)
+            )
+
     def test_check_tensor_packed_subbyte_raw_data(self) -> None:
         """Reject packed sub-byte tensors whose raw_data payload is too small."""
         # 4-bit types (INT4, UINT4, FLOAT4E2M1): 2 elements per byte.


### PR DESCRIPTION
### Motivation and Context

Commit [1c1a28d61](https://github.com/onnx/onnx/pull/8319) extended `check_tensor`'s raw_data size check to all element types, but it wrongly rejects segmented tensors: their `dims` describe the full tensor, while `raw_data` holds a single chunk of length `end - begin`. A segmented tensor that is otherwise valid now fails the checker.

This PR fixes the regression by computing the expected raw_data size from the segment range instead of `nelem`, and validates that `begin`/`end` lie within `[0, nelem]`.

While here, move the per-element bit-width table out of `tensor/defs.cc` into `tensor_proto_util.{h,cc}` as a public `ONNX_API` helper so the checker and BitCast shape inference share one copy.