### PR TITLE
fix(inliner): handle Constant nodes without outputs

### DIFF
--- a/onnx/inliner/inliner.cc
+++ b/onnx/inliner/inliner.cc
@@ -393,7 +393,9 @@ using ConstNodeMap = std::unordered_map<std::string, const NodeProto*>;
 ConstNodeMap FindConstantNodes(const GraphProto& graph) {
   ConstNodeMap result;
   for (const NodeProto& node : graph.node()) {
-    if (IsOnnxDomain(node.domain()) && (node.op_type() == "Constant")) {
+    // Malformed Constant nodes can have no outputs; do not index an absent
+    // protobuf field while collecting constants for function conversion.
+    if (IsOnnxDomain(node.domain()) && (node.op_type() == "Constant") && !node.output().empty()) {
       result[node.output(0)] = &node;
     }
   }

--- a/tests/python/inliner_test.py
+++ b/tests/python/inliner_test.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import pytest
 
-from onnx import checker, inliner, parser
+from onnx import TensorProto, checker, helper, inliner, parser
 
 
 class TestInliner:
@@ -138,3 +138,37 @@ class TestInliner:
         )
         inlined_nodes = inlined.graph.node
         assert "Abs" in [n.op_type for n in inlined_nodes]
+
+    def test_inline_ignores_constant_without_outputs(self):
+        function = helper.make_function(
+            "local",
+            "identity",
+            ["X"],
+            ["Y"],
+            [helper.make_node("Identity", ["X"], ["Y"])],
+            opset_imports=[helper.make_opsetid("", 12)],
+        )
+        graph = helper.make_graph(
+            [
+                helper.make_node("Constant", [], []),
+                helper.make_node("identity", ["X"], ["Y"], domain="local"),
+            ],
+            "constant_without_outputs",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (1,))],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, (1,))],
+        )
+        model = helper.make_model(
+            graph,
+            functions=[function],
+            opset_imports=[
+                helper.make_opsetid("", 13),
+                helper.make_opsetid("local", 1),
+            ],
+        )
+
+        inlined = inliner.inline_local_functions(model, convert_version=True)
+
+        assert [node.op_type for node in inlined.graph.node] == [
+            "Constant",
+            "Identity",
+        ]


### PR DESCRIPTION
`FindConstantNodes` assumes every `Constant` has an output and indexes an absent protobuf field during function conversion. Skip malformed constants without outputs.

Reproducer: [model.onnx.zip](https://github.com/user-attachments/files/31175136/model.onnx.zip)

```python
import onnx
import onnx.inliner
model = onnx.load("model.onnx")
onnx.inliner.inline_local_functions(model, convert_version=True)
```

### Security Impact
A malicious or malformed ONNX model can crash an application during local-function inlining with version conversion, causing denial of service. Model execution is not required.

### Motivation and Context
This bug was found by Artur Cygan of Trail of Bits in collaboration with OpenAI (Patch the Planet initiative).
