### PR TITLE
fix(reference): reject out-of-range Concat axes

### DIFF
--- a/onnx/reference/ops/op_concat.py
+++ b/onnx/reference/ops/op_concat.py
@@ -10,11 +10,13 @@ from onnx.reference.op_run import OpRun
 
 class Concat(OpRun):
     def _preprocess(self, a: np.ndarray, axis: int) -> np.ndarray:
-        if len(a.shape) == 0:
+        rank = len(a.shape)
+        if rank == 0:
             raise RuntimeError(f"Concat: one input has an empty shape: {a!r}.")
-        if axis >= len(a.shape):
-            new_shape = a.shape + (1,) * (axis + 1 - len(a.shape))
-            return a.reshape(new_shape)
+        if not -rank <= axis < rank:
+            raise ValueError(
+                f"Concat: axis {axis} is out of range for input rank {rank}."
+            )
         return a
 
     def _run(self, *args, axis=None):

--- a/tests/python/reference_evaluator_test.py
+++ b/tests/python/reference_evaluator_test.py
@@ -694,6 +694,16 @@ class TestReferenceEvaluator:
         got = sess.run(None, {"X": x, "Y": y})[0]
         assert_allclose(got, expected)
 
+    @pytest.mark.parametrize("axis", [-2, 1])
+    def test_concat_rejects_axis_out_of_range(self, axis: int):
+        node = make_node("Concat", ["X"], ["Y"], axis=axis)
+        sess = ReferenceEvaluator(node)
+
+        with pytest.raises(
+            ValueError, match=rf"axis {axis} is out of range for input rank 1"
+        ):
+            sess.run(None, {"X": np.ones((1,), dtype=np.float32)})
+
     def test_greater_or_equal(self):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None])
         Y = make_tensor_value_info("Y", TensorProto.FLOAT, [None])


### PR DESCRIPTION
The Concat reference implementation implicitly extends input rank for axes beyond the valid range, allocating a model-controlled tuple. Reject axes outside `[-rank, rank-1]` before evaluation.

Reproducer: [model.onnx.zip](https://github.com/user-attachments/files/31177450/model.onnx.zip)

`model.onnx` contains a single opset-5 `Concat` node with one rank-1 input and `axis = 2147483647`. It is loaded and executed through public Python APIs:

```python
import numpy as np
import onnx
from onnx.reference import ReferenceEvaluator

model = onnx.load("model.onnx")
ReferenceEvaluator(model).run(None, {"value0": np.zeros((1,), dtype=np.float32)})
```

### Security Impact
A malicious ONNX model can exhaust memory during Concat evaluation by specifying an extremely large axis, causing denial of service. Model execution through the reference evaluator is required.

### Motivation and Context
This bug was found by Artur Cygan of Trail of Bits in collaboration with OpenAI (Patch the Planet initiative).