### PR TITLE
Add Value/Node::hasUsesInCurrentGraph(): O(1) alternative to uses()/hasUses()

### DIFF
--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -396,15 +396,9 @@ struct Value final {
   const Graph* owningGraph() const;
   use_list uses() const;
 
-  // Cheap (O(1)) equivalent of ``!uses().empty()`` that only sees uses from
-  // nodes directly in this value's owning graph, not uses().'s additional
-  // owningGraph()->forEachNode() scan for kCaptured placeholders in nested
-  // If/Loop/Scan subgraph bodies (see uses()'s definition below). Safe to use
-  // in place of ``!uses().empty()`` only when the caller has separately
-  // established that no such capture is possible -- e.g. the whole graph
-  // tree contains no node with a subgraph attribute at all, which a caller
-  // visiting every node in a loop (as DCE/CSE do) can check once up front
-  // instead of paying uses()'s full-graph subgraph scan on every node.
+  // Cheap (O(1)) equivalent of ``!uses().empty()`` that skips uses()'s scan
+  // for kCaptured placeholders in nested subgraphs -- safe only when the
+  // caller has established the graph tree has no control-flow subgraphs.
   bool hasUsesInCurrentGraph() const {
     return !uses_in_current_graph_.empty();
   }

--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -396,6 +396,19 @@ struct Value final {
   const Graph* owningGraph() const;
   use_list uses() const;
 
+  // Cheap (O(1)) equivalent of ``!uses().empty()`` that only sees uses from
+  // nodes directly in this value's owning graph, not uses().'s additional
+  // owningGraph()->forEachNode() scan for kCaptured placeholders in nested
+  // If/Loop/Scan subgraph bodies (see uses()'s definition below). Safe to use
+  // in place of ``!uses().empty()`` only when the caller has separately
+  // established that no such capture is possible -- e.g. the whole graph
+  // tree contains no node with a subgraph attribute at all, which a caller
+  // visiting every node in a loop (as DCE/CSE do) can check once up front
+  // instead of paying uses()'s full-graph subgraph scan on every node.
+  bool hasUsesInCurrentGraph() const {
+    return !uses_in_current_graph_.empty();
+  }
+
   // Replaces all uses of this node with 'newValue'.
   //
   // Given:   %3 = f(%1, %2)
@@ -573,6 +586,15 @@ struct Node : public Attributes<Node> {
   bool hasUses() const {
     for (const auto* o : outputs()) {
       if (!o->uses().empty())
+        return true;
+    }
+    return false;
+  }
+  // Cheap equivalent of hasUses() -- see Value::hasUsesInCurrentGraph()'s
+  // comment for exactly what this does and doesn't see.
+  bool hasUsesInCurrentGraph() const {
+    for (const auto* o : outputs()) {
+      if (o->hasUsesInCurrentGraph())
         return true;
     }
     return false;


### PR DESCRIPTION
Value::uses() pays a full owningGraph()->forEachNode() scan on every call, purely to find a kCaptured placeholder in a nested If/Loop/Scan subgraph body that captures this value -- see its own doc comment. A caller in a tight per-node loop (e.g. onnx-optimizer's eliminate_deadend/eliminate_common_subexpression) that only cares about ordinary same-graph uses, and has separately established the whole graph tree has no control-flow ops at all (the overwhelming common case), can use these new O(1)/O(num_outputs) accessors instead and skip that scan entirely.

Purely additive: no existing behavior changes. The actual O(N) callers this unblocks are onnxsim/optimizer's companion commit: https://github.com/onnxsim/optimizer/commit/e0d85388ee279c33890227ca762f3809cbb26b23 (https://github.com/onnxsim/onnxsim/issues/651).

Claude-Session: https://claude.ai/code/session_01ADw2idu5qWKonBuaBcJEP4 (cherry picked from commit 5f0b66cf6339b5b741845f604a69443f84645c15)



### Motivation and Context

Fixes #
