### PR TITLE
Add ConstantOfShape 20 to 19 adapter

### DIFF
--- a/onnx/version_converter/convert.h
+++ b/onnx/version_converter/convert.h
@@ -651,6 +651,15 @@ class DefaultVersionConverter : public BaseVersionConverter {
     registerAdapter(std::make_unique<GridSample_19_20>());
 
     /******** 20 -> 19 ********/
+    const std::vector<TensorProto_DataType> constant_of_shape_9_unallowed_types = {
+        TensorProto_DataType_BFLOAT16,
+        TensorProto_DataType_FLOAT8E4M3FN,
+        TensorProto_DataType_FLOAT8E4M3FNUZ,
+        TensorProto_DataType_FLOAT8E5M2,
+        TensorProto_DataType_FLOAT8E5M2FNUZ};
+    registerAdapter(
+        std::make_unique<TypeRestriction>(
+            "ConstantOfShape", OpSetID(20), OpSetID(19), constant_of_shape_9_unallowed_types));
     const std::vector<TensorProto_DataType> is_nan_13_unallowed_types = {
         TensorProto_DataType_FLOAT8E4M3FN,
         TensorProto_DataType_FLOAT8E4M3FNUZ,

--- a/tests/python/version_converter/automatic_downgrade_test.py
+++ b/tests/python/version_converter/automatic_downgrade_test.py
@@ -52,6 +52,30 @@ class TestAutomaticDowngrade(automatic_conversion_test_base.TestAutomaticConvers
             initializer=[axes],
         )
 
+    def test_constant_of_shape_20_to_19(self) -> None:
+        self._test_model_conversion(
+            to_opset=19,
+            model="""
+                <ir_version: 9, opset_import: [ "" : 20]>
+                constant_of_shape (int64[2] shape) => (float[2, 3] output)
+                {
+                    output = ConstantOfShape (shape)
+                }
+            """,
+        )
+
+    def test_constant_of_shape_20_to_19_bfloat16_fails(self) -> None:
+        self._test_model_conversion_fails(
+            to_opset=19,
+            model="""
+                <ir_version: 9, opset_import: [ "" : 20]>
+                constant_of_shape (int64[2] shape) => (bfloat16[2, 3] output)
+                {
+                    output = ConstantOfShape <value = bfloat16[1] {0}> (shape)
+                }
+            """,
+        )
+
     def test_dft20_no_axis(self) -> None:
         self._test_model_conversion(
             to_opset=19,


### PR DESCRIPTION
### Motivation and Context
This PR is a small quality-of-life improvement for the version converter.

`ConstantOfShape-20` only adds bfloat16 and float8 output types compared with `ConstantOfShape-9`. Nodes using the previously supported types can therefore be represented at opset 19 and continue downgrading to opset 9.

### Impact
This is encountered in [kokoro-onnx#181](https://github.com/thewh1teagle/kokoro-onnx/issues/181) and can affect other opset-20 models containing compatible `ConstantOfShape` nodes that need to be downgraded. Currently, conversion fails because no adapter is registered.

```python
import onnx
from onnx import TensorProto, helper, version_converter

shape = helper.make_tensor("shape", TensorProto.INT64, [1], [2])
model = helper.make_model(
    helper.make_graph(
        [helper.make_node("ConstantOfShape", ["shape"], ["y"])],
        "test",
        [],
        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [2])],
        initializer=[shape],
    ),
    opset_imports=[helper.make_opsetid("", 20)],
)

version_converter.convert_version(model, 19)
```
Result:

```text
No Adapter To Version $19 for ConstantOfShape
```