### PR TITLE
fix(reference): stabilize LogSoftmax and SoftmaxCrossEntropyLoss

### DIFF
--- a/onnx/reference/ops/op_log_softmax.py
+++ b/onnx/reference/ops/op_log_softmax.py
@@ -10,6 +10,9 @@ from onnx.reference.ops.op_softmax import Softmax
 
 class LogSoftmax(Softmax):
     def _run(self, X):
-        Y = Softmax._run(self, X)[0]
-        np.log(Y, out=Y)
+        if X.size == 0:
+            return (X,)
+        tmp = X - X.max(axis=self.axis, keepdims=True)
+        Y = tmp - np.log(np.exp(tmp).sum(axis=self.axis, keepdims=True))
+        Y = Y.astype(X.dtype)
         return (Y,)

--- a/onnx/reference/ops/op_softmax_cross_entropy_loss.py
+++ b/onnx/reference/ops/op_softmax_cross_entropy_loss.py
@@ -25,7 +25,7 @@ def softmaxcrossentropy(
     inp = shifted_x - np.log(np.sum(np.exp(shifted_x), axis=1, keepdims=True))
     log_prob = None
     if get_log_prob is True:
-        log_prob = np.copy(inp)
+        log_prob = np.copy(inp).astype(x.dtype)
 
     # initialize the positional weights when required
     gather_weight = None

--- a/onnx/reference/ops/op_softmax_cross_entropy_loss.py
+++ b/onnx/reference/ops/op_softmax_cross_entropy_loss.py
@@ -22,9 +22,7 @@ def softmaxcrossentropy(
     # compute log_softmax
     max_x = np.max(x, axis=1, keepdims=True)
     shifted_x = x - max_x
-    inp = shifted_x - np.log(
-        np.sum(np.exp(shifted_x), axis=1, keepdims=True)
-    )
+    inp = shifted_x - np.log(np.sum(np.exp(shifted_x), axis=1, keepdims=True))
     log_prob = None
     if get_log_prob is True:
         log_prob = np.copy(inp)

--- a/onnx/reference/ops/op_softmax_cross_entropy_loss.py
+++ b/onnx/reference/ops/op_softmax_cross_entropy_loss.py
@@ -21,9 +21,10 @@ def softmaxcrossentropy(
 
     # compute log_softmax
     max_x = np.max(x, axis=1, keepdims=True)
-    exp_x = np.exp(x - max_x)
-    p = exp_x / np.sum(exp_x, axis=1, keepdims=True)
-    inp = np.log(p)
+    shifted_x = x - max_x
+    inp = shifted_x - np.log(
+        np.sum(np.exp(shifted_x), axis=1, keepdims=True)
+    )
     log_prob = None
     if get_log_prob is True:
         log_prob = np.copy(inp)

--- a/tests/python/reference_evaluator_test.py
+++ b/tests/python/reference_evaluator_test.py
@@ -7018,6 +7018,65 @@ class TestReferenceEvaluator:
         assert_allclose(got[0].sum(), 1.0)
         assert_allclose(got[0], _softmax(x[:1])[0])
 
+    def test_logsoftmax_large_finite_gap_stays_finite(self):
+        x_info = make_tensor_value_info("X", TensorProto.FLOAT, [1, 2])
+        y_info = make_tensor_value_info("Y", TensorProto.FLOAT, [1, 2])
+        model = make_model(
+            make_graph(
+                [make_node("LogSoftmax", ["X"], ["Y"], axis=-1)],
+                "logsoftmax_large_finite_gap",
+                [x_info],
+                [y_info],
+            ),
+            opset_imports=[make_opsetid("", 23)],
+        )
+        x = np.array([[0.0, -104.0]], dtype=np.float32)
+
+        (got,) = ReferenceEvaluator(model).run(None, {"X": x})
+
+        assert np.isfinite(got).all()
+        assert got.dtype == np.float32
+        assert_allclose(got, x, rtol=0, atol=0)
+
+    def test_softmax_cross_entropy_large_finite_gap_stays_finite(self):
+        x_info = make_tensor_value_info("X", TensorProto.FLOAT, [1, 2])
+        label_info = make_tensor_value_info("label", TensorProto.INT64, [1])
+        loss_info = make_tensor_value_info("loss", TensorProto.FLOAT, [1])
+        log_prob_info = make_tensor_value_info(
+            "log_prob", TensorProto.FLOAT, [1, 2]
+        )
+        model = make_model(
+            make_graph(
+                [
+                    make_node(
+                        "SoftmaxCrossEntropyLoss",
+                        ["X", "label"],
+                        ["loss", "log_prob"],
+                        reduction="none",
+                    )
+                ],
+                "softmax_cross_entropy_large_finite_gap",
+                [x_info, label_info],
+                [loss_info, log_prob_info],
+            ),
+            opset_imports=[make_opsetid("", 23)],
+        )
+        x = np.array([[0.0, -104.0]], dtype=np.float32)
+        label = np.array([1], dtype=np.int64)
+
+        loss, log_prob = ReferenceEvaluator(model).run(
+            None, {"X": x, "label": label}
+        )
+
+        assert np.isfinite(loss).all()
+        assert np.isfinite(log_prob).all()
+        assert loss.dtype == np.float32
+        assert log_prob.dtype == np.float32
+        assert_allclose(
+            loss, np.array([104.0], dtype=np.float32), rtol=0, atol=0
+        )
+        assert_allclose(log_prob, x, rtol=0, atol=0)
+
     def test_center_crop_pad_no_change_when_shape_equals_dim(self):
         """Test CenterCropPad when target shape equals current dimension.
 

--- a/tests/python/reference_evaluator_test.py
+++ b/tests/python/reference_evaluator_test.py
@@ -7071,6 +7071,41 @@ class TestReferenceEvaluator:
         assert_allclose(loss, np.array([104.0], dtype=np.float32), rtol=0, atol=0)
         assert_allclose(log_prob, x, rtol=0, atol=0)
 
+    def test_softmax_cross_entropy_weighted_mean_preserves_float16_dtype(self):
+        x_info = make_tensor_value_info("X", TensorProto.FLOAT16, [1, 2])
+        label_info = make_tensor_value_info("label", TensorProto.INT64, [1])
+        weight_info = make_tensor_value_info("weight", TensorProto.FLOAT16, [2])
+        loss_info = make_tensor_value_info("loss", TensorProto.FLOAT16, [])
+        log_prob_info = make_tensor_value_info("log_prob", TensorProto.FLOAT16, [1, 2])
+        model = make_model(
+            make_graph(
+                [
+                    make_node(
+                        "SoftmaxCrossEntropyLoss",
+                        ["X", "label", "weight"],
+                        ["loss", "log_prob"],
+                        reduction="mean",
+                    )
+                ],
+                "softmax_cross_entropy_weighted_mean_float16",
+                [x_info, label_info, weight_info],
+                [loss_info, log_prob_info],
+            ),
+            opset_imports=[make_opsetid("", 23)],
+        )
+        x = np.array([[0.0, -10.0]], dtype=np.float16)
+        label = np.array([1], dtype=np.int64)
+        weight = np.ones(2, dtype=np.float16)
+
+        loss, log_prob = ReferenceEvaluator(model).run(
+            None, {"X": x, "label": label, "weight": weight}
+        )
+
+        assert loss.dtype == np.float16
+        assert log_prob.dtype == np.float16
+        assert np.isfinite(loss).all()
+        assert np.isfinite(log_prob).all()
+
     def test_center_crop_pad_no_change_when_shape_equals_dim(self):
         """Test CenterCropPad when target shape equals current dimension.
 

--- a/tests/python/reference_evaluator_test.py
+++ b/tests/python/reference_evaluator_test.py
@@ -7042,9 +7042,7 @@ class TestReferenceEvaluator:
         x_info = make_tensor_value_info("X", TensorProto.FLOAT, [1, 2])
         label_info = make_tensor_value_info("label", TensorProto.INT64, [1])
         loss_info = make_tensor_value_info("loss", TensorProto.FLOAT, [1])
-        log_prob_info = make_tensor_value_info(
-            "log_prob", TensorProto.FLOAT, [1, 2]
-        )
+        log_prob_info = make_tensor_value_info("log_prob", TensorProto.FLOAT, [1, 2])
         model = make_model(
             make_graph(
                 [
@@ -7064,17 +7062,13 @@ class TestReferenceEvaluator:
         x = np.array([[0.0, -104.0]], dtype=np.float32)
         label = np.array([1], dtype=np.int64)
 
-        loss, log_prob = ReferenceEvaluator(model).run(
-            None, {"X": x, "label": label}
-        )
+        loss, log_prob = ReferenceEvaluator(model).run(None, {"X": x, "label": label})
 
         assert np.isfinite(loss).all()
         assert np.isfinite(log_prob).all()
         assert loss.dtype == np.float32
         assert log_prob.dtype == np.float32
-        assert_allclose(
-            loss, np.array([104.0], dtype=np.float32), rtol=0, atol=0
-        )
+        assert_allclose(loss, np.array([104.0], dtype=np.float32), rtol=0, atol=0)
         assert_allclose(log_prob, x, rtol=0, atol=0)
 
     def test_center_crop_pad_no_change_when_shape_equals_dim(self):


### PR DESCRIPTION
### Motivation and Context

The reference implementations currently materialize softmax probabilities and then take their logarithm. For finite float32 input `[[0, -104]]`, the suppressed probability underflows to zero, so `LogSoftmax` returns `[[0, -inf]]` and `SoftmaxCrossEntropyLoss` returns `[inf]` for target class 1.

The mathematically defined results are finite: `[[0, -104]]` and `[104]`. ONNX Runtime CPU returns those finite values for the same models. A stable backend can therefore appear to disagree with the reference exactly when it preserves the finite mathematical result.

### Change

Evaluate both operators directly in log space using max shifting:

```python
shifted = x - np.max(x, axis=axis, keepdims=True)
result = shifted - np.log(np.sum(np.exp(shifted), axis=axis, keepdims=True))
```

The expression is algebraically equivalent for finite inputs, preserves the input dtype, and retains the existing empty-input behavior.

### Tests

- Added a `LogSoftmax` regression with a finite 104-logit gap.
- Added a `SoftmaxCrossEntropyLoss` regression checking both the finite loss and optional `log_prob` output.
- Full `tests/python/reference_evaluator_test.py`: 444 passed, 4 skipped.

Classification: ordinary numerical correctness. This is not a security report and does not identify a defect in ONNX Runtime.

AI tool disclosure: OpenAI Codex assisted with reproducer drafting and patch preparation. The author independently executed the reproducer, reviewed the diff, and ran the reported test suite.