### PR TITLE
Fix copyMetadata() corrupting unknown rank into rank-0

### DIFF
--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -409,7 +409,16 @@ struct Value final {
 
   Value* copyMetadata(const Value* from) {
     setElemType(from->elemType());
-    setSizes(from->sizes());
+    if (from->has_sizes()) {
+      setSizes(from->sizes());
+    } else {
+      // Unconditionally calling setSizes(from->sizes()) here would copy an
+      // *empty* vector when `from` has no known rank (has_sizes() false),
+      // which setSizes() would then mark as a definite, present rank-0
+      // (scalar) shape -- silently corrupting "rank unknown" into "rank 0"
+      // for any Value copied from one with no shape info yet.
+      wipeSizes();
+    }
     if (from->has_unique_name()) {
       setUniqueName(from->uniqueName());
     }

--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -412,11 +412,7 @@ struct Value final {
     if (from->has_sizes()) {
       setSizes(from->sizes());
     } else {
-      // Unconditionally calling setSizes(from->sizes()) here would copy an
-      // *empty* vector when `from` has no known rank (has_sizes() false),
-      // which setSizes() would then mark as a definite, present rank-0
-      // (scalar) shape -- silently corrupting "rank unknown" into "rank 0"
-      // for any Value copied from one with no shape info yet.
+      // Don't let setSizes({}) turn "rank unknown" into "rank 0".
       wipeSizes();
     }
     if (from->has_unique_name()) {

--- a/tests/cpp/ir_test.cc
+++ b/tests/cpp/ir_test.cc
@@ -59,6 +59,40 @@ TEST(IR, ValidIdentifierTest) {
   }
 }
 
+// Regression: copyMetadata() used to unconditionally call
+// setSizes(from->sizes()), which copies an empty vector when `from` has no
+// known rank and setSizes() then marks that empty vector as a definite,
+// present rank-0 shape. A rank-unknown source must leave the destination
+// rank-unknown, not turn it into a scalar.
+TEST(IR, CopyMetadataPreservesUnknownRank) {
+  Graph g;
+  g.setName("test");
+  Value* from = g.addInput();
+  Value* to = g.addInput();
+  to->setSizes({Dimension(1)});
+  ASSERT_FALSE(from->has_sizes());
+  ASSERT_TRUE(to->has_sizes());
+
+  to->copyMetadata(from);
+  EXPECT_FALSE(to->has_sizes());
+}
+
+// copyMetadata() must still copy a known rank/shape over.
+TEST(IR, CopyMetadataCopiesKnownSizes) {
+  Graph g;
+  g.setName("test");
+  Value* from = g.addInput();
+  from->setSizes({Dimension(2), Dimension(3)});
+  Value* to = g.addInput();
+  ASSERT_FALSE(to->has_sizes());
+
+  to->copyMetadata(from);
+  ASSERT_TRUE(to->has_sizes());
+  ASSERT_EQ(to->sizes().size(), 2u);
+  EXPECT_EQ(to->sizes()[0].dim, 2);
+  EXPECT_EQ(to->sizes()[1].dim, 3);
+}
+
 // Regression tests for Graph's name-uniqueness bookkeeping (used_names_ /
 // subgraph_bearing_nodes_, backing isNameUnique()/getNextUniqueName()): a
 // name can have more than one live holder at once (an initializer's Tensor

--- a/tests/cpp/ir_test.cc
+++ b/tests/cpp/ir_test.cc
@@ -59,11 +59,7 @@ TEST(IR, ValidIdentifierTest) {
   }
 }
 
-// Regression: copyMetadata() used to unconditionally call
-// setSizes(from->sizes()), which copies an empty vector when `from` has no
-// known rank and setSizes() then marks that empty vector as a definite,
-// present rank-0 shape. A rank-unknown source must leave the destination
-// rank-unknown, not turn it into a scalar.
+// Regression: copyMetadata() must not turn "rank unknown" into rank 0.
 TEST(IR, CopyMetadataPreservesUnknownRank) {
   Graph g;
   g.setName("test");


### PR DESCRIPTION
copyMetadata() unconditionally called setSizes(from->sizes()), which copies an *empty* vector when `from` has no known rank (has_sizes() == false). setSizes() then marks that empty vector as a definite, present shape -- silently turning "rank unknown" into "rank 0 (scalar)" for any Value copied from one with no shape info yet.

Found while building Graph-native shape inference (a separate, follow-up change): a Value freshly created mid-inference (before any shape is known) and then copied via copyMetadata() -- as onnx-optimizer's fuse_matmul_add_bias_into_gemm and split passes both do -- would silently gain a bogus rank-0 shape instead of staying rank-unknown.



### Motivation and Context

Fixes #
