### PR TITLE
Fix ReduceLogSumExp reference implementation for integer inputs

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -29665,6 +29665,34 @@ expect(
 
 
 <details>
+<summary>integer_input</summary>
+
+```python
+axes = np.array([], dtype=np.int64)
+keepdims = 1
+
+node = onnx.helper.make_node(
+    "ReduceLogSumExp",
+    inputs=["data", "axes"],
+    outputs=["reduced"],
+    keepdims=keepdims,
+)
+
+data = np.array([1, 2, 3], dtype=np.int64)
+reduced = np.log(np.sum(np.exp(data.astype(np.float64)), axis=None, keepdims=True))
+
+expect(
+    node,
+    inputs=[data, axes],
+    outputs=[reduced],
+    name="test_reduce_log_sum_exp_integer_input",
+)
+```
+
+</details>
+
+
+<details>
 <summary>keepdims</summary>
 
 ```python

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -21381,7 +21381,7 @@ expect(
 
 
 ### ReduceLogSumExp
-There are 5 test cases, listed as following:
+There are 6 test cases, listed as following:
 <details>
 <summary>default_axes_keepdims</summary>
 
@@ -21491,6 +21491,32 @@ expect(
     inputs=[data, axes],
     outputs=[reduced],
     name="test_reduce_log_sum_exp_empty_set",
+)
+```
+
+</details>
+<details>
+<summary>integer_input</summary>
+
+```python
+axes = np.array([], dtype=np.int64)
+keepdims = 1
+
+node = onnx.helper.make_node(
+    "ReduceLogSumExp",
+    inputs=["data", "axes"],
+    outputs=["reduced"],
+    keepdims=keepdims,
+)
+
+data = np.array([1, 2, 3], dtype=np.int64)
+reduced = np.log(np.sum(np.exp(data.astype(np.float64)), axis=None, keepdims=True))
+
+expect(
+    node,
+    inputs=[data, axes],
+    outputs=[reduced],
+    name="test_reduce_log_sum_exp_integer_input",
 )
 ```
 

--- a/onnx/backend/test/case/node/reduce_log_sum_exp.py
+++ b/onnx/backend/test/case/node/reduce_log_sum_exp.py
@@ -168,6 +168,28 @@ class ReduceLogSumExp(Base):
         )
 
     @staticmethod
+    def export_integer_input() -> None:
+        axes = np.array([], dtype=np.int64)
+        keepdims = 1
+
+        node = onnx.helper.make_node(
+            "ReduceLogSumExp",
+            inputs=["data", "axes"],
+            outputs=["reduced"],
+            keepdims=keepdims,
+        )
+
+        data = np.array([1, 2, 3], dtype=np.int64)
+        reduced = np.log(np.sum(np.exp(data.astype(np.float64)), axis=None, keepdims=True))
+
+        expect(
+            node,
+            inputs=[data, axes],
+            outputs=[reduced],
+            name="test_reduce_log_sum_exp_integer_input",
+        )
+
+    @staticmethod
     def export_empty_set() -> None:
         shape = [2, 0, 4]
         keepdims = 1

--- a/onnx/reference/ops/op_reduce_log_sum_exp.py
+++ b/onnx/reference/ops/op_reduce_log_sum_exp.py
@@ -8,7 +8,20 @@ import numpy as np
 from onnx.reference.ops._op import OpRunReduceNumpy
 
 
+def _cast_integer_to_float(data):
+    """Cast integer tensors to float64.
+
+    ``log``/``exp`` are undefined for integer dtypes and the ``-np.inf``
+    constant cannot be stored in an integer array, so the reference
+    implementation works in floating point for integer inputs.
+    """
+    if np.issubdtype(data.dtype, np.integer):
+        return data.astype(np.float64)
+    return data
+
+
 def compute_log_sum_exp(data, axes, keepdims):
+    data = _cast_integer_to_float(data)
     data_max = data.copy()
     ind = np.isinf(data_max)
     data_max[ind] = -np.inf
@@ -26,6 +39,7 @@ class ReduceLogSumExp_1(OpRunReduceNumpy):
     def _run(self, data, axes=None, keepdims=None):
         tax = tuple(axes) if axes is not None else None
 
+        data = _cast_integer_to_float(data)
         if data.size == 0:
             return self.reduce_constant(data, -np.inf, tax, keepdims)
         return compute_log_sum_exp(data, tax, keepdims)
@@ -37,6 +51,7 @@ class ReduceLogSumExp_18(OpRunReduceNumpy):
 
         keepdims = keepdims != 0
 
+        data = _cast_integer_to_float(data)
         if data.size == 0:
             return self.reduce_constant(data, -np.inf, axes, keepdims)
 


### PR DESCRIPTION
Fixes #7141.

## Summary

The reference implementation of `ReduceLogSumExp` crashed for integer inputs (int32/int64/uint32/uint64), which are explicitly listed as supported types in the operator spec. The crash occurred because `data_max[ind] = -np.inf` cannot store a float infinity in an integer array.

## Fix

Cast integer tensors to `float64` before computing the log-sum-exp (and before the empty-set `-inf` reduction path). `log`/`exp` are undefined for integer dtypes, so the reference implementation now works in floating point for integer inputs.

## Test

Added backend test case `test_reduce_log_sum_exp_integer_input` covering int64 input, and verified the reference implementation returns the expected `float64` result for int32/int64/uint32/uint64 inputs.

## Verification

```python
from onnx.reference import ReferenceEvaluator
import onnx, numpy as np
node = onnx.helper.make_node('ReduceLogSumExp', inputs=['data'], outputs=['res'])
sess = ReferenceEvaluator(node, optimized=False)
res, = sess.run(None, {'data': np.asarray([1, 2, 3], np.int64)})
# res == [3.40760596] float64
```
