### PR TITLE
feat(test): support per-case tolerances in node test definitions

### DIFF
--- a/onnx/backend/test/case/node/__init__.py
+++ b/onnx/backend/test/case/node/__init__.py
@@ -263,8 +263,16 @@ def expect(
     inputs: Sequence[np.ndarray | TensorProto],
     outputs: Sequence[np.ndarray | TensorProto],
     name: str,
+    *,
+    rtol: float = 1e-3,
+    atol: float = 1e-7,
     **kwargs: Any,
 ) -> None:
+    """Register a node case and its function expansions with output tolerances.
+
+    Tolerances apply to all numeric outputs; backend test_kwargs can override them.
+    Other keyword arguments are forwarded to model construction.
+    """
     # skip if the node_op's op_type is not same as the given one
     if _TargetOpType and node_op.op_type != _TargetOpType:
         return
@@ -324,8 +332,8 @@ def expect(
             model=model,
             data_sets=[(inputs, outputs)],
             kind="node",
-            rtol=1e-3,
-            atol=1e-7,
+            rtol=rtol,
+            atol=atol,
         )
     )
 
@@ -396,8 +404,8 @@ def expect(
                 model=model,
                 data_sets=[(inputs, outputs)],
                 kind="node",
-                rtol=1e-3,
-                atol=1e-7,
+                rtol=rtol,
+                atol=atol,
             )
         )
 

