### PR TITLE
fix(shape_inference): reject zero scalar SplitToSequence split

### DIFF
--- a/onnx/defs/sequence/utils.cc
+++ b/onnx/defs/sequence/utils.cc
@@ -128,6 +128,9 @@ std::function<void(OpSchema&)> SplitToSequenceOpGenerator(
               const auto& splitShape = getInputShape(ctx, 1);
               if (splitShape.dim_size() == 0) {
                 // split is scalar
+                if (splitSizes[0] <= 0) {
+                  fail_shape_inference("Scalar input 'split' must be greater than zero.");
+                }
                 if (splitDimValue % splitSizes[0] == 0) {
                   // all output chunks have the same shape, assign that to output sequence shape.
                   return splitSizes[0];

--- a/tests/python/shape_inference_test.py
+++ b/tests/python/shape_inference_test.py
@@ -8813,6 +8813,22 @@ class TestShapeInference(TestShapeInferenceHelper):
             ],
         )
 
+    @pytest.mark.parametrize("version", all_versions_for("SplitToSequence"))
+    def test_split_to_sequence_zero_scalar(self, version: int) -> None:
+        graph = self._make_graph(
+            [("input", TensorProto.FLOAT, (6, 4)), ("split", TensorProto.INT32, ())],
+            [make_node("SplitToSequence", ["input", "split"], ["output_sequence"])],
+            [],
+            initializer=[make_tensor("split", TensorProto.INT32, (), (0,))],
+        )
+        with pytest.raises(
+            onnx.shape_inference.InferenceError, match="greater than zero"
+        ):
+            self._inferred(
+                graph,
+                opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
+            )
+
     def test_split_to_sequence_keepdims(self) -> None:
         graph = self._make_graph(
             [("input", TensorProto.FLOAT, (6, 4))],


### PR DESCRIPTION
SplitToSequence shape inference performs modulo by a scalar split value without checking whether it is zero. Reject zero scalar splits before the calculation.

### Security impact
A malicious or malformed ONNX model can crash an application during shape inference through integer division by zero, causing denial of service. Model execution is not required.

### Motivation and Context
This bug was found by Artur Cygan of Trail of Bits in collaboration with OpenAI (Patch the Planet initiative).
