### PR TITLE
Fix GridSample mode names in the reference evaluator for opset 16

### DIFF
--- a/onnx/reference/ops/_op_list.py
+++ b/onnx/reference/ops/_op_list.py
@@ -108,7 +108,8 @@ __all__ = [
     "GlobalMaxPool",
     "Greater",
     "GreaterOrEqual",
-    "GridSample",
+    "GridSample_16",
+    "GridSample_20",
     "GRU",
     "HammingWindow",
     "HannWindow",
@@ -374,7 +375,7 @@ from onnx.reference.ops.op_global_lp_pool import GlobalLpPool
 from onnx.reference.ops.op_global_max_pool import GlobalMaxPool
 from onnx.reference.ops.op_greater import Greater
 from onnx.reference.ops.op_greater_or_equal import GreaterOrEqual
-from onnx.reference.ops.op_grid_sample import GridSample
+from onnx.reference.ops.op_grid_sample import GridSample_16, GridSample_20
 from onnx.reference.ops.op_gru import GRU
 from onnx.reference.ops.op_hamming_window import HammingWindow
 from onnx.reference.ops.op_hann_window import HannWindow

--- a/onnx/reference/ops/op_deform_conv.py
+++ b/onnx/reference/ops/op_deform_conv.py
@@ -121,7 +121,7 @@ def _deform_conv_implementation(
                             kernel = np.flip(
                                 kernel, 3
                             )  # spatial GridSample expects (x, y) input
-                            grid_sample_output = op_grid_sample.GridSample.eval(
+                            grid_sample_output = op_grid_sample.GridSample_20.eval(
                                 X[batch_idx : batch_idx + 1, ic_idx : ic_idx + 1],
                                 kernel,
                                 align_corners=1,

--- a/onnx/reference/ops/op_grid_sample.py
+++ b/onnx/reference/ops/op_grid_sample.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import numbers
+from typing import ClassVar
 
 import numpy as np
 
@@ -11,7 +12,14 @@ from onnx.reference.op_run import OpRun
 from onnx.reference.ops.op_resize import _get_all_coords
 
 
-class GridSample(OpRun):
+class _CommonGridSample(OpRun):
+    """Shared implementation for every version of GridSample.
+
+    Subclasses declare the mode names their opset defines via ``mode_mapping``.
+    """
+
+    mode_mapping: ClassVar[dict[str, str]] = {}
+
     # https://github.com/pytorch/pytorch/blob/v2.0.0/aten/src/ATen/native/GridSampler.h#L26
     def _gs_denormalize(self, n, length: int, align_corners: bool):
         # n is the normalized coordinate (float)
@@ -290,6 +298,14 @@ class GridSample(OpRun):
         padding_mode = padding_mode or self.padding_mode
         align_corners = align_corners or self.align_corners
 
+        if mode not in self.mode_mapping:
+            raise ValueError(
+                f"Unexpected value {mode!r} for attribute 'mode' of operator "
+                f"GridSample, it must be one of "
+                f"{sorted(self.mode_mapping)}."
+            )
+        mode = self.mode_mapping[mode]
+
         x_dims = X.shape
         grid_dims = grid.shape
         N = x_dims[0]
@@ -363,3 +379,19 @@ class GridSample(OpRun):
                         )
 
         return (Y.astype(X.dtype),)
+
+
+class GridSample_16(_CommonGridSample):
+    mode_mapping: ClassVar[dict[str, str]] = {
+        "bilinear": "linear",
+        "nearest": "nearest",
+        "bicubic": "cubic",
+    }
+
+
+class GridSample_20(_CommonGridSample):
+    mode_mapping: ClassVar[dict[str, str]] = {
+        "linear": "linear",
+        "nearest": "nearest",
+        "cubic": "cubic",
+    }

--- a/tests/python/reference_evaluator_test.py
+++ b/tests/python/reference_evaluator_test.py
@@ -7415,6 +7415,77 @@ class TestReferenceEvaluator:
         with pytest.raises(ValueError, match="identical dtypes"):
             ref.run(None, {"A": a, "B": b})
 
+    @staticmethod
+    def _grid_sample_model(opset: int, mode: str | None):
+        X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None, None, None])
+        grid = make_tensor_value_info(
+            "grid", TensorProto.FLOAT, [None, None, None, None]
+        )
+        Y = make_tensor_value_info("Y", TensorProto.FLOAT, [None, None, None, None])
+        kwargs = {} if mode is None else {"mode": mode}
+        node = make_node(
+            "GridSample",
+            ["X", "grid"],
+            ["Y"],
+            padding_mode="border",
+            align_corners=0,
+            **kwargs,
+        )
+        graph = make_graph([node], "gs", [X, grid], [Y])
+        return make_model(graph, opset_imports=[make_opsetid("", opset)])
+
+    @staticmethod
+    def _grid_sample_inputs():
+        x = np.arange(1, 17, dtype=np.float32).reshape((1, 1, 4, 4))
+        grid = np.array(
+            [
+                [
+                    [[-1.0, -1.0], [-0.4, -0.7], [0.3, 0.15]],
+                    [[0.55, 0.9], [1.2, -1.3], [0.0, 0.0]],
+                ]
+            ],
+            dtype=np.float32,
+        )
+        return x, grid
+
+    @pytest.mark.parametrize(
+        ("mode_16", "mode_20"),
+        [("bilinear", "linear"), ("nearest", "nearest"), ("bicubic", "cubic")],
+    )
+    def test_grid_sample_16_mode_names(self, mode_16: str, mode_20: str) -> None:
+        x, grid = self._grid_sample_inputs()
+        model_16 = self._grid_sample_model(16, mode_16)
+        check_model(model_16)
+        got = ReferenceEvaluator(model_16).run(None, {"X": x, "grid": grid})[0]
+        expected = ReferenceEvaluator(self._grid_sample_model(20, mode_20)).run(
+            None, {"X": x, "grid": grid}
+        )[0]
+        assert_allclose(got, expected, atol=1e-6)
+
+    def test_grid_sample_16_default_mode(self) -> None:
+        x, grid = self._grid_sample_inputs()
+        got = ReferenceEvaluator(self._grid_sample_model(16, None)).run(
+            None, {"X": x, "grid": grid}
+        )[0]
+        expected = ReferenceEvaluator(self._grid_sample_model(16, "bilinear")).run(
+            None, {"X": x, "grid": grid}
+        )[0]
+        assert_allclose(got, expected, atol=1e-6)
+
+    @pytest.mark.parametrize("mode", ["linear", "cubic"])
+    def test_grid_sample_16_rejects_opset_20_mode_names(self, mode: str) -> None:
+        x, grid = self._grid_sample_inputs()
+        sess = ReferenceEvaluator(self._grid_sample_model(16, mode))
+        with pytest.raises(ValueError, match="attribute 'mode'"):
+            sess.run(None, {"X": x, "grid": grid})
+
+    @pytest.mark.parametrize("mode", ["bilinear", "bicubic"])
+    def test_grid_sample_20_rejects_opset_16_mode_names(self, mode: str) -> None:
+        x, grid = self._grid_sample_inputs()
+        sess = ReferenceEvaluator(self._grid_sample_model(20, mode))
+        with pytest.raises(ValueError, match="attribute 'mode'"):
+            sess.run(None, {"X": x, "grid": grid})
+
 
 class TestReferenceEvaluatorShapeAnnotationChecking:
     """Tests for the opt-in runtime shape-annotation validation feature


### PR DESCRIPTION
GridSample-16 spells its interpolation modes 'bilinear' (the default), 'nearest' and 'bicubic'. Opset 20 renamed them to 'linear', 'nearest' and 'cubic'. The reference implementation was version agnostic and only accepted the opset 20 spelling, so evaluating an opset 16 model with an explicit mode of 'bilinear' or 'bicubic' raised "GridSample interpolation only supports nearest, linear, and cubic modes".

A node with no 'mode' attribute did run, but for the wrong reason: the single class was named GridSample, so its default came from the most recent schema ('linear') rather than from the opset 16 one. That happened to select the same interpolation, so the results were correct.

Split the implementation into a shared base plus GridSample_16 and GridSample_20, each declaring the mode names its opset defines. Both now also pick up the attribute defaults of their own schema. The rename mapping matches the existing GridSample_19_20 version converter adapter. An unknown mode now raises a ValueError listing the names valid for that opset instead of the previous generic message.

DeformConv evaluates GridSample internally and now refers to GridSample_20 explicitly, which keeps its current behaviour.


Claude-Session: https://claude.ai/code/session_01JPAaKqiWCwrHCh2tMJ3ufj



### Motivation and Context

Fixes #
