### PR TITLE
Add move-taking overloads for Graph::addInitializer

### DIFF
--- a/onnx/common/ir.h
+++ b/onnx/common/ir.h
@@ -1084,6 +1084,18 @@ struct Graph final {
     useName(initializer.name());
   }
 
+  // Move-taking overload: skips the copy above for a Tensor the caller is
+  // discarding. Existing lvalue call sites are unaffected.
+  void addInitializer(Tensor&& initializer) {
+    if (initializer.name().empty()) {
+      initializer.setName(getNextUniqueName());
+    }
+    // Read the name before the move below invalidates it.
+    initializer_names_.push_back(initializer.name());
+    useName(initializer.name());
+    initializers_.push_back(std::move(initializer));
+  }
+
   // For IR >= 4, initializer is not required to exist in input
   // Add initializer into initializer node list and return its Value
   Value* addInitializerAndCreateValue(Tensor& initializer) {
@@ -1093,6 +1105,23 @@ struct Graph final {
     init_value->setUniqueName(initializer.name());
     init_value->setSizes(dim_sizes);
     init_value->setElemType(initializer.elem_type());
+    return init_value;
+  }
+
+  // Move-taking counterpart to addInitializer(Tensor&&) above. Everything
+  // the returned Value needs is read before initializer is moved from.
+  Value* addInitializerAndCreateValue(Tensor&& initializer) {
+    if (initializer.name().empty()) {
+      initializer.setName(getNextUniqueName());
+    }
+    auto* init_value = initializer_node_->addOutput();
+    std::vector<Dimension> dim_sizes{initializer.sizes().cbegin(), initializer.sizes().cend()};
+    init_value->setUniqueName(initializer.name());
+    init_value->setSizes(dim_sizes);
+    init_value->setElemType(initializer.elem_type());
+    initializer_names_.push_back(initializer.name());
+    useName(initializer.name());
+    initializers_.push_back(std::move(initializer));
     return init_value;
   }
 


### PR DESCRIPTION
Graph::addInitializer(Tensor&) and addInitializerAndCreateValue(Tensor&) always copy the given Tensor into storage, even when the caller's argument is a scratch value it discards immediately after the call -- a common pattern in onnx-optimizer passes that build a fresh Tensor, rename it, and hand it straight to addInitializerAndCreateValue.

Add Tensor&& overloads of both that move from the argument instead, leaving the existing lvalue overloads (and every current call site) untouched -- passing an lvalue still binds to the copying overload, so this is purely additive. A caller with a Tensor it no longer needs can opt in with std::move() to skip the deep copy of raw_data/typed-data fields. Both overloads read everything the caller/return value needs (name/sizes/elem_type) before moving from the argument, and mirror the existing lvalue overloads' useName() bookkeeping.

Motivated by profiling onnxsim's extract_constant_to_initializer pass, which was hand-copying a Tensor about to be moved into an initializer right before discarding it.



### Motivation and Context

Fixes #
