### PR TITLE
Strip PYTHONHOME/PYTHONPATH before invoking pixi in pixi-shim.py

### DIFF
--- a/tools/pixi-shim.py
+++ b/tools/pixi-shim.py
@@ -14,6 +14,7 @@ The 'default' environment is used if Pixi is available.
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import sys
@@ -22,7 +23,15 @@ import warnings
 args = sys.argv[1:]
 
 if shutil.which("pixi"):
-    raise SystemExit(subprocess.call(["pixi", "run", "--", *args]))  # noqa: S603, S607
+    # If this script itself is running under a Python that sets PYTHONHOME
+    # (e.g. a uv-managed interpreter), that value leaks into the pixi-managed
+    # environment's own Python and breaks its site-packages resolution.
+    # PYTHONHOME/PYTHONPATH are specific to *this* interpreter, not the one
+    # pixi is about to invoke, so don't propagate them.
+    env = dict(os.environ)
+    env.pop("PYTHONHOME", None)
+    env.pop("PYTHONPATH", None)
+    raise SystemExit(subprocess.call(["pixi", "run", "--", *args], env=env))  # noqa: S603, S607
 
 warnings.warn(
     "pixi not found. Running tools directly from PATH. "


### PR DESCRIPTION
## Summary
- `tools/pixi-shim.py` runs pre-commit hook tools via `pixi run -- <tool> <args>`, invoked as `python3 tools/pixi-shim.py <tool> <args>`.
- When the `python3` running this script is a uv-managed interpreter, it sets `PYTHONHOME` for itself. That value was inherited unchanged by the `pixi` subprocess and, transitively, by the target pixi environment's own Python — which broke that Python's site-packages resolution.
- Concretely, the `reuse` hook (`reuse` only lives in its own standalone pixi environment, per `pixi.toml`'s `[environments]` table) failed with `ModuleNotFoundError: No module named 'reuse'` even though `reuse` was correctly installed in that environment, purely because of the leaked `PYTHONHOME`. The same class of leak could affect any other Python-based tool shimmed this way (e.g. `mypy`).
- Fix: drop `PYTHONHOME`/`PYTHONPATH` from the environment passed to the `pixi` subprocess, since they describe the shim's own interpreter, not the one pixi is about to invoke.

## Test plan
- [x] Reproduced the failure reliably via `python3 tools/pixi-shim.py reuse lint` before the fix (consistent `ModuleNotFoundError`), confirmed a plain `pixi run -- reuse lint` from a shell (no python3 parent) always succeeded, and confirmed `PYTHONHOME` was present in `python3`'s `os.environ` but not in the parent shell's environment.
- [x] After the fix, ran `python3 tools/pixi-shim.py reuse lint` 3x in a row — passes every time.
- [x] Spot-checked other shimmed tools (`ruff check`, `clang-format --version`) still work.
- [x] `git commit` on this change went through the full pre-commit hook chain (including `reuse lint`) successfully.