### PR TITLE
Update hasInput and hasOutput methods of InferenceContextImpl

### DIFF
--- a/onnx/defs/quantization/defs.cc
+++ b/onnx/defs/quantization/defs.cc
@@ -123,6 +123,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The type of the input `y_zero_point` and the output `y`.")
         .SetDoc(QuantizeLinear_ver25_doc)
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+          // y_zero_point's type is known only if it is present as an input *and* its type could be inferred
+          // (e.g. it is not simply an unresolved formal parameter of an enclosing function).
           auto const zp_type = ctx.hasInput(2) ? ctx.getInputType(2) : nullptr;
           auto const output_dtype =
               static_cast<TensorProto_DataType>(getAttribute(ctx, "output_dtype", TensorProto::UNDEFINED));
@@ -139,9 +141,12 @@ ONNX_OPERATOR_SET_SCHEMA(
             propagateElemTypeFromInputToOutput(ctx, 2, 0);
           } else if (output_dtype != TensorProto::UNDEFINED) {
             propagateElemTypeFromAttributeToOutput(ctx, "output_dtype", 0);
-          } else {
+          } else if (!ctx.hasInput(2)) {
+            // y_zero_point is not provided: the output type defaults to uint8.
             updateOutputElemType(ctx, 0, TensorProto::UINT8);
           }
+          // Otherwise, y_zero_point is provided but its type could not be inferred, and no output_dtype
+          // attribute was specified: the output type cannot be determined, so it is left uninferred.
           if (!hasInputShape(ctx, 0)) {
             return;
           }

--- a/onnx/defs/quantization/old.cc
+++ b/onnx/defs/quantization/old.cc
@@ -119,6 +119,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The type of the input `y_zero_point` and the output `y`.")
         .SetDoc(QuantizeLinear_ver24_doc)
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+          // y_zero_point's type is known only if it is present as an input *and* its type could be inferred
+          // (e.g. it is not simply an unresolved formal parameter of an enclosing function).
           auto const zp_type = ctx.hasInput(2) ? ctx.getInputType(2) : nullptr;
           auto const output_dtype =
               static_cast<TensorProto_DataType>(getAttribute(ctx, "output_dtype", TensorProto::UNDEFINED));
@@ -135,9 +137,12 @@ ONNX_OPERATOR_SET_SCHEMA(
             propagateElemTypeFromInputToOutput(ctx, 2, 0);
           } else if (output_dtype != TensorProto::UNDEFINED) {
             propagateElemTypeFromAttributeToOutput(ctx, "output_dtype", 0);
-          } else {
+          } else if (!ctx.hasInput(2)) {
+            // y_zero_point is not provided: the output type defaults to uint8.
             updateOutputElemType(ctx, 0, TensorProto::UINT8);
           }
+          // Otherwise, y_zero_point is provided but its type could not be inferred, and no output_dtype
+          // attribute was specified: the output type cannot be determined, so it is left uninferred.
           if (!hasInputShape(ctx, 0)) {
             return;
           }
@@ -310,6 +315,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The type of the input `y_zero_point` and the output `y`.")
         .SetDoc(QuantizeLinear_ver23_doc)
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+          // y_zero_point's type is known only if it is present as an input *and* its type could be inferred
+          // (e.g. it is not simply an unresolved formal parameter of an enclosing function).
           auto const zp_type = ctx.hasInput(2) ? ctx.getInputType(2) : nullptr;
           auto const output_dtype =
               static_cast<TensorProto_DataType>(getAttribute(ctx, "output_dtype", TensorProto::UNDEFINED));
@@ -326,9 +333,12 @@ ONNX_OPERATOR_SET_SCHEMA(
             propagateElemTypeFromInputToOutput(ctx, 2, 0);
           } else if (output_dtype != TensorProto::UNDEFINED) {
             propagateElemTypeFromAttributeToOutput(ctx, "output_dtype", 0);
-          } else {
+          } else if (!ctx.hasInput(2)) {
+            // y_zero_point is not provided: the output type defaults to uint8.
             updateOutputElemType(ctx, 0, TensorProto::UINT8);
           }
+          // Otherwise, y_zero_point is provided but its type could not be inferred, and no output_dtype
+          // attribute was specified: the output type cannot be determined, so it is left uninferred.
           if (!hasInputShape(ctx, 0)) {
             return;
           }
