### PR TITLE
test: fix typo flagged by the typos lint hook

### DIFF
--- a/tests/python/printer_test.py
+++ b/tests/python/printer_test.py
@@ -165,7 +165,7 @@ class TestBasicFunctions:
         ],
     )
     def test_raw_data_size_mismatch_raises(self, data_type, dims, raw_data) -> None:
-        # Printing a mis-sized tensor would emit text that re-parses as valid.
+        # Printing a wrongly sized tensor would emit text that re-parses as valid.
         initializer = onnx.TensorProto(name="weights", data_type=data_type)
         initializer.dims.extend(dims)
         initializer.raw_data = raw_data


### PR DESCRIPTION
### Motivation and Context

The `Lint` job is failing on `main` and therefore on every open PR (e.g. #8108):

```
typos....................................................................Failed
  error: `mis` should be `miss`, `mist`
      ╭▸ tests/python/printer_test.py:168:22
  168 │         # Printing a mis-sized tensor would emit text that re-parses as valid.
```

My fault — the comment came in with #8337. `typos` runs as a `prek` hook via `pixi run lint`, not through `lintrunner`, which is why it slipped past my local checks.

### Changes

Reword the comment to "wrongly sized".

### Validation

- `typos` clean on all files touched by #8337.
- `pytest tests/python/printer_test.py`: 34 passed.
- `lintrunner` clean.

### Maintainer label note

Suggested labels: `topic: CI`.