### PR TITLE
Add onnx_proto_headers target to depend on generated proto C++ files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ include(cmake/Utils.cmake)
 cmake_policy(SET CMP0063 NEW)
 # Modules FindPython3 and FindPython use LOCATION for lookup strategy.
 cmake_policy(SET CMP0094 NEW)
+# Allow the protoc-generated proto sources to be added to the built-in
+# `codegen` target (CMake 3.31+); see the CODEGEN option below.
+if(POLICY CMP0171)
+  cmake_policy(SET CMP0171 NEW)
+endif()
 
 # Set default build type
 get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
@@ -400,6 +405,7 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP SRCS)
 
   set(GEN_PROTO_PY "${ONNX_ROOT}/onnx/gen_proto.py")
   set(GENERATED_FILES)
+  set(PROTOC_OUTPUTS)
   foreach(INFILE ${ARGN})
     set(ABS_FILE "${ONNX_ROOT}/${INFILE}")
     get_filename_component(FILE_DIR ${ABS_FILE} DIRECTORY)
@@ -498,11 +504,21 @@ function(RELATIVE_PROTOBUF_GENERATE_CPP SRCS)
       endif()
     endif()
 
+    set(_codegen_option)
+    if(POLICY CMP0171)
+      set(_codegen_option CODEGEN)
+    endif()
     add_custom_command(OUTPUT ${_protoc_outputs}
         COMMAND "${ONNX_PROTOC_EXECUTABLE}" ${PROTOC_ARGS}
         DEPENDS ${GENERATED_FILES}
-        COMMENT "Running C++ protocol buffer compiler on ${GENERATED_PROTO}")
+        COMMENT "Running C++ protocol buffer compiler on ${GENERATED_PROTO}"
+        ${_codegen_option})
+    list(APPEND PROTOC_OUTPUTS ${_protoc_outputs})
   endforeach()
+
+  # A target tooling (clang-tidy, clangd, ...) can build to force generation
+  # of the proto C++ sources/headers without building the rest of ONNX.
+  add_custom_target(onnx_proto_headers DEPENDS ${PROTOC_OUTPUTS})
 
   set(${SRCS} ${${SRCS}} PARENT_SCOPE)
   set(ONNX_PROTO_PY_FILES ${_py_files} PARENT_SCOPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -534,6 +534,12 @@ relative_protobuf_generate_cpp(ONNX_PROTO_SRCS
 # generated .proto files; protoc and C++ compilation still overlap afterwards.
 add_custom_target(onnx_proto_gen DEPENDS ${ONNX_GENERATED_PROTO_FILES})
 
+# onnx_proto_headers also needs the generated .proto files (transitively, via
+# the protoc step). Without this, Xcode's build system rejects the shared
+# custom command: it requires that when two independent targets need the same
+# generated file, one be a dependency of the other.
+add_dependencies(onnx_proto_headers onnx_proto_gen)
+
 set(LINKED_PROTOBUF_TARGET protobuf::libprotobuf)
 if(ONNX_USE_LITE_PROTO)
   if(TARGET protobuf::libprotobuf-lite)
@@ -542,10 +548,14 @@ if(ONNX_USE_LITE_PROTO)
 endif()
 
 # Compile the generated .pb.cc sources in exactly one target: Xcode's build
-# system rejects a protoc custom command shared across several targets.
+# system rejects a protoc custom command shared across several targets. Since
+# onnx_proto_headers also depends on those same .pb.cc files (it just doesn't
+# compile them), make onnx_proto depend on onnx_proto_headers so Xcode treats
+# it as the owner of that custom command instead of erroring out.
 add_library(onnx_proto ${ONNX_PROTO_SRCS})
 add_onnx_global_defines(onnx_proto)
 add_dependencies(onnx_proto onnx_proto_gen)
+add_dependencies(onnx_proto onnx_proto_headers)
 
 # Core library. Hand-written sources come from target_sources(onnx ...) in the
 # subdirectories; the protobuf objects are pulled in from onnx_proto.


### PR DESCRIPTION
### Motivation and Context

Fixes #7652

After #6992 (commit 86e0f9527ae32d09f8152aea5c8ec368ee2b8c9), there was no
CMake target that a developer or tool could build to force generation of the
protoc C++ outputs (`onnx.pb.h`, `onnx.pb.cc`, etc.) without also building
the rest of ONNX. This matters for tooling such as `clang-tidy` and
`clangd`, which need `onnx.pb.h` to exist but don't need `libonnx`/`libonnx_proto`
built.

Note the existing `onnx_proto_gen` target (added in #8003) does not solve
this: it only depends on the intermediate `.proto` files produced by
`gen_proto.py`, not on the protoc-generated C++ sources/headers.

### Approach

- In `RELATIVE_PROTOBUF_GENERATE_CPP`, accumulate the protoc step's outputs
  across the function's `foreach` loop and add a new `onnx_proto_headers`
  custom target that depends on them. Building just this target
  (`cmake --build . --target onnx_proto_headers`) runs `gen_proto.py` and
  `protoc`, producing `onnx.pb.h`/`onnx.pb.cc` without compiling or linking
  anything else.
- On CMake 3.31+, also pass the new `CODEGEN` option to the protoc
  `add_custom_command`, gated behind `if(POLICY CMP0171)` so it's a no-op on
  older CMake. This wires the same outputs into CMake's built-in `codegen`
  meta-target, so `cmake --build . --target codegen` also works, as
  requested in the issue. Note this option is only supported by the Ninja
  and Makefile generators (CMake ignores it elsewhere), and its isolation
  is generator-dependent — see Validation below.

### Validation

Configured and built locally with CMake 4.4.2 and a system protobuf
(`-DONNX_BUILD_PYTHON=OFF -DONNX_BUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF`,
Unix Makefiles generator):

- `cmake -S . -B build ...` configures cleanly, no policy warnings/errors.
- `cmake --build build --target onnx_proto_headers` (fresh build dir) runs
  only `gen_proto.py` and `protoc`, producing `onnx-ml.pb.h`/`onnx-ml.pb.cc`,
  and does **not** compile or link `onnx_proto`/`onnx` — confirming the core
  ask of the issue.
- `cmake --build build --target codegen` (fresh build dir) also succeeds and
  produces the same headers, but on this system's Makefiles generator it
  additionally compiled and linked `libonnx_proto.a`. This is a
  generator-level limitation of CMake's `codegen` meta-target described in
  its own docs (isolation is best on Ninja, which was not available to test
  in this environment); it is not something this change can control, and it
  doesn't regress anything — `onnx_proto_headers` remains the fully isolated
  option.
- A subsequent full `cmake --build build` succeeds with no errors, building
  `libonnx.a` as before.
- `git grep` confirms no pre-existing target or subdirectory named
  `codegen`, so reserving that name via `CMP0171 NEW` introduces no
  collision.

I was not able to test the Ninja generator in this environment (not
installed), nor Windows/MSVC, though the CODEGEN option is documented to be
ignored (not an error) on generators that don't support it.