@@ -509,6 +519,8 @@ ONNX_OPERATOR_SET_SCHEMA(
             "The type of the input `y_zero_point` and the output `y`.")
         .SetDoc(QuantizeLinear_ver21_doc)
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
+          // y_zero_point's type is known only if it is present as an input *and* its type could be inferred
+          // (e.g. it is not simply an unresolved formal parameter of an enclosing function).
           auto const zp_type = ctx.hasInput(2) ? ctx.getInputType(2) : nullptr;
           auto const output_dtype =
               static_cast<TensorProto_DataType>(getAttribute(ctx, "output_dtype", TensorProto::UNDEFINED));
@@ -525,9 +537,12 @@ ONNX_OPERATOR_SET_SCHEMA(
             propagateElemTypeFromInputToOutput(ctx, 2, 0);
           } else if (output_dtype != TensorProto::UNDEFINED) {
             propagateElemTypeFromAttributeToOutput(ctx, "output_dtype", 0);
-          } else {
+          } else if (!ctx.hasInput(2)) {
+            // y_zero_point is not provided: the output type defaults to uint8.
             updateOutputElemType(ctx, 0, TensorProto::UINT8);
           }
+          // Otherwise, y_zero_point is provided but its type could not be inferred, and no output_dtype
+          // attribute was specified: the output type cannot be determined, so it is left uninferred.
           if (!hasInputShape(ctx, 0)) {
             return;
           }
