### PR TITLE
fix(reference): reorder Unique outputs correctly when sorted=0

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -44364,6 +44364,67 @@ expect(
 
 
 <details>
+<summary>not_sorted_single_output</summary>
+
+```python
+node_not_sorted = onnx.helper.make_node(
+    "Unique",
+    inputs=["X"],
+    outputs=["Y"],
+    sorted=0,
+)
+
+# Y keeps the order of first occurrence even when the optional outputs
+# are not requested.
+x = np.array([2.0, 1.0, 1.0, 3.0, 4.0, 3.0], dtype=np.float32)
+y = np.array([2.0, 1.0, 3.0, 4.0], dtype=np.float32)
+
+expect(
+    node_not_sorted,
+    inputs=[x],
+    outputs=[y],
+    name="test_unique_not_sorted_single_output",
+    output_type_protos=unique_output_types(x)[:1],
+)
+```
+
+</details>
+
+
+<details>
+<summary>not_sorted_with_axis</summary>
+
+```python
+node_not_sorted = onnx.helper.make_node(
+    "Unique",
+    inputs=["X"],
+    outputs=["Y", "indices", "inverse_indices", "counts"],
+    sorted=0,
+    axis=1,
+)
+
+# The unique columns are [3.0, 4.0] and [1.0, 2.0], kept in the order
+# they first appear in X instead of ascending order. indices point into
+# the columns of X, inverse_indices and counts follow the order of Y.
+x = np.array([[3.0, 1.0, 3.0], [4.0, 2.0, 4.0]], dtype=np.float32)
+y = np.array([[3.0, 1.0], [4.0, 2.0]], dtype=np.float32)
+indices = np.array([0, 1], dtype=np.int64)
+inverse_indices = np.array([0, 1, 0], dtype=np.int64)
+counts = np.array([2, 1], dtype=np.int64)
+
+expect(
+    node_not_sorted,
+    inputs=[x],
+    outputs=[y, indices, inverse_indices, counts],
+    name="test_unique_not_sorted_with_axis",
+    output_type_protos=unique_output_types(x, axis=1),
+)
+```
+
+</details>
+
+
+<details>
 <summary>not_sorted_without_axis</summary>
 
 ```python
@@ -44408,6 +44469,38 @@ expect(
     inputs=[x],
     outputs=[y, indices, inverse_indices, counts],
     name="test_unique_not_sorted_without_axis",
+    output_type_protos=unique_output_types(x),
+)
+```
+
+</details>
+
+
+<details>
+<summary>not_sorted_without_axis_2d</summary>
+
+```python
+node_not_sorted = onnx.helper.make_node(
+    "Unique",
+    inputs=["X"],
+    outputs=["Y", "indices", "inverse_indices", "counts"],
+    sorted=0,
+)
+
+# X is flattened to [2.0, 1.0, 1.0, 3.0] because axis is not set, and Y
+# holds its unique values in order of first occurrence. indices point
+# into the flattened X, inverse_indices and counts follow the order of Y.
+x = np.array([[2.0, 1.0], [1.0, 3.0]], dtype=np.float32)
+y = np.array([2.0, 1.0, 3.0], dtype=np.float32)
+indices = np.array([0, 1, 3], dtype=np.int64)
+inverse_indices = np.array([0, 1, 1, 2], dtype=np.int64)
+counts = np.array([1, 2, 1], dtype=np.int64)
+
+expect(
+    node_not_sorted,
+    inputs=[x],
+    outputs=[y, indices, inverse_indices, counts],
+    name="test_unique_not_sorted_without_axis_2d",
     output_type_protos=unique_output_types(x),
 )
 ```

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -32200,7 +32200,7 @@ expect(node, inputs=[x, k], outputs=[y], name="test_triu_zero")
 
 
 ### Unique
-There are 7 test cases, listed as following:
+There are 10 test cases, listed as following:
 <details>
 <summary>length_1</summary>
 
@@ -32234,6 +32234,63 @@ expect(
     outputs=[y, indices, inverse_indices, counts],
     name="test_unique_length_1",
     output_type_protos=unique_output_types(x),
+)
+```
+
+</details>
+<details>
+<summary>not_sorted_single_output</summary>
+
+```python
+node_not_sorted = onnx.helper.make_node(
+    "Unique",
+    inputs=["X"],
+    outputs=["Y"],
+    sorted=0,
+)
+
+# Y keeps the order of first occurrence even when the optional outputs
+# are not requested.
+x = np.array([2.0, 1.0, 1.0, 3.0, 4.0, 3.0], dtype=np.float32)
+y = np.array([2.0, 1.0, 3.0, 4.0], dtype=np.float32)
+
+expect(
+    node_not_sorted,
+    inputs=[x],
+    outputs=[y],
+    name="test_unique_not_sorted_single_output",
+    output_type_protos=unique_output_types(x)[:1],
+)
+```
+
+</details>
+<details>
+<summary>not_sorted_with_axis</summary>
+
+```python
+node_not_sorted = onnx.helper.make_node(
+    "Unique",
+    inputs=["X"],
+    outputs=["Y", "indices", "inverse_indices", "counts"],
+    sorted=0,
+    axis=1,
+)
+
+# The unique columns are [3.0, 4.0] and [1.0, 2.0], kept in the order
+# they first appear in X instead of ascending order. indices point into
+# the columns of X, inverse_indices and counts follow the order of Y.
+x = np.array([[3.0, 1.0, 3.0], [4.0, 2.0, 4.0]], dtype=np.float32)
+y = np.array([[3.0, 1.0], [4.0, 2.0]], dtype=np.float32)
+indices = np.array([0, 1], dtype=np.int64)
+inverse_indices = np.array([0, 1, 0], dtype=np.int64)
+counts = np.array([2, 1], dtype=np.int64)
+
+expect(
+    node_not_sorted,
+    inputs=[x],
+    outputs=[y, indices, inverse_indices, counts],
+    name="test_unique_not_sorted_with_axis",
+    output_type_protos=unique_output_types(x, axis=1),
 )
 ```
 
@@ -32283,6 +32340,36 @@ expect(
     inputs=[x],
     outputs=[y, indices, inverse_indices, counts],
     name="test_unique_not_sorted_without_axis",
+    output_type_protos=unique_output_types(x),
+)
+```
+
+</details>
+<details>
+<summary>not_sorted_without_axis_2d</summary>
+
+```python
+node_not_sorted = onnx.helper.make_node(
+    "Unique",
+    inputs=["X"],
+    outputs=["Y", "indices", "inverse_indices", "counts"],
+    sorted=0,
+)
+
+# X is flattened to [2.0, 1.0, 1.0, 3.0] because axis is not set, and Y
+# holds its unique values in order of first occurrence. indices point
+# into the flattened X, inverse_indices and counts follow the order of Y.
+x = np.array([[2.0, 1.0], [1.0, 3.0]], dtype=np.float32)
+y = np.array([2.0, 1.0, 3.0], dtype=np.float32)
+indices = np.array([0, 1, 3], dtype=np.int64)
+inverse_indices = np.array([0, 1, 1, 2], dtype=np.int64)
+counts = np.array([1, 2, 1], dtype=np.int64)
+
+expect(
+    node_not_sorted,
+    inputs=[x],
+    outputs=[y, indices, inverse_indices, counts],
+    name="test_unique_not_sorted_without_axis_2d",
     output_type_protos=unique_output_types(x),
 )
 ```

--- a/onnx/backend/test/case/node/unique.py
+++ b/onnx/backend/test/case/node/unique.py
@@ -102,6 +102,81 @@ class Unique(Base):
         )
 
     @staticmethod
