### PR TITLE
fix(reference): select OneHot values without arithmetic

### DIFF
--- a/onnx/reference/ops/op_one_hot.py
+++ b/onnx/reference/ops/op_one_hot.py
@@ -27,6 +27,6 @@ def _one_hot(indices, depth, axis=-1, dtype=np.float32):
 class OneHot(OpRun):
     def _run(self, indices, depth, values, axis=None):
         off_value, on_value = values
-        y = _one_hot(indices, depth, axis=axis, dtype=values.dtype)
-        y = y * (on_value - off_value) + off_value
+        mask = _one_hot(indices, depth, axis=axis, dtype=np.bool_)
+        y = np.where(mask, on_value, off_value).astype(values.dtype)
         return (y,)

--- a/tests/python/reference_evaluator_test.py
+++ b/tests/python/reference_evaluator_test.py
@@ -857,6 +857,28 @@ class TestReferenceEvaluator:
         got = sess.run(None, {"X": x, "Y": y})[0]
         assert_allclose(got, expected)
 
+    @pytest.mark.parametrize(
+        "values",
+        [
+            np.array([-3e38, 3e38], dtype=np.float32),
+            np.array([False, True]),
+            np.array(["off", "on"]),
+        ],
+    )
+    def test_one_hot_selects_values_without_arithmetic(self, values: np.ndarray):
+        node = make_node("OneHot", ["indices", "depth", "values"], ["output"])
+        indices = np.array([0, 1], dtype=np.int64)
+        depth = np.array(2, dtype=np.int64)
+        expected = np.array(
+            [[values[1], values[0]], [values[0], values[1]]], dtype=values.dtype
+        )
+
+        got = ReferenceEvaluator(node).run(
+            None, {"indices": indices, "depth": depth, "values": values}
+        )[0]
+
+        assert_array_equal(got, expected)
+
     @pytest.mark.parametrize("axis", [-2, 1])
     def test_concat_rejects_axis_out_of_range(self, axis: int):
         node = make_node("Concat", ["X"], ["Y"], axis=axis)


### PR DESCRIPTION
### Motivation and Context

The reference evaluator currently constructs `OneHot` output with
`mask * (on_value - off_value) + off_value`. This is algebraically equivalent
to selection only when the arithmetic intermediate is representable and the
value type supports subtraction.

For finite float32 values `[-3e38, 3e38]`, the subtraction overflows and the
reference returns `[[inf, NaN], [NaN, inf]]`, although every output must be one
of the two finite supplied values. Boolean and string values raise `TypeError`
even though both are allowed by the operator's value type constraint.

### Changes

- Build the one-hot indicator as a boolean mask.
- Select `on_value` or `off_value` directly with `numpy.where`.
- Add one parameterized regression covering extreme finite float32, boolean,
  and string values.

### Validation

- `463 passed, 4 skipped` in `tests/python/reference_evaluator_test.py`.
- Mutation check: restoring arithmetic selection makes all three new cases
  fail: float32 produces `inf`/`NaN`, and boolean/string inputs raise
  `TypeError`.
- Independent 25-case audit across axes and value types agrees exactly with a
  direct-indexing oracle.
- Official lintrunner: no issues in the two modified files.
- `git diff --check`: clean.

The refreshed PR is based on current main and changes only the reference
implementation and its direct regression test; stale generated-documentation
changes have been removed.
