### PR TITLE
ci: ignore link-checker URLs that block automated requests

### DIFF
--- a/.github/workflows/check_urls.yml
+++ b/.github/workflows/check_urls.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     paths:
       - "**/*.md"
+      - ".lycheeignore"
       - ".github/workflows/check_urls.yml"
   schedule:
     # Run every month

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -11,8 +11,14 @@ https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-fina
 
 # slack blocks automated requests. This is problematic since the invites expire after ~30 days, but lychee is not going to fix that
 https://join.slack.com/t/lfaifoundation/shared_invite/zt-3wx5vohc3-MeSYi3_dscb~u~cqs7zlPg
+# Same block applies to the workspace itself: the root and every channel archive
+# link redirect to a login page that answers 403
+https://lfaifoundation\.slack\.com/.*
 # Also blocked:
 https://en.cppreference.com/c/language/identifier
+
+# gitlab.kitware.com answers 403 to CI runners
+https://gitlab.kitware.com/cmake/cmake/-/issues/25145
 
 # stackoverflow seems to block requests from github action runners
 https://stackoverflow.com/questions/34128872/google-protobuf-maximum-size


### PR DESCRIPTION
### Motivation and Context

The **Check URLs** workflow is failing on `main` — every scheduled and push run for the last several days ([latest](https://github.com/onnx/onnx/actions/runs/32334272449)):

```
🔍 2079 Total  🔗 1331 Unique  ✅ 2053 OK  🚫 6 Errors  👻 20 Excluded  🔀 58 Redirects
```

All 6 are `403 Forbidden` from live pages that reject the link checker, not broken links:

| URL | Referenced from |
|---|---|
| `https://lfaifoundation.slack.com/` | `CONTRIBUTING.md:13`, `README.md:70` |
| `https://lfaifoundation.slack.com/archives/C016UBNDBL2` | `docs/OnnxReleases.md:136` |
| `https://lfaifoundation.slack.com/archives/C018VGGJUGK` | `docs/OnnxReleases.md:15`, `:136` |
| `https://gitlab.kitware.com/cmake/cmake/-/issues/25145` | `CMakeLists.txt:148` |

The Slack links 302-redirect to a login page that then answers 403. The Kitware issue is reachable — it returns 200 to a plain request and 403 to a browser-like one, i.e. fingerprint-based bot filtering, not a dead page. In both cases the destination is correct and should stay in the docs.

### Changes

Add all four to `.lycheeignore`, which already carries entries for exactly this category (`join.slack.com`, Cloudflare-fronted pages, StackOverflow).

The Slack workspace is matched by host — `https://lfaifoundation\.slack\.com/.*` — rather than URL by URL. Every link to that workspace is blocked the same way, and `docs/OnnxReleases.md` gains channel archive links over time; matching per-URL would just break the workflow again on the next one. Verified the pattern matches the five failing occurrences and nothing else in the repo (in particular it does not swallow the existing `join.slack.com` invite entry).

The Kitware link is listed individually since it is the only one.

### Validation

`lychee` is not installable in my environment, so I could not run the checker locally. Verified instead that:

- each URL is live and returns 403 only to automated requests
- the regex matches exactly the 5 failing occurrences and no other URL in the tree

CI on this PR will exercise the real check, since `.lycheeignore` changes are picked up by the same workflow. Worth confirming the run goes green before merging.

### Maintainer label note

Suggested labels: `topic: CI`.
