### PR TITLE
docs: clarify release and reproducibility guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,15 @@ across different environments. A reproducibility check must also use the same
 source revision, dependency versions, toolchain, target platform, and build
 configuration, and then compare the resulting artifacts.
 
+### Why this matters
+
+A fixed build timestamp removes one known source of nondeterminism. When
+independent builds use the same controlled inputs, their artifacts can be
+compared byte for byte, with cryptographic digests providing a practical
+shortcut. A byte-for-byte match demonstrates identical outputs, while a
+mismatch identifies a difference that needs investigation. This comparison
+complements release provenance attestations; it does not replace them.
+
 Release artifacts are available from [PyPI](https://pypi.org/project/onnx/).
 
 # License

--- a/README.md
+++ b/README.md
@@ -112,20 +112,19 @@ pytest
 
 Check out the [contributor guide](https://github.com/onnx/onnx/blob/main/CONTRIBUTING.md) for instructions.
 
-# Reproducible Builds (Linux)
+# Reproducible Build Support
 
-This project provides reproducible builds for Linux.
+ONNX build and release workflows set
+[`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/)
+to the source commit timestamp. This removes timestamp-dependent variation from
+supported build steps and makes independent build comparison easier.
 
-A *reproducible build* means that the same source code will always produce identical binary outputs, no matter who builds it or where it is built.
+`SOURCE_DATE_EPOCH` alone does not guarantee byte-for-byte identical artifacts
+across different environments. A reproducibility check must also use the same
+source revision, dependency versions, toolchain, target platform, and build
+configuration, and then compare the resulting artifacts.
 
-To achieve this, we use the [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/) standard. This ensures that build timestamps and other time-dependent information are fixed, making the output bit-for-bit identical across different environments.
-
-### Why this matters
-- **Transparency**: Anyone can verify that the distributed binaries were created from the published source code.
-- **Security**: Prevents tampering or hidden changes in the build process.
-- **Trust**: Users can be confident that the binaries they download are exactly what the maintainers intended.
-
-If you prefer, you can use the prebuilt reproducible binaries instead of building from source yourself.
+Release artifacts are available from [PyPI](https://pypi.org/project/onnx/).
 
 # License
 

--- a/docs/OnnxReleases.md
+++ b/docs/OnnxReleases.md
@@ -6,11 +6,11 @@ SPDX-License-Identifier: Apache-2.0
 
 # ONNX Releases
 
-The ONNX project, going forward, will plan to release roughly on a four month cadence. We follow the [Semver](https://semver.org/) versioning approach and will make decisions as a community on a release by release basis on whether to do a major or minor release.
+The ONNX project plans to release roughly every three months. We follow the [Semver](https://semver.org/) versioning approach and make decisions as a community on a release-by-release basis on whether to produce a major or minor release.
 
 ## Preparation
 
-* Reach out to the SIG Arch/Infra leads to confirm whether the required status checks for the release branches are still valid and up to date, and whether any rely on outdated hardcoded runner image versions that may need updatingCheck whether the 'required checks' for the release branches are still up to date or need to be adjusted: 'Branches' -> 'Branch protection rules'
+* Reach out to the Architecture & Infra SIG leads to confirm whether the required status checks for release branches are current and whether any rely on outdated, hardcoded runner images. Update the checks or branch protection rules as needed.
 * Determine version (X.Y.Z) for the new release
     * Discuss in Slack channel for Releases (https://lfaifoundation.slack.com/archives/C018VGGJUGK)
     * For (v.X.Y.Z), if release is to be 1.16.0,
@@ -92,7 +92,7 @@ RC-Candidates
 
 # Official Release
 
-Validation steps must be completed before this point! This is the point of new return.
+Validation steps must be completed before this point. This is the point of no return.
 
 * git tags should not be changed once published
 * Once pushed to PyPI there is no way to update the release. A new release must be made instead
@@ -125,8 +125,8 @@ Validation steps must be completed before this point! This is the point of new r
 ### NOTES:
 
 * Once the packages are uploaded to PyPI, **you cannot overwrite it on the same PyPI instance**.
-  * Please make sure everything is good on TestPyPI before uploading to PyPI**
-* PyPI has separate logins, passwords, and API tokens from TestPyPI but the process is the same. An ONNX PyPI owner will need to grant access, etc.
+  * Make sure everything is correct on TestPyPI before uploading to PyPI.
+* Publishing uses GitHub Actions, protected deployment environments, and PyPI Trusted Publishing. Release managers do not enter PyPI passwords or API tokens into the workflow. The Architecture & Infra SIG administers the deployment environments and PyPI project access.
 
 ## After PyPI Release
 
@@ -165,18 +165,6 @@ Conda builds of ONNX are done via [conda-forge/onnx-feedstock](https://github.co
    * If urgent changes were made directly into the release branch, merge the release branch back into main branch.
    * If all PRs merged into the release branch (after it was cut) were cherry-picks from main, the merge PR will show as empty and this step is not needed.
 
-**Remove old onnx-weekly packages on PyPI**
-
-* Remove all [onnx-weekly packages](https://pypi.org/project/onnx-weekly/#history) from PyPI for the just released version to save space.
-* Steps:
-    * Go to [PyPI onnx-weekly/releases](https://pypi.org/manage/project/onnx-weekly/releases/)
-        * This is a separate project than the onnx releases so you may need to request access from an owner
-    * Click target package -> Options -> Delete.
-
-**Remove old release-candidate packages on PyPI**
-
-* Remove [onnx-release-candidate packages](https://test.pypi.org/project/onnx/#history) from PyPI up to at least the time specified by the previous release version to save space.
-* Steps:
-    * Go to [PyPI onnx-weekly/releases](https://test.pypi.org/manage/project/onnx/releases/)
-       * This is a separate project than the onnx releases so you may need to request access from an owner
-   * Click target package -> Options -> Delete.
+PyPI storage cleanup is not part of the release manager's responsibilities. It
+is performed separately by Architecture & Infra SIG administrators as described
+in [Release Administration](ReleaseAdministration.md).

--- a/docs/ReleaseAdministration.md
+++ b/docs/ReleaseAdministration.md
@@ -1,0 +1,41 @@
+<!--
+Copyright (c) ONNX Project Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Release Administration
+
+This document covers privileged maintenance tasks associated with ONNX releases.
+These tasks are owned by administrators in the Architecture & Infra SIG and are
+not part of the release manager's release checklist.
+
+## PyPI Storage Cleanup
+
+Package deletion is irreversible. Before deleting a distribution, verify the
+project, version, package type, and target package index, and coordinate the
+cleanup with the Architecture & Infra SIG.
+
+### Weekly Packages
+
+After a stable ONNX release, administrators may remove
+[`onnx-weekly`](https://pypi.org/project/onnx-weekly/#history) distributions for
+the version that was just released to conserve project storage.
+
+1. Open the [onnx-weekly release management page](https://pypi.org/manage/project/onnx-weekly/releases/).
+2. Select the obsolete release and verify its version and files.
+3. Use **Options > Delete** to remove it.
+
+The `onnx-weekly` and `onnx` projects have separate access control. Request
+access from an existing project owner when necessary.
+
+### TestPyPI Release Candidates
+
+After the corresponding stable release and partner validation are complete,
+administrators may remove obsolete ONNX release-candidate distributions from
+TestPyPI. Retain candidates that are still needed to investigate the current
+release.
+
+1. Open the [ONNX TestPyPI release management page](https://test.pypi.org/manage/project/onnx/releases/).
+2. Select the obsolete release candidate and verify its version and files.
+3. Use **Options > Delete** to remove it.


### PR DESCRIPTION
## Summary

- align the release-manager guide with the three-month cadence and Trusted Publishing workflow
- describe `SOURCE_DATE_EPOCH` as reproducibility support without promising identical artifacts across uncontrolled environments
- move irreversible PyPI cleanup out of the release-manager checklist into a separate Architecture & Infra SIG administration guide

## Testing

- `git diff --check`
- verified local documentation targets and trailing whitespace
- Pixi documentation hooks could not run because dependency downloads failed TLS certificate verification