### PR TITLE
Update shape inference test to use check type option

### DIFF
--- a/tests/python/shape_inference_test.py
+++ b/tests/python/shape_inference_test.py
@@ -145,7 +145,7 @@ class TestShapeInferenceHelper:
         else:
             orig_model = graph_or_model
         inferred_model = onnx.shape_inference.infer_shapes(
-            orig_model, strict_mode=True, data_prop=data_prop
+            orig_model, check_type=True, strict_mode=True, data_prop=data_prop
         )
         checker.check_model(inferred_model)
         return inferred_model
@@ -4438,12 +4438,12 @@ class TestShapeInference(TestShapeInferenceHelper):
         self._logical_binary_op_with_broadcasting("Xor", TensorProto.BOOL)
 
     def test_greater(self) -> None:
-        self._logical_binary_op("Greater", TensorProto.BOOL)
-        self._logical_binary_op_with_broadcasting("Greater", TensorProto.BOOL)
+        self._logical_binary_op("Greater", TensorProto.FLOAT)
+        self._logical_binary_op_with_broadcasting("Greater", TensorProto.FLOAT)
 
     def test_less(self) -> None:
-        self._logical_binary_op("Less", TensorProto.BOOL)
-        self._logical_binary_op_with_broadcasting("Less", TensorProto.BOOL)
+        self._logical_binary_op("Less", TensorProto.FLOAT)
+        self._logical_binary_op_with_broadcasting("Less", TensorProto.FLOAT)
 
     def test_equal(self) -> None:
         self._logical_binary_op("Equal", TensorProto.BOOL)
@@ -4462,12 +4462,12 @@ class TestShapeInference(TestShapeInferenceHelper):
         )
 
     def test_less_or_equal(self) -> None:
-        self._logical_binary_op("LessOrEqual", TensorProto.BOOL)
-        self._logical_binary_op_with_broadcasting("LessOrEqual", TensorProto.BOOL)
+        self._logical_binary_op("LessOrEqual", TensorProto.FLOAT)
+        self._logical_binary_op_with_broadcasting("LessOrEqual", TensorProto.FLOAT)
 
     def test_greater_or_equal(self) -> None:
