### PR TITLE
Bump nanobind to v3.0.1

### DIFF
--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -51,9 +51,9 @@
     {
       "type": "library",
       "name": "nanobind",
-      "version": "2.15.0",
+      "version": "3.0.1",
       "bom-ref": "nanobind",
-      "purl": "pkg:github/wjakob/nanobind@v2.15.0",
+      "purl": "pkg:github/wjakob/nanobind@v3.0.1",
       "externalReferences": [
         {
           "type": "vcs",


### PR DESCRIPTION
## Summary

Tracks #8380 — moving from nanobind 2.15.0 (current pin) to nanobind 3.0.1. Targeting 1.24 rather than 1.23, since this touches build-critical native binding code across all three platforms and isn't a routine dependency bump like prior nanobind updates (#8302, #8352).

This PR currently only bumps the version pin in `sbom.cdx.json`. It is **not expected to build yet** — see decisions/work below before this is ready for review.

## Open decisions before merging

- [ ] **Split mode**: nanobind 3.0's headline feature lets a single wheel per platform cover multiple Python versions via a stable-ABI frontend, with the version-specific backend published separately on PyPI. Do we adopt this now, or bump the dependency version only and leave `release_*.yml` / wheel-building untouched for a later, separate decision? *(Leaning: defer — bigger scope, not needed to unblock the version bump itself.)*
- [ ] **`ONNX_DEFINE_TYPE_CASTER` macro** (`onnx/cpp2py_export.cc`, lines 61-74): the custom `from_cpp(..., rv_policy, cleanup_list*)` / `from_python` type-caster hooks use APIs the 3.0 changelog calls out directly (return-value policies now compile-time tags; `from_python` flags param widened to `uint32_t`). Needs a real patch + compile check, not just a version bump.
- [ ] **`nb::rv_policy::reference_internal`** call sites (`cpp2py_export.cc:508`, `:725`): confirm these still compile as-is under the tag-based policy model.
- [ ] **`nb::none()`** call site (`cpp2py_export.cc:110`): `nb::none()` changed from a function to a wrapper class - confirm the existing call still compiles/behaves correctly.
- [ ] **CI scope**: needs full matrix, not just Linux - Windows clang-cl job, macOS, and the debug/ASAN/TSAN Ubuntu jobs all build the same `cpp2py_export.cc`.

## Non-issues (already checked)

- Python 3.9 support: already dropped project-wide (`requires-python = ">=3.10"` in `pyproject.toml`), so nanobind 3.0's Python-3.10-minimum requirement is a non-blocker.
- `NB_TRAMPOLINE`: unused in ONNX's bindings - the trampoline redesign doesn't affect us.
- Pinned 3.0.1, not 3.0.0: 3.0.0 shipped Aug 22 2026 and 3.0.1 (Aug 28) already fixed real regressions (`std::chrono::duration` caster, a `constexpr`-annotation OOB write, stub-generation naming).

## Test plan

- [ ] `pytest` full suite passes on all CI platforms/configs
- [ ] `onnx_gtests` passes (Linux/macOS)
- [ ] Wheel builds successfully end-to-end (`release_linux.yml`, `release_mac.yml`, `release_win.yml`) if split mode is in scope