### PR TITLE
Fix inconsistent indentation in OperatorStatus enum

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,7 @@ python onnx/gen_proto.py -l --ml
 
 ### Coding style
 
-We adopted the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html) and [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) for this project.
+We adopted the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html) and [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) for this project. `.proto`/`.in.proto` files follow the [Google Protocol Buffer Style Guide](https://protobuf.dev/programming-guides/style/) (2-space indentation, no tabs).
 
 We use `lintrunner` to drive multiple linters defined in `.lintrunner.toml` to lint the codebase.
 

--- a/onnx/onnx-ml.proto
+++ b/onnx/onnx-ml.proto
@@ -941,8 +941,8 @@ message OperatorSetIdProto {
 
 // Operator/function status.
 enum OperatorStatus {
-    EXPERIMENTAL = 0;
-    STABLE = 1;
+  EXPERIMENTAL = 0;
+  STABLE = 1;
 }
 
 message FunctionProto {

--- a/onnx/onnx-ml.proto3
+++ b/onnx/onnx-ml.proto3
@@ -941,8 +941,8 @@ message OperatorSetIdProto {
 
 // Operator/function status.
 enum OperatorStatus {
-    EXPERIMENTAL = 0;
-    STABLE = 1;
+  EXPERIMENTAL = 0;
+  STABLE = 1;
 }
 
 message FunctionProto {

--- a/onnx/onnx.in.proto
+++ b/onnx/onnx.in.proto
@@ -938,8 +938,8 @@ message OperatorSetIdProto {
 
 // Operator/function status.
 enum OperatorStatus {
-    EXPERIMENTAL = 0;
-    STABLE = 1;
+  EXPERIMENTAL = 0;
+  STABLE = 1;
 }
 
 message FunctionProto {

--- a/onnx/onnx.proto
+++ b/onnx/onnx.proto
@@ -939,8 +939,8 @@ message OperatorSetIdProto {
 
 // Operator/function status.
 enum OperatorStatus {
-    EXPERIMENTAL = 0;
-    STABLE = 1;
+  EXPERIMENTAL = 0;
+  STABLE = 1;
 }
 
 message FunctionProto {

--- a/onnx/onnx.proto3
+++ b/onnx/onnx.proto3
@@ -939,8 +939,8 @@ message OperatorSetIdProto {
 
 // Operator/function status.
 enum OperatorStatus {
-    EXPERIMENTAL = 0;
-    STABLE = 1;
+  EXPERIMENTAL = 0;
+  STABLE = 1;
 }
 
 message FunctionProto {


### PR DESCRIPTION
## Summary
- `OperatorStatus` in `onnx.in.proto` used 4-space indentation while every other top-level enum in the file (e.g. `Version`) uses 2 spaces. Aligned it with the file's existing convention and regenerated the derived `.proto`/`.proto3` files (`onnx.proto`, `onnx-ml.proto`, and their `.proto3` counterparts) via `python onnx/gen_proto.py -l` / `--ml`.
- Documented in `CONTRIBUTING.md` that `.proto`/`.in.proto` files follow the [Google Protocol Buffer Style Guide](https://protobuf.dev/programming-guides/style/) (2-space indentation, no tabs), alongside the existing Google Python/C++ style guide references, so this convention is written down rather than only implicit in the file.

## Test plan
- [x] Regenerated all derived proto files and confirmed the diff is limited to the whitespace change.
- [x] `lintrunner`-adjacent pre-commit hooks pass on the commit (trim trailing whitespace, reuse lint, etc.).