### PR TITLE
fix(shape_inference): bound inferred rank materialization

### DIFF
--- a/onnx/defs/nn/defs.cc
+++ b/onnx/defs/nn/defs.cc
@@ -2352,6 +2352,11 @@ static void col2imShapeInference(InferenceContext& ctx) {
   if (!n_input_dims.has_dim_value()) {
     return;
   }
+  // Do not materialize an attacker-controlled number of Dimension messages
+  // when only Col2Im's spatial rank is known.
+  if (n_input_dims.dim_value() < 0 || n_input_dims.dim_value() > kMaxMaterializedRank) {
+    return;
+  }
 
   // Final shape will be (N, C, dim_1, ..., dim_N)
   auto* final_image_shape = ctx.getOutputType(0)->mutable_tensor_type()->mutable_shape();

--- a/onnx/defs/shape_inference.cc
+++ b/onnx/defs/shape_inference.cc
@@ -478,7 +478,12 @@ getShapeInput(const InferenceContext& ctx, size_t input_index, bool fail_if_nega
     }
     if (shape_input_shape.dim(0).has_dim_value()) {
       // Attempt rank inference using shape of shape input
-      int64_t dim_value = shape_input_shape.dim(0).dim_value();
+      const int64_t dim_value = shape_input_shape.dim(0).dim_value();
+      // Rank-only inference is optional. Avoid materializing an attacker-controlled
+      // number of empty Dimension messages when the shape values are unavailable.
+      if (dim_value < 0 || dim_value > kMaxMaterializedRank) {
+        return shape_input;
+      }
       for (int64_t i = 0; i < dim_value; ++i) {
         shape_input.add_dim();
       }

--- a/onnx/defs/shape_inference.h
+++ b/onnx/defs/shape_inference.h
@@ -20,6 +20,9 @@ namespace ONNX_NAMESPACE {
 
 using Dim = TensorShapeProto_Dimension;
 
+// Bound optional rank-only inference to prevent unbounded protobuf materialization.
+constexpr int64_t kMaxMaterializedRank = 1024;
+
 struct ShapeInferenceOptions {
   // Checks the type-equality for input and output
   bool check_type;

--- a/tests/python/shape_inference_test.py
+++ b/tests/python/shape_inference_test.py
@@ -255,6 +255,36 @@ class TestShapeInferenceHelper:
 
 
 class TestShapeInference(TestShapeInferenceHelper):
+    def test_shape_input_excessive_length_leaves_output_rank_unknown(self) -> None:
+        graph = make_graph(
+            [make_node("ConstantOfShape", ["shape"], ["output"])],
+            "excessive_shape_input_length",
+            [make_tensor_value_info("shape", TensorProto.INT64, (2**31,))],
+            [make_empty_tensor_value_info("output")],
+        )
+        inferred = onnx.shape_inference.infer_shapes(make_model(graph))
+        output_type = inferred.graph.output[0].type.tensor_type
+        assert output_type.elem_type == TensorProto.FLOAT
+        assert not output_type.HasField("shape")
+
+    def test_col2im_excessive_spatial_rank_leaves_output_rank_unknown(self) -> None:
+        graph = make_graph(
+            [make_node("Col2Im", ["data", "image_shape", "block_shape"], ["output"])],
+            "excessive_col2im_spatial_rank",
+            [
+                make_tensor_value_info("data", TensorProto.FLOAT, (1, 1, 8)),
+                make_tensor_value_info("image_shape", TensorProto.INT64, (2**63 - 1,)),
+                make_tensor_value_info("block_shape", TensorProto.INT64, (2**63 - 1,)),
+            ],
+            [make_empty_tensor_value_info("output")],
+        )
+        model = make_model(graph, opset_imports=[make_opsetid("", 18)])
+
+        inferred = onnx.shape_inference.infer_shapes(model, strict_mode=True)
+        output_type = inferred.graph.output[0].type.tensor_type
+        assert output_type.elem_type == TensorProto.FLOAT
+        assert not output_type.HasField("shape")
+
     def test_empty_graph(self) -> None:
         graph = self._make_graph(["y"], [], [])
         with pytest.raises(onnx.shape_inference.InferenceError):


### PR DESCRIPTION
Shape inference can materialize an unbounded number of dimensions when a model declares an extremely large shape-vector length. This affects both generic shape-input inference and Col2Im, allowing a very small model to exhaust memory. This change applies a shared rank-materialization limit and adds regression tests for both paths.

Reproducers: [models.zip](https://github.com/user-attachments/files/31149903/models.zip)

### Security Impact
A malicious or malformed ONNX model can exhaust memory and CPU during shape inference, potentially crashing or making applications that inspect uploaded models unavailable. No model execution is required; loading the model and running shape inference is sufficient.

### Motivation and Context
This bug was found by Artur Cygan of Trail of Bits in collaboration with OpenAI (Patch the Planet initiative).

