### PR TITLE
fix(checker): reject non-canonical FLOAT6 encodings

### DIFF
--- a/onnx/checker.cc
+++ b/onnx/checker.cc
@@ -199,6 +199,19 @@ void check_tensor(const TensorProto& tensor, const CheckerContext& ctx) {
               ") has a shape too large to validate against its data type.");
         }
         expected_bytes = (expected_bits / 8) + (expected_bits % 8 != 0);
+        if (expected_bytes > 0 && static_cast<int64_t>(tensor.raw_data().size()) >= expected_bytes) {
+          const auto used_bits = static_cast<uint8_t>(expected_bits % 8);
+          if (used_bits != 0) {
+            const auto last_byte = static_cast<uint8_t>(tensor.raw_data()[expected_bytes - 1]);
+            const auto unused_bits_mask = static_cast<uint8_t>(0xFFU << used_bits);
+            if ((last_byte & unused_bits_mask) != 0) {
+              fail_check(
+                  "TensorProto (tensor name: ",
+                  tensor.name(),
+                  ") has non-zero padding bits in its packed FLOAT6 raw_data.");
+            }
+          }
+        }
         break;
       }
       case TensorProto::UINT8:
@@ -341,6 +354,14 @@ void check_tensor(const TensorProto& tensor, const CheckerContext& ctx) {
                 ") is too small for the declared shape (",
                 expected_int32s,
                 " int32 values required).");
+          }
+          if (tensor.data_type() == TensorProto::FLOAT6E2M3 || tensor.data_type() == TensorProto::FLOAT6E3M2) {
+            for (const auto value : tensor.int32_data()) {
+              if (value < 0 || value > 0x3F) {
+                fail_check(
+                    "TensorProto (tensor name: ", tensor.name(), ") FLOAT6 int32_data values must use only bits 0-5.");
+              }
+            }
           }
         }
         break;

--- a/tests/python/checker_test.py
+++ b/tests/python/checker_test.py
@@ -1502,6 +1502,48 @@ class TestChecker:
             tensor.raw_data = b"\x00" * 8
             checker.check_tensor(tensor)
 
+    @pytest.mark.parametrize("dtype", (TensorProto.FLOAT6E2M3, TensorProto.FLOAT6E3M2))
+    @pytest.mark.parametrize(
+        ("num_elements", "invalid_last_byte"),
+        ((1, 0x40), (2, 0x10), (3, 0x04)),
+    )
+    def test_check_tensor_float6_raw_data_padding(
+        self, dtype: int, num_elements: int, invalid_last_byte: int
+    ) -> None:
+        tensor = TensorProto()
+        tensor.data_type = dtype
+        tensor.dims.extend([num_elements])
+        tensor.name = "t"
+        tensor.raw_data = bytes((num_elements * 6 + 7) // 8 - 1) + bytes(
+            [invalid_last_byte]
+        )
+        with pytest.raises(checker.ValidationError, match="non-zero padding bits"):
+            checker.check_tensor(tensor)
+
+        tensor.raw_data = bytes((num_elements * 6 + 7) // 8)
+        checker.check_tensor(tensor)
+
+    @pytest.mark.parametrize("dtype", (TensorProto.FLOAT6E2M3, TensorProto.FLOAT6E3M2))
+    @pytest.mark.parametrize("invalid_value", (-1, 64))
+    def test_check_tensor_float6_int32_data_high_bits(
+        self, dtype: int, invalid_value: int
+    ) -> None:
+        int32_tensor = helper.make_tensor(
+            "int32", TensorProto.INT32, [1], [invalid_value]
+        )
+        checker.check_tensor(int32_tensor)
+
+        tensor = TensorProto()
+        tensor.data_type = dtype
+        tensor.dims.extend([1])
+        tensor.name = "t"
+        tensor.int32_data.append(invalid_value)
+        with pytest.raises(checker.ValidationError, match="must use only bits 0-5"):
+            checker.check_tensor(tensor)
+
+        tensor.int32_data[0] = 63
+        checker.check_tensor(tensor)
+
     def test_check_tensor_packed_subbyte_int32_data(self) -> None:
         """Reject packed sub-byte tensors whose int32_data payload is too small."""
         # 4-bit types: 8 elements per int32.


### PR DESCRIPTION
### Motivation and Context

Follow-up to #8349. The FLOAT6 wire-format rules require `int32_data` entries to use only bits 0–5 and packed `raw_data` to zero unused high bits in the final byte. The checker previously accepted violations, allowing different consumers to interpret the same malformed tensor inconsistently.

This change rejects non-canonical encodings for both `FLOAT6E2M3` and `FLOAT6E3M2`, while preserving existing validation behavior for other `int32_data`-backed types. It adds coverage for every partial packed group and both invalid signed/high-bit `int32_data` cases.

cc @andife

### Testing

- `pixi run lint`
- `pixi run install`
- `pixi run pytest tests/python/checker_test.py`