### PR TITLE
Fix warnings from docs-build and ensure we fail on warnings in the future

### DIFF
--- a/docs/OnnxReleases.md
+++ b/docs/OnnxReleases.md
@@ -107,7 +107,7 @@ Validation steps must be completed before this point! This is the point of new r
     * DO NOT click `Publish release` until you are sure no more changes are needed.
         * Use `Save Draft` if need to save and update more later.
         * Publishing will create the new git tag
-    * Tag: See top of [Preparation](#Preparation) for tag to create.
+    * Tag: See top of [Preparation](#preparation) for tag to create.
     * Target: The release branch that was just cut
     * Previous tag: Select the previous release.
     * Write:

--- a/docs/PythonAPIOverview.md
+++ b/docs/PythonAPIOverview.md
@@ -431,7 +431,7 @@ onnx.compose.expand_out_dims(model1, dim_idx=0, inplace=True)
 
 Function `update_inputs_outputs_dims` updates the dimension of the inputs and outputs of the model,
 to the provided values in the parameter. You could provide both static and dynamic dimension size,
-by using dim_param. For more information on static and dynamic dimension size, checkout [Tensor Shapes](IR.md#tensor-shapes).
+by using dim_param. For more information on static and dynamic dimension size, checkout [Tensor Shapes](IR.md#static-tensor-shapes).
 
 The function runs model checker after the input/output sizes are updated.
 

--- a/docs/docsgen/Makefile
+++ b/docs/docsgen/Makefile
@@ -7,7 +7,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/docs/docsgen/source/api/classes.md
+++ b/docs/docsgen/source/api/classes.md
@@ -221,8 +221,8 @@ This is used to store metadata in ModelProto.
 
 This defines a tensor. A tensor is fully described with a shape
 (see ShapeProto), the element type (see TypeProto), and the
-elements themselves. All available types are listed in
-{ref}`l-mod-onnx-mapping`.
+elements themselves. The correspondence between ONNX and numpy types
+is available through the functions defined in {ref}`l-mod-onnx-helper`.
 
 ```{eval-rst}
 .. autoclass:: onnx.TensorProto

--- a/docs/docsgen/source/api/index.md
+++ b/docs/docsgen/source/api/index.md
@@ -58,7 +58,6 @@ defs
 external_data_helper
 helper
 inliner
-mapping
 model_container
 numpy_helper
 parser

--- a/docs/docsgen/source/api/serialization.md
+++ b/docs/docsgen/source/api/serialization.md
@@ -16,8 +16,8 @@ with open("model.onnx", "wb") as f:
 This method has the following signature.
 
 ```{eval-rst}
-.. autoclass:: onnx.ModelProto
-    :members: SerializeToString
+.. automethod:: onnx.ModelProto.SerializeToString
+    :no-index:
 ```
 
 Every Proto class implements method `SerializeToString`.
@@ -92,8 +92,8 @@ of the saved data. Therefore, this class must be known before
 restoring an object.
 
 ```{eval-rst}
-.. autoclass:: onnx.ModelProto
-    :members: ParseFromString
+.. automethod:: onnx.ModelProto.ParseFromString
+    :no-index:
 ```
 
 Next example shows how to restore a {ref}`l-nodeproto`.

--- a/docs/docsgen/source/conf.py
+++ b/docs/docsgen/source/conf.py
@@ -55,6 +55,7 @@ extensions = [
     "sphinx.ext.viewcode",
 ]
 
+myst_heading_anchors = 6
 myst_enable_extensions = [
     "amsmath",
     "attrs_inline",

--- a/docs/docsgen/source/intro/concepts.md
+++ b/docs/docsgen/source/intro/concepts.md
@@ -175,8 +175,8 @@ full array with no stride.
 
 ONNX was initially developed to help deploying deep learning model.
 That's why the specifications were initially designed for floats (32 bits).
-The current version supports all common types. Dictionary
-{ref}`l-onnx-types-mapping` gives the correspondence between *ONNX*
+The current version supports all common types. The functions defined in
+{ref}`l-mod-onnx-helper` give the correspondence between *ONNX*
 and {mod}`numpy`.
 
 ```{eval-rst}

--- a/docs/docsgen/source/onnx_sphinx.py
+++ b/docs/docsgen/source/onnx_sphinx.py
@@ -15,11 +15,14 @@ import re
 import shutil
 import sys
 import textwrap
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import jinja2
 import numpy as np
 from sphinx.util import logging
+
+if TYPE_CHECKING:
+    from sphinx.application import Sphinx
 
 import onnx
 from onnx.backend.test.case.base import _Exporter
@@ -867,17 +870,102 @@ def _generate_op_doc(app):
     onnx_documentation_folder(folder, flog=logger.info, max_opsets=max_opsets)
 
 
-def _copy_repo_docs(app):
+_MD_LINK_RE = re.compile(r"(?<=\]\()([^)\s]+)(?=\))")
+_GITHUB_BLOB = "https://github.com/onnx/onnx/blob/main/"
+# Repository directory (``docs``), the root of the ``repo-docs`` copies.
+_DOCS_DIR = pathlib.Path(__file__).parent.parent.parent
+_REPO_ROOT = _DOCS_DIR.parent
+_SOURCE_DIR = pathlib.Path(__file__).parent
+
+
+def _doc_dirs(docname: str) -> tuple[pathlib.Path, pathlib.Path]:
+    """Return the ``(resolve_dir, tree_dir)`` for ``docname``.
+
+    ``resolve_dir`` is the directory relative links were authored against;
+    ``tree_dir`` is the document's actual directory in the Sphinx source tree.
+    They differ for ``repo-docs`` documents, which are verbatim copies of the
+    repository's ``docs/*.md`` files: their links were authored against the
+    repository ``docs`` directory, but the copies live under ``repo-docs``.
+    """
+    tree_dir = (_SOURCE_DIR / docname).parent
+    if docname.startswith("repo-docs/"):
+        return _DOCS_DIR, tree_dir
+    return tree_dir, tree_dir
+
+
+def _intree_location(abspath: pathlib.Path) -> pathlib.Path | None:
+    """Return the Sphinx-tree path for ``abspath``, or ``None`` if external.
+
+    A resolved link target is internal to the documentation when it already
+    lives under the source tree, or when it is one of the ``docs/*.md`` files
+    copied into ``repo-docs`` (see ``_copy_repo_docs`` / ``REPO_DOCS_EXCLUDE``).
+    """
+    if abspath.is_relative_to(_SOURCE_DIR):
+        return abspath
+    if (
+        abspath.parent == _DOCS_DIR
+        and abspath.suffix == ".md"
+        and abspath.name not in REPO_DOCS_EXCLUDE
+    ):
+        return _SOURCE_DIR / "repo-docs" / abspath.name
+    return None
+
+
+def _rewrite_repo_links(
+    text: str, resolve_dir: pathlib.Path, tree_dir: pathlib.Path
+) -> str:
+    """Rewrite links to repository files as absolute GitHub URLs.
+
+    The Markdown files are authored to render on GitHub, where links such as
+    ``/onnx/onnx.proto`` or ``../onnx/checker.py`` point at repository sources.
+    Those targets are absent from the Sphinx document tree, so they are turned
+    into absolute GitHub URLs. Links whose target is internal to the
+    documentation are rewritten to a path relative to ``tree_dir`` so Sphinx
+    resolves them internally. Fragment suffixes are preserved.
+    """
+
+    def replace(match: re.Match[str]) -> str:
+        target = match.group(1)
+        if target.startswith(("#", "http://", "https://", "mailto:")):
+            return target
+        path, _, fragment = target.partition("#")
+        if not path:
+            return target
+        if path.startswith("/"):
+            abspath = pathlib.Path(os.path.normpath(_REPO_ROOT / path.lstrip("/")))
+        else:
+            abspath = pathlib.Path(os.path.normpath(resolve_dir / path))
+        if not abspath.exists():
+            return target
+        intree = _intree_location(abspath)
+        if intree is not None:
+            rel = os.path.relpath(intree, tree_dir)
+            return f"{rel}#{fragment}" if fragment else rel
+        repo_rel = abspath.relative_to(_REPO_ROOT).as_posix()
+        url = _GITHUB_BLOB + repo_rel
+        return f"{url}#{fragment}" if fragment else url
+
+    return _MD_LINK_RE.sub(replace, text)
+
+
+def _rewrite_source_links(app: Sphinx, docname: str, source: list[str]) -> None:
+    """Rewrite repository links in every Markdown document as it is read."""
+    if not source:
+        return
+    resolve_dir, tree_dir = _doc_dirs(docname)
+    source[0] = _rewrite_repo_links(source[0], resolve_dir, tree_dir)
+
+
+def _copy_repo_docs(app: Sphinx) -> None:
     logger = logging.getLogger(__name__)
     dest_name = app.config.onnx_md_folder
 
-    docs_dir = pathlib.Path(__file__).parent.parent.parent  # docs
-    dest_folder = docs_dir / "docsgen" / "source" / dest_name
+    dest_folder = _DOCS_DIR / "docsgen" / "source" / dest_name
     dest_folder.mkdir(parents=True, exist_ok=True)
     # Copy all the markdown files from the folder except for the blocklisted ones
 
-    logger.info("Copying Markdown files from '%s' to '%s'", docs_dir, dest_folder)
-    for file in docs_dir.glob("*.md"):
+    logger.info("Copying Markdown files from '%s' to '%s'", _DOCS_DIR, dest_folder)
+    for file in _DOCS_DIR.glob("*.md"):
         if file.name in REPO_DOCS_EXCLUDE:
             continue
         shutil.copy(file, dest_folder)
@@ -896,6 +984,7 @@ def setup(app):
     app.add_config_value("max_opsets", {}, "env")
     app.connect("builder-inited", _generate_op_doc)
     app.connect("builder-inited", _copy_repo_docs)
+    app.connect("source-read", _rewrite_source_links)
     return {"version": sphinx.__display_version__, "parallel_read_safe": True}
 
 

--- a/docs/docsgen/source/technical/index.md
+++ b/docs/docsgen/source/technical/index.md
@@ -18,4 +18,5 @@ float8
 int4
 float4
 int2
+kv_cache
 ```

--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -203,9 +203,9 @@ def extract_model(
 
     The sub-model is defined by the names of the input and output tensors *exactly*.
 
-    Note: For control-flow operators, e.g. If and Loop, the _boundary of sub-model_,
-    which is defined by the input and output tensors, should not _cut through_ the
-    subgraph that is connected to the _main graph_ as attributes of these operators.
+    Note: For control-flow operators, e.g. If and Loop, the *boundary of sub-model*,
+    which is defined by the input and output tensors, should not *cut through* the
+    subgraph that is connected to the *main graph* as attributes of these operators.
 
     Note: When the extracted model size is larger than 2GB, the extra data will be saved in "output_path.data".
 


### PR DESCRIPTION
This will turn our docs build job red (see first commit) if there are any broken internal anchors etc. Repository-links in the markdown files are re-written on-the-fly to urls pointing to the appropriate file on github.com (all those links are currently broken in the docs hosted on onnx.ai).

Related to #8291 

