### PR TITLE
Raise on malformed proto bytes instead of ignoring parse failure

### DIFF
--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -99,7 +99,7 @@ template <typename ProtoType>
 static std::vector<ProtoType> ParseProtoVector(const std::vector<nb::bytes>& bytes_vec) {
   std::vector<ProtoType> protos(bytes_vec.size());
   for (size_t i = 0; i < bytes_vec.size(); ++i) {
-    ParseProtoFromPyBytes(&protos[i], bytes_vec[i]);
+    ParseProtoFromPyBytesOrThrow(&protos[i], bytes_vec[i]);
   }
   return protos;
 }
@@ -122,7 +122,7 @@ static std::tuple<bool, nb::bytes, nb::bytes> Parse(const char* cstr) {
 template <typename ProtoType>
 static std::string ProtoBytesToText(const nb::bytes& bytes) {
   ProtoType proto{};
-  ParseProtoFromPyBytes(&proto, bytes);
+  ParseProtoFromPyBytesOrThrow(&proto, bytes);
   return ProtoToString(proto);
 }
 
@@ -133,7 +133,7 @@ static std::pair<std::vector<Ts>, std::unordered_map<std::string, T*>> ParseProt
   std::unordered_map<std::string, T*> result;
   size_t i = 0;
   for (const auto& [key, bytes] : bytesMap) {
-    ParseProtoFromPyBytes(&values[i], bytes);
+    ParseProtoFromPyBytesOrThrow(&values[i], bytes);
     result[key] = &values[i];
     i++;
   }
@@ -150,7 +150,7 @@ static std::unordered_map<std::string, nb::bytes> CallNodeInferenceFunction(
     std::unordered_map<std::string, int> opsetImports,
     const int irVersion) {
   NodeProto node{};
-  ParseProtoFromPyBytes(&node, nodeBytes);
+  ParseProtoFromPyBytesOrThrow(&node, nodeBytes);
   // Early fail if node is badly defined - may throw ValidationError
   schema->Verify(node);
 
@@ -212,7 +212,7 @@ template <typename ProtoType, typename... Ctx>
 static auto MakeChecker(void (*check_fn)(const ProtoType&, const Ctx&...)) {
   return [check_fn](const nb::bytes& bytes, const Ctx&... ctx) {
     ProtoType proto{};
-    ParseProtoFromPyBytes(&proto, bytes);
+    ParseProtoFromPyBytesOrThrow(&proto, bytes);
     check_fn(proto, ctx...);
   };
 }
@@ -299,7 +299,7 @@ NB_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) { // NOLINT(cppcoreguidelines-
             // Attributes with default values are not required
             auto bytes = nb::cast<nb::bytes>(default_value.attr("SerializeToString")());
             AttributeProto proto{};
-            ParseProtoFromPyBytes(&proto, bytes);
+            ParseProtoFromPyBytesOrThrow(&proto, bytes);
             new (self) OpSchema::Attribute(std::move(name), std::move(description), std::move(proto));
           },
           nb::arg("name"),
@@ -474,7 +474,7 @@ NB_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) { // NOLINT(cppcoreguidelines-
           "get_context_dependent_function",
           [](OpSchema* op, const nb::bytes& bytes, const std::vector<nb::bytes>& input_types_bytes) -> nb::bytes {
             NodeProto proto{};
-            ParseProtoFromPyBytes(&proto, bytes);
+            ParseProtoFromPyBytesOrThrow(&proto, bytes);
             if (op->HasContextDependentFunction()) {
               std::vector<TypeProto> input_types = ParseProtoVector<TypeProto>(input_types_bytes);
               FunctionBodyBuildContextImpl ctx(proto, input_types);
@@ -489,7 +489,7 @@ NB_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) { // NOLINT(cppcoreguidelines-
           [](OpSchema* op, int opset_version, const nb::bytes& bytes, const std::vector<nb::bytes>& input_types_bytes)
               -> nb::bytes {
             NodeProto proto{};
-            ParseProtoFromPyBytes(&proto, bytes);
+            ParseProtoFromPyBytesOrThrow(&proto, bytes);
             if (op->HasContextDependentFunctionWithOpsetVersion(opset_version)) {
               std::vector<TypeProto> input_types = ParseProtoVector<TypeProto>(input_types_bytes);
               FunctionBodyBuildContextImpl ctx(proto, input_types);
@@ -621,7 +621,7 @@ NB_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) { // NOLINT(cppcoreguidelines-
       [](const nb::bytes& bytes, bool full_check, bool skip_opset_compatibility_check, bool check_custom_domain)
           -> void {
         ModelProto proto{};
-        ParseProtoFromPyBytes(&proto, bytes);
+        ParseProtoFromPyBytesOrThrow(&proto, bytes);
         checker::check_model(proto, full_check, skip_opset_compatibility_check, check_custom_domain);
       },
       nb::arg("bytes"),
@@ -650,7 +650,7 @@ NB_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) { // NOLINT(cppcoreguidelines-
 
   version_converter.def("convert_version", [](const nb::bytes& bytes, int target) {
     ModelProto proto{};
-    ParseProtoFromPyBytes(&proto, bytes);
+    ParseProtoFromPyBytesOrThrow(&proto, bytes);
     shape_inference::InferShapes(proto);
     return ProtoToBytes(version_conversion::ConvertVersion(proto, target));
   });
@@ -661,7 +661,7 @@ NB_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) { // NOLINT(cppcoreguidelines-
 
   inliner.def("inline_local_functions", [](const nb::bytes& bytes, bool convert_version) {
     ModelProto model{};
-    ParseProtoFromPyBytes(&model, bytes);
+    ParseProtoFromPyBytesOrThrow(&model, bytes);
     inliner::InlineLocalFunctions(model, convert_version);
     return ProtoToBytes(model);
   });
@@ -673,7 +673,7 @@ NB_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) { // NOLINT(cppcoreguidelines-
       "inline_selected_functions",
       [](const nb::bytes& bytes, std::vector<std::pair<std::string, std::string>> function_ids, bool exclude) {
         ModelProto model{};
-        ParseProtoFromPyBytes(&model, bytes);
+        ParseProtoFromPyBytesOrThrow(&model, bytes);
         auto function_id_set = inliner::FunctionIdSet::Create(std::move(function_ids), exclude);
         inliner::InlineSelectedLocalFunctions(model, *function_id_set);
         return ProtoToBytes(model);
@@ -683,7 +683,7 @@ NB_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) { // NOLINT(cppcoreguidelines-
       "inline_selected_functions2",
       [](const nb::bytes& bytes, std::vector<std::pair<std::string, std::string>> function_ids, bool exclude) {
         ModelProto model{};
-        ParseProtoFromPyBytes(&model, bytes);
+        ParseProtoFromPyBytesOrThrow(&model, bytes);
         auto function_id_set = inliner::FunctionIdSet::Create(std::move(function_ids), exclude);
         inliner::InlineSelectedFunctions(model, *function_id_set, nullptr);
         return ProtoToBytes(model);
@@ -750,7 +750,7 @@ NB_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) { // NOLINT(cppcoreguidelines-
       "infer_shapes",
       [](const nb::bytes& bytes, bool check_type, bool strict_mode, bool data_prop) {
         ModelProto proto{};
-        ParseProtoFromPyBytes(&proto, bytes);
+        ParseProtoFromPyBytesOrThrow(&proto, bytes);
         ShapeInferenceOptions options{check_type, strict_mode ? 1 : 0, data_prop};
         shape_inference::InferShapes(proto, OpSchemaRegistry::Instance(), options);
         return ProtoToBytes(proto);
@@ -777,7 +777,7 @@ NB_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) { // NOLINT(cppcoreguidelines-
          const std::vector<nb::bytes>& input_types_bytes,
          const std::vector<nb::bytes>& attributes_bytes) -> std::vector<nb::bytes> {
         FunctionProto proto{};
-        ParseProtoFromPyBytes(&proto, function_proto_bytes);
+        ParseProtoFromPyBytesOrThrow(&proto, function_proto_bytes);
 
         std::vector<TypeProto> input_types = ParseProtoVector<TypeProto>(input_types_bytes);
         std::vector<AttributeProto> attributes = ParseProtoVector<AttributeProto>(attributes_bytes);

--- a/onnx/py_utils.h
+++ b/onnx/py_utils.h
@@ -6,6 +6,8 @@
 
 #include <nanobind/nanobind.h>
 
+#include <stdexcept>
+
 #include "onnx/proto_utils.h"
 
 namespace ONNX_NAMESPACE {
@@ -18,5 +20,16 @@ bool ParseProtoFromPyBytes(Proto* proto, const nb::bytes& bytes) {
   size_t length = bytes.size();
 
   return ParseProtoFromBytes(proto, buffer, length);
+}
+
+// Same as ParseProtoFromPyBytes, but raises a Python-visible exception instead of
+// silently leaving `proto` partially populated when `bytes` is malformed, truncated,
+// or exceeds the proto size limit.
+template <typename Proto>
+void ParseProtoFromPyBytesOrThrow(Proto* proto, const nb::bytes& bytes) {
+  if (!ParseProtoFromPyBytes(proto, bytes)) {
+    throw std::invalid_argument(
+        "Unable to parse proto from the given bytes: data is malformed, truncated, or exceeds the size limit.");
+  }
 }
 } // namespace ONNX_NAMESPACE

--- a/tests/python/checker_test.py
+++ b/tests/python/checker_test.py
@@ -333,6 +333,13 @@ class TestChecker:
 
         checker.check_model(model.SerializeToString())
 
+    def test_check_model_malformed_bytes_raises(self) -> None:
+        # Bytes that cannot be parsed as a ModelProto (e.g. truncated or
+        # corrupted data) must raise instead of silently checking whatever
+        # partially-populated proto happened to result from the failed parse.
+        with pytest.raises(ValueError):
+            checker.check_model(b"\xff\xff\xff\xff\xff not a valid protobuf")
+
     def test_check_model_protobuf_size_boundary(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary
- `ParseProtoFromPyBytes` (`onnx/py_utils.h`) returns `false` when the input is malformed, truncated, or exceeds the proto size limit.
- Every call site in `onnx/cpp2py_export.cc` that uses it as a plain statement was discarding that return value, so passing bad bytes from Python (e.g. to `checker.check_model`, `shape_inference.infer_shapes`, `version_converter.convert_version`, the inliner bindings, etc.) silently proceeded with a partially-populated or empty proto instead of raising an error.
- Add `ParseProtoFromPyBytesOrThrow`, which raises `ValueError` on parse failure, and route all ~15 statement-form call sites through it.
- The `ONNX_DEFINE_TYPE_CASTER` macro's `from_python` still uses the raw boolean-returning `ParseProtoFromPyBytes`, since nanobind's type-caster protocol needs the `bool` itself to report a cast failure rather than an exception.

## Test plan
- [x] Added `test_check_model_malformed_bytes_raises` in `tests/python/checker_test.py`, asserting `checker.check_model(b"...")` with unparseable bytes raises `ValueError` instead of silently succeeding or producing a confusing downstream error.
- [x] `pixi run pytest tests/python/checker_test.py` — 61 passed.
- [x] `pixi run pytest tests/python/shape_inference_test.py tests/python/basic_test.py tests/python/parser_test.py` — 1066 passed, 53 skipped, 2 xfailed, no failures.
- [x] Full rebuild via `pixi run install` (ONNX_BUILD_TESTS=1, ONNX_HARDENING=ON, ONNX_WERROR=ON) succeeded.