### PR TITLE
Fix LRN reference implementation channel iteration

### DIFF
--- a/onnx/backend/test/case/node/lrn.py
+++ b/onnx/backend/test/case/node/lrn.py
@@ -28,14 +28,16 @@ class LRN(Base):
             bias=bias,
             size=nsize,
         )
-        x = np.random.randn(5, 5, 5, 5).astype(np.float32)
-        square_sum = np.zeros((5, 5, 5, 5)).astype(np.float32)
+        # Use N != C so the reference implementation is exercised over the
+        # channel dimension rather than the batch dimension (see gh-7805).
+        x = np.random.randn(1, 5, 5, 5).astype(np.float32)
+        square_sum = np.zeros((1, 5, 5, 5)).astype(np.float32)
         for n, c, h, w in np.ndindex(x.shape):
             square_sum[n, c, h, w] = sum(
                 x[
                     n,
                     max(0, c - math.floor((nsize - 1) / 2)) : min(
-                        5, c + math.ceil((nsize - 1) / 2) + 1
+                        x.shape[1], c + math.ceil((nsize - 1) / 2) + 1
                     ),
                     h,
                     w,
@@ -52,14 +54,16 @@ class LRN(Base):
         bias = 1.0
         nsize = 3
         node = onnx.helper.make_node("LRN", inputs=["x"], outputs=["y"], size=3)
-        x = np.random.randn(5, 5, 5, 5).astype(np.float32)
-        square_sum = np.zeros((5, 5, 5, 5)).astype(np.float32)
+        # Use N != C so the reference implementation is exercised over the
+        # channel dimension rather than the batch dimension (see gh-7805).
+        x = np.random.randn(1, 5, 5, 5).astype(np.float32)
+        square_sum = np.zeros((1, 5, 5, 5)).astype(np.float32)
         for n, c, h, w in np.ndindex(x.shape):
             square_sum[n, c, h, w] = sum(
                 x[
                     n,
                     max(0, c - math.floor((nsize - 1) / 2)) : min(
-                        5, c + math.ceil((nsize - 1) / 2) + 1
+                        x.shape[1], c + math.ceil((nsize - 1) / 2) + 1
                     ),
                     h,
                     w,

--- a/onnx/reference/ops/op_lrn.py
+++ b/onnx/reference/ops/op_lrn.py
@@ -20,7 +20,7 @@ class LRN(OpRun):
         minc = x.shape[1]
         c1 = math.floor((size - 1) / 2)
         c2 = math.ceil((size - 1) / 2) + 1
-        for c in range(x.shape[0]):
+        for c in range(x.shape[1]):
             begin = max(0, c - c1)
             end = min(minc, c + c2)
             square_sum[:, c, :, :] = np.sum(x[:, begin:end, :, :] ** 2, axis=1)


### PR DESCRIPTION
Fixes #7805.

## Problem

The LRN reference implementation (`onnx/reference/ops/op_lrn.py`) iterated over `x.shape[0]` (batch) instead of `x.shape[1]` (channel) when computing the local square sum. Per the [LRN spec](https://onnx.ai/onnx/operators/onnx__LRN.html), the normalization window slides over the channel dimension.

The bug was masked in the existing backend test because it used `(5, 5, 5, 5)` input where `N == C == 5`. With `N != C` (e.g. `(1, 5, 5, 5)`), the loop runs once and leaves all channels except the first with an empty `square_sum`.

## Fix

- `for c in range(x.shape[0])` → `for c in range(x.shape[1])`.
- Update `test_lrn` and `test_lrn_default` to use `(1, 5, 5, 5)` input (N != C) and `x.shape[1]` in the expected-output computation, so the regression is caught.

## Tests

`pytest tests/python/backend_reference_test.py -k test_lrn` → 2 passed.