### PR TITLE
fix(shape_inference): handle missing function inputs in subgraphs

### DIFF
--- a/onnx/shape_inference/implementation.cc
+++ b/onnx/shape_inference/implementation.cc
@@ -670,8 +670,6 @@ class ShapeInferenceImplBase {
         // TODO(ONNX): investigate whether we can eliminate use of temporary copy
         types_cache[i] = *type_ptr;
         value_types_by_name[parameter_name] = &types_cache[i];
-      } else {
-        value_types_by_name[parameter_name] = nullptr;
       }
       if (!caller_has_input) {
         // unbound_value_names starts out empty (see assert above) and each parameter_name is

--- a/tests/python/shape_inference_test.py
+++ b/tests/python/shape_inference_test.py
@@ -13119,6 +13119,41 @@ class TestShapeInference(TestShapeInferenceHelper):
         with pytest.raises(onnx.shape_inference.InferenceError):
             onnx.shape_inference.infer_shapes(model, strict_mode=True)
 
+    def test_function_missing_input_used_as_output_does_not_crash(self):
+        model = onnx.parser.parse_model(
+            """
+            <ir_version: 8, opset_import: ["": 25, "local": 1]>
+            g (bool condition) => (float output) { output = local.F(condition) }
+            <opset_import: ["": 25], domain: "local">
+            F (condition, missing) => (missing) { unused = Identity(condition) }
+            """
+        )
+
+        onnx.checker.check_model(model)
+        onnx.shape_inference.infer_shapes(model, strict_mode=True)
+
+    def test_function_subgraph_initializer_replaces_missing_outer_type(self):
+        model = onnx.parser.parse_model(
+            """
+            <ir_version: 8, opset_import: ["": 25, "local": 1]>
+            g (bool condition) => (float output) { output = local.F(condition) }
+            <opset_import: ["": 25], domain: "local">
+            F (condition, missing) => (output) {
+                output = If(condition) <
+                    then_branch = then () => (float output)
+                        <float missing = {1.0}> { output = Identity(missing) },
+                    else_branch = else () => (float output)
+                        <float one = {1.0}> { output = Identity(one) }
+                >
+            }
+            """
+        )
+
+        onnx.checker.check_model(model)
+        inferred = onnx.shape_inference.infer_shapes(model, strict_mode=True)
+        assert inferred.graph.output[0].type.tensor_type.elem_type == TensorProto.FLOAT
+        assert len(inferred.graph.output[0].type.tensor_type.shape.dim) == 0
+
     def test_conv_transpose_undersized_weight_raises(self):
         # Weight rank < 3 violates ConvTranspose spec (C x M/group x k1...kn).
         model = onnx.parser.parse_model(


### PR DESCRIPTION
Shape inference can dereference a null pointer when a missing model-local function input shares its name with an initializer inside a nested subgraph.

Reproducer: [model.onnx.zip](https://github.com/user-attachments/files/31086307/model.onnx.zip)

### Security Impact
A specially crafted, checker-accepted ONNX model can reliably crash applications performing shape inference or full model validation, causing denial of service. No data disclosure or code execution has been demonstrated.

### Motivation and Context
This bug was found by Artur Cygan of Trail of Bits in collaboration with OpenAI (Patch the Planet initiative).
