### PR TITLE
Make opaque type unconditional

### DIFF
--- a/docs/ONNXTypes.md
+++ b/docs/ONNXTypes.md
@@ -8,23 +8,30 @@ SPDX-License-Identifier: Apache-2.0
 
 ## Opaque Type
 
-An Opaque type (`TypeProto.Opaque`) represents a value whose internal
-representation is not defined by the ONNX spec. It is identified by a
-`(domain, name)` pair, analogous to how a custom op is identified by a
-`(domain, op_type)` pair: the meaning and internal representation of an
-Opaque type are defined by, and only need to be understood by, the
-producer/consumer of the custom-domain ops that use it. ONNX itself treats
-values of an Opaque type as unstructured/unknown data (with type identified
-solely by `domain` and `name`) that gets passed between nodes.
+An Opaque type (`TypeProto.Opaque`) enables the definition of user-defined
+types, beyond the built-in kinds (tensors, sequences, maps, optionals, and
+sparse tensors) that ONNX defines directly in its proto schema. It is
+identified by a `(domain, name)` pair, analogous to how a custom op is
+identified by a `(domain, op_type)` pair: the meaning of an Opaque type is
+defined by, and only needs to be understood by, the producer/consumer of
+the custom-domain ops that use it. As with all ONNX types (including
+Tensor), the ONNX spec does not define how a value of an Opaque type is
+represented internally by a backend -- that is entirely up to the
+implementation. ONNX itself just treats an Opaque-typed value as an opaque
+piece of data (identified solely by its `domain` and `name`) that gets
+passed between nodes.
 
 ### Use-cases
 
-Opaque types let a custom domain introduce new kinds of values -- beyond
-tensors, sequences, maps, optionals, and sparse tensors -- that are only
-meaningful to the ops of that domain, without requiring any change to the
-ONNX spec itself. A typical use-case is a stateful *handle* (e.g., a file
-handle, a database connection, or a random-number generator) that is
-created by one custom op and consumed by others.
+Opaque types let a custom domain introduce new kinds of values -- along
+with custom ops that produce/consume them -- that are only meaningful to
+the ops of that domain, without requiring any change to the ONNX spec
+itself. This is useful, for example, to represent a stateful *handle*
+(e.g., a file handle, a database connection, or a random-number
+generator) that is created by one custom op and consumed by others. More
+generally, the Opaque type also gives the ONNX standard itself a way to
+introduce new built-in types in the future without needing to change the
+`TypeProto` schema.
 
 ### Example: a stateful random-number generator (RNG)
 

--- a/docs/ONNXTypes.md
+++ b/docs/ONNXTypes.md
@@ -21,6 +21,11 @@ implementation. ONNX itself just treats an Opaque-typed value as an opaque
 piece of data (identified solely by its `domain` and `name`) that gets
 passed between nodes.
 
+The `name` is required (an Opaque type must be named). The `domain`
+follows the same convention used for operator domains: it is optional,
+and an empty/unspecified `domain` is treated as equivalent to the
+standard `"ai.onnx"` domain.
+
 ### Use-cases
 
 Opaque types let a custom domain introduce new kinds of values -- along

--- a/docs/ONNXTypes.md
+++ b/docs/ONNXTypes.md
@@ -6,6 +6,81 @@ SPDX-License-Identifier: Apache-2.0
 
 # ONNX Types
 
+## Opaque Type
+
+An Opaque type (`TypeProto.Opaque`) represents a value whose internal
+representation is not defined by the ONNX spec. It is identified by a
+`(domain, name)` pair, analogous to how a custom op is identified by a
+`(domain, op_type)` pair: the meaning and internal representation of an
+Opaque type are defined by, and only need to be understood by, the
+producer/consumer of the custom-domain ops that use it. ONNX itself treats
+values of an Opaque type as unstructured/unknown data (with type identified
+solely by `domain` and `name`) that gets passed between nodes.
+
+### Use-cases
+
+Opaque types let a custom domain introduce new kinds of values -- beyond
+tensors, sequences, maps, optionals, and sparse tensors -- that are only
+meaningful to the ops of that domain, without requiring any change to the
+ONNX spec itself. A typical use-case is a stateful *handle* (e.g., a file
+handle, a database connection, or a random-number generator) that is
+created by one custom op and consumed by others.
+
+### Example: a stateful random-number generator (RNG)
+
+The example below illustrates using an Opaque type to represent a stateful
+random-number generator (RNG). It uses two illustrative custom ops (in a
+custom domain `test.rng`, not part of the ONNX spec):
+
+* `CreateRNG(seed) -> rng` creates a new RNG (of Opaque type
+  `test.rng.RNG`) from an integer seed.
+* `RandomTensor(rng) -> Y, rng_out` uses the given RNG to generate a
+  tensor `Y` of a requested shape (with values drawn, say, from a standard
+  normal distribution), and also returns an updated RNG `rng_out`.
+
+Note that since ONNX ops are (side-effect free) functions, `RandomTensor`
+cannot simply mutate its input RNG in place to reflect the fact that
+generating a random value conceptually advances the RNG's internal state.
+Instead, that state update is made explicit: the op returns a new/updated
+RNG as an additional output, alongside the generated tensor. A caller that
+wants to draw a sequence of random tensors would thread the RNG through a
+sequence of calls to `RandomTensor`, using the `rng_out` from one call as
+the `rng` input to the next.
+
+This example is deliberately simple: it does not implement an actual RNG
+algorithm, nor does it pin down all the details (such as the precise
+semantics of the state update) that a real-world stateful-RNG design would
+need to address. Its purpose is just to illustrate how an Opaque type can
+be declared, produced, consumed, and type/shape-inferred.
+
+A model using these ops, expressed using ONNX's text format (see
+[Syntax.md](Syntax.md)), looks like this:
+
+```
+<
+    ir_version: 10,
+    opset_import: ["": 21, "test.rng": 1]
+>
+agraph (int64 seed) => (float[2,3] Y, rng2)
+{
+    rng = test.rng.CreateRNG (seed)
+    Y, rng2 = test.rng.RandomTensor <shape = [2, 3]> (rng)
+}
+```
+
+Here, `rng` (the intermediate value produced by `CreateRNG`) and `rng2`
+(the second graph output, produced by `RandomTensor`) are both of the
+Opaque type `test.rng.RNG`. Since Opaque types are not (yet) expressible
+directly in ONNX's text format, they are left untyped in the source text
+above; running shape inference on the parsed model determines (and fills
+in) their types, based on the type/shape-inference functions registered
+for the `CreateRNG` and `RandomTensor` op schemas. See
+`tests/python/opaque_type_test.py` for a complete, runnable version of
+this example (including the schema and type/shape-inference-function
+definitions for `CreateRNG` and `RandomTensor`), which also checks that
+the resulting model passes both `onnx.checker.check_model` and
+`onnx.shape_inference.infer_shapes`.
+
 ## Optional Type
 
 An optional type represents a reference to either an element (could be Tensor, Sequence, Map, or Sparse Tensor) or a null value. The optional type appears in model inputs, outputs, as well as intermediate values.

