### PR TITLE
fix(shape_inference): prevent use-after-scope during function inference

### DIFF
--- a/onnx/shape_inference/implementation.cc
+++ b/onnx/shape_inference/implementation.cc
@@ -1126,13 +1126,16 @@ std::vector<TypeProto> InferFunctionOutputTypes(
   ShapeInferenceOptions options{true, 1, false};
   FunctionInferenceContext ctx(function_proto, input_types, attributes, options);
   auto opset_imports = GetOpsetImportsFromProto(function_proto);
+  // ShapeInferenceImplBase stores this map by reference, so bind it to the
+  // function scope instead of passing a temporary that immediately dangles.
+  ModelLocalFunctionsMap model_local_functions_map;
   ShapeInferenceImplBase base(
       nullptr, // no graph
       {}, // outer_scope_value_types_by_name
       opset_imports,
       options,
       /*symbol_table*/ nullptr,
-      /*model_local_functions_map*/ {},
+      model_local_functions_map,
       /*schema_registry*/ OpSchemaRegistry::Instance(),
       /*generated_shape_data_by_name*/ nullptr);
   base.Process(function_proto, ctx);

--- a/tests/python/function_inference_test.py
+++ b/tests/python/function_inference_test.py
@@ -119,3 +119,12 @@ class TestFunctionInference(TestShapeInferenceHelper):
 
         # A failing test-case with a non-trailing missing optional parameter
         self._check_fails(code, [float_type_, no_type_, int8_type_], [])
+
+    def test_fi_unsupported_op(self):
+        code = """
+            <opset_import: [ "" : 26, "unknown" : 1 ], domain: "local">
+            Unsupported (x) => (y) {
+                y = unknown.Op (x)
+            }
+        """
+        self._check(code, [float_type_], [], [no_type_])


### PR DESCRIPTION
`ShapeInferenceImplBase` stores the model-local function map by reference, but `InferFunctionOutputTypes` passed a temporary empty map. Accessing that dangling reference results in an ASan stack-use-after-scope report.

Reproducer: [model.onnx.zip](https://github.com/user-attachments/files/31066618/model.onnx.zip)

Fix: Keep the map alive for the duration of inference and add a regression test for a function containing an unsupported operator.

### Security Impact
A specially crafted ONNX model can cause function output type inference to access an object after it has gone out of scope. This may crash applications that inspect untrusted models or produce unpredictable results; AddressSanitizer detects it as a stack-use-after-scope. We have not demonstrated data disclosure or code execution.

### Motivation and Context
This bug was found by Artur Cygan of Trail of Bits in collaboration with OpenAI (Patch the Planet initiative).
