### PR TITLE
fix(reference): use absolute values for LpNormalization

### DIFF
--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -46611,3 +46611,4 @@ expect(
 
 </details>
 
+

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -22157,6 +22157,27 @@ expect(node, inputs=[x], outputs=[y], name="test_l1normalization_axis_last")
 
 
 <details>
+<summary>l1normalization_negative_values</summary>
+
+```python
+node = onnx.helper.make_node(
+    "LpNormalization", inputs=["x"], outputs=["y"], axis=0, p=1
+)
+x = np.array([1.0, -1.0], dtype=np.float32)
+l1_norm = np.sum(abs(x), axis=0, keepdims=True)
+y = x / l1_norm
+expect(
+    node,
+    inputs=[x],
+    outputs=[y],
+    name="test_l1normalization_negative_values",
+)
+```
+
+</details>
+
+
+<details>
 <summary>l2normalization_axis_0</summary>
 
 ```python
@@ -46589,5 +46610,4 @@ expect(
 ```
 
 </details>
-
 

--- a/docs/TestCoverage.md
+++ b/docs/TestCoverage.md
@@ -16311,7 +16311,7 @@ expect(
 
 
 ### LpNormalization
-There are 6 test cases, listed as following:
+There are 7 test cases, listed as following:
 <details>
 <summary>default</summary>
 
@@ -16369,6 +16369,25 @@ x = np.array(
 l1_norm_axis_last = np.sum(abs(x), axis=-1, keepdims=True)
 y = x / l1_norm_axis_last
 expect(node, inputs=[x], outputs=[y], name="test_l1normalization_axis_last")
+```
+
+</details>
+<details>
+<summary>l1normalization_negative_values</summary>
+
+```python
+node = onnx.helper.make_node(
+    "LpNormalization", inputs=["x"], outputs=["y"], axis=0, p=1
+)
+x = np.array([1.0, -1.0], dtype=np.float32)
+l1_norm = np.sum(abs(x), axis=0, keepdims=True)
+y = x / l1_norm
+expect(
+    node,
+    inputs=[x],
+    outputs=[y],
+    name="test_l1normalization_negative_values",
+)
 ```
 
 </details>

--- a/onnx/backend/test/case/node/lpnormalization.py
+++ b/onnx/backend/test/case/node/lpnormalization.py
@@ -46,6 +46,21 @@ class LpNormalization(Base):
         expect(node, inputs=[x], outputs=[y], name="test_l1normalization_axis_0")
 
     @staticmethod
+    def export_l1normalization_negative_values() -> None:
+        node = onnx.helper.make_node(
+            "LpNormalization", inputs=["x"], outputs=["y"], axis=0, p=1
+        )
+        x = np.array([1.0, -1.0], dtype=np.float32)
+        l1_norm = np.sum(abs(x), axis=0, keepdims=True)
+        y = x / l1_norm
+        expect(
+            node,
+            inputs=[x],
+            outputs=[y],
+            name="test_l1normalization_negative_values",
+        )
+
+    @staticmethod
     def export_l1normalization_axis_1() -> None:
         node = onnx.helper.make_node(
             "LpNormalization", inputs=["x"], outputs=["y"], axis=1, p=1

--- a/onnx/reference/ops/op_lp_normalization.py
+++ b/onnx/reference/ops/op_lp_normalization.py
@@ -12,7 +12,7 @@ class LpNormalization(OpRunUnaryNum):
     def _run(self, x, axis=None, p=None):
         axis = axis or self.axis
         p = p or self.p
-        norm = np.power(np.power(x, p).sum(axis=axis), 1.0 / p)
+        norm = np.power(np.power(np.abs(x), p).sum(axis=axis), 1.0 / p)
         norm = np.expand_dims(norm, axis)
         # When norm is 0, return 0 instead of NaN (0/0 = 0)
         result = np.where(norm == 0, 0, x / norm)


### PR DESCRIPTION
### Description

Fix the Python ReferenceEvaluator implementation of `LpNormalization` so the
Lp norm is computed from absolute values. Add a `p=1` backend case containing
negative values.

### Motivation and context

The current implementation computes `sum(x ** p)`. This happens to work for
`p=2`, but for `p=1` it is a signed sum rather than the L1 norm.

Minimal counterexample (`axis=0`, `p=1`):

```text
X                              [ 1.0, -1.0]
ReferenceEvaluator             [ 0.0,  0.0]
ONNX Runtime 1.29.0            [ 0.5, -0.5]
X / sum(abs(X))                [ 0.5, -0.5]
```

The existing `p=1` backend examples contain only non-negative inputs, so they
do not distinguish `sum(x)` from `sum(abs(x))`.

### Validation

- Reproduced with `onnx==1.22.0`, `onnxruntime==1.29.0`, and `numpy==2.5.2`.
- Added a negative-input backend regression case.
- Ran `py_compile` for both modified Python files and `git diff --check`.
- Standalone executable reproducer:
  https://github.com/kadyrbekovhamit-cyber/gero-onnx-reference-lpnormalization-audit

Classification: ordinary ReferenceEvaluator correctness defect; not a
security finding.
