### PR TITLE
docs(defs): correct GroupNormalization divisibility wording

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -24916,9 +24916,9 @@ This version of the operator has been available since version 21 of the default 
   y = scale * (x - mean) / sqrt(variance + epsilon) + bias,
   ```
   where the mean and variance are computed per instance per group of channels, and
-  `scale` and `bias` should be specified for each channel. The number of
-  groups `num_groups` should be divisible by the number of channels so that there are
-  an equal number of channels per group.
+  `scale` and `bias` should be specified for each channel. The number of channels
+  should be divisible by `num_groups` so that there are an equal number of channels
+  per group.
 
   The overall computation has two stages: the first stage normalizes the elements to
   have zero mean and unit variance for each instance in each group, and the second

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -18019,9 +18019,9 @@ expect(
   y = scale * (x - mean) / sqrt(variance + epsilon) + bias,
   ```
   where the mean and variance are computed per instance per group of channels, and
-  `scale` and `bias` should be specified for each channel. The number of
-  groups `num_groups` should be divisible by the number of channels so that there are
-  an equal number of channels per group.
+  `scale` and `bias` should be specified for each channel. The number of channels
+  should be divisible by `num_groups` so that there are an equal number of channels
+  per group.
 
   The overall computation has two stages: the first stage normalizes the elements to
   have zero mean and unit variance for each instance in each group, and the second

--- a/onnx/defs/doc_strings.cc
+++ b/onnx/defs/doc_strings.cc
@@ -2947,9 +2947,9 @@ This operator transforms input according to
 y = scale * (x - mean) / sqrt(variance + epsilon) + bias,
 ```
 where the mean and variance are computed per instance per group of channels, and
-`scale` and `bias` should be specified for each channel. The number of
-groups `num_groups` should be divisible by the number of channels so that there are
-an equal number of channels per group.
+`scale` and `bias` should be specified for each channel. The number of channels
+should be divisible by `num_groups` so that there are an equal number of channels
+per group.
 
 The overall computation has two stages: the first stage normalizes the elements to
 have zero mean and unit variance for each instance in each group, and the second


### PR DESCRIPTION
## Summary
- correct the GroupNormalization divisibility condition
- regenerate the operator documentation

## Validation
- rebuilt ONNX with `ONNX_ML=1`
- regenerated docs with `python onnx/defs/gen_doc.py`
- verified the runtime schema text
- `lintrunner onnx/defs/doc_strings.cc docs/Operators.md docs/Changelog.md`

Fixes #8422.