### PR TITLE
Add Graph::reserveUniqueNames(): batch-reserve fresh unique names in one scan

### DIFF
--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -1040,13 +1040,8 @@ struct Graph final {
     return true;
   }
 
-  // Same traversal as isNameUnique() above (initializer_names_, every node's
-  // inputs/outputs via uniqueName() -- which falls back to a derived name for
-  // an unnamed Value, so this must run for every Value, not just named ones
-  // -- recursing into g/gs subgraph attributes), but collecting every name
-  // seen into `out` instead of checking one candidate at a time. Used by
-  // reserveUniqueNames() below to pay this scan once for a whole batch of
-  // names instead of once per name.
+  // Same traversal as isNameUnique(), but collects every name into `out`
+  // instead of checking one candidate at a time.
   void collectAllNames(std::unordered_set<std::string>& out) const {
     out.insert(initializer_names_.cbegin(), initializer_names_.cend());
     for (const auto& node_entry : all_nodes) {
@@ -1185,16 +1180,9 @@ struct Graph final {
     return toVarName(getNextUnique());
   }
 
-  // Reserves `count` distinct names, each guaranteed unique against every
-  // name currently used anywhere in the graph tree -- matching exactly what
-  // `count` consecutive getNextUniqueName() calls would produce, but paying
-  // isNameUnique()'s full graph (and subgraph) scan once for the whole batch
-  // (via collectAllNames() above) instead of once per name via
-  // getNextUnique() -> isNameUnique(). Intended for passes that mint many
-  // fresh names in one runPass() call (see onnxsim issue #651's follow-up,
-  // where extract_constant_to_initializer's one-getNextUniqueName()-call-
-  // per-match pattern made that pass accidentally quadratic); a single
-  // getNextUniqueName() call remains simplest for the common one-name case.
+  // Like `count` consecutive getNextUniqueName() calls, but pays
+  // isNameUnique()'s full graph scan once for the batch instead of once
+  // per name.
   std::vector<std::string> reserveUniqueNames(size_t count) {
     std::vector<std::string> names;
     names.reserve(count);

--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -1040,6 +1040,35 @@ struct Graph final {
     return true;
   }
 
+  // Same traversal as isNameUnique() above (initializer_names_, every node's
+  // inputs/outputs via uniqueName() -- which falls back to a derived name for
+  // an unnamed Value, so this must run for every Value, not just named ones
+  // -- recursing into g/gs subgraph attributes), but collecting every name
+  // seen into `out` instead of checking one candidate at a time. Used by
+  // reserveUniqueNames() below to pay this scan once for a whole batch of
+  // names instead of once per name.
+  void collectAllNames(std::unordered_set<std::string>& out) const {
+    out.insert(initializer_names_.cbegin(), initializer_names_.cend());
+    for (const auto& node_entry : all_nodes) {
+      const Node* node = node_entry.first;
+      for (const auto& attr : node->attributeNames()) {
+        if (node->kindOf(attr) == AttributeKind::g) {
+          node->g(attr)->collectAllNames(out);
+        } else if (node->kindOf(attr) == AttributeKind::gs) {
+          for (const auto& subgraph : node->gs(attr)) {
+            subgraph->collectAllNames(out);
+          }
+        }
+      }
+      for (const Value* v : node->inputs()) {
+        out.insert(v->uniqueName());
+      }
+      for (const Value* v : node->outputs()) {
+        out.insert(v->uniqueName());
+      }
+    }
+  }
+
  public:
   Graph() : output_(initOutput(create(kReturn, 0))), input_(create(kParam, 0)), initializer_node_(create(kParam, 0)) {}
 
@@ -1154,6 +1183,35 @@ struct Graph final {
 
   std::string getNextUniqueName() {
     return toVarName(getNextUnique());
+  }
+
+  // Reserves `count` distinct names, each guaranteed unique against every
+  // name currently used anywhere in the graph tree -- matching exactly what
+  // `count` consecutive getNextUniqueName() calls would produce, but paying
+  // isNameUnique()'s full graph (and subgraph) scan once for the whole batch
+  // (via collectAllNames() above) instead of once per name via
+  // getNextUnique() -> isNameUnique(). Intended for passes that mint many
+  // fresh names in one runPass() call (see onnxsim issue #651's follow-up,
+  // where extract_constant_to_initializer's one-getNextUniqueName()-call-
+  // per-match pattern made that pass accidentally quadratic); a single
+  // getNextUniqueName() call remains simplest for the common one-name case.
+  std::vector<std::string> reserveUniqueNames(size_t count) {
+    std::vector<std::string> names;
+    names.reserve(count);
+    if (count == 0) {
+      return names;
+    }
+    std::unordered_set<std::string> used;
+    collectAllNames(used);
+    for (size_t i = 0; i < count; i++) {
+      std::string name = toVarName(++next_unique_);
+      while (used.count(name) != 0) {
+        name = toVarName(++next_unique_);
+      }
+      used.insert(name);
+      names.push_back(std::move(name));
+    }
+    return names;
   }
 
   // These invocations of begin() on output of function are OK


### PR DESCRIPTION
Graph::getNextUniqueName() calls isNameUnique(), which pays a full graph (and subgraph) scan on every call to guard against colliding with an existing name -- including a Value's own fallback name (derived from its internal id when it has no explicit name), which is exactly why the check must cover every node's inputs and outputs, not just explicitly-named ones. A pass that mints many fresh names in one runPass() call (e.g. extract_constant_to_initializer, once per extracted Constant node) was paying that full scan once per name, turning an otherwise-linear pass into an accidental O(names * graph size) cost -- see https://github.com/onnxsim/onnxsim/issues/651's follow-up. The batch-reserving caller is onnxsim/optimizer's companion commit: https://github.com/onnxsim/optimizer/commit/674339ccf5a3528f0ff7528bc775ec03d18e6667

reserveUniqueNames(count) pays that scan once (via the new collectAllNames(), a straight transformation of isNameUnique()'s own traversal that collects every name into a set instead of checking one candidate at a time) and then hands out `count` names checked against that set in O(1) each, advancing the graph's next_unique_ counter exactly as `count` consecutive getNextUniqueName() calls would. Purely additive -- isNameUnique()/getNextUniqueName() themselves are unchanged, so every existing caller keeps its current behavior.

Claude-Session: https://claude.ai/code/session_01ADw2idu5qWKonBuaBcJEP4 (cherry picked from commit c8d9ceb1de224743d4a4a4f6f3d073a16b420d93)



### Motivation and Context

Fixes #
