### PR TITLE
fix(version_converter): support Mul downgrade from opset 14

### DIFF
--- a/onnx/version_converter/convert.h
+++ b/onnx/version_converter/convert.h
@@ -521,6 +521,9 @@ class DefaultVersionConverter : public BaseVersionConverter {
     registerAdapter(std::make_unique<BatchNormalization_13_14>());
 
     /******** 14 -> 13 ********/
+    const std::vector<TensorProto_DataType> mul_14_unallowed_types = {
+        TensorProto_DataType_UINT8, TensorProto_DataType_INT8, TensorProto_DataType_UINT16, TensorProto_DataType_INT16};
+    registerAdapter(std::make_unique<TypeRestriction>("Mul", OpSetID(14), OpSetID(13), mul_14_unallowed_types));
     registerAdapter("GRU", 14, 13, RemoveAttribute(klayout, 0));
     registerAdapter("LSTM", 14, 13, RemoveAttribute(klayout, 0));
     registerAdapter("RNN", 14, 13, RemoveAttribute(klayout, 0));

--- a/tests/python/version_converter_test.py
+++ b/tests/python/version_converter_test.py
@@ -313,6 +313,53 @@ class TestVersionConverter:
         assert converted_model.graph.node[0].op_type == "Mul"
         assert converted_model.opset_import[0].version == 8
 
+    def test_mul_14_13_float(self) -> None:
+        nodes = [helper.make_node("Mul", ["X1", "X2"], ["Y"])]
+        graph = helper.make_graph(
+            nodes,
+            "test",
+            [
+                helper.make_tensor_value_info("X1", TensorProto.FLOAT, (5,)),
+                helper.make_tensor_value_info("X2", TensorProto.FLOAT, (5,)),
+            ],
+            [helper.make_tensor_value_info("Y", TensorProto.FLOAT, (5,))],
+        )
+
+        converted_model = self._converted(graph, helper.make_operatorsetid("", 14), 13)
+
+        assert converted_model.graph.node[0].op_type == "Mul"
+        assert (
+            converted_model.graph.output[0].type.tensor_type.elem_type
+            == TensorProto.FLOAT
+        )
+        assert converted_model.opset_import[0].version == 13
+
+    @pytest.mark.parametrize(
+        "data_type",
+        [
+            TensorProto.UINT8,
+            TensorProto.INT8,
+            TensorProto.UINT16,
+            TensorProto.INT16,
+        ],
+    )
+    def test_mul_14_13_rejects_opset14_only_types(self, data_type: int) -> None:
+        nodes = [helper.make_node("Mul", ["X1", "X2"], ["Y"])]
+        graph = helper.make_graph(
+            nodes,
+            "test",
+            [
+                helper.make_tensor_value_info("X1", data_type, (5,)),
+                helper.make_tensor_value_info("X2", data_type, (5,)),
+            ],
+            [helper.make_tensor_value_info("Y", data_type, (5,))],
+        )
+
+        with pytest.raises(
+            RuntimeError, match=r"operator 'Mul' is unallowed for Opset Version 13"
+        ):
+            self._converted(graph, helper.make_operatorsetid("", 14), 13)
+
     # Test Gemm Adapter: 1 -> 8
     def test_gemm_up(self) -> None:
         nodes = [helper.make_node("Gemm", ["A", "B", "C"], ["Y"])]


### PR DESCRIPTION
Fixes #6297.

## Summary

- register the existing type-restriction adapter for `Mul` opset 14 to 13 conversion
- allow shared element types and reject `uint8`, `int8`, `uint16`, and `int16`, which were introduced at opset 14
- add focused success and rejection coverage for the converter

## Validation

- `.venv/bin/python -m pytest tests/python/version_converter_test.py -q`
- `PATH="$PWD/.venv/bin:$PATH" lintrunner onnx/version_converter/convert.h tests/python/version_converter_test.py`
- `.venv/bin/clang-format --dry-run --Werror onnx/version_converter/convert.h`
