### PR TITLE
fix(version_converter): prevent initializer-name use-after-free

### DIFF
--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -1076,17 +1076,21 @@ struct Graph final {
   }
 
   void eraseInitializer(const std::string& name) {
+    // Preserve an aliased initializer name before erase invalidates its storage;
+    // otherwise later comparisons read freed string memory.
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+    const std::string stable_name = name;
     initializers_.erase(
         std::remove_if(
             initializers_.begin(),
             initializers_.end(),
-            [&name](Tensor& initializer) { return initializer.name() == name; }),
+            [&stable_name](Tensor& initializer) { return initializer.name() == stable_name; }),
         initializers_.end());
     initializer_names_.erase(
-        std::remove(initializer_names_.begin(), initializer_names_.end(), name), initializer_names_.end());
-    releaseName(name);
+        std::remove(initializer_names_.begin(), initializer_names_.end(), stable_name), initializer_names_.end());
+    releaseName(stable_name);
     for (size_t i = 0; i < initializer_node_->outputs().size(); i++) {
-      if (initializer_node_->outputs()[i]->uniqueName() == name) {
+      if (initializer_node_->outputs()[i]->uniqueName() == stable_name) {
         initializer_node_->eraseOutput(i);
         break;
       }

--- a/tests/python/version_converter_test.py
+++ b/tests/python/version_converter_test.py
@@ -1379,20 +1379,22 @@ class TestVersionConverter:
         assert converted_model.opset_import[0].version == to_opset
 
     # Test Helper for Upsample Adapter: 9 -> 8
-    def helper_upsample_with_initializer(self, raw_scale: bool = False) -> None:
+    def helper_upsample_with_initializer(
+        self, raw_scale: bool = False, scale_name: str = "Scales"
+    ) -> None:
         from_opset = 9
         to_opset = 8
         data_type = TensorProto.FLOAT
 
         nodes = [
             onnx.helper.make_node(
-                "Upsample", inputs=["X", "Scales"], outputs=["Y"], mode="nearest"
+                "Upsample", inputs=["X", scale_name], outputs=["Y"], mode="nearest"
             )
         ]
 
         scale_value = [1.0, 1.0, 2.0, 3.0]
         scale_tensor = onnx.helper.make_tensor(
-            "Scales",
+            scale_name,
             onnx.TensorProto.FLOAT,
             [4],
             bytes(struct.pack("4f", *scale_value)) if raw_scale else scale_value,
@@ -1404,7 +1406,7 @@ class TestVersionConverter:
             "test_upsample",
             [
                 onnx.helper.make_tensor_value_info("X", data_type, [1, 1, 2, 2]),
-                onnx.helper.make_tensor_value_info("Scales", data_type, [4]),
+                onnx.helper.make_tensor_value_info(scale_name, data_type, [4]),
             ],
             [onnx.helper.make_tensor_value_info("Y", data_type, [1, 1, 4, 6])],
             [scale_tensor],
@@ -1473,6 +1475,11 @@ class TestVersionConverter:
     # Test Upsample Adapter: 9 -> 8
     def test_upsample_with_initializer_9_8(self) -> None:
         self.helper_upsample_with_initializer(raw_scale=False)
+
+    def test_upsample_with_long_initializer_name_9_8(self) -> None:
+        self.helper_upsample_with_initializer(
+            raw_scale=False, scale_name="scale_initializer_name_longer_than_sso"
+        )
 
     # Test Upsample Adapter: 9 -> 8
     def test_upsample_with_raw_initializer_9_8(self) -> None:


### PR DESCRIPTION
The Upsample 9-to-8 adapter contains a use-after-free: it passes an initializer-owned name by reference to `Graph::eraseInitializer`, which destroys the string before subsequent bookkeeping reuses it. Copy the name before erasure and add regression coverage using a heap-backed initializer name.

Reproducer: [model.onnx.zip](https://github.com/user-attachments/files/31218118/model.onnx.zip)

The reproducer contains an opset-9 Upsample node with initializer-backed scales and triggers the use-after-free when converted to opset 8.

```python
import onnx

model = onnx.load("model.onnx")
onnx.checker.check_model(model)
onnx.version_converter.convert_version(model, 8)
```

### Security Impact
A checker-accepted ONNX model can trigger this use-after-free during explicit conversion from opset 9 to 8, potentially crashing the process and causing denial of service. Exploitability appears low because the dangling reference is only read immediately after the free, with no intervening allocation that could replace its model-controlled contents; we found no write primitive, data disclosure, or path to code execution.

### Motivation and Context
This bug was found by Artur Cygan of Trail of Bits in collaboration with OpenAI (Patch the Planet initiative).