--- a/tests/python/backend_test_case_test.py
+++ b/tests/python/backend_test_case_test.py
@@ -1,0 +1,146 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import unittest
+
+import pytest
+
+import onnx.backend.test.runner as runner_module
+from onnx import checker
+from onnx.backend.base import Backend, BackendRep
+from onnx.backend.test.case import node
+from onnx.backend.test.loader import load_node_model_tests
+from onnx.backend.test.runner import Runner
+from onnx.reference import ReferenceEvaluator
+
+
+@pytest.fixture
+def make_cases(monkeypatch: pytest.MonkeyPatch):
+    # Reuse actual node fixtures without changing the process-wide registry.
+    sources = {case.name: case for case in load_node_model_tests()}
+    monkeypatch.setattr(node, "_NodeTestCases", [])
+    monkeypatch.setattr(node, "_existing_names", {})
+    monkeypatch.setattr(node, "_TargetOpType", None)
+
+    def make(source_name: str, **tolerances: float):
+        source = sources[source_name]
+        inputs, outputs = source.data_sets[0]
+        node.expect(
+            source.model.graph.node[0],
+            inputs,
+            outputs,
+            name=f"{source_name}_custom_tolerance",
+            opset_imports=list(source.model.opset_import),
+            doc_string="Tolerance test model",
+            **tolerances,
+        )
+        return node._NodeTestCases
+
+    return make
+
+
+@pytest.mark.parametrize("source_name", ["test_dynamicquantizelinear", "test_celu"])
+@pytest.mark.parametrize(
+    "tolerances, expected",
+    [
+        ({}, (1e-3, 1e-7)),
+        ({"rtol": 0.0}, (0.0, 1e-7)),
+        ({"atol": 0.0}, (1e-3, 0.0)),
+        ({"rtol": 0.125, "atol": 0.25}, (0.125, 0.25)),
+    ],
+)
+def test_expect_tolerances_propagate_to_function_expansions(
+    make_cases,
+    source_name: str,
+    tolerances: dict[str, float],
+    expected: tuple[float, float],
+) -> None:
+    cases = make_cases(source_name, **tolerances)
+    # DynamicQuantizeLinear has a static body; Celu uses a context-dependent body.
+    assert len(cases) >= 2
+    assert "_expanded" not in cases[0].name
+    assert all("_expanded" in case.name for case in cases[1:])
+    for case in cases:
+        assert (case.rtol, case.atol) == expected
+        assert case.model.doc_string == "Tolerance test model"
+        checker.check_model(case.model)
+        inputs, outputs = case.data_sets[0]
+        evaluator = ReferenceEvaluator(case.model)
+        actual = evaluator.run(
+            None, dict(zip(evaluator.input_names, inputs, strict=True))
+        )
+        Runner.assert_similar_outputs(outputs, actual, rtol=case.rtol, atol=case.atol)
+
+
+@pytest.mark.parametrize(
+    "source_name, tolerances, delta, override, passes",
+    [
+        ("test_dynamicquantizelinear", {"rtol": 0.0, "atol": 1.0}, 0, {}, True),
+        ("test_dynamicquantizelinear", {"rtol": 0.0, "atol": 1.0}, 1, {}, True),
+        ("test_dynamicquantizelinear", {"rtol": 0.0, "atol": 1.0}, -1, {}, True),
+        ("test_dynamicquantizelinear", {"rtol": 0.0, "atol": 1.0}, 2, {}, False),
+        ("test_dynamicquantizelinear", {"rtol": 0.0, "atol": 1.0}, -2, {}, False),
+        (
+            "test_dynamicquantizelinear",
+            {"rtol": 0.0, "atol": 1.0},
+            1,
+            {"atol": 0.0},
+            False,
+        ),
+        ("test_celu", {"rtol": 0.125, "atol": 0.0}, 0.0625, {}, True),
+        ("test_celu", {"rtol": 0.125, "atol": 0.0}, 0.25, {}, False),
+        ("test_celu", {"rtol": 0.125, "atol": 0.0}, 0.0625, {"rtol": 0.0}, False),
+    ],
+)
+def test_runner_uses_case_tolerances_and_backend_overrides(
+    make_cases,
+    monkeypatch: pytest.MonkeyPatch,
+    source_name: str,
+    tolerances: dict[str, float],
+    delta: float,
+    override: dict[str, float],
+    passes: bool,
+) -> None:
+    cases = make_cases(source_name, **tolerances)
+
+    class PerturbedReferenceRep(BackendRep):
+        def __init__(self, model):
+            self.evaluator = ReferenceEvaluator(model)
+
+        def run(self, inputs, **kwargs):  # noqa: ARG002
+            values = self.evaluator.run(
+                None, dict(zip(self.evaluator.input_names, inputs, strict=True))
+            )
+            values[0] = values[0].copy()
+            # The quantized fixture starts at 153. Convert to a Python scalar
+            # before adding signed deltas to avoid uint8 overflow in NumPy 2.
+            values[0].flat[0] = values[0].flat[0].item() + delta
+            return values
+
+    class PerturbedReferenceBackend(Backend):
+        @classmethod
+        def prepare(cls, model, device="CPU", **kwargs):  # noqa: ARG003
+            return PerturbedReferenceRep(model)
+
+        @classmethod
+        def supports_device(cls, device: str) -> bool:
+            return device == "CPU"
+
+    # Exercise the real runner while keeping unrelated models out of this test.
+    monkeypatch.setattr(
+        runner_module, "load_model_tests", lambda kind: cases if kind == "node" else []
+    )
+    runner = Runner(
+        PerturbedReferenceBackend,
+        test_kwargs={case.name: override for case in cases},
+    )
+    runner.include(r".*_cpu$")
+    result = unittest.TestResult()
+    runner.test_suite.run(result)
+    assert result.testsRun - len(result.skipped) == len(cases)
+    assert not result.errors, result.errors
+    assert len(result.failures) == (0 if passes else len(cases)), result.failures
+    for _, failure in result.failures:
+        assert "Not equal to tolerance" in failure


### PR DESCRIPTION
Related to #6433.

## Summary

- allow node-test authors to pass `rtol` and `atol` to `expect()`
- propagate the values to direct and function-expanded `TestCase` instances
- preserve the existing defaults, model kwargs, and per-backend `test_kwargs` precedence

This adds the in-memory test-case capability discussed in #6433. Existing DynamicQuantizeLinear fixture tolerances are unchanged, and the issue remains open for decisions about adopting tolerance changes in individual cases.

## Validation

- 17 new CPU cases cover static/context-dependent function expansions, zero values, numeric tolerance boundaries, and backend overrides.
- The new suite gives 15 failures and 2 passes before the implementation; it passes with the implementation.
- Focused backend/reference/shape/function/schema suite: **4,570 passed, 4,129 skipped**.
- `lintrunner` and `git diff --check` pass.

Validation used macOS arm64, Python 3.12.12, NumPy 2.5.2, and an editable build of this branch. Linux/Windows, C++ tests, and external backend integrations were not run.

Assisted-by: OpenAI Codex
