### PR TITLE
Fix GlobalMaxPool for 3D inputs

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -16996,6 +16996,54 @@ expect(node, inputs=[x], outputs=[y], name="test_globalmaxpool")
 
 
 <details>
+<summary>globalmaxpool_3d</summary>
+
+```python
+node = onnx.helper.make_node(
+    "GlobalMaxPool",
+    inputs=["x"],
+    outputs=["y"],
+)
+x = np.array(
+    [
+        [[1, 3, 2, 0], [4, -1, 2, 5], [-2, -3, -1, -4]],
+        [[8, 6, 7, 5], [0, 1, 2, 3], [9, 11, 10, 4]],
+    ],
+    dtype=np.float32,
+)
+y = np.array([[[3], [5], [-1]], [[8], [3], [11]]], dtype=np.float32)
+expect(node, inputs=[x], outputs=[y], name="test_globalmaxpool_3d")
+```
+
+</details>
+
+
+<details>
+<summary>globalmaxpool_5d</summary>
+
+```python
+node = onnx.helper.make_node(
+    "GlobalMaxPool",
+    inputs=["x"],
+    outputs=["y"],
+)
+x = np.array(
+    [
+        [
+            [[[1, 2], [3, 4]], [[5, 6], [7, 8]]],
+            [[[9, 8], [7, 6]], [[5, 4], [3, 2]]],
+        ]
+    ],
+    dtype=np.float32,
+)
+y = np.array([8, 9], dtype=np.float32).reshape(1, 2, 1, 1, 1)
+expect(node, inputs=[x], outputs=[y], name="test_globalmaxpool_5d")
+```
+
+</details>
+
+
+<details>
 <summary>globalmaxpool_precomputed</summary>
 
 ```python

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -12658,7 +12658,7 @@ expect(node, inputs=[x], outputs=[y], name="test_globalaveragepool_precomputed")
 
 
 ### GlobalMaxPool
-There are 2 test cases, listed as following:
+There are 4 test cases, listed as following:
 <details>
 <summary>globalmaxpool</summary>
 
@@ -12671,6 +12671,50 @@ node = onnx.helper.make_node(
 x = np.random.randn(1, 3, 5, 5).astype(np.float32)
 y = np.max(x, axis=tuple(range(2, np.ndim(x))), keepdims=True)
 expect(node, inputs=[x], outputs=[y], name="test_globalmaxpool")
+```
+
+</details>
+<details>
+<summary>globalmaxpool_3d</summary>
+
+```python
+node = onnx.helper.make_node(
+    "GlobalMaxPool",
+    inputs=["x"],
+    outputs=["y"],
+)
+x = np.array(
+    [
+        [[1, 3, 2, 0], [4, -1, 2, 5], [-2, -3, -1, -4]],
+        [[8, 6, 7, 5], [0, 1, 2, 3], [9, 11, 10, 4]],
+    ],
+    dtype=np.float32,
+)
+y = np.array([[[3], [5], [-1]], [[8], [3], [11]]], dtype=np.float32)
+expect(node, inputs=[x], outputs=[y], name="test_globalmaxpool_3d")
+```
+
+</details>
+<details>
+<summary>globalmaxpool_5d</summary>
+
+```python
+node = onnx.helper.make_node(
+    "GlobalMaxPool",
+    inputs=["x"],
+    outputs=["y"],
+)
+x = np.array(
+    [
+        [
+            [[[1, 2], [3, 4]], [[5, 6], [7, 8]]],
+            [[[9, 8], [7, 6]], [[5, 4], [3, 2]]],
+        ]
+    ],
+    dtype=np.float32,
+)
+y = np.array([8, 9], dtype=np.float32).reshape(1, 2, 1, 1, 1)
+expect(node, inputs=[x], outputs=[y], name="test_globalmaxpool_5d")
 ```
 
 </details>

--- a/onnx/backend/test/case/node/globalmaxpool.py
+++ b/onnx/backend/test/case/node/globalmaxpool.py
@@ -42,3 +42,39 @@ class GlobalMaxPool(Base):
         ).astype(np.float32)
         y = np.array([[[[9]]]]).astype(np.float32)
         expect(node, inputs=[x], outputs=[y], name="test_globalmaxpool_precomputed")
+
+    @staticmethod
+    def export_globalmaxpool_3d() -> None:
+        node = onnx.helper.make_node(
+            "GlobalMaxPool",
+            inputs=["x"],
+            outputs=["y"],
+        )
+        x = np.array(
+            [
+                [[1, 3, 2, 0], [4, -1, 2, 5], [-2, -3, -1, -4]],
+                [[8, 6, 7, 5], [0, 1, 2, 3], [9, 11, 10, 4]],
+            ],
+            dtype=np.float32,
+        )
+        y = np.array([[[3], [5], [-1]], [[8], [3], [11]]], dtype=np.float32)
+        expect(node, inputs=[x], outputs=[y], name="test_globalmaxpool_3d")
+
+    @staticmethod
+    def export_globalmaxpool_5d() -> None:
+        node = onnx.helper.make_node(
+            "GlobalMaxPool",
+            inputs=["x"],
+            outputs=["y"],
+        )
+        x = np.array(
+            [
+                [
+                    [[[1, 2], [3, 4]], [[5, 6], [7, 8]]],
+                    [[[9, 8], [7, 6]], [[5, 4], [3, 2]]],
+                ]
+            ],
+            dtype=np.float32,
+        )
+        y = np.array([8, 9], dtype=np.float32).reshape(1, 2, 1, 1, 1)
+        expect(node, inputs=[x], outputs=[y], name="test_globalmaxpool_5d")