-        self._logical_binary_op("GreaterOrEqual", TensorProto.BOOL)
-        self._logical_binary_op_with_broadcasting("GreaterOrEqual", TensorProto.BOOL)
+        self._logical_binary_op("GreaterOrEqual", TensorProto.FLOAT)
+        self._logical_binary_op_with_broadcasting("GreaterOrEqual", TensorProto.FLOAT)
 
     def test_flatten(self) -> None:
         graph = self._make_graph(
@@ -5815,7 +5815,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         graph = self._make_graph(
             [
                 ("X", TensorProto.FLOAT, (5, 3, 4, 4)),
-                ("rois", TensorProto.INT64, (2, 5)),
+                ("rois", TensorProto.FLOAT, (2, 5)),
             ],
             [make_node("MaxRoiPool", ["X", "rois"], ["Y"], pooled_shape=[2, 2])],
             [],
@@ -6449,7 +6449,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         graph = self._make_graph(
             [
                 ("xT", TensorProto.FLOAT, (1, 1, 2, 2)),
-                ("xI", TensorProto.FLOAT, (1, 1, 2, 2)),
+                ("xI", TensorProto.INT64, (1, 1, 2, 2)),
             ],
             [
                 make_node(
@@ -6466,8 +6466,8 @@ class TestShapeInference(TestShapeInferenceHelper):
         graph = self._make_graph(
             [
                 ("xT", TensorProto.FLOAT, (1, 1, 2, 2)),
-                ("xI", TensorProto.FLOAT, (1, 1, 2, 2)),
-                ("output_shape", TensorProto.FLOAT, (4,)),
+                ("xI", TensorProto.INT64, (1, 1, 2, 2)),
+                ("output_shape", TensorProto.INT64, (4,)),
             ],
             [
                 make_node(
@@ -6780,7 +6780,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         # but the body input protos differ slightly from the pre-conversion version.
         graph = parse_graph("""
             agraph (
-                int64[1] max_trip_count, float[1] cond_orig, float[2] loop_state_orig, float[3] outer_scope_input
+                int64[1] max_trip_count, bool[1] cond_orig, float[2] loop_state_orig, float[3] outer_scope_input
             ) => (loop_output)
             {
                 loop_state_final, loop_output = Loop (max_trip_count, cond_orig, loop_state_orig) <
@@ -6811,7 +6811,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         # Test-input alteration: cond_in/cond_out were declared with an explicit UNDEFINED element type in the
         # original make_graph version; the parser leaves them untyped, which shape inference fills identically.
         graph = parse_graph("""
-            agraph (int64[1] max_trip_count, float[1] cond_orig, float[3] outer_scope_input)
+            agraph (int64[1] max_trip_count, bool[1] cond_orig, float[3] outer_scope_input)
                 => (loop_output)
             {
                 loop_output = Loop (max_trip_count, cond_orig) <
@@ -6967,7 +6967,7 @@ class TestShapeInference(TestShapeInferenceHelper):
                 ("x", TensorProto.UINT8, (30, 4, 8, 8, 8)),
                 ("y", TensorProto.INT8, (50, 4, 3, 3, 3)),
                 ("x_zero_point", TensorProto.UINT8, ()),
-                ("y_zero_point", TensorProto.UINT8, ()),
+                ("y_zero_point", TensorProto.INT8, ()),
             ],
             [
                 make_node(
@@ -6988,8 +6988,8 @@ class TestShapeInference(TestShapeInferenceHelper):
             [
                 ("x", TensorProto.INT8, (30, 4, 8, 8, 8)),
                 ("y", TensorProto.INT8, (50, 4, 3, 3, 3)),
-                ("x_zero_point", TensorProto.UINT8, ()),
-                ("y_zero_point", TensorProto.UINT8, ()),
+                ("x_zero_point", TensorProto.INT8, ()),
+                ("y_zero_point", TensorProto.INT8, ()),
             ],
             [
                 make_node(
@@ -8407,7 +8407,7 @@ class TestShapeInference(TestShapeInferenceHelper):
 
     def test_cumprod(self) -> None:
         graph = self._make_graph(
-            [("x", TensorProto.FLOAT, (3, 2)), ("axis", TensorProto.FLOAT, (1,))],
+            [("x", TensorProto.FLOAT, (3, 2)), ("axis", TensorProto.INT64, (1,))],
             [make_node("CumProd", ["x", "axis"], "z")],
             [],
         )
@@ -8417,7 +8417,7 @@ class TestShapeInference(TestShapeInferenceHelper):
 
     def test_cumsum(self) -> None:
         graph = self._make_graph(
-            [("x", TensorProto.FLOAT, (2, 3)), ("axis", TensorProto.FLOAT, (1,))],
+            [("x", TensorProto.FLOAT, (2, 3)), ("axis", TensorProto.INT64, (1,))],
             [make_node("CumSum", ["x", "axis"], "z")],
             [],
         )
@@ -9397,19 +9397,17 @@ class TestShapeInference(TestShapeInferenceHelper):
     def test_pad_legacy_total_padding_overflow(self, version: int) -> None:
         int64_max = (1 << 63) - 1
         attribute_based_version = 2
-        inputs: list[tuple[str, TensorProto.DataType, Any]] = [
-            ("x", TensorProto.FLOAT, ("N",))
-        ]
+        inputs = [make_tensor_value_info("x", TensorProto.FLOAT, ("N",))]
         initializers = []
         if version == attribute_based_version:
             node = make_node("Pad", ["x"], ["y"], pads=[int64_max, 1])
         else:
-            inputs.append(("pads", TensorProto.INT64, (2,)))
+            inputs.append(make_tensor_value_info("pads", TensorProto.INT64, (2,)))
             initializers.append(
                 make_tensor("pads", TensorProto.INT64, (2,), (int64_max, 1))
             )
             node = make_node("Pad", ["x", "pads"], ["y"])
-        graph = self._make_graph(inputs, [node], [], initializer=initializers)
+        graph = make_graph([node], "test", inputs, [], initializer=initializers)
         with pytest.raises(onnx.shape_inference.InferenceError, match="overflow"):
             self._inferred(
                 graph, opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)]
@@ -10162,7 +10160,7 @@ class TestShapeInference(TestShapeInferenceHelper):
 
     def test_softmax_cross_entropy_none(self) -> None:
         graph = self._make_graph(
-            [("x", TensorProto.FLOAT, (2, 3)), ("y", TensorProto.FLOAT, (2,))],
+            [("x", TensorProto.FLOAT, (2, 3)), ("y", TensorProto.INT64, (2,))],
             [make_node("SoftmaxCrossEntropyLoss", ["x", "y"], ["z"], reduction="none")],
             [],
         )
@@ -10172,7 +10170,7 @@ class TestShapeInference(TestShapeInferenceHelper):
 
     def test_softmax_cross_entropy_mean(self) -> None:
         graph = self._make_graph(
-            [("x", TensorProto.FLOAT, (2, 3)), ("y", TensorProto.FLOAT, (2,))],
+            [("x", TensorProto.FLOAT, (2, 3)), ("y", TensorProto.INT64, (2,))],
             [make_node("SoftmaxCrossEntropyLoss", ["x", "y"], ["z"], reduction="mean")],
             [],
         )
@@ -10184,7 +10182,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (2, 3, 5, 8)),
-                ("y", TensorProto.FLOAT, (2, 5, 8)),
+                ("y", TensorProto.INT64, (2, 5, 8)),
             ],
             [make_node("SoftmaxCrossEntropyLoss", ["x", "y"], ["z"], reduction="none")],
             [],
@@ -10197,7 +10195,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (2, 3, 4, 5)),
-                ("y", TensorProto.FLOAT, (2, 4, 5)),
+                ("y", TensorProto.INT64, (2, 4, 5)),
             ],
             [make_node("SoftmaxCrossEntropyLoss", ["x", "y"], ["z"], reduction="mean")],
             [],
@@ -11109,7 +11107,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (1, 1, 3, 3)),
-                ("grid", TensorProto.INT64, (1, 3, 3, 2)),
+                ("grid", TensorProto.FLOAT, (1, 3, 3, 2)),
             ],
             [
                 make_node(
@@ -11131,7 +11129,7 @@ class TestShapeInference(TestShapeInferenceHelper):
         graph = self._make_graph(
             [
                 ("x", TensorProto.FLOAT, (1, 1, 3, 3, 3)),
-                ("grid", TensorProto.INT64, (1, 3, 2, 3, 3)),
+                ("grid", TensorProto.FLOAT, (1, 3, 2, 3, 3)),
             ],
             [
                 make_node(
@@ -12128,7 +12126,7 @@ class TestShapeInference(TestShapeInferenceHelper):
                     [],
                     ["window"],
                     value=make_tensor(
-                        "window", TensorProto.INT64, (5,), (1, 2, 3, 4, 5)
+                        "window", TensorProto.FLOAT, (5,), (1, 2, 3, 4, 5)
                     ),
                 ),
                 make_node("STFT", ["signal", "frame_step", "window"], ["output"]),
@@ -12141,7 +12139,7 @@ class TestShapeInference(TestShapeInferenceHelper):
             [
                 make_tensor_value_info("signal", TensorProto.FLOAT, (2, 10, 1)),
                 make_tensor_value_info("frame_step", TensorProto.INT64, ()),
-                make_tensor_value_info("window", TensorProto.INT64, (5,)),
+                make_tensor_value_info("window", TensorProto.FLOAT, (5,)),
                 make_tensor_value_info("output", TensorProto.FLOAT, (2, 3, 5, 2)),
             ],
         )
@@ -12171,7 +12169,7 @@ class TestShapeInference(TestShapeInferenceHelper):
                     [],
                     ["window"],
                     value=make_tensor(
-                        "window", TensorProto.INT64, (5,), (1, 2, 3, 4, 5)
+                        "window", TensorProto.FLOAT, (5,), (1, 2, 3, 4, 5)
                     ),
                 ),
                 make_node(
@@ -12190,7 +12188,7 @@ class TestShapeInference(TestShapeInferenceHelper):
             [
                 make_tensor_value_info("signal", TensorProto.FLOAT, (2, 10, 1)),
                 make_tensor_value_info("frame_step", TensorProto.INT64, ()),
-                make_tensor_value_info("window", TensorProto.INT64, (5,)),
+                make_tensor_value_info("window", TensorProto.FLOAT, (5,)),
                 make_tensor_value_info("frame_length", TensorProto.INT64, ()),
                 make_tensor_value_info("output", TensorProto.FLOAT, (2, 3, 5, 2)),
             ],


### PR DESCRIPTION
The shape inference tests were not validating that the types respect the schema constraints (it requires passing in an explicit `check_type=True` option). Add this option, and fix the errors in test cases.