### PR TITLE
docs: refresh community governance docs, add History section

### DIFF
--- a/community/readme.md
+++ b/community/readme.md
@@ -12,7 +12,7 @@ ONNX is rolling out open governance to encourage broader participation beyond th
 
 ONNX open governance creates 3 roles: Member, Contributor and Approver. 3 structures are also created: Steering Committee, Special Interest Groups (SIGs), Working Groups. Contributors and Approvers can vote for the Steering Committee members. The Steering Committee charters SIGs and appoints SIG chairs. Every piece of ONNX belongs to some SIG. Contributors and Approvers participate in one or more SIGs. Our governance structure is based on the successful model of Kubernetes.
 
-The effort is bootstrapped with an initial Steering Committee and set of SIGs with the first elections to occur after 1 year.
+See [History](#history) for how this structure was originally bootstrapped.
 
 ## Principles
 
@@ -71,10 +71,10 @@ The ONNX community is organized in the following manner, with all governance and
 The Steering Committee has a set of rights and responsibilities including the following:
 
 * Define, evolve, and defend the vision, values, mission, and scope of the project.
-* Define, evolve, and defend a Code of Conduct,  which must include a neutral, unbiased process for resolving conflicts.
+* Define, evolve, and defend a Code of Conduct, which must include a neutral, unbiased process for resolving conflicts.
 * Define and evolve project governance structures and policies, including how members become contributors, approvers, SIG chairs, etc.
 * Charter and refine policy for defining new community groups (Special Interest Groups, Working Groups, and any future possible defined structure), and establish transparency and accountability policies for such groups.
-* Decide, for the purpose of elections, who is a  member of standing of the ONNX project, and what privileges that entails.
+* Decide, for the purpose of elections, who is a member of standing of the ONNX project, and what privileges that entails.
 * Decide which functional areas and scope are part of the ONNX project, including accepting new or pruning old SIGs and Working Groups.
 * Decide how and when official releases of ONNX artifacts are made and what they include.
 * Declare releases when quality/feature/other requirements are met.
@@ -86,17 +86,13 @@ The Steering Committee has a set of rights and responsibilities including the fo
 
 #### Structure
 
-The Steering Committee consists of 5 individuals. No single Member Company may have more than 1 representative. Members serve 1 year terms.
-
-The starting composition will be individuals from Microsoft, Facebook, Amazon, and 2 other Member Companies, who have been picked by the three founding members based on contributions and experience.
-
-After the initial term of each Steering Committee representative is completed, their seat will be open for any contributor in the community to be elected into the seat via a community vote. Only contributors may vote, but would be restricted to one vote per Member Company.
+The Steering Committee consists of 5 individuals. No single Member Company may have more than 1 representative. Members serve 1 year terms and are elected by community vote; see the [Steering Committee election guidelines](sc-election-guidelines.md) for eligibility and process.
 
 If a member of the Steering Committee changes companies, by default they retain and may continue on with the role. If the employment change results in a single Member Company having more than one representative, then one of them must resign. When there is a vacancy on the Steering Committee, the remaining members can appoint a new representative for the remainder of the term until the next election.
 
-The Steering Committee will decide on and publish an election process within 3 months of formalizing this organizational structure. This will cover voting eligibility, eligibility for candidacy, election process and schedule. During this time period, the Steering Committee will also establish SIGs and Working Groups.
-
 A Steering Committee member can be removed due to Code of Conduct violations.
+
+See [History](#history) for how the founding Steering Committee was originally composed.
 
 ### SIG - Special Interest Groups
 
@@ -104,22 +100,28 @@ A Steering Committee member can be removed due to Code of Conduct violations.
 
 The ONNX project is organized primarily into Special Interest Groups, or SIGs. Each SIG is comprised of individuals from multiple companies and organizations, with a common purpose of advancing the project with respect to a specific topic.
 
-Our goal is to enable a distributed decision structure and code ownership, as well as providing focused forums for getting work done, making decisions, and on-boarding new contributors. Every identifiable part of the project (e.g., repository, subdirectory, API, test, issue, PR, Slack channel) is intended to be owned by some SIG. At the time of inception of this organizational structure, the following SIGs will be present:
+Our goal is to enable a distributed decision structure and code ownership, as well as providing focused forums for getting work done, making decisions, and on-boarding new contributors. Every identifiable part of the project (e.g., repository, subdirectory, API, test, issue, PR, Slack channel) is intended to be owned by some SIG. The following SIGs are currently chartered:
 
 * Architecture & Infra
     * This SIG is responsible for defining and maintaining the core ONNX format, the build and CI/CD systems for ONNX repositories, publishing release packages for ONNX, and creating tools to help integrate with and test against the ONNX standard. This SIG is also the defacto owner of files in the main ONNX repository unless explicitly owned by another SIG.
-* Operator Standardization
+* Operators
     * This SIG is responsible for determining the operators that are part of the ONNX spec (ONNX and ONNX-ML domains), ensuring high quality operator definitions and documentation, establishing criteria for adding new operators, managing ops domains and compliance tiers, and enforcing versioning mechanisms.
 * Converters
     * This SIG is responsible for developing and maintaining the various converter repositories under ONNX.
 * Models and tutorials
     * This SIG is responsible for tutorials and for maintaining the collection of ONNX models on the [ONNX community on Hugging Face](https://huggingface.co/onnx-community), with the charter of providing a comprehensive collection of state of the art ONNX models from a variety of sources and making it easy for users to get started with ONNX and the ecosystem around it.
+* Compilers
+    * This SIG is responsible for developing and maintaining core compiler technology for optimizing and lowering the ONNX format.
+* Optimizations
+    * This SIG is responsible for developing and maintaining solutions to optimize ONNX models, including model compression techniques (e.g. quantization, pruning, distillation, etc.).
+
+The current list of SIGs, including membership and meeting notes, is maintained in the [sigs repository](https://github.com/onnx/sigs).
 
 #### Structure
 
 SIGs must have at least one, and may have up to two SIG chairs at any given time. SIG chairs are intended to be organizers and facilitators, responsible for the operation of the SIG and for communication and coordination with the other SIGs, the Steering Committee, and the broader community. All SIG chairs are appointed by the Steering Committee. If there are more than two contributors being considered for a particular SIG, the Steering Committee will vote on and resolve who the chairs would be. Candidates need to be Approvers.
 
-Each SIG must have a charter that specifies its scope (topics, subsystems, code repos and directories), responsibilities, and areas of authority. Charters are submitted to the ONNX GitHub via PR for review and approval by the Steering Committee who will be looking to ensure the scope of the SIG as represented in the charter is reasonable. All SIGs are expected to follow the standards established by the Steering Committee for how Contributors are roles of authority/leadership are selected/granted, how decisions are made, and how conflicts are resolved.
+Each SIG must have a charter that specifies its scope (topics, subsystems, code repos and directories), responsibilities, and areas of authority. Charters are submitted to the ONNX GitHub via PR for review and approval by the Steering Committee who will be looking to ensure the scope of the SIG as represented in the charter is reasonable. All SIGs are expected to follow the standards established by the Steering Committee for how Contributors and roles of authority/leadership are selected/granted, how decisions are made, and how conflicts are resolved.
 
 A primary reason that SIGs exist is as forums for collaboration. Much work in a SIG should stay local within that SIG. However, SIGs must communicate in the open, ensure other SIGs and community members can find meeting notes, discussions, designs, and decisions, and periodically communicate a high-level summary of the SIG's work to the community. SIGs are also responsible to:
 
@@ -134,7 +136,7 @@ A primary reason that SIGs exist is as forums for collaboration. Much work in a 
 
 #### Decision making
 
-When it is time to formalize the work-product from a SIG, votes are taken from every contributor who participates in the SIG. The list of active contributors is determined by the one (or two) SIG leads to ensure that only those who have actively participated in the SIG can vote. At this time there are no restrictions on how many contributors from any one Member Company can participate (and hence vote). The Steering Committee will monitor how the community behaves and apply constraints if needed in the future.
+When it is time to formalize the work-product from a SIG, votes are taken from every contributor who participates in the SIG. The list of active contributors is determined by the one (or two) SIG leads to ensure that only those who have actively participated in the SIG can vote. There are no restrictions on how many contributors from any one Member Company can participate in a SIG (and hence vote).
 
 While most work shouldn’t require expensive coordination with other SIGs, there will be efforts (features, refactoring, etc.) that cross SIG boundaries. In this case, it is expected that the SIGs coordinate with each other and come to mutually agreed solutions. In some cases, it may make sense to form a Working Group for joint work. Cross-SIG coordination will naturally require more time and implies a certain amount of overhead. This is intentional to encourage changes to be well encapsulated whenever possible.
 
@@ -148,7 +150,7 @@ Working Groups (WGs) are primarily used to facilitate topics of discussion that 
 
 Working Groups can create specifications, recommendations, or implementations for submission to the relevant SIGs for approval and acceptance.
 
-A list of all active, inactive, and completed working groups can be found in the [working-groups repository](https://github.com/onnx/working-groups)
+A list of all active, inactive, and completed working groups can be found in the [working-groups repository](https://github.com/onnx/working-groups).
 
 Working Groups are formed by submitting a proposal via PR to the Steering Committee. The proposal should cover:
 
@@ -161,8 +163,14 @@ Working Groups are disbanded when there is no activity for more than *3 months* 
 
 ## Repository Guidelines
 
-The current guidelines for all repos under ONNX github.org could be found [here](repo_guidelines.md).
+The current guidelines for all repos under ONNX github.org can be found [here](repo_guidelines.md).
 
 ## CLA / DCO
 
 As of October 2020, the CLA (https://cla-assistant.io/onnx/onnx) has been retired. All commits are subject to the DCO (https://www.developercertificate.com/) and need to be signed.
+
+## History
+
+ONNX open governance was announced in March 2018. The founding Steering Committee was composed of representatives from Microsoft, Facebook, and Amazon plus 2 other Member Companies, selected by the three founding members based on contributions and experience, and it served for the first year while the initial SIGs and Working Groups were established.
+
+Within that first year, the Steering Committee published the [election guidelines](sc-election-guidelines.md) covering voting eligibility, candidacy, and election process/schedule, and Steering Committee seats have been filled by annual community election ever since. The full history of past terms and members is tracked in the [steering-committee repository](https://github.com/onnx/steering-committee).

--- a/community/sc-election-guidelines.md
+++ b/community/sc-election-guidelines.md
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0
 
 To encourage community participation and wider adoption in the industry, ONNX has introduced [open governance](https://github.com/onnx/onnx/wiki/Expanded-ONNX-Steering-Committee-Announced!) in March 2018. The governance has three defined structures to propel the development of ONNX project forward: [Steering Committee](/community/readme.md#steering-committee), [Special Interest Groups (SIGs)](/community/readme.md#sig---special-interest-groups), and [Working Groups (WGs)](/community/readme.md#wg---working-groups). While SIGs and WGs primarily focus on the technical roadmap of ONNX, the Steering Committee is responsible for setting the vision and governance process of the ONNX community.
 
-For the first year of its ONNX open governance, representatives from Facebook, Microsoft, AWS, Intel and Nvidia are chosen to serve as the ONNX Steering Committee to help guide the project. The Steering Committee will be elected by the [Contributors](/community/readme.md#community-roles) in its second year and will be re-elected every year.
+For the first year of ONNX open governance, representatives from Facebook, Microsoft, AWS, Intel and Nvidia were chosen to serve as the founding ONNX Steering Committee to help guide the project. Starting in its second year, the Steering Committee has been elected by the [Contributors](/community/readme.md#community-roles) and re-elected every year since. See the [History](/community/readme.md#history) section of the governance doc and the [steering-committee repository](https://github.com/onnx/steering-committee) for past terms and members.
 
 This document is created to provide guidelines for the election process to ensure maximum transparency and fairness.
 
@@ -39,9 +39,13 @@ Candidates will be self-nominated, and they do not necessarily need to be a [Con
 
 To participate in the Steering committee election, you must be a Contributor to the ONNX project. As defined in the community guideline, Contributor is sponsored by 2 approvers from different companies.
 
-Contributors are further required to submit their github handle, email address, and affiliated company name to be eligible for voting. Any Contributor who has not submitted their information by before April 31st will not be able to participate in the election. The Steering Committee is currently reviewing options for collecting contributor information, and the best option will be notified to the Contributors shortly.
+Contributors are further required to submit their github handle, email address, and affiliated company name to be eligible for voting. Any Contributor who has not submitted their information by before April 31st will not be able to participate in the election.
 
 ## Candidacy process
+
+Candidates self-nominate during the application window in the Timeline above (see [Eligibility for Steering Committee candidacy](#eligibility-for-steering-committee-candidacy)). A nomination consists of the candidate's name, company/institution, and a short statement of interest.
+
+Each year's nomination form and the resulting public candidate list are published in that year's folder in the [steering-committee repository](https://github.com/onnx/steering-committee/tree/main/elections), which is the source of truth for the current cycle's exact submission process.
 
 ## Voting process
 


### PR DESCRIPTION
### Description

`community/readme.md` and `community/sc-election-guidelines.md` still described the 2018 open-governance bootstrap (founding Steering Committee composition, "first elections to occur after 1 year", an election process "to be published within 3 months") in the present/future tense, as if it hadn't happened yet — even though the Steering Committee has been elected annually for years and `sc-election-guidelines.md` has existed the whole time.

This PR moves that one-time bootstrap context into a new `## History` section instead of deleting it, and keeps the Steering Committee/SIG sections focused on the current, durable process. It also fixes a few other things noticed along the way.

### Changes

- Add a `History` section to `community/readme.md` covering the 2018 founding Steering Committee composition and the transition to annual elections, cross-linked from the TL;DR and Steering Committee Structure sections.
- Update the SIG list to the current 6 SIGs (add Compilers and Optimizations, rename Operator Standardization to Operators) and point to the [sigs repository](https://github.com/onnx/sigs) as the live source of truth.
- Cut two stale, years-old placeholders that had since been settled in practice: "The Steering Committee will monitor how the community behaves and apply constraints if needed in the future" (SIG decision making), and "The Steering Committee is currently reviewing options for collecting contributor information... shortly" (`sc-election-guidelines.md`).
- Fill in the previously empty `## Candidacy process` section in `sc-election-guidelines.md`, based on the process actually used in the [steering-committee repository](https://github.com/onnx/steering-committee/tree/main/elections), without duplicating the per-year details (nomination form link, etc.) that already live there.
- Reword the `sc-election-guidelines.md` introduction out of the future tense describing the 2018 launch, consistent with the History section above.
- Minor grammar fixes (double spaces, a garbled sentence, missing periods).

### Motivation and Context

Noticed while reviewing the governance docs that several sections read as if ONNX open governance had just launched and elections/SIGs/candidacy hadn't happened yet, which is misleading for anyone new reading the doc today. No change in substance to current process — this is a documentation freshness pass.

---------

Signed-off-by: Andreas Fehlner <fehlner@arcor.de>