### PR TITLE
Fix Mingw/Windows build failure from OPTIONAL macro clash in path.h

### DIFF
--- a/onnx/common/path.h
+++ b/onnx/common/path.h
@@ -14,6 +14,12 @@
 #define NOMINMAX
 #endif
 #include <windows.h>
+// windows.h (via winnt.h) defines OPTIONAL as an empty macro for SAL
+// annotations. onnx-data.pb.h declares enum members literally named
+// OPTIONAL (SequenceProto::DataType::OPTIONAL,
+// OptionalProto::DataType::OPTIONAL), so the macro must be undefined
+// before any header that transitively includes onnx-data.pb.h is parsed.
+#undef OPTIONAL
 
 #include "onnx/checker.h"
 #endif

--- a/onnx/common/path.h
+++ b/onnx/common/path.h
@@ -14,11 +14,7 @@
 #define NOMINMAX
 #endif
 #include <windows.h>
-// windows.h (via winnt.h) defines OPTIONAL as an empty macro for SAL
-// annotations. onnx-data.pb.h declares enum members literally named
-// OPTIONAL (SequenceProto::DataType::OPTIONAL,
-// OptionalProto::DataType::OPTIONAL), so the macro must be undefined
-// before any header that transitively includes onnx-data.pb.h is parsed.
+// windows.h defines OPTIONAL, which clashes with enum members of the same name in onnx-data.pb.h.
 #undef OPTIONAL
 
 #include "onnx/checker.h"


### PR DESCRIPTION

### Motivation and Context

Fixes #

`onnx/common/path.h` includes `<windows.h>` and then, on the very next lines,
includes `onnx/checker.h`, which transitively includes the protobuf-generated
`onnx/onnx-data.pb.h`. That generated header declares enum aliases literally
named `OPTIONAL` (from the `SequenceProto.DataType` and `OptionalProto.DataType`
proto enums). `windows.h` (via `winnt.h`) `#define`s `OPTIONAL` as an empty
macro used for SAL annotations, so the preprocessor erases the `OPTIONAL`
token before the compiler ever sees it, turning
`static constexpr DataType OPTIONAL = ...;` into invalid syntax. This exactly
reproduces the build failure reported in
https://github.com/onnx/onnx/issues/6506 ("Cannot build using Mingw"), which
shows the identical error at the identical construct:
```
onnx-data.pb.h:259:38: error: expected unqualified-id before '=' token
  259 |   static constexpr DataType OPTIONAL =
```

### Approach

Add `#undef OPTIONAL` in `onnx/common/path.h`, right after `#include <windows.h>`
and before `#include "onnx/checker.h"`, so the macro is cleared before any
header that transitively includes `onnx-data.pb.h` is parsed. This mirrors the
existing `NOMINMAX` pattern already present in the same file for the
`min`/`max` macro clash. The change is guarded by the existing `#ifdef _WIN32`
block, so it has no effect on non-Windows builds.

Checked the other `.in.proto` files (`onnx.in.proto`, `onnx-operators.in.proto`)
and the rest of `onnx-data.in.proto` for other enum values that collide with
classic Windows.h macros (`IN`, `OUT`, `ERROR`, `DELETE`, `MIN`, `MAX`, `NEAR`,
`FAR`, `CONST`, `VOID`, `TRUE`, `FALSE`, `INTERFACE`) — `OPTIONAL` is the only
match, so no broader change is needed.

### Validation

- No Windows/Mingw toolchain was available in this environment, so the fix
  could not be validated with an actual Mingw build. Instead, the exact
  preprocessor mechanism was reproduced platform-independently: the real
  `onnx-data.pb.h` was generated with `protoc` from this repo's `.proto`
  files, then compiled with `clang++` after `#define OPTIONAL` (mimicking
  `windows.h`) — this reproduces the reported error verbatim, at the same
  `static constexpr DataType OPTIONAL = ...;` construct. Adding
  `#undef OPTIONAL` before the include (mimicking the fix) makes the same
  compile succeed.
- Full local build: `ONNX_BUILD_TESTS=1 pip install -e . -v` — succeeds
  (macOS/clang; this doesn't exercise the `_WIN32` branch, but confirms the
  header edit doesn't break the non-Windows build).
- C++ tests: `LD_LIBRARY_PATH=./.setuptools-cmake-build/ .setuptools-cmake-build/onnx_gtests`
  — 149/149 tests passed.
- Python tests: `pytest` — 6349 passed, 0 failed, 4117 skipped, 2 xfailed.

Fixes #6506