### PR TITLE
ci: lint only changed files on pull requests

### DIFF
--- a/.github/workflows/pixi_build.yml
+++ b/.github/workflows/pixi_build.yml
@@ -39,7 +39,16 @@ jobs:
           environments: default reuse
       - name: Install repository
         run: pixi run install
+      # On pull requests, lint only what the branch changed: `prek run -a` means
+      # an unrelated issue on main fails this job on every open PR at once.
+      # Pushes to main still lint everything, so drift is still caught.
+      - name: Lint changed files
+        if: github.event_name == 'pull_request'
+        run: >-
+          pixi run lint-diff --show-diff-on-failure
+          --from-ref ${{ github.event.pull_request.base.sha }} --to-ref HEAD
       - name: Lint
+        if: github.event_name != 'pull_request'
         run: pixi run lint --show-diff-on-failure
 
   xcode-build:

--- a/pixi.toml
+++ b/pixi.toml
@@ -68,6 +68,9 @@ cmd = "prek install"
 [feature.lint.tasks.lint]
 description = "Run linters against all files (requires a prior 'install')"
 cmd = "prek run -a"
+[feature.lint.tasks.lint-diff]
+description = "Run linters against a range of commits, e.g. --from-ref main --to-ref HEAD"
+cmd = "prek run"
 
 [feature.lintrunner.tasks.lintrunner-init]
 cmd = "lintrunner init"


### PR DESCRIPTION
`pixi run lint` is `prek run -a`, so a lint issue introduced on main fails the **Install and lint** job on every open pull request at once, regardless of what those branches touch. A one-word typo in #8337 simultaneously blocked #8108, #8338 and the rest until it was fixed — none of which had touched the file.

### Changes

- New `lint-diff` pixi task (`prek run`, taking the ref range as arguments); `lint` keeps `-a` for local use.
- On `pull_request`, run prek over the PR's own diff. On pushes to main, keep `-a`, so drift is still caught — just without blocking unrelated contributors.

### Validation

Ran the diff-based invocation locally against this branch: only the hooks covering the two changed files execute, the rest report `(no files to check) Skipped`.

Not covered here: `lint.yml` runs `lintrunner --all-files` on pull requests too, with the same fan-out property. That job also uploads SARIF and would need `fetch-depth: 0`, so it seemed better kept separate — happy to follow up if you want the same treatment there.

Suggested labels: `topic: CI`.