### PR TITLE
build(docs): harden Sphinx generation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,6 +31,8 @@ jobs:
           environments: docs
       - name: Install repository
         run: pixi run -e docs install
+      - name: Test Docs Tooling
+        run: pixi run -e docs docs-test
       - name: Build Docs
         run: pixi run -e docs docs-build
       - name: Upload artifact

--- a/docs/docsgen/source/onnx_sphinx.py
+++ b/docs/docsgen/source/onnx_sphinx.py
@@ -24,6 +24,7 @@ from sphinx.util import logging
 import onnx
 from onnx.backend.test.case.base import _Exporter
 from onnx.defs import OpSchema
+from onnx.defs._documentation import generate_formal_parameter_tags
 
 REPO_DOCS_EXCLUDE = {
     "Changelog-ml.md",
@@ -104,10 +105,6 @@ This version of the operator has been {% if
 sch.deprecated %}deprecated{% else %}available{% endif %}
 **since version {{sch.since_version}}{% if
 sch.domain %} of domain {{sch.domain}}{% endif %}**.
-{% if len(sch.versions) > 1 %}
-Other versions of this operator:
-{% for v in sch.version[:-1] %} {{v}} {% endfor %}
-{% endif %}
 {% endif %}
 
 ### Summary
@@ -290,9 +287,6 @@ def get_operator_schemas(op_name, version=None, domain=None):
     :param domain: domain
     :return: list of schemas
     """
-    if version == "last" and op_name is not None:
-        if domain is not None:
-            return [onnx.defs.get_schema(op_name, domain=domain)]
     all_schemas = _get_all_schemas_with_history()
     if domain is None:
         domains = []
@@ -322,6 +316,11 @@ def get_operator_schemas(op_name, version=None, domain=None):
         elif op_name in ops:
             if version is None:
                 sch.extend(ops[op_name].values())
+            elif version == "last":
+                try:
+                    sch.append(onnx.defs.get_schema(op_name, domain=dom))
+                except onnx.defs.SchemaError:
+                    sch.append(ops[op_name][max(ops[op_name])])
             elif version in ops[op_name]:
                 sch.append(ops[op_name][version])
 
@@ -361,18 +360,6 @@ def get_markdown_doc(
         if sch.domain:
             return f"{sch.name} - {sch.since_version} ({sch.domain})"
         return f"{sch.name} - {sch.since_version}"
-
-    def format_option(obj):
-        opts = []
-        if OpSchema.FormalParameterOption.Optional == obj.option:
-            opts.append("optional")
-        elif OpSchema.FormalParameterOption.Variadic == obj.option:
-            opts.append("variadic")
-        if getattr(obj, "is_homogeneous", False):
-            opts.append("heterogeneous")
-        if opts:
-            return f" ({', '.join(opts)})"
-        return ""
 
     def format_example(code):
         return code
@@ -461,7 +448,7 @@ def get_markdown_doc(
         len=len,
         getattr=getattr,
         sorted=sorted,
-        format_option=format_option,
+        format_option=generate_formal_parameter_tags,
         get_constraint=get_constraint,
         getname=getname,
         enumerate=enumerate,
@@ -714,6 +701,13 @@ def is_last_schema(sch: OpSchema) -> bool:
     return last.since_version == sch.since_version
 
 
+def _clean_operator_docs(folder: str | os.PathLike[str]) -> None:
+    output_folder = pathlib.Path(folder)
+    for pattern in ("onnx_*.md", "text_diff_*.rst", "index.rst"):
+        for generated_file in output_folder.glob(pattern):
+            generated_file.unlink()
+
+
 def onnx_documentation_folder(
     folder, title="ONNX Operators", flog=None, max_opsets=None
 ):
@@ -803,6 +797,8 @@ def onnx_documentation_folder(
     if not os.path.exists(folder):
         os.makedirs(folder)
 
+    _clean_operator_docs(folder)
+
     pages = []
     tables = []
 
@@ -877,9 +873,16 @@ def _copy_repo_docs(app):
     # Copy all the markdown files from the folder except for the blocklisted ones
 
     logger.info("Copying Markdown files from '%s' to '%s'", docs_dir, dest_folder)
-    for file in docs_dir.glob("*.md"):
-        if file.name in REPO_DOCS_EXCLUDE:
-            continue
+    source_files = {
+        file.name: file
+        for file in docs_dir.glob("*.md")
+        if file.name not in REPO_DOCS_EXCLUDE
+    }
+    for stale_file in dest_folder.glob("*.md"):
+        if stale_file.name != "index.md" and stale_file.name not in source_files:
+            stale_file.unlink()
+            logger.info("Removing stale Markdown file '%s'", stale_file.name)
+    for file in source_files.values():
         shutil.copy(file, dest_folder)
         logger.info("Copying '%s'", file.name)
 

--- a/onnx/defs/_documentation.py
+++ b/onnx/defs/_documentation.py
@@ -1,0 +1,29 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from onnx.defs import OpSchema
+
+
+def generate_formal_parameter_tags(
+    formal_parameter: OpSchema.FormalParameter,
+) -> str:
+    """Generate the tags displayed beside an operator input or output."""
+    tags: list[str] = []
+    if OpSchema.FormalParameterOption.Optional == formal_parameter.option:
+        tags.append("optional")
+    elif OpSchema.FormalParameterOption.Variadic == formal_parameter.option:
+        tags.append("variadic")
+        if not formal_parameter.is_homogeneous:
+            tags.append("heterogeneous")
+
+    differentiable = OpSchema.DifferentiationCategory.Differentiable
+    non_differentiable = OpSchema.DifferentiationCategory.NonDifferentiable
+    if differentiable == formal_parameter.differentiation_category:
+        tags.append("differentiable")
+    elif non_differentiable == formal_parameter.differentiation_category:
+        tags.append("non-differentiable")
+
+    return "" if not tags else f" ({', '.join(tags)})"

--- a/onnx/defs/gen_doc.py
+++ b/onnx/defs/gen_doc.py
@@ -15,6 +15,7 @@ from onnx import defs, helper
 from onnx.backend.sample.ops import collect_sample_implementations
 from onnx.backend.test.case import collect_snippets
 from onnx.defs import ONNX_ML_DOMAIN, OpSchema
+from onnx.defs._documentation import generate_formal_parameter_tags
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -75,29 +76,6 @@ def display_domain_short(domain: str) -> str:
 def display_version_link(name: str, version: int, changelog: str) -> str:
     name_with_ver = f"{name}-{version}"
     return f'<a href="{changelog}#{name_with_ver}">{version}</a>'
-
-
-def generate_formal_parameter_tags(formal_parameter: OpSchema.FormalParameter) -> str:
-    tags: list[str] = []
-    if OpSchema.FormalParameterOption.Optional == formal_parameter.option:
-        tags = ["optional"]
-    elif OpSchema.FormalParameterOption.Variadic == formal_parameter.option:
-        if formal_parameter.is_homogeneous:
-            tags = ["variadic"]
-        else:
-            tags = ["variadic", "heterogeneous"]
-    differentiable: OpSchema.DifferentiationCategory = (
-        OpSchema.DifferentiationCategory.Differentiable
-    )
-    non_differentiable: OpSchema.DifferentiationCategory = (
-        OpSchema.DifferentiationCategory.NonDifferentiable
-    )
-    if differentiable == formal_parameter.differentiation_category:
-        tags.append("differentiable")
-    elif non_differentiable == formal_parameter.differentiation_category:
-        tags.append("non-differentiable")
-
-    return "" if len(tags) == 0 else " (" + ", ".join(tags) + ")"
 
 
 def display_schema(

--- a/pixi.toml
+++ b/pixi.toml
@@ -78,6 +78,10 @@ cmd = "lintrunner --all-files"
 description = "Build sphinx documentation"
 cmd = "cd docs/docsgen && make html"
 
+[feature.docs.tasks.docs-test]
+description = "Test sphinx documentation tooling"
+cmd = "pytest tests/python/defs_documentation_test.py tests/python/docsgen_test.py"
+
 [dependencies]
 libdate = ">=3.0.1,<4"
 libprotobuf = "<7"  # libprotobuf>=7 has breaking changes which need a dedicated PR

--- a/tests/python/defs_documentation_test.py
+++ b/tests/python/defs_documentation_test.py
@@ -1,0 +1,50 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from onnx.defs import OpSchema
+from onnx.defs._documentation import generate_formal_parameter_tags
+
+
+@pytest.mark.parametrize(
+    ("option", "is_homogeneous", "expected"),
+    [
+        (OpSchema.FormalParameterOption.Single, True, ""),
+        (OpSchema.FormalParameterOption.Optional, True, " (optional)"),
+        (OpSchema.FormalParameterOption.Variadic, True, " (variadic)"),
+        (
+            OpSchema.FormalParameterOption.Variadic,
+            False,
+            " (variadic, heterogeneous)",
+        ),
+    ],
+)
+def test_generate_formal_parameter_tags(
+    option: OpSchema.FormalParameterOption,
+    is_homogeneous: bool,
+    expected: str,
+) -> None:
+    parameter = OpSchema.FormalParameter(
+        "input",
+        "T",
+        "An input.",
+        param_option=option,
+        is_homogeneous=is_homogeneous,
+    )
+
+    assert generate_formal_parameter_tags(parameter) == expected
+
+
+def test_generate_formal_parameter_differentiation_tag() -> None:
+    parameter = OpSchema.FormalParameter(
+        "input",
+        "T",
+        "An input.",
+        differentiation_category=OpSchema.DifferentiationCategory.Differentiable,
+    )
+
+    assert generate_formal_parameter_tags(parameter) == " (differentiable)"

--- a/tests/python/docsgen_test.py
+++ b/tests/python/docsgen_test.py
@@ -1,0 +1,58 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+from typing import Any
+
+import pytest
+
+pytest.importorskip("sphinx")
+
+
+def _load_onnx_sphinx() -> Any:
+    source = (
+        pathlib.Path(__file__).parents[2]
+        / "docs"
+        / "docsgen"
+        / "source"
+        / "onnx_sphinx.py"
+    )
+    spec = importlib.util.spec_from_file_location("onnx_sphinx", source)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+onnx_sphinx = _load_onnx_sphinx()
+
+
+def test_get_latest_operator_schema_without_domain() -> None:
+    schemas = onnx_sphinx.get_operator_schemas("Add", version="last")
+
+    assert len(schemas) == 1
+    assert schemas[0].name == "Add"
+    assert schemas[0].since_version == max(
+        schema.since_version
+        for schema in onnx_sphinx.get_operator_schemas("Add", version=None)
+    )
+
+
+def test_operator_generation_removes_stale_files(tmp_path: pathlib.Path) -> None:
+    stale_operator = tmp_path / "onnx_Stale.md"
+    stale_diff = tmp_path / "text_diff_Stale.rst"
+    unrelated = tmp_path / "keep.txt"
+    stale_operator.touch()
+    stale_diff.touch()
+    unrelated.touch()
+
+    onnx_sphinx._clean_operator_docs(tmp_path)
+
+    assert not stale_operator.exists()
+    assert not stale_diff.exists()
+    assert unrelated.exists()


### PR DESCRIPTION
## Summary

- share formal-parameter tag rendering between the canonical and Sphinx operator generators, fixing homogeneous/heterogeneous labels
- fix latest-schema lookup, remove dead version-template fields, and clean stale generated pages before rebuilding
- add focused docs-tooling tests and run them in the Pages workflow

## Testing

- `git diff --check`
- `pixi run -e docs docs-test` *(blocked locally before execution because Pixi dependency downloads failed TLS validation with `UnknownIssuer`; the new Pages step runs this in CI)*

This PR is independent of #8291. Enabling Sphinx warning-as-error remains a follow-up after #8291 removes the existing warning baseline.