### PR TITLE
fix(printer): decode all fixed-width raw_data types

### DIFF
--- a/onnx/defs/printer.cc
+++ b/onnx/defs/printer.cc
@@ -20,16 +20,11 @@ namespace {
 
 using StringStringEntryProtos = google::protobuf::RepeatedPtrField<StringStringEntryProto>;
 
-std::vector<int32_t> Parse16BitRawData(const TensorProto& tensor) {
-  const std::string& raw_data = tensor.raw_data();
-  std::vector<int32_t> values;
-  values.reserve(raw_data.size() / sizeof(uint16_t));
-  for (size_t i = 0; i + 1 < raw_data.size(); i += sizeof(uint16_t)) {
-    const auto low = static_cast<uint8_t>(raw_data[i]);
-    const auto high = static_cast<uint8_t>(raw_data[i + 1]);
-    values.push_back(static_cast<int32_t>(low | (static_cast<uint16_t>(high) << 8)));
-  }
-  return values;
+// Widen a decoded raw_data element to the field type the printer emits.
+template <typename Element, typename Widened>
+std::vector<Widened> ParseRawIntData(const TensorProto& tensor) {
+  const std::vector<Element> elements = ParseRawData<Element>(tensor, /*exact_fit=*/true);
+  return std::vector<Widened>(elements.begin(), elements.end());
 }
 
 // Format numbers with std::to_chars: locale-independent and, for floating
@@ -303,24 +298,51 @@ void ProtoPrinter::print(const TensorProto& tensor, bool is_initializer) {
     print(tensor.external_data());
   } else if (tensor.has_raw_data()) {
     switch (static_cast<TensorProto::DataType>(tensor.data_type())) {
-      case TensorProto::DataType::TensorProto_DataType_INT32:
-        printSet(" {", ",", "}", ParseData<int32_t>(&tensor));
+      case TensorProto::DataType::TensorProto_DataType_INT8:
+        printSet(" {", ",", "}", ParseRawIntData<int8_t, int32_t>(tensor));
         break;
-      case TensorProto::DataType::TensorProto_DataType_INT64:
-        printSet(" {", ",", "}", ParseData<int64_t>(&tensor));
+      case TensorProto::DataType::TensorProto_DataType_UINT8:
+      case TensorProto::DataType::TensorProto_DataType_BOOL:
+      // FLOAT8 types print their unsigned byte pattern, as FLOAT16 does below.
+      case TensorProto::DataType::TensorProto_DataType_FLOAT8E4M3FN:
+      case TensorProto::DataType::TensorProto_DataType_FLOAT8E4M3FNUZ:
+      case TensorProto::DataType::TensorProto_DataType_FLOAT8E5M2:
+      case TensorProto::DataType::TensorProto_DataType_FLOAT8E5M2FNUZ:
+      case TensorProto::DataType::TensorProto_DataType_FLOAT8E8M0:
+        printSet(" {", ",", "}", ParseRawIntData<uint8_t, int32_t>(tensor));
         break;
-      case TensorProto::DataType::TensorProto_DataType_FLOAT:
-        printSet(" {", ",", "}", ParseData<float>(&tensor));
+      case TensorProto::DataType::TensorProto_DataType_INT16:
+        printSet(" {", ",", "}", ParseRawIntData<int16_t, int32_t>(tensor));
         break;
-      case TensorProto::DataType::TensorProto_DataType_DOUBLE:
-        printSet(" {", ",", "}", ParseData<double>(&tensor));
-        break;
+      case TensorProto::DataType::TensorProto_DataType_UINT16:
+      // FLOAT16/BFLOAT16 print the unsigned 16-bit pattern, which the parser accepts.
       case TensorProto::DataType::TensorProto_DataType_FLOAT16:
       case TensorProto::DataType::TensorProto_DataType_BFLOAT16:
-        printSet(" {", ",", "}", Parse16BitRawData(tensor));
+        printSet(" {", ",", "}", ParseRawIntData<uint16_t, int32_t>(tensor));
+        break;
+      case TensorProto::DataType::TensorProto_DataType_INT32:
+        printSet(" {", ",", "}", ParseRawData<int32_t>(tensor, /*exact_fit=*/true));
+        break;
+      // UINT32/UINT64 print into uint64_data, matching the non-raw branch.
+      case TensorProto::DataType::TensorProto_DataType_UINT32:
+        printSet(" {", ",", "}", ParseRawIntData<uint32_t, uint64_t>(tensor));
+        break;
+      case TensorProto::DataType::TensorProto_DataType_INT64:
+        printSet(" {", ",", "}", ParseRawData<int64_t>(tensor, /*exact_fit=*/true));
+        break;
+      case TensorProto::DataType::TensorProto_DataType_UINT64:
+        printSet(" {", ",", "}", ParseRawData<uint64_t>(tensor, /*exact_fit=*/true));
+        break;
+      case TensorProto::DataType::TensorProto_DataType_FLOAT:
+        printSet(" {", ",", "}", ParseRawData<float>(tensor, /*exact_fit=*/true));
+        break;
+      case TensorProto::DataType::TensorProto_DataType_DOUBLE:
+        printSet(" {", ",", "}", ParseRawData<double>(tensor, /*exact_fit=*/true));
         break;
       default:
-        output_ << "..."; // ParseData not instantiated for other types.
+        // Sub-byte packed types need an element count sizeof() cannot express;
+        // complex and string need a different element form.
+        output_ << "...";
         break;
     }
   } else {
@@ -333,6 +355,11 @@ void ProtoPrinter::print(const TensorProto& tensor, bool is_initializer) {
       case TensorProto::DataType::TensorProto_DataType_BOOL:
       case TensorProto::DataType::TensorProto_DataType_FLOAT16:
       case TensorProto::DataType::TensorProto_DataType_BFLOAT16:
+      case TensorProto::DataType::TensorProto_DataType_FLOAT8E4M3FN:
+      case TensorProto::DataType::TensorProto_DataType_FLOAT8E4M3FNUZ:
+      case TensorProto::DataType::TensorProto_DataType_FLOAT8E5M2:
+      case TensorProto::DataType::TensorProto_DataType_FLOAT8E5M2FNUZ:
+      case TensorProto::DataType::TensorProto_DataType_FLOAT8E8M0:
         printSet(" {", ",", "}", tensor.int32_data());
         break;
       case TensorProto::DataType::TensorProto_DataType_INT64:
@@ -359,6 +386,7 @@ void ProtoPrinter::print(const TensorProto& tensor, bool is_initializer) {
         break;
       }
       default:
+        output_ << "...";
         break;
     }
   }

--- a/onnx/defs/tensor_proto_util.cc
+++ b/onnx/defs/tensor_proto_util.cc
@@ -4,17 +4,35 @@
 
 #include "onnx/defs/tensor_proto_util.h"
 
-#include <algorithm>
-#include <cstddef>
 #include <string>
 #include <vector>
 
-#include "onnx/common/platform_helpers.h"
 #include "onnx/common/safe_math.h"
 #include "onnx/defs/data_type_utils.h"
 #include "onnx/defs/shape_inference.h"
 
 namespace ONNX_NAMESPACE {
+
+int64_t RawDataElementCount(const TensorProto& tensor, size_t element_size, bool exact_fit) {
+  const int64_t num_elements = safe_dim_product(
+      tensor.dims(), [&](const char* msg) { fail_shape_inference(msg, " for tensor: ", tensor.name()); });
+  const size_t size = tensor.raw_data().size();
+  // Divide rather than multiply so no product can overflow.
+  const auto available = static_cast<uint64_t>(size / element_size);
+  const auto required = static_cast<uint64_t>(num_elements);
+  if (exact_fit ? (available != required || size % element_size != 0) : available < required) {
+    fail_shape_inference(
+        "Data size mismatch. Tensor: ",
+        tensor.name(),
+        " has ",
+        size,
+        " bytes of raw_data for ",
+        num_elements,
+        " elements of size ",
+        element_size);
+  }
+  return num_elements;
+}
 
 #define DEFINE_TO_TENSOR_ONE(type, enumType, field) \
   template <>                                       \
@@ -37,80 +55,51 @@ namespace ONNX_NAMESPACE {
     return t;                                                   \
   }
 
-#define DEFINE_PARSE_DATA(type, typed_data_fetch, tensorproto_datatype)                                              \
-  template <>                                                                                                        \
-  std::vector<type> ParseData(const TensorProto* tensor_proto) {                                                     \
-    if (!tensor_proto->has_data_type() || tensor_proto->data_type() == TensorProto_DataType_UNDEFINED) {             \
-      fail_shape_inference("The type of tensor: ", tensor_proto->name(), " is undefined so it cannot be parsed.");   \
-    } else if (tensor_proto->data_type() != (tensorproto_datatype)) {                                                \
-      fail_shape_inference(                                                                                          \
-          "ParseData type mismatch for tensor: ",                                                                    \
-          tensor_proto->name(),                                                                                      \
-          ". Expected:",                                                                                             \
-          Utils::DataTypeUtils::ToDataTypeString(tensorproto_datatype),                                              \
-          " Actual:",                                                                                                \
-          Utils::DataTypeUtils::ToDataTypeString(tensor_proto->data_type()));                                        \
-    }                                                                                                                \
-    int64_t num_elements = safe_dim_product(tensor_proto->dims(), [&](const char* msg) {                             \
-      fail_shape_inference(msg, " for tensor: ", tensor_proto->name());                                              \
-    });                                                                                                              \
-    std::vector<type> res;                                                                                           \
-    if (tensor_proto->has_data_location() && tensor_proto->data_location() == TensorProto_DataLocation_EXTERNAL) {   \
-      fail_shape_inference(                                                                                          \
-          "Cannot parse data from external tensors. Please ",                                                        \
-          "load external data into raw data for tensor: ",                                                           \
-          tensor_proto->name());                                                                                     \
-    } else if (!tensor_proto->has_raw_data()) {                                                                      \
-      const auto& data = tensor_proto->typed_data_fetch();                                                           \
-      if (data.size() != num_elements) {                                                                             \
-        fail_shape_inference(                                                                                        \
-            "Data size mismatch. Tensor: ",                                                                          \
-            tensor_proto->name(),                                                                                    \
-            " expected num elements ",                                                                               \
-            num_elements,                                                                                            \
-            " does not match the actual num elements ",                                                              \
-            data.size());                                                                                            \
-      }                                                                                                              \
-      res.insert(res.end(), data.begin(), data.end());                                                               \
-      return res;                                                                                                    \
-    }                                                                                                                \
-    if (tensor_proto->data_type() == TensorProto_DataType_STRING) {                                                  \
-      fail_shape_inference(                                                                                          \
-          tensor_proto->name(),                                                                                      \
-          " data type is string. string",                                                                            \
-          " content is required to be stored in repeated bytes string_data field.",                                  \
-          " raw_data type cannot be string.");                                                                       \
-    }                                                                                                                \
-    /* parse raw_data as the given type */                                                                           \
-    const std::string& raw_data = tensor_proto->raw_data();                                                          \
-    constexpr size_t element_size = sizeof(type);                                                                    \
-    int64_t required_bytes;                                                                                          \
-    if (checked_mul_overflow(num_elements, static_cast<int64_t>(element_size), &required_bytes)) {                   \
-      fail_shape_inference("Tensor byte size overflow for tensor: ", tensor_proto->name());                          \
-    }                                                                                                                \
-    const size_t required_bytes_sz = safe_cast_to_size(                                                              \
-        required_bytes, [&](const char* msg) { fail_shape_inference(msg, " for tensor: ", tensor_proto->name()); }); \
-    if (raw_data.size() < required_bytes_sz) {                                                                       \
-      fail_shape_inference(                                                                                          \
-          "Data size mismatch. Tensor: ",                                                                            \
-          tensor_proto->name(),                                                                                      \
-          " does not have sufficient raw_data. Required bytes: ",                                                    \
-          required_bytes,                                                                                            \
-          ", actual bytes: ",                                                                                        \
-          raw_data.size());                                                                                          \
-    }                                                                                                                \
-    /* copy byte-wise: raw_data may be unaligned for type */                                                         \
-    res.resize(required_bytes_sz / element_size);                                                                    \
-    std::byte* bytes = reinterpret_cast<std::byte*>(res.data());                                                     \
-    std::copy_n(reinterpret_cast<const std::byte*>(raw_data.data()), required_bytes_sz, bytes);                      \
-    /* swap byte order on big-endian hosts */                                                                        \
-    if (!is_processor_little_endian()) {                                                                             \
-      for (auto& element : res) {                                                                                    \
-        std::byte* start_byte = reinterpret_cast<std::byte*>(&element);                                              \
-        std::reverse(start_byte, start_byte + element_size);                                                         \
-      }                                                                                                              \
-    }                                                                                                                \
-    return res;                                                                                                      \
+#define DEFINE_PARSE_DATA(type, typed_data_fetch, tensorproto_datatype)                                            \
+  template <>                                                                                                      \
+  std::vector<type> ParseData(const TensorProto* tensor_proto) {                                                   \
+    if (!tensor_proto->has_data_type() || tensor_proto->data_type() == TensorProto_DataType_UNDEFINED) {           \
+      fail_shape_inference("The type of tensor: ", tensor_proto->name(), " is undefined so it cannot be parsed."); \
+    } else if (tensor_proto->data_type() != (tensorproto_datatype)) {                                              \
+      fail_shape_inference(                                                                                        \
+          "ParseData type mismatch for tensor: ",                                                                  \
+          tensor_proto->name(),                                                                                    \
+          ". Expected:",                                                                                           \
+          Utils::DataTypeUtils::ToDataTypeString(tensorproto_datatype),                                            \
+          " Actual:",                                                                                              \
+          Utils::DataTypeUtils::ToDataTypeString(tensor_proto->data_type()));                                      \
+    }                                                                                                              \
+    if (tensor_proto->has_data_location() && tensor_proto->data_location() == TensorProto_DataLocation_EXTERNAL) { \
+      fail_shape_inference(                                                                                        \
+          "Cannot parse data from external tensors. Please ",                                                      \
+          "load external data into raw data for tensor: ",                                                         \
+          tensor_proto->name());                                                                                   \
+    } else if (!tensor_proto->has_raw_data()) {                                                                    \
+      const int64_t num_elements = safe_dim_product(tensor_proto->dims(), [&](const char* msg) {                   \
+        fail_shape_inference(msg, " for tensor: ", tensor_proto->name());                                          \
+      });                                                                                                          \
+      std::vector<type> res;                                                                                       \
+      const auto& data = tensor_proto->typed_data_fetch();                                                         \
+      if (data.size() != num_elements) {                                                                           \
+        fail_shape_inference(                                                                                      \
+            "Data size mismatch. Tensor: ",                                                                        \
+            tensor_proto->name(),                                                                                  \
+            " expected num elements ",                                                                             \
+            num_elements,                                                                                          \
+            " does not match the actual num elements ",                                                            \
+            data.size());                                                                                          \
+      }                                                                                                            \
+      res.insert(res.end(), data.begin(), data.end());                                                             \
+      return res;                                                                                                  \
+    }                                                                                                              \
+    if (tensor_proto->data_type() == TensorProto_DataType_STRING) {                                                \
+      fail_shape_inference(                                                                                        \
+          tensor_proto->name(),                                                                                    \
+          " data type is string. string",                                                                          \
+          " content is required to be stored in repeated bytes string_data field.",                                \
+          " raw_data type cannot be string.");                                                                     \
+    }                                                                                                              \
+    return ParseRawData<type>(*tensor_proto);                                                                      \
   }
 
 DEFINE_TO_TENSOR_ONE(float, TensorProto_DataType_FLOAT, float)

--- a/onnx/defs/tensor_proto_util.h
+++ b/onnx/defs/tensor_proto_util.h
@@ -3,8 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
 #include <vector>
 
+#include "onnx/common/platform_helpers.h"
 #include "onnx/onnx_pb.h"
 
 namespace ONNX_NAMESPACE {
@@ -17,5 +23,33 @@ ONNX_API TensorProto ToTensor(const std::vector<T>& values);
 
 template <typename T>
 std::vector<T> ParseData(const TensorProto* tensor_proto);
+
+// Elements that dims implies, checked against raw_data's length. With exact_fit
+// the two must agree exactly; otherwise raw_data may hold trailing bytes, which
+// are ignored. Kept out of the template below so the error path is emitted once,
+// not per element type.
+ONNX_API int64_t RawDataElementCount(const TensorProto& tensor, size_t element_size, bool exact_fit);
+
+// Decode a tensor's raw_data as values of type T. Defined here rather than in
+// the .cc so callers can instantiate it for element types ParseData does not
+// cover. raw_data may be unaligned for T, so it is copied byte-wise.
+template <typename T>
+std::vector<T> ParseRawData(const TensorProto& tensor, bool exact_fit = false) {
+  static_assert(std::is_arithmetic_v<T>, "T must be an arithmetic type");
+  // num_elements <= raw_data.size(), so the cast cannot truncate.
+  const auto num_elements = static_cast<size_t>(RawDataElementCount(tensor, sizeof(T), exact_fit));
+  std::vector<T> values(num_elements);
+  if (num_elements != 0) {
+    std::memcpy(values.data(), tensor.raw_data().data(), num_elements * sizeof(T));
+    // raw_data is little-endian per the ONNX spec.
+    if (!is_processor_little_endian()) {
+      for (T& value : values) {
+        auto* start = reinterpret_cast<std::byte*>(&value);
+        std::reverse(start, start + sizeof(T));
+      }
+    }
+  }
+  return values;
+}
 
 } // namespace ONNX_NAMESPACE

--- a/tests/cpp/tensor_test.cc
+++ b/tests/cpp/tensor_test.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "onnx/common/assertions.h"
 #include "onnx/common/tensor.h"
+#include "onnx/defs/tensor_proto_util.h"
 #include "onnx/defs/tensor_util.h"
 
 namespace ONNX_NAMESPACE::Test {
@@ -71,6 +72,69 @@ TEST(TensorTest, ParseDataAcceptsAlignedRawData) {
 #else
   EXPECT_EQ(ParseData<int32_t>(&t).size(), 2u);
 #endif
+}
+
+namespace {
+TensorProto MakeRawTensor(int32_t data_type, std::initializer_list<int64_t> dims, const std::string& raw_data) {
+  TensorProto t;
+  t.set_name("t");
+  t.set_data_type(data_type);
+  for (int64_t dim : dims) {
+    t.add_dims(dim);
+  }
+  t.set_raw_data(raw_data);
+  return t;
+}
+} // namespace
+
+TEST(ParseRawDataTest, DecodesLittleEndianRegardlessOfHost) {
+  // 1, -2 as little-endian int32.
+  const TensorProto t =
+      MakeRawTensor(TensorProto_DataType_INT32, {2}, std::string("\x01\0\0\0\xfe\xff\xff\xff", 8));
+  const std::vector<int32_t> values = ParseRawData<int32_t>(t);
+  ASSERT_EQ(values.size(), 2u);
+  EXPECT_EQ(values[0], 1);
+  EXPECT_EQ(values[1], -2);
+}
+
+TEST(ParseRawDataTest, ToleratesTrailingBytesByDefault) {
+  // dims implies one int32, raw_data holds two; the second is ignored.
+  const TensorProto t =
+      MakeRawTensor(TensorProto_DataType_INT32, {1}, std::string("\x01\0\0\0\x02\0\0\0", 8));
+  const std::vector<int32_t> values = ParseRawData<int32_t>(t);
+  ASSERT_EQ(values.size(), 1u);
+  EXPECT_EQ(values[0], 1);
+}
+
+TEST(ParseRawDataTest, ExactFitRejectsTrailingBytes) {
+#ifndef ONNX_NO_EXCEPTIONS
+  const TensorProto t =
+      MakeRawTensor(TensorProto_DataType_INT32, {1}, std::string("\x01\0\0\0\x02\0\0\0", 8));
+  EXPECT_THROW(ParseRawData<int32_t>(t, /*exact_fit=*/true), std::runtime_error);
+#endif
+}
+
+TEST(ParseRawDataTest, RejectsInsufficientRawData) {
+#ifndef ONNX_NO_EXCEPTIONS
+  const TensorProto t = MakeRawTensor(TensorProto_DataType_INT32, {4}, std::string(8, '\0'));
+  EXPECT_THROW(ParseRawData<int32_t>(t), std::runtime_error);
+  EXPECT_THROW(ParseRawData<int32_t>(t, /*exact_fit=*/true), std::runtime_error);
+#endif
+}
+
+TEST(ParseRawDataTest, DecodesFloatBitPatterns) {
+  // 1.0f, -2.0f as little-endian IEEE-754.
+  const TensorProto t =
+      MakeRawTensor(TensorProto_DataType_FLOAT, {2}, std::string("\0\0\x80\x3f\0\0\0\xc0", 8));
+  const std::vector<float> values = ParseRawData<float>(t);
+  ASSERT_EQ(values.size(), 2u);
+  EXPECT_FLOAT_EQ(values[0], 1.0F);
+  EXPECT_FLOAT_EQ(values[1], -2.0F);
+}
+
+TEST(ParseRawDataTest, EmptyTensorYieldsNoElements) {
+  const TensorProto t = MakeRawTensor(TensorProto_DataType_INT32, {0}, "");
+  EXPECT_TRUE(ParseRawData<int32_t>(t, /*exact_fit=*/true).empty());
 }
 
 } // namespace ONNX_NAMESPACE::Test

--- a/tests/python/printer_test.py
+++ b/tests/python/printer_test.py
@@ -10,6 +10,11 @@ import onnx
 from onnx import helper, numpy_helper, parser, printer
 
 
+def print_initializer(initializer: onnx.TensorProto) -> str:
+    """Print a graph holding `initializer` and nothing else."""
+    return printer.to_text(helper.make_graph([], "graph", [], [], [initializer]))
+
+
 class TestBasicFunctions:
     def check_graph(self, graph: onnx.GraphProto) -> None:
         assert len(graph.node) == 3
@@ -83,18 +88,103 @@ class TestBasicFunctions:
         assert list(node2.output) == ["C"]
         assert list(node2.input) == ["S"]
 
-    def test_float16_initializer_roundtrip(self) -> None:
-        values = np.array([1.0, -2.0, 0.5], dtype=np.float16)
-        initializer = numpy_helper.from_array(values, name="weights")
-        graph = helper.make_graph([], "graph", [], [], [initializer])
+    @pytest.mark.parametrize(
+        ("dtype", "values", "expected"),
+        [
+            (np.float16, [1.0, -2.0, 0.5], "{15360,49152,14336}"),
+            (np.int8, [1, -2, 127, -128], "{1,-2,127,-128}"),
+            (np.uint8, [0, 1, 255], "{0,1,255}"),
+            (np.bool_, [True, False, True], "{1,0,1}"),
+            (np.int16, [1, -2, 32767, -32768], "{1,-2,32767,-32768}"),
+            (np.uint16, [1, 2, 65535], "{1,2,65535}"),
+            (np.int32, [1, -2, 2147483647], "{1,-2,2147483647}"),
+            (np.uint32, [1, 2, 4294967295], "{1,2,4294967295}"),
+            (np.int64, [1, -2, 9223372036854775807], "{1,-2,9223372036854775807}"),
+            (np.uint64, [1, 2, 18446744073709551615], "{1,2,18446744073709551615}"),
+            (np.float32, [1.5, -2.5, 0.0], "{1.5,-2.5,0}"),
+            (np.float64, [1.5, -2.5, 0.0], "{1.5,-2.5,0}"),
+        ],
+    )
+    def test_raw_initializer_roundtrip(self, dtype, values, expected) -> None:
+        array = np.array(values, dtype=dtype)
 
-        text = printer.to_text(graph)
+        text = print_initializer(numpy_helper.from_array(array, name="weights"))
 
-        assert "{15360,49152,14336}" in text
+        assert expected in text
         parsed = parser.parse_graph(text)
         np.testing.assert_array_equal(
-            numpy_helper.to_array(parsed.initializer[0]), values
+            numpy_helper.to_array(parsed.initializer[0]), array
         )
+
+    # Bit patterns printed into int32_data; the float16 row is the non-raw one.
+    @pytest.mark.parametrize(
+        ("data_type", "data", "raw", "expected"),
+        [
+            (
+                onnx.TensorProto.BFLOAT16,
+                b"\x80\x3f\x00\xc0\x00\x3f",
+                True,
+                [16256, 49152, 16128],
+            ),
+            (onnx.TensorProto.FLOAT16, [1.0, -2.0, 0.5], False, [15360, 49152, 14336]),
+            *[
+                (dtype, b"\x38\xc0\x30", True, [56, 192, 48])
+                for dtype in (
+                    onnx.TensorProto.FLOAT8E4M3FN,
+                    onnx.TensorProto.FLOAT8E4M3FNUZ,
+                    onnx.TensorProto.FLOAT8E5M2,
+                    onnx.TensorProto.FLOAT8E5M2FNUZ,
+                    onnx.TensorProto.FLOAT8E8M0,
+                )
+            ],
+        ],
+    )
+    def test_initializer_prints_int32_data(
+        self, data_type, data, raw, expected
+    ) -> None:
+        initializer = helper.make_tensor("weights", data_type, [3], data, raw=raw)
+
+        text = print_initializer(initializer)
+
+        assert "{" + ",".join(map(str, expected)) + "}" in text
+        assert list(parser.parse_graph(text).initializer[0].int32_data) == expected
+
+    @pytest.mark.parametrize(
+        ("data_type", "dims", "raw_data"),
+        [
+            (onnx.TensorProto.FLOAT16, [4], b"\x00\x3c"),  # too few bytes
+            (onnx.TensorProto.FLOAT16, [2], b"\x00\x3c\x00\xc0\x00\x38"),  # too many
+            (onnx.TensorProto.FLOAT16, [1], b"\x00\x3c\x00"),  # ragged
+            (onnx.TensorProto.FLOAT, [2], b"\x00\x00\x80\x3f"),  # too few bytes
+            (
+                onnx.TensorProto.FLOAT,
+                [1],
+                b"\x00\x00\x80\x3f\x00\x00\x80\x3f",
+            ),  # too many
+            (onnx.TensorProto.FLOAT, [1], b"\x00\x00\x80\x3f\x00"),  # ragged
+        ],
+    )
+    def test_raw_data_size_mismatch_raises(self, data_type, dims, raw_data) -> None:
+        # Printing a mis-sized tensor would emit text that re-parses as valid.
+        initializer = onnx.TensorProto(name="weights", data_type=data_type)
+        initializer.dims.extend(dims)
+        initializer.raw_data = raw_data
+
+        with pytest.raises(
+            onnx.shape_inference.InferenceError, match="Data size mismatch"
+        ):
+            print_initializer(initializer)
+
+    @pytest.mark.parametrize(
+        ("data", "raw"), [(b"\x21\x43", True), ([1, 2, 3, 4], False)]
+    )
+    def test_undecodable_type_prints_placeholder(self, data, raw) -> None:
+        # Not decoded; "..." fails to re-parse rather than losing data silently.
+        initializer = helper.make_tensor(
+            "weights", onnx.TensorProto.INT4, [4], data, raw=raw
+        )
+
+        assert "..." in print_initializer(initializer)
 
     def test_to_text_unsupported_type_raises(self) -> None:
         # to_text dispatches on proto type and raises TypeError for unsupported


### PR DESCRIPTION
### Motivation and Context

Follow-up to #8308, which added 16-bit `raw_data` decoding to the textual printer. Three gaps remained:

1. **`raw_data` length was not validated against `dims`.** The 16-bit decoder consumed whatever bytes were present, so `dims=[2]` with 6 bytes printed three elements and round-tripped silently (`checker.cc` only rejects `int32_data().size() < nelem`), while `dims=[4]` with 2 bytes printed text that later failed `check_model` with a confusing "int32_data size too small".

2. **Most fixed-width types still printed `...`.** INT8, UINT8, BOOL, INT16, UINT16, UINT32, UINT64 and the FLOAT8 types are all byte-addressable and already accepted by the parser, and the printer's own non-raw branch already prints them — but their `raw_data` was undecodable. Since `numpy_helper.from_array` produces `raw_data`, `onnx.save_model(m, p, format="onnxtxt")` → `onnx.load_model(p, format="onnxtxt")` was broken for every quantized model.

3. **The non-raw branch printed nothing for types it did not handle**, so a FLOAT8 or INT4 tensor printed `float8e4m3fn[3] w = ` and re-parsed into an empty tensor — silent data loss with no error.

### Changes

- Lift the raw-decode tail out of `DEFINE_PARSE_DATA` into a shared `ParseRawData<T>` template in `tensor_proto_util.h`, plus a non-template `RawDataElementCount` for the length check. `ParseData`'s raw branch becomes a one-line delegate (the macro loses ~30 lines), and the printer instantiates the same template for the element types `ParseData` does not cover.
- The decode itself is unchanged — bulk `memcpy`, then a per-element `std::reverse` only on big-endian hosts, exactly as `ParseData` already did.
- Require `raw_data.size()` to match `dims` exactly **in the printer** (`exact_fit`). `ParseData` keeps its existing leniency — too-short fatal, trailing bytes ignored — so no existing caller changes behavior.
- Route INT8, UINT8/BOOL/FLOAT8\*, INT16, UINT16/FLOAT16/BFLOAT16, INT32 into `int32_data`; UINT32/UINT64 into `uint64_data`; INT64 into `int64_data` — matching what the non-raw branch and the parser already do for each type.
- Add the FLOAT8 types to the non-raw `int32_data` case, and give that branch the same `...` fallback the raw branch already had.

FLOAT16/BFLOAT16 output is unchanged — still the unsigned 16-bit pattern the parser accepts.

Sub-byte packed types (INT2/INT4/UINT2/UINT4/FLOAT4E2M1) still print `...`: their element count cannot be derived from `sizeof()`, and the packing rule (`ceil(n*k/8)`) exists in C++ only inline in `checker.cc`. Complex and string need a different element form.

### Behavior change

`to_text` now raises `InferenceError` on any fixed-width tensor whose `raw_data` does not match `dims`, where FLOAT16/BFLOAT16 previously printed a best-effort initializer and the newly-decoded types previously printed `...`. This makes all fixed-width types consistent, and matches `ParseData`'s long-standing behavior for too-short data.

Two things worth a maintainer's call:

- A printer that refuses to print a malformed tensor cuts against its role as a debugging aid, and under `ONNX_DISABLE_EXCEPTIONS` this path `abort()`s rather than throwing. Happy to emit a placeholder for the bad tensor instead of failing the whole document.
- This validation arguably belongs in `checker.cc`. `check_tensor`'s `expected_bytes` switch covers only the sub-byte types and `default: break`s on every fixed-width one, so `check_model` currently **passes** a FLOAT16 tensor with `dims=[4]` and 2 bytes of `raw_data`. The printer is the only thing in the tree that catches this. Tightening the checker has ecosystem blast radius, so I left it alone — flagging it so the gap does not stay invisible.

### Known gaps, not addressed here

- Sub-byte packed types are excluded because `RawDataElementCount` takes a `size_t element_size`, which cannot express half a byte — not because the round-trip is out of reach. `parser.cc` already accepts INT2/INT4/UINT2/UINT4/FLOAT4E2M1 into `int32_data`, and the packing formula already exists inline at `checker.cc:184` and `:188`. A `bits_per_element` parameter would cover them.
- `data_type → destination field` is still enumerated independently in three places: the printer's raw and non-raw switches and `parser.cc`. This PR had to add the five FLOAT8 cases to both printer switches, which is the drift that mapping would prevent. C++ has no analogue of Python's `helper.tensor_dtype_to_field`.
- A complex initializer in `float_data`/`double_data` still prints `...` even though `parser.cc` accepts exactly that form.

### Validation

- `pytest tests/python/printer_test.py`: 34 passed. Full `pytest tests/`: 6346 passed (3 failures pre-exist on `be2925b6` and are unrelated). `onnx_gtests`: 147 passed.
- `ParseRawData` and `RawDataElementCount` are new shared symbols on the `ParseData` path, so `tests/cpp/tensor_test.cc` gains six direct tests: little-endian decode, trailing bytes tolerated by default, `exact_fit` rejecting them, insufficient data, float bit patterns, and the empty tensor.
- Confirmed `ParseData`'s leniency survives the refactor: a `Reshape` shape initializer with two trailing bytes still infers `[2,3]` rather than raising.
- Verified `to_text` → `parse_graph` → `numpy_helper.to_array` round-trips for all 12 fixed-width dtypes, including `int8 -128`, `uint16 65535`, `uint64 2**64-1`, and float/double `inf`/`-inf`/`nan`/`-0`.
- Reverting only `printer.cc` makes the new tests fail, so they lock in the fix.
- `lintrunner` and `clang-tidy` clean on both changed files.

Suggested labels: `topic: bug fix`, `module: parser`.
