### PR TITLE
Fix encodeTensor missing FLOAT8E8M0 case in IR pb converter

### DIFF
--- a/onnx/common/ir_pb_converter.cc
+++ b/onnx/common/ir_pb_converter.cc
@@ -483,6 +483,7 @@ static void encodeTensor(ONNX_NAMESPACE::TensorProto& p, const Tensor& tensor) {
     case ONNX_NAMESPACE::TensorProto_DataType_FLOAT8E4M3FNUZ:
     case ONNX_NAMESPACE::TensorProto_DataType_FLOAT8E5M2:
     case ONNX_NAMESPACE::TensorProto_DataType_FLOAT8E5M2FNUZ:
+    case ONNX_NAMESPACE::TensorProto_DataType_FLOAT8E8M0:
     case ONNX_NAMESPACE::TensorProto_DataType_FLOAT4E2M1:
     case ONNX_NAMESPACE::TensorProto_DataType_BOOL:
     case ONNX_NAMESPACE::TensorProto_DataType_UINT2:


### PR DESCRIPTION
## Summary
- `encodeTensor()` in `onnx/common/ir_pb_converter.cc` handles every other int32-backed data type (FLOAT8E4M3FN, FLOAT8E5M2, FLOAT4E2M1, etc.) in its switch, but was missing `FLOAT8E8M0`.
- `tensorProtoToTensor()` (the corresponding read path) already handles `FLOAT8E8M0` via the same int32 representation, so the write path was inconsistent with the read path.
- Without this case, a `Tensor` holding `FLOAT8E8M0` data falls through with no `int32_data` written, silently producing an empty tensor on round-trip through the IR.

Split out from a review comment on #8349, where this gap was noticed but is unrelated to that PR's FP6 feature work.

## Test plan
- [ ] Add/confirm a round-trip test (graphProtoToGraph / encodeGraph) for a FLOAT8E8M0 tensor