### PR TITLE
fix(reference): exclude ignored NLLLoss targets from mean

### DIFF
--- a/onnx/reference/ops/op_negative_log_likelihood_loss.py
+++ b/onnx/reference/ops/op_negative_log_likelihood_loss.py
@@ -34,7 +34,7 @@ def _compute_negative_log_likelihood_loss(
             gather_weight = np.where(target == ignore_index, 0, gather_weight).astype(
                 dtype=x.dtype
             )
-    elif ignore_index != -1:
+    elif ignore_index is not None:
         gather_weight = np.where(target == ignore_index, 0, 1).astype(dtype=x.dtype)
 
     # if input is 4-d and above, make it 3-d

--- a/tests/python/reference_evaluator_test.py
+++ b/tests/python/reference_evaluator_test.py
@@ -366,6 +366,35 @@ class TestReferenceEvaluator:
         got = ReferenceEvaluator(model).run(None, {"X": x, "Y": y})[0]
         np.testing.assert_array_equal(got, np.array(expected, dtype=np_dtype))
 
+    @pytest.mark.parametrize("ignore_index", [-1, -100])
+    def test_nllloss_mean_excludes_ignore_index_without_weight(
+        self, ignore_index: int
+    ) -> None:
+        x = np.log(np.array([[0.25, 0.75], [0.5, 0.5]], dtype=np.float32))
+        target = np.array([0, ignore_index], dtype=np.int64)
+        graph = make_graph(
+            [
+                make_node(
+                    "NegativeLogLikelihoodLoss",
+                    ["X", "target"],
+                    ["loss"],
+                    reduction="mean",
+                    ignore_index=ignore_index,
+                )
+            ],
+            "nllloss_ignore_index",
+            [
+                make_tensor_value_info("X", TensorProto.FLOAT, [2, 2]),
+                make_tensor_value_info("target", TensorProto.INT64, [2]),
+            ],
+            [make_tensor_value_info("loss", TensorProto.FLOAT, [])],
+        )
+        model = make_model(graph, opset_imports=[make_opsetid("", 22)])
+
+        got = ReferenceEvaluator(model).run(None, {"X": x, "target": target})[0]
+
+        assert_allclose(got, -x[0, 0])
+
     @staticmethod
     def _linear_regression(clip=False, opset=None, min_value=-1.0, max_value=1.0):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [None, None])


### PR DESCRIPTION
### Motivation and Context

`NegativeLogLikelihoodLoss` must exclude targets equal to `ignore_index` from
the denominator of a mean reduction. The reference implementation already
does this for arbitrary sentinels, except when the sentinel is exactly `-1`
and the optional `weight` input is absent.

The unweighted branch currently checks `ignore_index != -1`, so `-1` skips
creation of the positional mask. The ignored loss is set to zero, but
`np.mean` still counts it in the denominator.

For:

```text
input = log([[0.25, 0.75], [0.5, 0.5]])
target = [0, -1]
ignore_index = -1
reduction = "mean"
weight = omitted
```

the released reference returns `0.6931472`; the correct result is
`1.3862944`, because only the first observation contributes. ONNX Runtime
returns the latter value.

### Changes

- Test whether the optional `ignore_index` attribute is present instead of
  treating the valid sentinel `-1` as absence.
- Add a regression test comparing equivalent `-1` and `-100` sentinels.

### Validation

- `462 passed, 4 skipped` in `tests/python/reference_evaluator_test.py`.
- Mutation check: restoring `ignore_index != -1` makes the new `-1` case fail
  with `0.6931472` versus `1.3862944`; the `-100` control still passes.
- Official lintrunner: no issues in the two modified files.
- `git diff --check`: clean.

This changes only the Python ReferenceEvaluator. It does not modify the
operator schema or runtime implementations.