--- a/onnx/reference/ops/op_global_max_pool.py
+++ b/onnx/reference/ops/op_global_max_pool.py
@@ -3,17 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import numpy as np
+from typing import TYPE_CHECKING
 
 from onnx.reference.op_run import OpRun
 
+if TYPE_CHECKING:
+    import numpy as np
+
 
 def _global_max_pool(x: np.ndarray) -> np.ndarray:
-    spatial_shape = np.ndim(x) - 2
-    y = x.max(axis=tuple(range(spatial_shape, spatial_shape + 2)))
-    for _ in range(spatial_shape):
-        y = np.expand_dims(y, -1)
-    return y
+    return x.max(axis=tuple(range(2, x.ndim)), keepdims=True)
 
 
 class GlobalMaxPool(OpRun):

--- a/tests/python/reference_evaluator_global_max_pool_test.py
+++ b/tests/python/reference_evaluator_global_max_pool_test.py
@@ -1,0 +1,92 @@
+# Copyright (c) ONNX Project Contributors
+
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from onnx.helper import make_node
+from onnx.reference import ReferenceEvaluator
+
+
+@pytest.mark.parametrize(
+    ("x", "expected"),
+    [
+        (
+            np.array(
+                [
+                    [[1, 3, 2, 0], [4, -1, 2, 5], [-2, -3, -1, -4]],
+                    [[8, 6, 7, 5], [0, 1, 2, 3], [9, 11, 10, 4]],
+                ],
+                dtype=np.float32,
+            ),
+            np.array([[[3], [5], [-1]], [[8], [3], [11]]], dtype=np.float32),
+        ),
+        (
+            np.array(
+                [
+                    [
+                        [[1, 2, 3], [4, 5, 6]],
+                        [[9, 8, 7], [6, 5, 4]],
+                    ]
+                ],
+                dtype=np.float64,
+            ),
+            np.array([6, 9], dtype=np.float64).reshape(1, 2, 1, 1),
+        ),
+        (
+            np.array(
+                [
+                    [
+                        [[[1, 2], [3, 4]], [[5, 6], [7, 8]]],
+                        [[[9, 8], [7, 6]], [[5, 4], [3, 2]]],
+                    ]
+                ],
+                dtype=np.float32,
+            ),
+            np.array([8, 9], dtype=np.float32).reshape(1, 2, 1, 1, 1),
+        ),
+        (
+            np.arange(32, dtype=np.float64).reshape(1, 2, 2, 2, 2, 2),
+            np.array([15, 31], dtype=np.float64).reshape(1, 2, 1, 1, 1, 1),
+        ),
+    ],
+    ids=["ncw", "nchw", "ncdhw", "four-spatial-dimensions"],
+)
+def test_global_max_pool_spatial_ranks(x, expected):
+    node = make_node("GlobalMaxPool", ["X"], ["Y"])
+    got = ReferenceEvaluator(node).run(None, {"X": x})[0]
+
+    assert got.shape == expected.shape
+    assert got.dtype == expected.dtype
+    assert_allclose(got, expected)
+
+
+def test_global_max_pool_nan():
+    x = np.array([[[np.nan, 1], [2, 3]]], dtype=np.float64)
+    expected = np.array([[[np.nan], [3]]], dtype=np.float64)
+    node = make_node("GlobalMaxPool", ["X"], ["Y"])
+
+    got = ReferenceEvaluator(node).run(None, {"X": x})[0]
+
+    assert_allclose(got, expected)
+
+
+def test_global_max_pool_zero_batch():
+    x = np.empty((0, 2, 3), dtype=np.float32)
+    node = make_node("GlobalMaxPool", ["X"], ["Y"])
+
+    got = ReferenceEvaluator(node).run(None, {"X": x})[0]
+
+    assert got.shape == (0, 2, 1)
+    assert got.dtype == x.dtype
+
+
+def test_global_max_pool_empty_spatial_dimension():
+    x = np.empty((1, 2, 0), dtype=np.float32)
+    node = make_node("GlobalMaxPool", ["X"], ["Y"])
+
+    with pytest.raises(ValueError, match="zero-size array"):
+        ReferenceEvaluator(node).run(None, {"X": x})


### PR DESCRIPTION

### Motivation and Context
This PR fixes incorrect handling of 3D inputs (N, C, W) in GlobalMaxPool, ensuring the operator correctly reduces over spatial dimensions and produces output shape (N, C, 1) as defined in the ONNX specification. It also adds test coverage for 3D inputs, which were previously untested, to ensure correct behavior for rank 3 inputs.

Fixes #7682


New PR is created as per comment https://github.com/onnx/onnx/pull/7683#issuecomment-5503913368