+    def export_not_sorted_without_axis_2d() -> None:
+        node_not_sorted = onnx.helper.make_node(
+            "Unique",
+            inputs=["X"],
+            outputs=["Y", "indices", "inverse_indices", "counts"],
+            sorted=0,
+        )
+
+        # X is flattened to [2.0, 1.0, 1.0, 3.0] because axis is not set, and Y
+        # holds its unique values in order of first occurrence. indices point
+        # into the flattened X, inverse_indices and counts follow the order of Y.
+        x = np.array([[2.0, 1.0], [1.0, 3.0]], dtype=np.float32)
+        y = np.array([2.0, 1.0, 3.0], dtype=np.float32)
+        indices = np.array([0, 1, 3], dtype=np.int64)
+        inverse_indices = np.array([0, 1, 1, 2], dtype=np.int64)
+        counts = np.array([1, 2, 1], dtype=np.int64)
+
+        expect(
+            node_not_sorted,
+            inputs=[x],
+            outputs=[y, indices, inverse_indices, counts],
+            name="test_unique_not_sorted_without_axis_2d",
+            output_type_protos=unique_output_types(x),
+        )
+
+    @staticmethod
+    def export_not_sorted_with_axis() -> None:
+        node_not_sorted = onnx.helper.make_node(
+            "Unique",
+            inputs=["X"],
+            outputs=["Y", "indices", "inverse_indices", "counts"],
+            sorted=0,
+            axis=1,
+        )
+
+        # The unique columns are [3.0, 4.0] and [1.0, 2.0], kept in the order
+        # they first appear in X instead of ascending order. indices point into
+        # the columns of X, inverse_indices and counts follow the order of Y.
+        x = np.array([[3.0, 1.0, 3.0], [4.0, 2.0, 4.0]], dtype=np.float32)
+        y = np.array([[3.0, 1.0], [4.0, 2.0]], dtype=np.float32)
+        indices = np.array([0, 1], dtype=np.int64)
+        inverse_indices = np.array([0, 1, 0], dtype=np.int64)
+        counts = np.array([2, 1], dtype=np.int64)
+
+        expect(
+            node_not_sorted,
+            inputs=[x],
+            outputs=[y, indices, inverse_indices, counts],
+            name="test_unique_not_sorted_with_axis",
+            output_type_protos=unique_output_types(x, axis=1),
+        )
+
+    @staticmethod
+    def export_not_sorted_single_output() -> None:
+        node_not_sorted = onnx.helper.make_node(
+            "Unique",
+            inputs=["X"],
+            outputs=["Y"],
+            sorted=0,
+        )
+
+        # Y keeps the order of first occurrence even when the optional outputs
+        # are not requested.
+        x = np.array([2.0, 1.0, 1.0, 3.0, 4.0, 3.0], dtype=np.float32)
+        y = np.array([2.0, 1.0, 3.0, 4.0], dtype=np.float32)
+
+        expect(
+            node_not_sorted,
+            inputs=[x],
+            outputs=[y],
+            name="test_unique_not_sorted_single_output",
+            output_type_protos=unique_output_types(x)[:1],
+        )
+
+    @staticmethod
     def export_sorted_with_axis() -> None:
         node_sorted = onnx.helper.make_node(
             "Unique",

--- a/onnx/reference/ops/op_unique.py
+++ b/onnx/reference/ops/op_unique.py
@@ -18,32 +18,38 @@ def _specify_int64(indices, inverse_indices, counts):
 
 class Unique(OpRun):
     def _run(self, x, axis=None, sorted=None):  # type: ignore[override]  # noqa: A002
-        if axis is None or np.isnan(axis):
+        if axis is not None and np.isnan(axis):
+            axis = None
+        if axis is None:
             y, indices, inverse_indices, counts = np.unique(x, True, True, True)
         else:
             y, indices, inverse_indices, counts = np.unique(
                 x, True, True, True, axis=axis
             )
-        if len(self.onnx_node.output) == 1:
-            return (y,)
+        # numpy 2.0 returns inverse_indices with the shape of x when axis is None,
+        # numpy 1.x and ONNX use a flat tensor.
+        inverse_indices = np.reshape(inverse_indices, (-1,))
 
         if not sorted:
+            # np.unique always sorts, so put the unique values, their indices and
+            # their counts back into order of first occurrence.
             argsorted_indices = np.argsort(indices)
             inverse_indices_map = dict(
                 zip(argsorted_indices, np.arange(len(argsorted_indices)), strict=True)
             )
+            y = np.take(y, argsorted_indices, axis=0 if axis is None else axis)
             indices = indices[argsorted_indices]
-            y = np.take(x, indices, axis=0)
             inverse_indices = np.asarray(
                 [inverse_indices_map[i] for i in inverse_indices], dtype=np.int64
             )
             counts = counts[argsorted_indices]
 
+        if len(self.onnx_node.output) == 1:
+            return (y,)
+
         indices, inverse_indices, counts = _specify_int64(
             indices, inverse_indices, counts
         )
-        # numpy 2.0 has a different behavior than numpy 1.x.
-        inverse_indices = inverse_indices.reshape(-1)
         if len(self.onnx_node.output) == 2:
             return (y, indices)
         if len(self.onnx_node.output) == 3:

--- a/tests/python/reference_evaluator_test.py
+++ b/tests/python/reference_evaluator_test.py
@@ -7330,6 +7330,47 @@ class TestReferenceEvaluator:
         with pytest.raises(ValueError, match="identical dtypes"):
             ref.run(None, {"A": a, "B": b})
 
+    def test_unique_not_sorted_single_output(self) -> None:
+        # Y follows the order of first occurrence even when the optional
+        # outputs are not requested (spec example 1).
+        node = make_node("Unique", ["X"], ["Y"], sorted=0)
+        x = np.array([2.0, 1.0, 1.0, 3.0, 4.0, 3.0], dtype=np.float32)
+        (y,) = ReferenceEvaluator(node).run(None, {"X": x})
+        assert_array_equal(y, np.array([2.0, 1.0, 3.0, 4.0], dtype=np.float32))
+
+    def test_unique_not_sorted_without_axis_2d(self) -> None:
+        node = make_node(
+            "Unique", ["X"], ["Y", "indices", "inverse", "counts"], sorted=0
+        )
+        x = np.array([[2.0, 1.0], [1.0, 3.0]], dtype=np.float32)
+        y, indices, inverse, counts = ReferenceEvaluator(node).run(None, {"X": x})
+        assert_array_equal(y, np.array([2.0, 1.0, 3.0], dtype=np.float32))
+        assert_array_equal(indices, np.array([0, 1, 3], dtype=np.int64))
+        assert_array_equal(inverse, np.array([0, 1, 1, 2], dtype=np.int64))
+        assert_array_equal(counts, np.array([1, 2, 1], dtype=np.int64))
+
+    def test_unique_not_sorted_with_axis(self) -> None:
+        node = make_node(
+            "Unique", ["X"], ["Y", "indices", "inverse", "counts"], sorted=0, axis=1
+        )
+        x = np.array([[3.0, 1.0, 3.0], [4.0, 2.0, 4.0]], dtype=np.float32)
+        y, indices, inverse, counts = ReferenceEvaluator(node).run(None, {"X": x})
+        assert_array_equal(y, np.array([[3.0, 1.0], [4.0, 2.0]], dtype=np.float32))
+        assert_array_equal(indices, np.array([0, 1], dtype=np.int64))
+        assert_array_equal(inverse, np.array([0, 1, 0], dtype=np.int64))
+        assert_array_equal(counts, np.array([2, 1], dtype=np.int64))
+
+    def test_unique_sorted_with_negative_axis(self) -> None:
+        node = make_node(
+            "Unique", ["X"], ["Y", "indices", "inverse", "counts"], sorted=1, axis=-1
+        )
+        x = np.array([[3.0, 1.0, 3.0], [4.0, 2.0, 4.0]], dtype=np.float32)
+        y, indices, inverse, counts = ReferenceEvaluator(node).run(None, {"X": x})
+        assert_array_equal(y, np.array([[1.0, 3.0], [2.0, 4.0]], dtype=np.float32))
+        assert_array_equal(indices, np.array([1, 0], dtype=np.int64))
+        assert_array_equal(inverse, np.array([1, 0, 1], dtype=np.int64))
+        assert_array_equal(counts, np.array([1, 2], dtype=np.int64))
+
 
 class TestReferenceEvaluatorShapeAnnotationChecking:
     """Tests for the opt-in runtime shape-annotation validation feature


### PR DESCRIPTION
### Description

`Unique` with `sorted=0` has to return every output in order of first occurrence, and that reordering has to follow the `axis` attribute. The reference implementation gets both parts wrong, in `onnx/reference/ops/op_unique.py`.

`Unique._run` returns early with `return (y,)` (line 28 before this change) when the node declares only the `Y` output, and that early return happens before the `if not sorted:` block, so a single-output node silently ignores `sorted=0` and returns ascending order. When the optional outputs are present, the block rebuilds `Y` with `np.take(x, indices, axis=0)` (line 36 before this change). `indices` are positions in the flattened input when `axis` is unset, and positions along `axis` otherwise, so indexing the input along axis 0 with them is wrong in both cases: a rank-2 input with no `axis` raises `IndexError`, and `axis=1` returns the wrong subtensors with the wrong shape.

The three failures on current main:

```python
import numpy as np
from onnx.helper import make_node
from onnx.reference import ReferenceEvaluator

# 1. single output, sorted=0 -> [1. 2. 3. 4.], spec example 1 says [2. 1. 3. 4.]
node = make_node("Unique", ["X"], ["Y"], sorted=0)
ReferenceEvaluator(node).run(None, {"X": np.array([2.0, 1.0, 1.0, 3.0, 4.0, 3.0], dtype=np.float32)})

# 2. rank-2 input, no axis, sorted=0 -> IndexError: index 3 is out of bounds for axis 0 with size 2
node = make_node("Unique", ["X"], ["Y", "i", "inv", "c"], sorted=0)
ReferenceEvaluator(node).run(None, {"X": np.array([[2.0, 1.0], [1.0, 3.0]], dtype=np.float32)})

# 3. axis=1, sorted=0 -> Y is [[3. 1. 3.], [4. 2. 4.]], shape (2, 3), for 2 unique columns
node = make_node("Unique", ["X"], ["Y", "i", "inv", "c"], sorted=0, axis=1)
ReferenceEvaluator(node).run(None, {"X": np.array([[3.0, 1.0, 3.0], [4.0, 2.0, 4.0]], dtype=np.float32)})
```

The existing node test `test_unique_not_sorted_without_axis` is the only `sorted=0` case and its input is rank 1, which is the one shape where taking along axis 0 with flat indices happens to be right.

The fix reorders the unique values `np.unique` already returned, `np.take(y, argsorted_indices, axis=0 if axis is None else axis)`, and moves the whole `if not sorted:` block above the single-output early return. `inverse_indices` is flattened up front instead of at the end, because numpy 2.0 returns it shaped like the input when `axis` is unset and the first-occurrence remap iterates over it element by element.

### Motivation and Context

`sorted` has been an attribute of `Unique` since opset 11. A model that sets it to 0 currently gets ascending order back when it asks only for `Y`, and either wrong values or an `IndexError` as soon as the input has rank above 1 or sets `axis`. Spec example 1 is rank 1 with all four outputs, the one `sorted=0` shape the reference evaluator already handles correctly, which is why the gap does not show up in the node tests.

### Testing

Four tests added to `tests/python/reference_evaluator_test.py`, one per failure above plus a `sorted=1, axis=-1` control that already passed and still passes.

```
$ python -m pytest tests/python/reference_evaluator_test.py -k unique -q
4 passed, 446 deselected

$ python -m pytest tests/python/reference_evaluator_test.py -q
442 passed, 8 skipped in 1.50s

$ python -m pytest tests/python/backend_reference_test.py -q -k unique
7 passed, 7 skipped, 4076 deselected

$ lintrunner
ok No lint issues.
```

On unmodified main the three new `not_sorted` tests fail with the output shown above; `test_unique_sorted_with_negative_axis` passes on both. Spec examples 1, 2 and 3 from the `Unique` operator docs were also checked by hand before and after and are unchanged.
