### PR TITLE
fix(version_converter): validate Reshape output in Softmax downgrade

### DIFF
--- a/onnx/version_converter/adapters/softmax_13_12.h
+++ b/onnx/version_converter/adapters/softmax_13_12.h
@@ -47,6 +47,7 @@ class Softmax_13_12 final : public Adapter {
     for (Use u : node->output()->uses()) {
       if (u.user->kind() == kReshape) {
         Node* reshape = u.user;
+        ONNX_ASSERTM(!reshape->outputs().empty(), "Reshape node must have at least 1 output")
         auto* const reshape_output = reshape->outputs()[0];
         node->output()->replaceAllUsesWith(reshape_output);
         reshape->destroy();

--- a/tests/python/version_converter_test.py
+++ b/tests/python/version_converter_test.py
@@ -2333,6 +2333,30 @@ class TestVersionConverter:
         with pytest.raises((RuntimeError, shape_inference.InferenceError)):
             test()
 
+    def test_softmax_13_12_rejects_reshape_without_output(self) -> None:
+        graph = helper.make_graph(
+            [
+                helper.make_node("Softmax", ["X"], ["Y"], axis=-1),
+                helper.make_node("Reshape", ["Y"], [], domain="local.test"),
+            ],
+            "test_softmax_13_12_rejects_reshape_without_output",
+            [helper.make_tensor_value_info("X", TensorProto.FLOAT, (1, 2))],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, (1, 2))],
+        )
+        model = helper.make_model(
+            graph,
+            opset_imports=[
+                helper.make_operatorsetid("", 13),
+                helper.make_operatorsetid("local.test", 1),
+            ],
+        )
+        checker.check_model(model)
+
+        with pytest.raises(
+            RuntimeError, match="Reshape node must have at least 1 output"
+        ):
+            onnx.version_converter.convert_version(model, 12)
+
     @pytest.mark.parametrize(
         "x_shape, scale_shape, axis, block_size, output_dtype, zero_point_dtype, compatible",
         [


### PR DESCRIPTION
The Softmax 13-to-12 adapter assumes a following `Reshape` node has an output and indexes it without validation. Reject a missing output before rewriting the graph.

Reproducer: [model.onnx.zip](https://github.com/user-attachments/files/31176184/model.onnx.zip)

```python
import onnx
model = onnx.load('model.onnx')
onnx.version_converter.convert_version(model, 12)
```

### Security Impact
A malicious ONNX model can crash an application during opset conversion from 13 to 12 through a null-pointer dereference, causing denial of service. Model execution is not required.

### Motivation and Context
This bug was found by Artur Cygan of Trail of Bits in collaboration with OpenAI (Patch the Planet initiative).