### PR TITLE
Fix TensorScatter circular mode wrapping non-sequence coordinates

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -31302,9 +31302,10 @@ This version of the operator has been available since version 24 of the default 
   for prefix_idx in np.ndindex(past_cache.shape[:axis]):
       batch_idx = prefix_idx[0]
       for sequence_idx in range(sequence_length):
-          cache_idx = (*prefix_idx, write_indices[batch_idx] + sequence_idx)
+          cache_sequence_idx = write_indices[batch_idx] + sequence_idx
           if mode == "circular":
-              cache_idx = tuple(np.mod(np.asarray(cache_idx), max_sequence_length))
+              cache_sequence_idx = cache_sequence_idx % max_sequence_length
+          cache_idx = (*prefix_idx, cache_sequence_idx)
           update_idx = (*prefix_idx, sequence_idx)
           present_cache[cache_idx] = update[update_idx]
   ```

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -41087,9 +41087,10 @@ expect(node, inputs=[x], outputs=[y], name="test_tanh")
   for prefix_idx in np.ndindex(past_cache.shape[:axis]):
       batch_idx = prefix_idx[0]
       for sequence_idx in range(sequence_length):
-          cache_idx = (*prefix_idx, write_indices[batch_idx] + sequence_idx)
+          cache_sequence_idx = write_indices[batch_idx] + sequence_idx
           if mode == "circular":
-              cache_idx = tuple(np.mod(np.asarray(cache_idx), max_sequence_length))
+              cache_sequence_idx = cache_sequence_idx % max_sequence_length
+          cache_idx = (*prefix_idx, cache_sequence_idx)
           update_idx = (*prefix_idx, sequence_idx)
           present_cache[cache_idx] = update[update_idx]
   ```

--- a/onnx/defs/tensor/defs.cc
+++ b/onnx/defs/tensor/defs.cc
@@ -3705,9 +3705,10 @@ The operation can be described using the following pseudocode:
 for prefix_idx in np.ndindex(past_cache.shape[:axis]):
     batch_idx = prefix_idx[0]
     for sequence_idx in range(sequence_length):
-        cache_idx = (*prefix_idx, write_indices[batch_idx] + sequence_idx)
+        cache_sequence_idx = write_indices[batch_idx] + sequence_idx
         if mode == "circular":
-            cache_idx = tuple(np.mod(np.asarray(cache_idx), max_sequence_length))
+            cache_sequence_idx = cache_sequence_idx % max_sequence_length
+        cache_idx = (*prefix_idx, cache_sequence_idx)
         update_idx = (*prefix_idx, sequence_idx)
         present_cache[cache_idx] = update[update_idx]
 ```

--- a/onnx/reference/ops/op_tensor_scatter.py
+++ b/onnx/reference/ops/op_tensor_scatter.py
@@ -39,11 +39,10 @@ class TensorScatter(OpRun):
         for prefix_idx in np.ndindex(input_shape[:axis]):
             batch_idx = prefix_idx[0]
             for sequence_idx in range(sequence_length):
-                cache_idx = (*prefix_idx, write_indices[batch_idx] + sequence_idx)
+                cache_sequence_idx = write_indices[batch_idx] + sequence_idx
                 if mode == "circular":
-                    cache_idx = tuple(
-                        np.mod(np.asarray(cache_idx), max_sequence_length)
-                    )
+                    cache_sequence_idx = cache_sequence_idx % max_sequence_length
+                cache_idx = (*prefix_idx, cache_sequence_idx)
                 update_idx = (*prefix_idx, sequence_idx)
                 present_cache[cache_idx] = update[update_idx]
 


### PR DESCRIPTION
### Description

In `circular` mode, `TensorScatter` applies the modulo to the **entire index tuple** rather than to the sequence coordinate alone. Any prefix coordinate (batch, head, ...) that is `>= max_sequence_length` therefore also wraps, and one sample's cache write lands in a different sample's cache.

The specification prose states the intended behavior twice, both times scoping the modulo to the index along the sequence axis:

- op doc: *"When the `mode` attribute is set to "circular", the write index is modulo max_sequence_length."*
- `mode` attribute doc: *"For `circular` mode, the updates happen in wrap-around fashion, ie, the update index is modulo `max_sequence_length`"*

The pseudocode is the outlier, and `onnx/reference/ops/op_tensor_scatter.py` implements the pseudocode.

### Reproduction (on `main`)

`batch_size=5`, `max_sequence_length=4`, `axis=1`, every sample writing its own value at slot 0:

```python
past_cache    = np.full((5, 4, 1), -1.0, dtype=np.float32)
update        = np.arange(1, 6, dtype=np.float32).reshape(5, 1, 1)
write_indices = np.zeros((5,), dtype=np.int64)
# TensorScatter(mode="circular", axis=1)
```

```
got      slot0 per batch: [5.0, 2.0, 3.0, 4.0, -1.0]
expected slot0 per batch: [1.0, 2.0, 3.0, 4.0, 5.0]
```

Batch 4 wraps onto batch 0: it overwrites sample 0's cache entry, and sample 4 silently keeps its stale contents. For the KV-cache use case this op was standardized for, that is cross-sample corruption rather than a degraded result — and it is silent.

### Fix

Wrap only the sequence coordinate, in both the pseudocode and the reference implementation:

```python
cache_sequence_idx = write_indices[batch_idx] + sequence_idx
if mode == "circular":
    cache_sequence_idx = cache_sequence_idx % max_sequence_length
cache_idx = (*prefix_idx, cache_sequence_idx)
```

### Why no test data changed

The existing `test_tensorscatter_circular` case uses shape `(2, 1, 4, 5)`. Its prefix coordinates (`batch_size=2`, one head) are both smaller than `max_sequence_length=4`, so `np.mod` is the identity on them and the case cannot distinguish the two readings. That is why the existing coverage does not catch this, and it is also why this fix leaves every existing expected output unchanged.

I verified the patched reference against both the discriminating case above (now correct) and the existing wrap case `(2, 1, 4, 2)` with `write_indices=[3, 3]`, which is unchanged:

```
[3, 4, -1, -1, -1, -1, 1, 2,   7, 8, -1, -1, -1, -1, 5, 6]
```

### Follow-up

Happy to add a node test whose prefix dimension exceeds `max_sequence_length` so this cannot regress — it needs generated test data, so I left it out of this change to keep the fix reviewable. Let me know if you would like it in this PR or a separate one.
