### PR TITLE
Fix LoadProtoFromPath's byte-at-a-time file read

### DIFF
--- a/onnx/common/file_utils.h
+++ b/onnx/common/file_utils.h
@@ -26,8 +26,23 @@ void LoadProtoFromPath(const std::string& proto_path, T& proto) {
   if (!proto_stream.good()) {
     fail_check("Unable to open proto file: ", proto_path, ". Please check if it is a valid proto. ");
   }
-  std::string data{std::istreambuf_iterator<char>{proto_stream}, std::istreambuf_iterator<char>{}};
-  if (!proto_stream.good()) {
+  // Single sized read instead of istreambuf_iterator's byte-at-a-time copy,
+  // which is slow on large model files.
+  std::error_code size_ec;
+  const std::uintmax_t file_size = std::filesystem::file_size(proto_u8_path, size_ec);
+  std::string data;
+  bool read_ok = false;
+  if (!size_ec) {
+    data.resize(file_size);
+    proto_stream.read(data.data(), static_cast<std::streamsize>(file_size));
+    // gcount(), not good()/fail(): a full read to EOF can still set eofbit.
+    read_ok = static_cast<std::uintmax_t>(proto_stream.gcount()) == file_size;
+  } else {
+    // Fall back for files whose size can't be determined (e.g. a pipe).
+    data.assign(std::istreambuf_iterator<char>{proto_stream}, std::istreambuf_iterator<char>{});
+    read_ok = true;
+  }
+  if (!read_ok) {
     fail_check("Unable to read proto file: ", proto_path, ". Please check if it is a valid proto. ");
   }
   if (!ParseProtoFromBytes(&proto, data.c_str(), data.size())) {


### PR DESCRIPTION
std::string data{istreambuf_iterator{stream}, istreambuf_iterator{}} copies a file one character at a time (each increment pays a stream buffer-boundary check), instead of one bulk read. For small models this is noise; for a large one it is seconds -- measured costing the bulk of a ~16s gap between onnx-optimizer's path-based loadModel/saveModel and the equivalent Python-side onnx.load on an 833MB model (https://github.com/onnxsim/onnxsim/issues/633's investigation into loadModel's path-based entry points, used by its own SimplifyPath fast path).

Sizes the file up front via std::filesystem::file_size and does a single read() into a pre-sized string; falls back to the old iterator-based read if the size can't be determined (e.g. a pipe). Correctness is checked via gcount() rather than the stream's good()/eof() flags, since a read() that consumes exactly to EOF can set eofbit on a stream implementation even though every requested byte was read.

(cherry picked from commit 4784075aa7d40a771eaf70c12d0eeaee3d5d3a17)



### Motivation and Context

Fixes #
