### PR TITLE
Bump nanobind to v2.14.0

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -29,7 +29,7 @@ License: Apache-2.0 (see LICENSE)
 
 Copyright (c) 2022 Wenzel Jakob <wenzel.jakob@epfl.ch>
 
-Version: 2.12.0
+Version: 2.14.0
 Source: https://github.com/wjakob/nanobind
 License: BSD-3-Clause
 

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -51,9 +51,9 @@
     {
       "type": "library",
       "name": "nanobind",
-      "version": "2.13.0",
+      "version": "2.14.0",
       "bom-ref": "nanobind",
-      "purl": "pkg:github/wjakob/nanobind@v2.13.0",
+      "purl": "pkg:github/wjakob/nanobind@v2.14.0",
       "externalReferences": [
         {
           "type": "vcs",


### PR DESCRIPTION
## Summary
- Bump the nanobind pin in `sbom.cdx.json` from 2.13.0 to 2.14.0 (the pin CMake's `sbom_get_dep()` reads for the `FetchContent`-based build; released 2026-08-07, past Renovate's `minimumReleaseAge` window)
- Fix `NOTICE`, which still listed nanobind 2.12.0 (already stale from a prior bump), to match the current pinned version

## Breaking changes in nanobind 2.14.0 to be aware of
- **Stricter integer argument conversion**: implicit conversion to integer-typed arguments now requires the input to implement Python's `__index__` protocol. Inputs previously accepted via looser coercion (e.g. non-`float`-subclass floats, numeric strings like `"123"`) are now rejected. `onnx/cpp2py_export.cc` has a few plain `int`/`int64_t` bindings (e.g. `convert_version`'s `target`, `opsetImports`, `irVersion`); these take ordinary Python ints in normal usage, so this shouldn't be a practical break, but it's worth a close look during review/CI.
- **ABI version bumped 20 → 21** (nanobind's `NB_DOMAIN`/stable ABI versioning), consistent with a minor version bump.
- Also includes STL-caster performance improvements and memory-leak/stub-generation fixes — see the [nanobind changelog](https://nanobind.readthedocs.io/en/latest/changelog.html) for full details.

## Scope note: pixi.lock is intentionally untouched
`pixi.lock` still resolves nanobind to the conda package `2.13.0`. When `find_package(nanobind CONFIG QUIET)` succeeds (any pixi-based build, e.g. `pixi_build.yml` / `pixi run install`), CMake uses that pre-installed nanobind and never consults `sbom.cdx.json`, so pixi-based builds stay on 2.13.0 for now. Per `renovate.json5`, `pixi.lock` is refreshed by a separate scheduled "lock-file maintenance" job rather than hand-edited in dependency-bump PRs, so it will pick up 2.14.0 on its own schedule. This PR's `sbom.cdx.json` bump does take effect for the non-pixi `FetchContent` path used by the actual release wheel/sdist builds (`release_linux_cibw.yml`, `release_macos_cibw.yml`, `release_windows_cibw.yml`, `release_sdist.yml`).

## Test plan
- [ ] CI build/test matrix (Linux/macOS/Windows) passes with nanobind 2.14.0
- [ ] `pytest` passes, in particular any tests exercising `convert_version`/`opsetImports`/`irVersion` argument coercion
- [ ] `lintrunner` passes
