### PR TITLE
Pin ml_dtypes==0.5.4 in numpy<2.0 CI test jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -272,7 +272,8 @@ jobs:
       - name: Run Python tests with numpy<2.0 (win, mac)
         if: (matrix.python_version == '3.10') && (matrix.os == 'windows-latest' || matrix.os == 'macos-latest') && (matrix.debug_build != 1)
         run: |
-          pip install "numpy<2.0" pillow
+          # ml_dtypes 0.6.0 dropped numpy 1 support, so pin the last version that supports it.
+          pip install "numpy<2.0" "ml_dtypes==0.5.4" pillow
           pytest -s
 
       - name: Run Python tests with numpy<2.0 (ubuntu, python<3.13)
@@ -281,5 +282,6 @@ jobs:
           # 2024.10.15: Error message: The headers or library files could not be found for jpeg, a required dependency when compiling Pillow from source.
           sudo apt-get update
           sudo apt-get install libjpeg-dev zlib1g-dev libpng-dev
-          pip install --prefer-binary "numpy<2.0" pillow
+          # ml_dtypes 0.6.0 dropped numpy 1 support, so pin the last version that supports it.
+          pip install --prefer-binary "numpy<2.0" "ml_dtypes==0.5.4" pillow
           pytest -s


### PR DESCRIPTION
## Summary
- ml_dtypes 0.6.0 dropped support for numpy 1.x, so the two `numpy<2.0` Python test jobs in `.github/workflows/main.yml` would resolve an incompatible ml_dtypes version and fail.
- Pin `ml_dtypes==0.5.4` (the last version supporting numpy 1) alongside `numpy<2.0` in both jobs.

## Test plan
- [x] `lintrunner`-equivalent pre-commit hooks pass on the change (yaml/whitespace checks)
- [x] CI run confirms the numpy<2.0 jobs (win/mac and ubuntu) install and pass with the pinned ml_dtypes version