@@ -668,8 +683,13 @@ ONNX_OPERATOR_SET_SCHEMA(
         .SetDoc(QuantizeLinear_ver19_doc)
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
           if (ctx.hasInput(2)) {
-            propagateElemTypeFromInputToOutput(ctx, 2, 0);
+            if (ctx.getInputType(2) != nullptr) {
+              propagateElemTypeFromInputToOutput(ctx, 2, 0);
+            }
+            // Otherwise, y_zero_point is provided but its type could not be inferred: the output
+            // type cannot be determined, so it is left uninferred.
           } else {
+            // y_zero_point is not provided: the output type defaults to uint8.
             updateOutputElemType(ctx, 0, TensorProto::UINT8);
           }
           if (!hasInputShape(ctx, 0)) {
@@ -775,8 +795,13 @@ ONNX_OPERATOR_SET_SCHEMA(
         .SetDoc(QuantizeLinear_ver13_doc)
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
           if (ctx.hasInput(2)) {
-            propagateElemTypeFromInputToOutput(ctx, 2, 0);
+            if (ctx.getInputType(2) != nullptr) {
+              propagateElemTypeFromInputToOutput(ctx, 2, 0);
+            }
+            // Otherwise, y_zero_point is provided but its type could not be inferred: the output
+            // type cannot be determined, so it is left uninferred.
           } else {
+            // y_zero_point is not provided: the output type defaults to uint8.
             updateOutputElemType(ctx, 0, TensorProto::UINT8);
           }
           if (!hasInputShape(ctx, 0)) {
@@ -864,8 +889,13 @@ ONNX_OPERATOR_SET_SCHEMA(
         .SetDoc(QuantizeLinear_ver10_doc)
         .TypeAndShapeInferenceFunction([](ONNX_NAMESPACE::InferenceContext& ctx) {
           if (ctx.hasInput(2)) {
-            propagateElemTypeFromInputToOutput(ctx, 2, 0);
+            if (ctx.getInputType(2) != nullptr) {
+              propagateElemTypeFromInputToOutput(ctx, 2, 0);
+            }
+            // Otherwise, y_zero_point is provided but its type could not be inferred: the output
+            // type cannot be determined, so it is left uninferred.
           } else {
+            // y_zero_point is not provided: the output type defaults to uint8.
             updateOutputElemType(ctx, 0, TensorProto::UINT8);
           }
           if (!hasInputShape(ctx, 0)) {

--- a/onnx/shape_inference/implementation.cc
+++ b/onnx/shape_inference/implementation.cc
@@ -5,6 +5,7 @@
 #include "onnx/shape_inference/implementation.h"
 
 #include <algorithm>
+#include <cassert>
 #include <fstream>
 #include <list>
 #include <string>
@@ -347,6 +348,14 @@ void BindValuesOnReturn(
   }
 }
 
+// ShapeInferenceImplBase drives type-and-shape inference over a GraphProto or FunctionProto.
+// A single instance is used to process one top-level graph, or one function-body invocation
+// (a "callee" scope): ProcessCall()/InferShapeForFunctionNodeInternal() construct a brand-new
+// ShapeInferenceImplBase for every function call encountered (including nested/recursive calls
+// and repeated calls to the same function), each with its own private copies of instance fields
+// such as value_types_by_name and unbound_value_names. Consequently, these fields are correctly
+// scoped to a single graph/function invocation and are never shared or aliased across distinct
+// (nested, sibling, or recursive) function-body invocations.
 class ShapeInferenceImplBase {
  public:
   void UpdateType(const std::string& name, TypeProto* inferred_type) {
@@ -469,7 +478,8 @@ class ShapeInferenceImplBase {
         input_sparse_data_by_name,
         options,
         generated_shape_data_by_name,
-        &graph_inference_context);
+        &graph_inference_context,
+        &unbound_value_names);
 
     ONNX_TRY {
       if (schema) {
@@ -606,6 +616,12 @@ class ShapeInferenceImplBase {
   }
 
   void Process(const FunctionProto& func_proto, InferenceContext& ctx) {
+    // This method processes a single function-body invocation. Per the class-level comment
+    // above, a fresh ShapeInferenceImplBase instance is created for each such invocation, so
+    // unbound_value_names must still be in its initial, empty state at this point (it is
+    // populated below, exclusively for the formal parameters of this invocation's own callee).
+    assert(unbound_value_names.empty());
+
     // Ensure Constant node tensor-attributes are copied
     bool old_reuse_constant_tensors = reuse_constant_tensors;
     reuse_constant_tensors = false;
@@ -616,8 +632,13 @@ class ShapeInferenceImplBase {
     std::vector<TypeProto> types_cache(num_func_inputs);
     for (int i = 0; i < num_func_inputs; ++i) {
       const auto& parameter_name = func_proto.input().Get(i);
-      const auto* const type_ptr = (i < num_actual_inputs) ? ctx.getInputType(i) : nullptr;
-      // nullptr is valid, and indicates a missing optional input
+      // A formal parameter is considered "provided" by the caller only if the caller's own
+      // hasInput() reports it as present. This correctly distinguishes a genuinely omitted
+      // optional argument (recorded in unbound_value_names, below) from an argument that is
+      // provided but whose type happens to be unknown (nullptr is valid here, and simply
+      // indicates that the type could not be determined).
+      const bool caller_has_input = (i < num_actual_inputs) && ctx.hasInput(i);
+      const auto* const type_ptr = caller_has_input ? ctx.getInputType(i) : nullptr;
       if (type_ptr != nullptr) {
         // Use a temporary copy of original type.
         // TODO(ONNX): investigate whether we can eliminate use of temporary copy
@@ -625,6 +646,11 @@ class ShapeInferenceImplBase {
         value_types_by_name[parameter_name] = &types_cache[i];
       } else {
         value_types_by_name[parameter_name] = nullptr;
+      }
+      if (!caller_has_input) {
+        // unbound_value_names starts out empty (see assert above) and each parameter_name is
+        // visited at most once (function inputs have unique names), so a plain insert suffices.
+        unbound_value_names.insert(parameter_name);
       }
     }
 
@@ -757,6 +783,18 @@ class ShapeInferenceImplBase {
   // reuse_constant_tensors: controls whether we need to copy tensors occurring as attributes
   // in Constant nodes. We avoid it for inference for graphs, but must make a copy for functions.
   bool reuse_constant_tensors = true;
+
+  // Names of function-formal-parameters that were not provided (structurally) by the caller of
+  // the function currently being processed (empty when processing a top-level graph). A function
+  // body's nodes reference formal parameters by name unconditionally, so hasInput()/hasOutput(),
+  // which check structural presence in the NodeProto, cannot by themselves distinguish "argument
+  // genuinely omitted by the caller" from "argument provided but its type happens to be unknown".
+  // This set lets InferenceContextImpl::hasInput() correctly report false for the former case,
+  // while still reporting true (with a null type) for the latter.
+  //
+  // Populated exactly once, by Process(const FunctionProto&, ...), starting from empty -- see the
+  // class-level comment above regarding per-invocation scoping of this and other instance fields.
+  std::unordered_set<std::string> unbound_value_names;
 };
 
 void InferShapesImpl(
@@ -950,6 +988,12 @@ void InferShapeForFunctionNode(
 
 namespace {
 
+// Note: input_types plays a dual role for this context: an entry with
+// value_case() == TypeProto::ValueCase::VALUE_NOT_SET indicates that the corresponding
+// (optional) input is absent, while any other value indicates that the input is present
+// with that type. Consequently, hasInput() (inherited, unmodified, from the base
+// InferenceContext) cannot distinguish an input that is present but has an unknown type
+// from one that is simply absent -- both are represented identically here.
 struct FunctionInferenceContext : public InferenceContext {
   FunctionInferenceContext(
       const FunctionProto& func_proto,
@@ -1048,6 +1092,9 @@ std::vector<TypeProto> InferFunctionOutputTypes(
     const FunctionProto& function_proto,
     const std::vector<TypeProto>& input_types,
     const std::vector<AttributeProto>& attributes) {
+  // See the doc-comment on the declaration (in implementation.h) for a description of the dual
+  // role played by input_types: it indicates both which inputs are present/absent and, for
+  // those that are present, their types.
   // TODO(ONNX): if it is desirable for infer_function_output_types to provide check_type, strict_mode, data_prop,
   // we can add them to the Python API. For now we just assume the default options.
   ShapeInferenceOptions options{true, 1, false};

--- a/onnx/shape_inference/implementation.h
+++ b/onnx/shape_inference/implementation.h
@@ -142,8 +142,12 @@ struct InferenceContextImpl : public InferenceContext {
       const std::unordered_map<std::string, const SparseTensorProto*>& inputSparseDataByName,
       const ShapeInferenceOptions& options,
       DataValueMap* generatedShapeData = nullptr,
-      GraphInferenceContext* graphInferenceContext = nullptr)
-      : graphInferenceContext_{graphInferenceContext}, options_(options), node_(&n) {
+      GraphInferenceContext* graphInferenceContext = nullptr,
+      const std::unordered_set<std::string>* unboundValueNames = nullptr)
+      : graphInferenceContext_{graphInferenceContext},
+        options_(options),
+        node_(&n),
+        unboundValueNames_(unboundValueNames) {
     for (auto& attr : *n.mutable_attribute()) {
       attributesByName_[attr.name()] = &attr;
       if (attr.has_g()) {
@@ -214,6 +218,24 @@ struct InferenceContextImpl : public InferenceContext {
     return allInputTypes_[index];
   }
 
+  bool hasInput(size_t index) const override {
+    if (node_ == nullptr || index >= static_cast<size_t>(node_->input_size())) {
+      return false;
+    }
+    const std::string& name = node_->input(static_cast<int>(index));
+    if (name.empty()) {
+      return false;
+    }
+    // Inside a function body, a formal parameter is always referenced by its (non-empty) name,
+    // regardless of whether the caller actually provided that optional argument. unboundValueNames_
+    // records which formal parameters were not provided by the caller, so that such references are
+    // correctly reported as structurally absent here too.
+    if (unboundValueNames_ != nullptr && unboundValueNames_->count(name) > 0) {
+      return false;
+    }
+    return true;
+  }
+
   const TensorProto* getInputData(size_t index) const override {
     if (index >= allInputData_.size()) {
       ONNX_THROW("Input " + ONNX_NAMESPACE::to_string(index) + " is out of bounds.");
@@ -245,6 +267,13 @@ struct InferenceContextImpl : public InferenceContext {
       ONNX_THROW("Output " + ONNX_NAMESPACE::to_string(index) + " is out of bounds.");
     }
     return &allOutputTypes_[index];
+  }
+
+  bool hasOutput(size_t index) override {
+    if (node_ == nullptr || index >= static_cast<size_t>(node_->output_size())) {
+      return false;
+    }
+    return !node_->output(static_cast<int>(index)).empty();
   }
 
   GraphInferencer* getGraphAttributeInferencer(const std::string& attr_name) override {
@@ -299,6 +328,7 @@ struct InferenceContextImpl : public InferenceContext {
   mutable std::unordered_map<std::string, std::unique_ptr<GraphInferencer>> graphAttributeInferencers_;
   ShapeInferenceOptions options_;
   NodeProto* node_;
+  const std::unordered_set<std::string>* unboundValueNames_;
 };
 
 struct DataPropagationContextImpl : public DataPropagationContext {
@@ -523,6 +553,12 @@ void InferShapeForFunctionNode(
 /// the attribute values supplied.
 /// A TypeProto with value_case() == TypeProto::ValueCase::VALUE_NOT_SET is used
 /// for missing optional parameters.
+/// Note that input_types plays a dual role here: it is used both to indicate which
+/// of the (optional) inputs of the function are actually present/absent (an input is
+/// considered absent iff its entry has value_case() == TypeProto::ValueCase::VALUE_NOT_SET),
+/// and, for each present input, to convey its type. Consequently, this API has no way to
+/// represent an input that is present but whose type is unknown: such an input is
+/// indistinguishable, from this API's perspective, from one that is simply absent.
 ///
 std::vector<TypeProto> InferFunctionOutputTypes(
     const FunctionProto& function_proto,

--- a/tests/cpp/shape_inference_test.cc
+++ b/tests/cpp/shape_inference_test.cc
@@ -507,6 +507,36 @@ TEST(GraphInferencerImplTest, Scan9BasicTest) {
   doInferencingTest(false);
 }
 
+TEST(InferenceContextImplTest, OptionalInputsAndOutputsUseNodeProtoPresence) {
+  NodeProto node;
+  node.add_input("X");
+  node.add_input("");
+  node.add_input("Z");
+  node.add_output("Y");
+  node.add_output("");
+  node.add_output("W");
+
+  TypeProto input_type;
+  input_type.mutable_tensor_type()->set_elem_type(TensorProto_DataType::TensorProto_DataType_FLOAT);
+
+  std::unordered_map<std::string, TypeProto*> value_types_by_name;
+  value_types_by_name["X"] = &input_type;
+  value_types_by_name["Z"] = &input_type;
+
+  ShapeInferenceOptions options;
+  shape_inference::InferenceContextImpl ctx(node, value_types_by_name, {}, {}, options);
+
+  EXPECT_TRUE(ctx.hasInput(0));
+  EXPECT_FALSE(ctx.hasInput(1));
+  EXPECT_TRUE(ctx.hasInput(2));
+  EXPECT_FALSE(ctx.hasInput(3));
+
+  EXPECT_TRUE(ctx.hasOutput(0));
+  EXPECT_FALSE(ctx.hasOutput(1));
+  EXPECT_TRUE(ctx.hasOutput(2));
+  EXPECT_FALSE(ctx.hasOutput(3));
+}
+
 static void ParseAndInfer(ModelProto& model, const char* modelStr) {
   OnnxParser parser(modelStr);
   auto status = parser.Parse(model);

--- a/tests/python/function_inference_test.py
+++ b/tests/python/function_inference_test.py
@@ -103,7 +103,9 @@ class TestFunctionInference(TestShapeInferenceHelper):
         # If the optional third parameter is specified, it determines the output type.
         self._check(code, [float_type_, float_type_, int8_type_], [], [int8_type_])
         self._check(code, [float_type_, float_type_, uint8_type_], [], [uint8_type_])
-        # If the optional third parameter is omitted, the output type is uint8 (default).
+        # If the optional third parameter is omitted (represented by no_type_, following the
+        # same convention used above for DoReduce's optional second parameter), the output type
+        # defaults to uint8.
         self._check(code, [float_type_, float_type_, no_type_], [], [uint8_type_])
 
         code = """


### PR DESCRIPTION
Fix an issue with the implementation of the hasInput/hasOutput methods of InferenceContextImpl. In its current form, hasOutput does not correctly handle missing optional outputs that are followed by other outputs (non-trailing missing optional outputs).

The issue shows up in the op in https://github.com/onnx/onnx/pull/8108 (if one wishes to do some sanity checks on the allowed combinations of optional outputs).

Other fixes:
* The update uncovered a bug in the inference method for QuantizeLinear (which confused absence of input with absence of input type).
* Update the shape-inference implementation to distinguish between a missing (optional) input and an input with unknown type (which arises in the context of FunctionProto where a named value may represent an optional formal parameter, which may be absent in a particular callsite.