--- a/docs/ONNXTypes.md
+++ b/docs/ONNXTypes.md
@@ -53,28 +53,32 @@ semantics of the state update) that a real-world stateful-RNG design would
 need to address. Its purpose is just to illustrate how an Opaque type can
 be declared, produced, consumed, and type/shape-inferred.
 
-A model using these ops, expressed using ONNX's text format (see
-[Syntax.md](Syntax.md)), looks like this:
+An Opaque type can be written explicitly in ONNX's text format (see
+[Syntax.md](Syntax.md)) using the syntax `opaque(domain, name)` (or
+`opaque(name)` when no domain is needed, or plain `opaque()` when neither
+is specified). A model using the `CreateRNG` and `RandomTensor` ops above,
+expressed using ONNX's text format, looks like this:
 
 ```
 <
     ir_version: 10,
     opset_import: ["": 21, "test.rng": 1]
 >
-agraph (int64 seed) => (float[2,3] Y, rng2)
+agraph (int64 seed) => (float[2,3] Y, opaque(test.rng, RNG) rng2)
 {
     rng = test.rng.CreateRNG (seed)
     Y, rng2 = test.rng.RandomTensor <shape = [2, 3]> (rng)
 }
 ```
 
-Here, `rng` (the intermediate value produced by `CreateRNG`) and `rng2`
-(the second graph output, produced by `RandomTensor`) are both of the
-Opaque type `test.rng.RNG`. Since Opaque types are not (yet) expressible
-directly in ONNX's text format, they are left untyped in the source text
-above; running shape inference on the parsed model determines (and fills
-in) their types, based on the type/shape-inference functions registered
-for the `CreateRNG` and `RandomTensor` op schemas. See
+Here, `rng2` (the second graph output, produced by `RandomTensor`) is
+explicitly declared with the Opaque type `test.rng.RNG` using the
+`opaque(test.rng, RNG)` syntax. The intermediate value `rng` (produced by
+`CreateRNG`) is left untyped in the source text above; running shape
+inference on the parsed model determines (and fills in) its type, based on
+the type/shape-inference function registered for the `CreateRNG` op
+schema -- intermediate and output values may always be left untyped in
+this way and have their types filled in by shape inference. See
 `tests/python/opaque_type_test.py` for a complete, runnable version of
 this example (including the schema and type/shape-inference-function
 definitions for `CreateRNG` and `RandomTensor`), which also checks that

--- a/docs/Syntax.md
+++ b/docs/Syntax.md
@@ -106,4 +106,8 @@ An `opaque` type is written as `opaque()`, `opaque(name)`, or
 The single-argument form `opaque(name)` (where `name` may itself be a
 dotted `qualified-id`, e.g. `opaque(test.rng.RNG)`) is parsed as `name`
 only, with `domain` left empty -- matching the existing convention used
-for type-constraint strings in operator schemas.
+for type-constraint strings in operator schemas. The grammar itself
+allows `opaque()` with neither `domain` nor `name`, but `onnx.checker`
+requires a non-empty `name` for any Opaque type that is checked; an
+empty/unspecified `domain` is treated as equivalent to the standard
+`"ai.onnx"` domain, matching the convention used for operator domains.

--- a/docs/Syntax.md
+++ b/docs/Syntax.md
@@ -49,12 +49,16 @@ The grammar below describes the syntax:
 
 ```bnf
    id-list ::= id (',' id)*
+   qualified-id ::= id ('.' id)*
    quotable-id-list ::= quotable-id (',' quotable-id)*
    tensor-dim ::= '?' | quotable-id | int-constant
    tensor-dims ::= tensor-dim (',' tensor-dim)*
    tensor-type ::= prim-type | prim-type '[' ']' | prim-type '[' tensor-dims ']'
    type ::= tensor-type | 'seq' '(' type ')' | 'map' '(' prim-type ',' type ')'
             | 'optional' '(' type ')' | 'sparse_tensor' '(' tensor-type ')'
+            | opaque-type
+   opaque-type ::= 'opaque' '(' ')' | 'opaque' '(' qualified-id ')'
+                   | 'opaque' '(' qualified-id ',' id ')'
    value-info ::= type quotable-id
    value-infos ::= value-info (',' value-info)*
    value-info-list ::= '(' value-infos? ')
@@ -95,3 +99,11 @@ The grammar below describes the syntax:
    function ::= other-data-list? id fun-attr-list? quotable-id fun-input-list '=>' fun-output-list fun-value-infos node-list
    model ::= other-data-list? graph function*
 ```
