### PR TITLE
Clarify Cast operator float-to-float rounding mode (round-to-nearest-even)

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -30040,7 +30040,7 @@ This version of the operator has been available since version 24 of the default 
   if the destination type is not a float 8 type.
 
   * Casting from floating point to:
-    * floating point: +/- infinity if OOR (out of range).
+    * floating point: round to nearest even (RNE) for in-range values; +/- infinity if OOR (out of range).
     * fixed point: undefined if OOR.
     * bool: +/- 0.0 to False; all else to True.
   * Casting from fixed point to:
@@ -31526,7 +31526,7 @@ This version of the operator has been available since version 24 of the default 
   if the destination type is not a float 8 type.
 
   * Casting from floating point to:
-    * floating point: +/- infinity if OOR (out of range).
+    * floating point: round to nearest even (RNE) for in-range values; +/- infinity if OOR (out of range).
     * fixed point: undefined if OOR.
     * bool: +/- 0.0 to False; all else to True.
   * Casting from fixed point to:

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -7020,7 +7020,7 @@ expect(
   if the destination type is not a float 8 type.
 
   * Casting from floating point to:
-    * floating point: +/- infinity if OOR (out of range).
+    * floating point: round to nearest even (RNE) for in-range values; +/- infinity if OOR (out of range).
     * fixed point: undefined if OOR.
     * bool: +/- 0.0 to False; all else to True.
   * Casting from fixed point to:

--- a/onnx/defs/doc_strings.cc
+++ b/onnx/defs/doc_strings.cc
@@ -449,7 +449,7 @@ In more detail, the conversion among numerical types should follow these rules
 if the destination type is not a float 8 type.
 
 * Casting from floating point to:
-  * floating point: +/- infinity if OOR (out of range).
+  * floating point: round to nearest even (RNE) for in-range values; +/- infinity if OOR (out of range).
   * fixed point: undefined if OOR.
   * bool: +/- 0.0 to False; all else to True.
 * Casting from fixed point to:

--- a/tests/python/schema_test.py
+++ b/tests/python/schema_test.py
@@ -64,6 +64,43 @@ class TestSchema:
         )
         assert if_schema.non_deterministic
 
+    def test_cast_float_to_float_rounding_mode(self) -> None:
+        """Cast doc must specify round-to-nearest-even for in-range float->float conversion.
+
+        The non-float8 floating-point to floating-point rule must state the
+        rounding mode used for in-range values (e.g. float32 -> bfloat16),
+        not only the out-of-range behavior. The tie rule must be even
+        (round-to-nearest-even, a.k.a. RNE).
+        """
+        import re
+
+        cast_schema = defs.get_schema("Cast", 25)
+        doc = cast_schema.doc
+
+        # Extract the "floating point:" sub-bullet that lives directly under
+        # the "Casting from floating point to:" rule. This is the float -> float
+        # conversion rule (the non-float8 one; float8 has its own tables under a
+        # separate heading and is intentionally not used here).
+        match = re.search(
+            r"Casting from floating point to:[^\n]*\n\s*\*\s*floating point:\s*([^\n]+)",
+            doc,
+        )
+        assert match, "Could not locate the float->float conversion rule in the Cast doc"
+        float_to_float_rule = match.group(1).strip()
+
+        # The rule must specify round-to-nearest-even (RNE) for in-range values.
+        # Plain "round to nearest" without the even tie rule is not sufficient.
+        lowered = float_to_float_rule.lower()
+        assert (
+            "round to nearest even" in lowered
+            or "round-to-nearest-even" in lowered
+            or "RNE" in float_to_float_rule
+        ), (
+            "Cast float->float conversion rule must specify round-to-nearest-even "
+            "(RNE) for in-range values, not only OOR behavior. "
+            f"Found rule: {float_to_float_rule!r}"
+        )
+
     def test_celu_type_constraints(self) -> None:
         def allowed(schema):
             return next(


### PR DESCRIPTION
Fixes #3876

## Summary

The Cast operator specification did not explicitly state the rounding mode for in-range floating-point to floating-point conversions (e.g. float32 -> bfloat16). The non-float8 conversion rule only described out-of-range behavior (`+/- infinity if OOR`), which could lead readers to infer truncation or implementation-defined behavior.

This PR clarifies the authoritative Cast doc string (`kDoc_Cast_ver24`, shared by opset 24 and 25) so the floating-point -> floating-point rule states that in-range values use **round-to-nearest-even (RNE)**, matching the IEEE 754 default and the existing reference implementation (numpy `astype`). The out-of-range `+/- infinity` rule is preserved.

## Changes

- `onnx/defs/doc_strings.cc`: updated the non-float8 float->float rule to read "round to nearest even (RNE) for in-range values; +/- infinity if OOR (out of range)."
- `docs/Operators.md`: regenerated from the doc string via the official `onnx/defs/gen_doc.py` generator.
- `tests/python/schema_test.py`: added a focused regression test that extracts the non-float8 float->float rule and asserts it specifies round-to-nearest-even (accepting "round to nearest even", "round-to-nearest-even", or the abbreviation "RNE").

## Behavior

- Runtime behavior is unchanged: the reference implementation already uses numpy `astype`, which applies round-to-nearest-even.
- The operator version (opset 25) is unchanged. Per ONNX Versioning.md, clarifying a specification ambiguity to match prevailing implementation practice is a non-breaking change.
- Float8 conversion tables and the `saturate`/`round_mode` attributes are untouched.

## Verification

- Focused Cast RNE schema test passed (1 test).
- All of `tests/python/schema_test.py` passed (38 tests).
- Official doc generator (`onnx/defs/gen_doc.py`) was idempotent on a second pass.
- `git diff --check` passed (no whitespace errors).

## AI-assistance disclosure

This change was produced with Claude Code (using `alwaysday1_max` through `super-relay`) and was independently tested and reviewed before submission.