### PR TITLE
docs: modernize backend test guidance

### DIFF
--- a/docs/ImplementingAnOnnxBackend.md
+++ b/docs/ImplementingAnOnnxBackend.md
@@ -8,120 +8,91 @@ SPDX-License-Identifier: Apache-2.0
 
 ## What is an ONNX backend
 
-An ONNX backend is a library that can run ONNX models. Since many deep learning frameworks already exist, you likely won't need to create everything from scratch. Rather, you'll likely create a converter that converts ONNX models to the corresponding framework specific representation and then delegate the execution to the framework. For example, [onnx-caffe2 (as part of caffe2)](https://github.com/pytorch/pytorch/tree/v2.3.1/caffe2/python/onnx) , [onnx-coreml](https://github.com/onnx/onnx-coreml), and [onnx-tensorflow](https://github.com/onnx/onnx-tensorflow) are all implemented as converters.
+An ONNX backend is an implementation capable of executing ONNX models. A
+backend may interpret a model, compile or lower it to another representation,
+translate it for an existing framework, execute it directly on hardware, or
+combine these approaches. ONNX does not require a particular implementation
+strategy.
 
-## Unified backend interface
+The ONNX Python package provides an adapter interface for exposing an
+implementation to ONNX's backend-test runner. This Python interface is useful
+for conformance testing, but it is not itself part of the ONNX model or runtime
+specification.
 
-ONNX has defined a unified (Python) backend interface at [onnx/backend/base.py](/onnx/backend/base.py).
+## Python backend adapter interface
 
-There are three core concepts in this interface: `Device`, `Backend` and `BackendRep`.
+The interface is defined in [`onnx/backend/base.py`](/onnx/backend/base.py) and
+has three core concepts:
 
-- `Device` is a lightweight abstraction over various hardware, e.g., CPU, GPU, etc.
+- `Device` describes a device type and optional device identifier, such as
+  `CPU`, `CUDA`, or `CUDA:1`.
+- `Backend` accepts an ONNX model and prepares it for execution. Its
+  `run_model` and `run_node` helpers support one-off execution where the backend
+  implements the corresponding methods.
+- `BackendRep` is the prepared-model handle returned by `Backend.prepare`.
+  Repeated calls to `BackendRep.run` execute the model with new inputs.
 
-- `Backend` is the entity that will take an ONNX model with inputs, perform a computation, and then return the output.
+The adapter may wrap an implementation written in any language. Only the
+Python-facing adapter needs to implement this interface.
 
-  For one-off execution, users can use `run_node` and `run_model` to obtain results quickly.
+The repository's
+[`ReferenceEvaluatorBackend`](/tests/python/backend_reference_test.py) is the
+canonical current example. It adapts `ReferenceEvaluator` to `Backend` and
+`BackendRep`, declares CPU support, and runs the ONNX backend suite. For an
+external integration, [ONNX-TensorRT's backend test](https://github.com/onnx/onnx-tensorrt/blob/main/onnx_backend_test.py)
+uses the same interface and runner. Historical Caffe2, onnx-coreml, and
+onnx-tensorflow integrations are no longer used as current implementation
+examples because those projects or integrations are archived or unmaintained.
 
-  For repeated execution, users should use `prepare`, in which the `Backend` does all of the preparation work for executing the model repeatedly (e.g., loading initializers), and returns a `BackendRep` handle.
+## Integrating ONNX Backend Test
 
-- `BackendRep` is the handle that a `Backend` returns after preparing to execute a model repeatedly. Users will then pass inputs to the `run` function of `BackendRep` to retrieve the corresponding results.
+Create a module containing the backend adapter, construct `BackendTest`, and
+export its generated test cases for pytest or unittest discovery:
 
-Note that even though the ONNX unified backend interface is defined in Python, your backend does not need to be implemented in Python. For example, yours can be created in C++, and tools such as [pybind11](https://github.com/pybind/pybind11) or [cython](http://cython.org/) can be used to fulfill the interface.
+```python
+import onnx.backend.test
 
-## ONNX backend test
+from my_backend import MyBackend
 
-ONNX provides a standard backend test suite to assist backend implementation verification. It's strongly encouraged that each ONNX backend runs this test.
+pytest_plugins = ("onnx.backend.test.report",)
 
-Integrating the ONNX Backend Test suite into your CI is simple. The following are some examples demonstrating how a backend performs the integration:
-
-- [onnx-caffe2 onnx backend test](https://github.com/pytorch/pytorch/blob/v2.3.1/caffe2/python/onnx/tests/onnx_backend_test.py)
-
-- [onnx-tensorflow onnx backend test](https://github.com/onnx/onnx-tensorflow/blob/main/test/backend/test_onnx_backend.py)
-
-- [onnx-coreml onnx backend test](https://github.com/onnx/onnx-coreml/blob/master/tests/onnx_backend_models_test.py)
-
-If you have [pytest](https://docs.pytest.org/en/latest/) installed, you can get a coverage report after running the ONNX backend test to see how well your backend is doing:
-
+backend_test = onnx.backend.test.BackendTest(MyBackend, __name__)
+globals().update(backend_test.enable_report().test_cases)
 ```
+
+Use `include`, `exclude`, or `xfail` patterns to describe the cases supported
+by the implementation. Prefer narrowly scoped patterns with comments that
+explain the unsupported behavior. See the in-repository reference-backend test
+for current examples.
+
+The suite includes individual node cases, small model cases, representative
+lightweight models, and retained converted-model fixtures. See
+[ONNX Backend Test](OnnxBackendTest.md) for their sources, contribution process,
+and the transition from serialized node fixtures to in-memory test cases.
+
+## Coverage report
+
+Calling `enable_report()` and loading the `onnx.backend.test.report` pytest
+plugin adds a summary such as:
+
+```text
 ---------- onnx coverage: ----------
-Operators (passed/loaded/total): 21/21/70
+Operators (passed/loaded/total): <passed>/<loaded>/<total>
 ------------------------------------
-╒════════════════════╤════════════════════╕
-│ Operator           │ Attributes         │
-│                    │ (name: #values)    │
-╞════════════════════╪════════════════════╡
-│ Slice              │ axes: 2            │
-│                    │ ends: 3            │
-│                    │ starts: 3          │
-├────────────────────┼────────────────────┤
-│ Constant           │ value: 1           │
-├────────────────────┼────────────────────┤
-│ Concat             │ axis: 0            │
-├────────────────────┼────────────────────┤
-│ Conv               │ group: 6           │
-│                    │ kernel_shape: 5    │
-│                    │ pads: 4            │
-│                    │ strides: 3         │
-│                    │ auto_pad: 0        │
-│                    │ dilations: 0       │
-├────────────────────┼────────────────────┤
-│ Reshape            │ shape: 9           │
-├────────────────────┼────────────────────┤
-│ BatchNormalization │ consumed_inputs: 1 │
-│                    │ epsilon: 2         │
-│                    │ is_test: 1         │
-│                    │ momentum: 0        │
-│                    │ spatial: 0         │
-├────────────────────┼────────────────────┤
-│ Dropout            │ is_test: 1         │
-│                    │ ratio: 2           │
-├────────────────────┼────────────────────┤
-│ MaxPool            │ kernel_shape: 2    │
-│                    │ pads: 3            │
-│                    │ strides: 2         │
-│                    │ auto_pad: 0        │
-│                    │ dilations: 0       │
-├────────────────────┼────────────────────┤
-│ Transpose          │ perm: 1            │
-├────────────────────┼────────────────────┤
-│ MatMul             │ No attributes      │
-├────────────────────┼────────────────────┤
-│ Relu               │ No attributes      │
-├────────────────────┼────────────────────┤
-│ LRN                │ alpha: 2           │
-│                    │ beta: 1            │
-│                    │ bias: 2            │
-│                    │ size: 1            │
-├────────────────────┼────────────────────┤
-│ Add                │ axis: 1            │
-│                    │ broadcast: 1       │
-├────────────────────┼────────────────────┤
-│ Abs                │ No attributes      │
-├────────────────────┼────────────────────┤
-│ Pad                │ mode: 3            │
-│                    │ paddings: 2        │
-│                    │ value: 1           │
-├────────────────────┼────────────────────┤
-│ Softmax            │ axis: 0            │
-├────────────────────┼────────────────────┤
-│ GlobalAveragePool  │ No attributes      │
-├────────────────────┼────────────────────┤
-│ Mul                │ axis: 1            │
-│                    │ broadcast: 1       │
-├────────────────────┼────────────────────┤
-│ Sum                │ No attributes      │
-├────────────────────┼────────────────────┤
-│ Gemm               │ broadcast: 1       │
-│                    │ transB: 1          │
-│                    │ alpha: 0           │
-│                    │ beta: 0            │
-│                    │ transA: 0          │
-├────────────────────┼────────────────────┤
-│ AveragePool        │ kernel_shape: 3    │
-│                    │ pads: 3            │
-│                    │ strides: 2         │
-│                    │ auto_pad: 0        │
-╘════════════════════╧════════════════════╛
 ```
 
-The numbers in the line `Operators (passed/loaded/total): 21/21/70` indicate 21 operators covered in all test cases of your backend have passed, 21 operators were covered in all test cases of the ONNX backend test, and ONNX has a total of 70 operators.
+- `passed` is the number of operator types whose loaded cases passed.
+- `loaded` is the number of operator types exercised by the selected cases.
+- `total` is calculated from the schema registry in the installed ONNX version.
+
+These values change as schemas and tests are added, so documentation should not
+hard-code a particular operator count. The generated
+[ONNX Core Test Coverage](/docs/TestCoverage.md) and
+[ONNX-ML Test Coverage](/docs/TestCoverage-ml.md) reports contain the current
+repository-wide coverage.
+
+Passing the backend suite measures the implementation against the cases that
+were loaded. It is not a certification of complete ONNX support. The proposed
+wording for the relationship between backend tests and the normative
+specification is being discussed in
+[issue #8287](https://github.com/onnx/onnx/issues/8287).

--- a/docs/OnnxBackendTest.md
+++ b/docs/OnnxBackendTest.md
@@ -8,18 +8,86 @@ SPDX-License-Identifier: Apache-2.0
 
 ## What is ONNX Backend Test
 
-ONNX Backend Test is a test suite that each ONNX backend should run to verify whether it fulfills ONNX's standard. It serves both as a verification tool for backend implementations and one of the two ways to define each operator's expected behavior (the other way is to add it to the documentation).
+ONNX Backend Test is a Python conformance-test suite that can be applied to an
+ONNX backend implementation. It runs models and nodes with known inputs and
+compares the backend's results with expected outputs. Passing the included
+tests demonstrates support for those cases; it does not by itself prove full
+ONNX compliance.
 
-There are two types of tests in this suite – Node Tests and Model Tests:
+### Relationship to the ONNX specification
 
-- **Node Tests** verify whether a backend is performing the correct computation, having the expected behavior of handling various attributes for each individual operator. In each test case, the backend will be given a node with some input, and the returned output will be compared with an expected output.
-- **Model Tests** verify the backend at the model level. The test cases are similar to those of Node Tests', but instead of a node, the backend will be given an ONNX model.
+> **Draft note:** The precise normative status and lifecycle of backend tests is being
+> discussed in [issue #8287](https://github.com/onnx/onnx/issues/8287). This
+> section is proposed wording for that discussion and will be finalized before
+> this documentation change is marked ready for review.
+
+The ONNX IR and versioned operator specifications define normative ONNX
+semantics. Backend tests provide executable conformance cases and examples
+derived from those specifications. They are also useful evidence when
+clarifying an ambiguity, but a test does not silently override a versioned
+operator specification.
+
+A discrepancy between a test, reference implementation, and operator
+specification should be reported and investigated. The resolution may correct
+the test or reference implementation, clarify an ambiguity according to the
+[ONNX versioning policy](Versioning.md), or introduce a new operator version
+when behavior changes.
+
+## Test categories
+
+The backend-test runner currently loads several categories:
+
+- **Node tests** exercise individual operators, including different attributes,
+  input types, shapes, and edge cases. Their Python definitions live in
+  [`onnx/backend/test/case/node`](/onnx/backend/test/case/node).
+- **Simple model tests** exercise small graphs defined in
+  [`onnx/backend/test/case/model`](/onnx/backend/test/case/model). Their
+  serialized fixtures are stored under
+  [`onnx/backend/test/data/simple`](/onnx/backend/test/data/simple).
+- **Real model tests** exercise representative models. The current models are
+  lightweight fixtures committed under
+  [`onnx/backend/test/data/light`](/onnx/backend/test/data/light), with metadata
+  under [`onnx/backend/test/data/real`](/onnx/backend/test/data/real).
+- **PyTorch-converted and PyTorch-operator tests** are historical model fixtures
+  retained under [`onnx/backend/test/data`](/onnx/backend/test/data).
+
+### Node-test data access
+
+PR [#7959](https://github.com/onnx/onnx/pull/7959) removed the generated node
+`.onnx` and `.pb` artifacts from the package. Node cases are now constructed in
+memory. Consumers should load them through
+[`load_model_tests(kind="node")`](/onnx/backend/test/loader/__init__.py) and use
+each returned `TestCase.model` and `TestCase.data_sets` instead of assuming that
+`onnx/backend/test/data/node` exists.
+
+Earlier documentation described the removed directory as the source of truth,
+and downstream projects consumed its serialized layout. A supported way to
+materialize the in-memory cases for file-based and non-Python consumers is
+being discussed in [issue #8288](https://github.com/onnx/onnx/issues/8288).
 
 ## Contributing
 
-As ONNX aims to become the spec of deep learning models format, it's important to ensure that there is no ambiguity in each ONNX operator's definition; adding more test cases is the only way to enforce this.
+### Node tests
 
-Node Tests are created as Python/Numpy code in [onnx/backend/test/case/node](/onnx/backend/test/case/node).
-Test cases of each operator lives in one standalone file, e.g. for the operator [Add](/docs/Operators.md#Add), its test cases are in [add.py](/onnx/backend/test/case/node/add.py), and each `expect(...)` statement in the code corresponds to one test case. The source code of all `export.*` functions will be also embedded as example code snippets in the [Operators documentation page](/docs/Operators.md). You are contributing to both the test and the documentation!
+Node tests are written in Python and NumPy. Each operator normally has a file
+under [`onnx/backend/test/case/node`](/onnx/backend/test/case/node); for example,
+[`add.py`](/onnx/backend/test/case/node/add.py) contains the tests for
+[`Add`](/docs/Operators.md#Add). Each `expect(...)` call defines a test case.
 
-For Model Tests, since each model protobuf file can be large in size, we don't place the file directly in the repo. Rather, we upload them to the cloud, and download them on demand when running the tests. Each test case consists of one model definition protobuf file, and several pairs of input and output files. Adding a new test case involves some manual work from admins (like uploading the files to the cloud), so if you have an ONNX model that you would like to contribute, please contact us.
+The source of exported test functions is also embedded as example code in the
+generated [Operators documentation](/docs/Operators.md). After changing node
+tests, regenerate the operator coverage and documentation as described in the
+[contributor guide](/CONTRIBUTING.md).
+
+### Model tests
+
+Small model tests can be defined with `expect(...)` under
+[`onnx/backend/test/case/model`](/onnx/backend/test/case/model). The
+`backend-test-tools generate-data` command serializes these cases into the
+model-test data directory; review all generated changes before committing them.
+
+The representative models under `data/light` were made small enough for the
+repository by replacing large initializers with `ConstantOfShape` nodes. Adding
+a large model or new generated binary fixtures affects repository and package
+size and should be discussed with maintainers first. It does not require an
+administrator to upload files to cloud storage.


### PR DESCRIPTION
## Draft status

This PR is intentionally a **Draft** and should not be merged yet. It provides a concrete documentation proposal for two linked discussions:

- #8287 - clarify the normative status and lifecycle of backend tests
- #8288 - define supported access to serialized backend node-test fixtures after #7959

The proposed specification-status wording is visibly marked as Draft text in `OnnxBackendTest.md`. It should be confirmed or revised by the Operators SIG before this PR is marked ready for review.

## Motivation

The backend guides combine statements written in 2017 with an implementation that has changed substantially:

- representative model tests switched from remote heavy models to local lightweight fixtures in #4861;
- generated node `.onnx` and `.pb` artifacts were removed in #7959 and cases are now constructed in memory;
- downstream projects had consumed the previously documented file layout;
- the implementation examples point to archived or unmaintained integrations;
- the coverage example hard-codes the historical total of 70 operators;
- the current text does not clearly distinguish the normative specification from executable conformance cases.

## Proposed changes

- describe backend tests as conformance cases whose coverage is limited to the loaded cases
- add proposed wording for their relationship to the IR and versioned operator specifications
- document the current node, simple-model, lightweight real-model, and retained converted-model categories
- document the in-memory node-test API and the compatibility discussion for file-based consumers
- replace historical Caffe2/CoreML/TensorFlow examples with the in-repository reference backend and maintained ONNX-TensorRT integration
- replace the static coverage snapshot and operator count with the current dynamic report semantics
- remove the obsolete cloud-upload/admin contribution instructions

## Questions for reviewers

1. Does #8287's proposed normative/informative/conformance distinction match the Operators SIG's intent?
2. Which loader fields and serialized layouts should be documented as stable interfaces under #8288?
3. Should the factual cleanup be split and merged before the policy wording is resolved?
4. Is ONNX-TensorRT the preferred maintained external example, or should the guide use only the in-repository reference backend?

## Validation

- `git diff --check`
- verified every local Markdown target in the two changed files exists
- checked the documented categories and in-memory access path against the current loader and runner
- checked the integration example against the in-repository reference backend and current ONNX-TensorRT backend test

`pixi run lint` could not complete because the environment failed to download conda-forge packages with TLS `UnknownIssuer`. No lint failure from the changed Markdown files was reported before dependency resolution stopped.