+
+An `opaque` type is written as `opaque()`, `opaque(name)`, or
+`opaque(domain, name)`, identifying a `TypeProto.Opaque` value by its
+`(domain, name)` pair (see [ONNXTypes.md](ONNXTypes.md#opaque-type)).
+The single-argument form `opaque(name)` (where `name` may itself be a
+dotted `qualified-id`, e.g. `opaque(test.rng.RNG)`) is parsed as `name`
+only, with `domain` left empty -- matching the existing convention used
+for type-constraint strings in operator schemas.

--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -99,8 +99,10 @@ void check_value_info(const ValueInfoProto& value_info, const CheckerContext& ct
       enforce_has_field(type, key_type);
       enforce_has_field(type, value_type);
     } break;
-    case TypeProto::kOpaqueType:
-      break;
+    case TypeProto::kOpaqueType: {
+      const auto& type = value_info.type().opaque_type();
+      enforce_non_empty_field(type, name);
+    } break;
     case TypeProto::kSparseTensorType: {
       const auto& type = value_info.type().sparse_tensor_type();
       enforce_has_field(type, elem_type);

--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -99,10 +99,8 @@ void check_value_info(const ValueInfoProto& value_info, const CheckerContext& ct
       enforce_has_field(type, key_type);
       enforce_has_field(type, value_type);
     } break;
-#ifdef ONNX_ML
     case TypeProto::kOpaqueType:
       break;
-#endif
     case TypeProto::kSparseTensorType: {
       const auto& type = value_info.type().sparse_tensor_type();
       enforce_has_field(type, elem_type);

--- a/onnx/defs/data_type_utils.cc
+++ b/onnx/defs/data_type_utils.cc
@@ -56,8 +56,7 @@ class StringRange final {
   StringRange(const char* data);
   const char* Data() const;
   size_t Size() const;
-  // Used only when ONNX_ML is enabled; suppress GCC -Wunused-function.
-  [[maybe_unused]] bool Empty() const;
+  bool Empty() const;
   bool StartsWith(const StringRange& str) const;
   bool EndsWith(const StringRange& str) const;
   bool LStrip();
@@ -131,7 +130,6 @@ std::string DataTypeUtils::ToString(const TypeProto& type_proto, const std::stri
       std::string map_str = "map(" + ToDataTypeString(type_proto.map_type().key_type()) + ",";
       return ToString(type_proto.map_type().value_type(), left + map_str, ")" + right);
     }
-#ifdef ONNX_ML
     case TypeProto::ValueCase::kOpaqueType: {
       std::string result;
       const auto& op_type = type_proto.opaque_type();
@@ -145,7 +143,6 @@ std::string DataTypeUtils::ToString(const TypeProto& type_proto, const std::stri
       result.append(")").append(right);
       return result;
     }
-#endif
     case TypeProto::ValueCase::kSparseTensorType: {
       // Note: We do not distinguish tensors with zero rank (a shape consisting
       // of an empty sequence of dimensions) here.
@@ -190,7 +187,6 @@ void DataTypeUtils::FromString(const std::string& type_str, TypeProto& type_prot
     FromString(std::string(v.Data(), v.Size()), *type_proto.mutable_map_type()->mutable_value_type());
     return;
   }
-#ifdef ONNX_ML
   if (s.LStrip("opaque")) {
     auto* opaque_type = type_proto.mutable_opaque_type();
     s.ParensWhitespaceStrip();
@@ -208,7 +204,6 @@ void DataTypeUtils::FromString(const std::string& type_str, TypeProto& type_prot
     }
     return;
   }
-#endif
   if (s.LStrip("sparse_tensor")) {
     s.ParensWhitespaceStrip();
     auto e = FromDataTypeString(std::string(s.Data(), s.Size()));

--- a/onnx/defs/parser.cc
+++ b/onnx/defs/parser.cc
@@ -454,6 +454,40 @@ Common::Status OnnxParser::Parse(TypeProto& typeProto) {
         MATCH(')');
         break;
       }
+      case KeyWordMap::KeyWord::OPAQUE_TYPE: {
+        // Grammar: opaque ( )
+        //          opaque ( name )
+        //          opaque ( domain , name )
+        // The optional domain (like a node's domain) may itself be a
+        // dot-separated identifier (e.g., "ai.onnx.ml"). To avoid requiring
+        // unbounded look-ahead, a single dot-separated identifier before
+        // ')' is treated as the (domain-less) name -- matching the
+        // convention used by Utils::DataTypeUtils::FromString/ToString.
+        MATCH('(');
+        auto* opaquetype = typeProto.mutable_opaque_type();
+        opaquetype->clear_domain();
+        opaquetype->clear_name();
+        if (!Matches(')')) {
+          std::string domain_or_name;
+          CHECK_PARSER_STATUS(ParseIdentifier(domain_or_name));
+          while (Matches('.')) {
+            std::string next_component;
+            CHECK_PARSER_STATUS(ParseIdentifier(next_component));
+            domain_or_name += ".";
+            domain_or_name += next_component;
+          }
+          if (Matches(',')) {
+            opaquetype->set_domain(domain_or_name);
+            std::string name;
+            CHECK_PARSER_STATUS(ParseIdentifier(name));
+            opaquetype->set_name(name);
+          } else {
+            opaquetype->set_name(domain_or_name);
+          }
+          MATCH(')');
+        }
+        break;
+      }
       default:
         return ParseError("Unexpected type.");
     }
@@ -689,6 +723,7 @@ bool OnnxParser::NextIsType() {
     case KeyWordMap::KeyWord::MAP_TYPE:
     case KeyWordMap::KeyWord::OPTIONAL_TYPE:
     case KeyWordMap::KeyWord::SPARSE_TENSOR_TYPE:
+    case KeyWordMap::KeyWord::OPAQUE_TYPE:
       return true;
     default:
       return false;

--- a/onnx/defs/parser.h
+++ b/onnx/defs/parser.h
@@ -145,6 +145,7 @@ class KeyWordMap {
     MAP_TYPE,
     OPTIONAL_TYPE,
     SPARSE_TENSOR_TYPE,
+    OPAQUE_TYPE,
     OVERLOAD_KW
   };
 
@@ -161,6 +162,7 @@ class KeyWordMap {
     map_["map"] = KeyWord::MAP_TYPE;
     map_["optional"] = KeyWord::OPTIONAL_TYPE;
     map_["sparse_tensor"] = KeyWord::SPARSE_TENSOR_TYPE;
+    map_["opaque"] = KeyWord::OPAQUE_TYPE;
     map_["overload"] = KeyWord::OVERLOAD_KW;
   }
 

--- a/onnx/defs/printer.cc
+++ b/onnx/defs/printer.cc
@@ -69,6 +69,8 @@ class ProtoPrinter {
 
   void print(const TypeProto_SparseTensor& sparseType);
 
+  void print(const TypeProto_Opaque& opaqueType);
+
   void print(const TensorProto& tensor, bool is_initializer = false);
 
   void print(const ValueInfoProto& value_info);
@@ -239,6 +241,22 @@ void ProtoPrinter::print(const TypeProto_SparseTensor& sparseType) {
   output_ << ")";
 }
 
+void ProtoPrinter::print(const TypeProto_Opaque& opaqueType) {
+  // Mirrors the grammar accepted by the parser:
+  //   opaque()
+  //   opaque(name)
+  //   opaque(domain,name)
+  output_ << "opaque(";
+  const bool has_domain = opaqueType.has_domain() && !opaqueType.domain().empty();
+  if (has_domain) {
+    output_ << opaqueType.domain() << ",";
+  }
+  if (opaqueType.has_name() && !opaqueType.name().empty()) {
+    output_ << opaqueType.name();
+  }
+  output_ << ")";
+}
+
 void ProtoPrinter::print(const TypeProto& type) {
   if (type.has_tensor_type())
     print(type.tensor_type());
@@ -250,6 +268,8 @@ void ProtoPrinter::print(const TypeProto& type) {
     print(type.optional_type());
   else if (type.has_sparse_tensor_type())
     print(type.sparse_tensor_type());
+  else if (type.has_opaque_type())
+    print(type.opaque_type());
 }
 
 void ProtoPrinter::print(const TensorProto& tensor, bool is_initializer) {

--- a/onnx/onnx-ml.proto
+++ b/onnx/onnx-ml.proto
@@ -877,7 +877,6 @@ message TypeProto {
     optional TensorShapeProto shape = 2;
   }
 
-
   message Opaque {
     // When missing, the domain is the same as the model's.
     optional string domain = 1;
@@ -887,7 +886,6 @@ message TypeProto {
     // DEPRECATED do not use.
     // repeated TypeProto parameters = 3;
   }
-
 
   oneof value {
     // The type of a tensor.
@@ -910,7 +908,6 @@ message TypeProto {
 
     // Type of the sparse tensor
     SparseTensor sparse_tensor_type = 8;
-
 
     Opaque opaque_type = 7;
 

--- a/onnx/onnx-ml.proto
+++ b/onnx/onnx-ml.proto
@@ -124,7 +124,11 @@ enum Version {
 
   // IR VERSION 13 published on November 6, 2025
   // Added UINT2, INT2.
-  IR_VERSION = 0x000000000000000D;
+  IR_VERSION_2025_11_06 = 0x000000000000000D;
+
+  // IR VERSION 14 published on TBD
+  // Made TypeProto.Opaque available in non-ONNX-ML builds.
+  IR_VERSION = 0x000000000000000E;
 }
 
 // Attributes
@@ -882,9 +886,9 @@ message TypeProto {
     optional string domain = 1;
     // The name is optional but significant when provided.
     optional string name = 2;
-    // parameters that help defining the type
-    // DEPRECATED do not use.
-    // repeated TypeProto parameters = 3;
+    // DEPRECATED: parameters that help define the type.
+    reserved 3;
+    reserved "parameters";
   }
 
   oneof value {

--- a/onnx/onnx-ml.proto3
+++ b/onnx/onnx-ml.proto3
@@ -124,7 +124,11 @@ enum Version {
 
   // IR VERSION 13 published on November 6, 2025
   // Added UINT2, INT2.
-  IR_VERSION = 0x000000000000000D;
+  IR_VERSION_2025_11_06 = 0x000000000000000D;
+
+  // IR VERSION 14 published on TBD
+  // Made TypeProto.Opaque available in non-ONNX-ML builds.
+  IR_VERSION = 0x000000000000000E;
 }
 
 // Attributes
@@ -882,9 +886,9 @@ message TypeProto {
     string domain = 1;
     // The name is optional but significant when provided.
     string name = 2;
-    // parameters that help defining the type
-    // DEPRECATED do not use.
-    // repeated TypeProto parameters = 3;
+    // DEPRECATED: parameters that help define the type.
+    reserved 3;
+    reserved "parameters";
   }
 
   oneof value {

--- a/onnx/onnx-ml.proto3
+++ b/onnx/onnx-ml.proto3
@@ -877,7 +877,6 @@ message TypeProto {
     TensorShapeProto shape = 2;
   }
 
-
   message Opaque {
     // When missing, the domain is the same as the model's.
     string domain = 1;
@@ -887,7 +886,6 @@ message TypeProto {
     // DEPRECATED do not use.
     // repeated TypeProto parameters = 3;
   }
-
 
   oneof value {
     // The type of a tensor.
@@ -910,7 +908,6 @@ message TypeProto {
 
     // Type of the sparse tensor
     SparseTensor sparse_tensor_type = 8;
-
 
     Opaque opaque_type = 7;
 

--- a/onnx/onnx.in.proto
+++ b/onnx/onnx.in.proto
@@ -121,7 +121,11 @@ enum Version {
 
   // IR VERSION 13 published on November 6, 2025
   // Added UINT2, INT2.
-  IR_VERSION = 0x000000000000000D;
+  IR_VERSION_2025_11_06 = 0x000000000000000D;
+
+  // IR VERSION 14 published on TBD
+  // Made TypeProto.Opaque available in non-ONNX-ML builds.
+  IR_VERSION = 0x000000000000000E;
 }
 
 // Attributes
@@ -879,9 +883,9 @@ message TypeProto {
     optional string domain = 1;
     // The name is optional but significant when provided.
     optional string name = 2;
-    // parameters that help defining the type
-    // DEPRECATED do not use.
-    // repeated TypeProto parameters = 3;
+    // DEPRECATED: parameters that help define the type.
+    reserved 3;
+    reserved "parameters";
   }
 
   oneof value {

--- a/onnx/onnx.in.proto
+++ b/onnx/onnx.in.proto
@@ -874,8 +874,6 @@ message TypeProto {
     optional TensorShapeProto shape = 2;
   }
 
-// #if ONNX-ML
-
   message Opaque {
     // When missing, the domain is the same as the model's.
     optional string domain = 1;
@@ -885,8 +883,6 @@ message TypeProto {
     // DEPRECATED do not use.
     // repeated TypeProto parameters = 3;
   }
-
-// #endif
 
   oneof value {
     // The type of a tensor.
@@ -910,11 +906,8 @@ message TypeProto {
     // Type of the sparse tensor
     SparseTensor sparse_tensor_type = 8;
 
-// #if ONNX-ML
-
     Opaque opaque_type = 7;
 
-// #endif
   }
 
   // An optional denotation can be used to denote the whole

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -875,6 +875,15 @@ message TypeProto {
     optional TensorShapeProto shape = 2;
   }
 
+  message Opaque {
+    // When missing, the domain is the same as the model's.
+    optional string domain = 1;
+    // The name is optional but significant when provided.
+    optional string name = 2;
+    // parameters that help defining the type
+    // DEPRECATED do not use.
+    // repeated TypeProto parameters = 3;
+  }
 
   oneof value {
     // The type of a tensor.
@@ -897,6 +906,8 @@ message TypeProto {
 
     // Type of the sparse tensor
     SparseTensor sparse_tensor_type = 8;
+
+    Opaque opaque_type = 7;
 
   }
 

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -122,7 +122,11 @@ enum Version {
 
   // IR VERSION 13 published on November 6, 2025
   // Added UINT2, INT2.
-  IR_VERSION = 0x000000000000000D;
+  IR_VERSION_2025_11_06 = 0x000000000000000D;
+
+  // IR VERSION 14 published on TBD
+  // Made TypeProto.Opaque available in non-ONNX-ML builds.
+  IR_VERSION = 0x000000000000000E;
 }
 
 // Attributes
@@ -880,9 +884,9 @@ message TypeProto {
     optional string domain = 1;
     // The name is optional but significant when provided.
     optional string name = 2;
-    // parameters that help defining the type
-    // DEPRECATED do not use.
-    // repeated TypeProto parameters = 3;
+    // DEPRECATED: parameters that help define the type.
+    reserved 3;
+    reserved "parameters";
   }
 
   oneof value {

--- a/onnx/onnx.proto3
+++ b/onnx/onnx.proto3
@@ -875,6 +875,15 @@ message TypeProto {
     TensorShapeProto shape = 2;
   }
 
+  message Opaque {
+    // When missing, the domain is the same as the model's.
+    string domain = 1;
+    // The name is optional but significant when provided.
+    string name = 2;
+    // parameters that help defining the type
+    // DEPRECATED do not use.
+    // repeated TypeProto parameters = 3;
+  }
 
   oneof value {
     // The type of a tensor.
@@ -897,6 +906,8 @@ message TypeProto {
 
     // Type of the sparse tensor
     SparseTensor sparse_tensor_type = 8;
+
+    Opaque opaque_type = 7;
 
   }
 

--- a/onnx/onnx.proto3
+++ b/onnx/onnx.proto3
@@ -122,7 +122,11 @@ enum Version {
 
   // IR VERSION 13 published on November 6, 2025
   // Added UINT2, INT2.
-  IR_VERSION = 0x000000000000000D;
+  IR_VERSION_2025_11_06 = 0x000000000000000D;
+
+  // IR VERSION 14 published on TBD
+  // Made TypeProto.Opaque available in non-ONNX-ML builds.
+  IR_VERSION = 0x000000000000000E;
 }
 
 // Attributes
@@ -880,9 +884,9 @@ message TypeProto {
     string domain = 1;
     // The name is optional but significant when provided.
     string name = 2;
-    // parameters that help defining the type
-    // DEPRECATED do not use.
-    // repeated TypeProto parameters = 3;
+    // DEPRECATED: parameters that help define the type.
+    reserved 3;
+    reserved "parameters";
   }
 
   oneof value {

--- a/onnx/shape_inference/implementation.cc
+++ b/onnx/shape_inference/implementation.cc
@@ -34,10 +34,8 @@ std::string GetValueCaseString(const TypeProto& type) {
       return "map_type";
     case TypeProto::ValueCase::kOptionalType:
       return "optional_type";
-#ifdef ONNX_ML
     case TypeProto::ValueCase::kOpaqueType:
       return "opaque_type";
-#endif
     case TypeProto::ValueCase::kSparseTensorType:
       return "sparse_tensor_type";
     case TypeProto::ValueCase::VALUE_NOT_SET:

--- a/onnx/shape_inference/implementation.cc
+++ b/onnx/shape_inference/implementation.cc
@@ -15,6 +15,7 @@
 
 #include "onnx/checker.h"
 #include "onnx/common/common.h"
+#include "onnx/common/constants.h"
 #include "onnx/common/file_utils.h"
 #include "onnx/common/proto_util.h"
 #include "onnx/common/scoped_resource.h"
@@ -143,7 +144,7 @@ void checkShapesAndTypes(const TypeProto& inferred_type, const TypeProto& existi
     const auto& inferred_opaque = inferred_type.opaque_type();
     const auto& existing_opaque = existing_type.opaque_type();
     if (existing_opaque.has_domain() && inferred_opaque.has_domain() &&
-        existing_opaque.domain() != inferred_opaque.domain()) {
+        NormalizeDomain(existing_opaque.domain()) != NormalizeDomain(inferred_opaque.domain())) {
       fail_type_inference(
           "domain mismatch for opaque type: existing=",
           existing_opaque.domain(),

--- a/onnx/shape_inference/implementation.cc
+++ b/onnx/shape_inference/implementation.cc
@@ -139,6 +139,21 @@ void checkShapesAndTypes(const TypeProto& inferred_type, const TypeProto& existi
           Utils::DataTypeUtils::ToDataTypeString(inferred_type.map_type().key_type()));
     }
     checkShapesAndTypes(inferred_type.map_type().value_type(), existing_type.map_type().value_type());
+  } else if (inferred_value_case == TypeProto::kOpaqueType && existing_value_case == TypeProto::kOpaqueType) {
+    const auto& inferred_opaque = inferred_type.opaque_type();
+    const auto& existing_opaque = existing_type.opaque_type();
+    if (existing_opaque.has_domain() && inferred_opaque.has_domain() &&
+        existing_opaque.domain() != inferred_opaque.domain()) {
+      fail_type_inference(
+          "domain mismatch for opaque type: existing=",
+          existing_opaque.domain(),
+          " inferred=",
+          inferred_opaque.domain());
+    }
+    if (existing_opaque.has_name() && inferred_opaque.has_name() && existing_opaque.name() != inferred_opaque.name()) {
+      fail_type_inference(
+          "name mismatch for opaque type: existing=", existing_opaque.name(), " inferred=", inferred_opaque.name());
+    }
   } else {
     fail_type_inference("type case unsupported. existing=", existing_value_case, " inferred=", inferred_value_case);
   }
@@ -209,6 +224,15 @@ void mergeShapesAndTypes(const TypeProto& inferred_type, TypeProto* existing_typ
       existing_type->mutable_map_type()->set_key_type(inferred_type.map_type().key_type());
     }
     mergeShapesAndTypes(inferred_type.map_type().value_type(), existing_type->mutable_map_type()->mutable_value_type());
+  } else if (inferred_val_case == TypeProto::kOpaqueType) {
+    auto* existing_opaque = existing_type->mutable_opaque_type();
+    const auto& inferred_opaque = inferred_type.opaque_type();
+    if (!existing_opaque->has_domain() && inferred_opaque.has_domain()) {
+      existing_opaque->set_domain(inferred_opaque.domain());
+    }
+    if (!existing_opaque->has_name() && inferred_opaque.has_name()) {
+      existing_opaque->set_name(inferred_opaque.name());
+    }
   }
 }
 
@@ -243,6 +267,9 @@ void MaterializeSymbolicShape(TypeProto* inferred_type, SymbolTable& symbol_tabl
     MaterializeSymbolicShape(inferred_type->mutable_optional_type()->mutable_elem_type(), symbol_table);
   } else if (inferred_val_case == TypeProto::kMapType) {
     MaterializeSymbolicShape(inferred_type->mutable_map_type()->mutable_value_type(), symbol_table);
+  } else if (inferred_val_case == TypeProto::kOpaqueType) {
+    // Opaque types have no shape to materialize.
+    return;
   } else {
     fail_shape_inference("type case unsupported for symbolic shape inference. inferred=", inferred_val_case);
   }

--- a/tests/cpp/parser_test.cc
+++ b/tests/cpp/parser_test.cc
@@ -138,6 +138,24 @@ TEST(ParserTest, TypeTest) {
   EXPECT_EQ(valtype.tensor_type().elem_type(), float_type);
   EXPECT_EQ(valtype.tensor_type().shape().dim_size(), 1);
 
+  // opaque type, with domain and name:
+  Parse(type, "opaque(test.domain,MyType)");
+  EXPECT_TRUE(type.has_opaque_type());
+  EXPECT_EQ(type.opaque_type().domain(), "test.domain");
+  EXPECT_EQ(type.opaque_type().name(), "MyType");
+
+  // opaque type, with name only (no domain):
+  Parse(type, "opaque(MyType)");
+  EXPECT_TRUE(type.has_opaque_type());
+  EXPECT_FALSE(type.opaque_type().has_domain());
+  EXPECT_EQ(type.opaque_type().name(), "MyType");
+
+  // opaque type, with neither domain nor name:
+  Parse(type, "opaque()");
+  EXPECT_TRUE(type.has_opaque_type());
+  EXPECT_FALSE(type.opaque_type().has_domain());
+  EXPECT_FALSE(type.opaque_type().has_name());
+
   // Quoted string as symbolic dimension (non-identifier dim_param):
   Parse(type, R"(float["M + N"])");
   EXPECT_TRUE(type.has_tensor_type());
@@ -710,7 +728,7 @@ TEST(ParserTest, TypesModelTest2) {
     ir_version: 8,
     opset_import: [ "" : 18 ]
     >
-    agraph (float[N] tensorX, seq(float[N]) seqX, map(int32, float[N]) mapX, optional(float[N]) optionalX, sparse_tensor(float[N]) sparseX) => (float[N] X)
+    agraph (float[N] tensorX, seq(float[N]) seqX, map(int32, float[N]) mapX, optional(float[N]) optionalX, sparse_tensor(float[N]) sparseX, opaque(test.domain,MyType) opaqueX) => (float[N] X)
     {
         X = Identity (tensorX)
     }

--- a/tests/python/basic_test.py
+++ b/tests/python/basic_test.py
@@ -214,7 +214,7 @@ class TestBasicFunctions:
         model_repr = repr(model)
         assert (
             model_repr
-            == "ModelProto(ir_version=13, producer_name='onnx-test', graph=GraphProto('test'))"
+            == "ModelProto(ir_version=14, producer_name='onnx-test', graph=GraphProto('test'))"
         )
 
         text_model = """

--- a/tests/python/checker_test.py
+++ b/tests/python/checker_test.py
@@ -192,6 +192,32 @@ class TestChecker:
 
         checker.check_graph(graph)
 
+    def test_check_opaque_type_requires_name(self) -> None:
+        # Opaque types must have a non-empty name (domain is optional and, if
+        # empty, is treated as equivalent to the standard "ai.onnx" domain,
+        # matching the convention used for operator domains).
+        model = onnx.parser.parse_model(
+            """
+            <ir_version: 10, opset_import: ["": 21]>
+            agraph (opaque() x) => (opaque() y) {
+                y = Identity(x)
+            }
+            """
+        )
+        with pytest.raises(checker.ValidationError):
+            checker.check_model(model)
+
+    def test_check_opaque_type_with_name(self) -> None:
+        model = onnx.parser.parse_model(
+            """
+            <ir_version: 10, opset_import: ["": 21]>
+            agraph (opaque(test.domain,MyType) x) => (opaque(test.domain,MyType) y) {
+                y = Identity(x)
+            }
+            """
+        )
+        checker.check_model(model)
+
     def test_check_graph_empty_initializer_name(self) -> None:
         node = helper.make_node("Relu", ["X"], ["Y"], name="test")
         graph = helper.make_graph(

--- a/tests/python/opaque_type_test.py
+++ b/tests/python/opaque_type_test.py
@@ -9,12 +9,14 @@ producer/consumer of a custom domain's ops (much like custom ops themselves).
 This test illustrates the idea with a toy "random number generator" (RNG)
 type: one custom op creates a stateful RNG (represented via an Opaque type)
 from a seed value, and another custom op consumes the RNG (together with a
-requested shape) to produce a random tensor. The example is deliberately
-simple -- it does not implement an actual RNG algorithm nor address the many
-details (such as how/whether the RNG state is meant to be updated) that a
-real-world stateful-RNG design would need to address -- the goal here is
-just to show how Opaque types can be declared, produced, consumed, and
-type/shape-inferred.
+requested shape) to produce a random tensor, returning both the generated
+tensor and an updated RNG (since ONNX ops are functions and cannot mutate
+their inputs in place: any state update must be reflected as an explicit
+output). The example is deliberately simple -- it does not implement an
+actual RNG algorithm nor address the many details (such as the precise
+semantics of the RNG state update) that a real-world stateful-RNG design
+would need to address -- the goal here is just to show how Opaque types can
+be declared, produced, consumed, and type/shape-inferred.
 """
 
 from __future__ import annotations
@@ -22,8 +24,9 @@ from __future__ import annotations
 import onnx
 import onnx.checker
 import onnx.defs
+import onnx.parser
 import onnx.shape_inference
-from onnx import TensorProto, TypeProto, checker, helper
+from onnx import TensorProto, TypeProto, checker
 from onnx.defs import OpSchema
 
 # Use a dedicated custom domain for the two illustrative ops below.
@@ -61,7 +64,14 @@ def _create_rng_schema() -> OpSchema:
 
 
 def _random_tensor_schema() -> OpSchema:
-    """Schema for a custom op that uses an RNG to produce a random tensor."""
+    """Schema for a custom op that uses an RNG to produce a random tensor.
+
+    ONNX ops are (mathematical) functions and cannot have side effects. Since
+    using an RNG to generate a random value conceptually advances/updates its
+    internal state, that update is made explicit by returning a new/updated
+    RNG as a second output (alongside the generated tensor), rather than
+    mutating the input RNG in place.
+    """
 
     def infer_shape(ctx: onnx.shape_inference.InferenceContext) -> None:
         shape_attr = ctx.get_attribute("shape")
@@ -71,6 +81,9 @@ def _random_tensor_schema() -> OpSchema:
         for dim in shape:
             out.tensor_type.shape.dim.add().dim_value = dim
         ctx.set_output_type(0, out)
+        # The second output is the updated RNG, of the same (opaque) type as
+        # the input RNG.
+        ctx.set_output_type(1, ctx.get_input_type(0))
 
     schema = OpSchema(
         "RandomTensor",
@@ -78,10 +91,15 @@ def _random_tensor_schema() -> OpSchema:
         1,
         doc=(
             "Generates a tensor of the given shape with values drawn from a "
-            "(standard normal) distribution, using the given RNG."
+            "(standard normal) distribution, using the given RNG. Returns "
+            "the generated tensor along with the updated RNG, reflecting "
+            "the state-update side-effect of generating random values."
         ),
         inputs=[OpSchema.FormalParameter("rng", RNG_TYPE_STR)],
-        outputs=[OpSchema.FormalParameter("Y", "tensor(float)")],
+        outputs=[
+            OpSchema.FormalParameter("Y", "tensor(float)"),
+            OpSchema.FormalParameter("rng_out", RNG_TYPE_STR),
+        ],
         attributes=[OpSchema.Attribute("shape", OpSchema.AttrType.INTS)],
     )
     schema.set_type_and_shape_inference_function(infer_shape)
@@ -93,8 +111,13 @@ class TestOpaqueTypeRNGExample:
 
     Two custom ops (in a custom domain) are used together in a single model:
     * ``CreateRNG(seed) -> rng`` produces an opaque ``RNG`` value.
-    * ``RandomTensor(rng) -> Y`` consumes the opaque ``RNG`` value (along
-      with a ``shape`` attribute) to produce a random tensor.
+    * ``RandomTensor(rng) -> Y, rng_out`` consumes the opaque ``RNG`` value
+      (along with a ``shape`` attribute) to produce a random tensor,
+      returning the updated RNG (``rng_out``) alongside the generated
+      tensor (``Y``).
+
+    The model itself is described using ``onnx.parser.parse_model``, ONNX's
+    compact text format, as a single string.
     """
 
     @staticmethod
@@ -114,42 +137,35 @@ class TestOpaqueTypeRNGExample:
         self._deregister_schemas()
 
     @staticmethod
-    def _make_model(shape: list[int]) -> onnx.ModelProto:
-        seed = helper.make_tensor_value_info("seed", TensorProto.INT64, [])
-        y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, shape)
-        rng_value_info = helper.make_value_info("rng", _make_rng_type_proto())
-
-        create_rng = helper.make_node("CreateRNG", ["seed"], ["rng"], domain=DOMAIN)
-        random_tensor = helper.make_node(
-            "RandomTensor", ["rng"], ["Y"], domain=DOMAIN, shape=shape
-        )
-
-        graph = helper.make_graph(
-            [create_rng, random_tensor],
-            "rng-example",
-            [seed],
-            [y],
-            value_info=[rng_value_info],
-        )
-        return helper.make_model(
-            graph,
-            opset_imports=[
-                helper.make_opsetid("", onnx.defs.onnx_opset_version()),
-                helper.make_opsetid(DOMAIN, 1),
-            ],
+    def _make_model() -> onnx.ModelProto:
+        # Note: the intermediate value "rng" and the second graph output
+        # "rng2" are of the opaque RNG type, which is not (yet) expressible
+        # in ONNX's text format. So they are left untyped here; their types
+        # are subsequently determined by shape inference (see below).
+        return onnx.parser.parse_model(
+            f"""
+            <
+                ir_version: 10,
+                opset_import: ["": {onnx.defs.onnx_opset_version()}, "{DOMAIN}": 1]
+            >
+            agraph (int64 seed) => (float[2,3] Y, rng2)
+            {{
+                rng = {DOMAIN}.CreateRNG (seed)
+                Y, rng2 = {DOMAIN}.RandomTensor <shape = [2, 3]> (rng)
+            }}
+            """
         )
 
     def test_opaque_rng_example(self) -> None:
-        shape = [2, 3]
-        model = self._make_model(shape)
-
-        # The model (using the opaque RNG type) should pass checker validation.
-        checker.check_model(model, full_check=True)
+        model = self._make_model()
 
         # Shape inference should successfully infer the opaque RNG type for
-        # the intermediate value, and the tensor type/shape for the final
-        # output.
+        # the intermediate value "rng" and the second output "rng2", as well
+        # as the tensor type/shape for the generated-tensor output "Y".
         inferred = onnx.shape_inference.infer_shapes(model, strict_mode=True)
+
+        # The inferred model should pass checker validation.
+        checker.check_model(inferred, full_check=True)
 
         value_infos = {vi.name: vi for vi in inferred.graph.value_info}
         rng_type = value_infos["rng"].type
@@ -157,6 +173,11 @@ class TestOpaqueTypeRNGExample:
         assert rng_type.opaque_type.domain == DOMAIN
         assert rng_type.opaque_type.name == "RNG"
 
+        rng_out_type = inferred.graph.output[1].type
+        assert rng_out_type.WhichOneof("value") == "opaque_type"
+        assert rng_out_type.opaque_type.domain == DOMAIN
+        assert rng_out_type.opaque_type.name == "RNG"
+
         output_type = inferred.graph.output[0].type
         assert output_type.tensor_type.elem_type == TensorProto.FLOAT
-        assert [d.dim_value for d in output_type.tensor_type.shape.dim] == shape
+        assert [d.dim_value for d in output_type.tensor_type.shape.dim] == [2, 3]

--- a/tests/python/opaque_type_test.py
+++ b/tests/python/opaque_type_test.py
@@ -1,0 +1,162 @@
+# Copyright (c) ONNX Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Illustrative example of using an Opaque type.
+
+Opaque types allow a model to carry values whose internal representation is
+not defined by the ONNX spec, but is instead understood only by the
+producer/consumer of a custom domain's ops (much like custom ops themselves).
+
+This test illustrates the idea with a toy "random number generator" (RNG)
+type: one custom op creates a stateful RNG (represented via an Opaque type)
+from a seed value, and another custom op consumes the RNG (together with a
+requested shape) to produce a random tensor. The example is deliberately
+simple -- it does not implement an actual RNG algorithm nor address the many
+details (such as how/whether the RNG state is meant to be updated) that a
+real-world stateful-RNG design would need to address -- the goal here is
+just to show how Opaque types can be declared, produced, consumed, and
+type/shape-inferred.
+"""
+
+from __future__ import annotations
+
+import onnx
+import onnx.checker
+import onnx.defs
+import onnx.shape_inference
+from onnx import TensorProto, TypeProto, checker, helper
+from onnx.defs import OpSchema
+
+# Use a dedicated custom domain for the two illustrative ops below.
+DOMAIN = "test.rng"
+
+# String representation (as accepted by OpSchema type constraints/parameters)
+# of the opaque RNG type: a type named "RNG" defined in DOMAIN.
+RNG_TYPE_STR = f"opaque({DOMAIN},RNG)"
+
+
+def _make_rng_type_proto() -> TypeProto:
+    """Builds a TypeProto representing the opaque RNG type."""
+    type_proto = TypeProto()
+    type_proto.opaque_type.domain = DOMAIN
+    type_proto.opaque_type.name = "RNG"
+    return type_proto
+
+
+def _create_rng_schema() -> OpSchema:
+    """Schema for a custom op that creates an RNG (opaque type) from a seed."""
+
+    def infer_shape(ctx: onnx.shape_inference.InferenceContext) -> None:
+        ctx.set_output_type(0, _make_rng_type_proto())
+
+    schema = OpSchema(
+        "CreateRNG",
+        DOMAIN,
+        1,
+        doc="Creates a stateful random-number generator (RNG) from a seed value.",
+        inputs=[OpSchema.FormalParameter("seed", "tensor(int64)")],
+        outputs=[OpSchema.FormalParameter("rng", RNG_TYPE_STR)],
+    )
+    schema.set_type_and_shape_inference_function(infer_shape)
+    return schema
+
+
+def _random_tensor_schema() -> OpSchema:
+    """Schema for a custom op that uses an RNG to produce a random tensor."""
+
+    def infer_shape(ctx: onnx.shape_inference.InferenceContext) -> None:
+        shape_attr = ctx.get_attribute("shape")
+        shape = list(shape_attr.ints) if shape_attr is not None else []
+        out = ctx.get_output_type(0)
+        out.tensor_type.elem_type = TensorProto.FLOAT
+        for dim in shape:
+            out.tensor_type.shape.dim.add().dim_value = dim
+        ctx.set_output_type(0, out)
+
+    schema = OpSchema(
+        "RandomTensor",
+        DOMAIN,
+        1,
+        doc=(
+            "Generates a tensor of the given shape with values drawn from a "
+            "(standard normal) distribution, using the given RNG."
+        ),
+        inputs=[OpSchema.FormalParameter("rng", RNG_TYPE_STR)],
+        outputs=[OpSchema.FormalParameter("Y", "tensor(float)")],
+        attributes=[OpSchema.Attribute("shape", OpSchema.AttrType.INTS)],
+    )
+    schema.set_type_and_shape_inference_function(infer_shape)
+    return schema
+
+
+class TestOpaqueTypeRNGExample:
+    """Illustrates Opaque types via a toy stateful-RNG example.
+
+    Two custom ops (in a custom domain) are used together in a single model:
+    * ``CreateRNG(seed) -> rng`` produces an opaque ``RNG`` value.
+    * ``RandomTensor(rng) -> Y`` consumes the opaque ``RNG`` value (along
+      with a ``shape`` attribute) to produce a random tensor.
+    """
+
+    @staticmethod
+    def _register_schemas() -> None:
+        onnx.defs.register_schema(_create_rng_schema())
+        onnx.defs.register_schema(_random_tensor_schema())
+
+    @staticmethod
+    def _deregister_schemas() -> None:
+        onnx.defs.deregister_schema("CreateRNG", 1, DOMAIN)
+        onnx.defs.deregister_schema("RandomTensor", 1, DOMAIN)
+
+    def setup_method(self):
+        self._register_schemas()
+
+    def teardown_method(self):
+        self._deregister_schemas()
+
+    @staticmethod
+    def _make_model(shape: list[int]) -> onnx.ModelProto:
+        seed = helper.make_tensor_value_info("seed", TensorProto.INT64, [])
+        y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, shape)
+        rng_value_info = helper.make_value_info("rng", _make_rng_type_proto())
+
+        create_rng = helper.make_node("CreateRNG", ["seed"], ["rng"], domain=DOMAIN)
+        random_tensor = helper.make_node(
+            "RandomTensor", ["rng"], ["Y"], domain=DOMAIN, shape=shape
+        )
+
+        graph = helper.make_graph(
+            [create_rng, random_tensor],
+            "rng-example",
+            [seed],
+            [y],
+            value_info=[rng_value_info],
+        )
+        return helper.make_model(
+            graph,
+            opset_imports=[
+                helper.make_opsetid("", onnx.defs.onnx_opset_version()),
+                helper.make_opsetid(DOMAIN, 1),
+            ],
+        )
+
+    def test_opaque_rng_example(self) -> None:
+        shape = [2, 3]
+        model = self._make_model(shape)
+
+        # The model (using the opaque RNG type) should pass checker validation.
+        checker.check_model(model, full_check=True)
+
+        # Shape inference should successfully infer the opaque RNG type for
+        # the intermediate value, and the tensor type/shape for the final
+        # output.
+        inferred = onnx.shape_inference.infer_shapes(model, strict_mode=True)
+
+        value_infos = {vi.name: vi for vi in inferred.graph.value_info}
+        rng_type = value_infos["rng"].type
+        assert rng_type.WhichOneof("value") == "opaque_type"
+        assert rng_type.opaque_type.domain == DOMAIN
+        assert rng_type.opaque_type.name == "RNG"
+
+        output_type = inferred.graph.output[0].type
+        assert output_type.tensor_type.elem_type == TensorProto.FLOAT
+        assert [d.dim_value for d in output_type.tensor_type.shape.dim] == shape

--- a/tests/python/printer_test.py
+++ b/tests/python/printer_test.py
@@ -47,6 +47,27 @@ class TestBasicFunctions:
         # Verify that "M + N" is preserved as a quoted string in the printed output
         assert '"M + N"' in text1
 
+    @pytest.mark.parametrize(
+        "type_text",
+        [
+            "opaque(test.domain,MyType)",
+            "opaque(MyType)",
+            "opaque()",
+        ],
+    )
+    def test_opaque_type_roundtrip(self, type_text: str) -> None:
+        # Test that Opaque types (added, along with this test, to illustrate
+        # producing/consuming custom types not defined by the ONNX spec) can
+        # be parsed and printed, and survive a parse/print round-trip.
+        text0 = f"agraph ({type_text} x) => ({type_text} y) {{ y = Identity(x) }}"
+        graph1 = parser.parse_graph(text0)
+        assert graph1.input[0].type.WhichOneof("value") == "opaque_type"
+        text1 = printer.to_text(graph1)
+        graph2 = parser.parse_graph(text1)
+        text2 = printer.to_text(graph2)
+        assert text1 == text2
+        assert graph2.input[0].type == graph1.input[0].type
+
     def test_parse_node_roundtrip(self) -> None:
         # Regression test for #7944: parse_node accepts NodeProto text but
         # printer.to_text(NodeProto) raised TypeError because NodeProto was


### PR DESCRIPTION
ONNX allows users to define custom ops using custom domains. It is useful to allow users to define custom types as well. We have had the ability to define custom types (called Opaque types), but the support was previously limited to ONNX_ML (conditionally supported only if the build flag for ONNX_ML is on).

This PR makes this support unconditional, making user-defined (custom) types possible in ONNX (without ONNX_ML) as well.