### PR TITLE
fix(utils): preserve subgraph local functions during extraction

### DIFF
--- a/onnx/utils.py
+++ b/onnx/utils.py
@@ -113,19 +113,24 @@ class Extractor:
         # a node in a model graph may refer a function.
         # a function contains nodes, some of which may in turn refer a function.
         # we need to find functions referred by graph nodes and
-        # by nodes used to define functions.
+        # by nodes used to define functions, including their subgraphs.
         function_map: dict[tuple[str, str], FunctionProto] = {}
         for function in self.model.functions:
             function_map[(function.name, function.domain)] = function
         referred_local_functions: list[FunctionProto] = []
         queue = deque(nodes)
-        while queue:
+        while queue and function_map:
             node = queue.popleft()
             # check if the node is a function op
             if (node.op_type, node.domain) in function_map:
                 function = function_map.pop((node.op_type, node.domain))
                 referred_local_functions.append(function)
                 queue.extend(function.node)
+            for attribute in node.attribute:
+                if attribute.HasField("g"):
+                    queue.extend(attribute.g.node)
+                for graph in attribute.graphs:
+                    queue.extend(graph.node)
         # needs to be topologically sorted
         return referred_local_functions
 

--- a/tests/python/function_test.py
+++ b/tests/python/function_test.py
@@ -3,8 +3,12 @@
 # Copyright (c) ONNX Project Contributors
 from __future__ import annotations
 
+import numpy as np
+import pytest
+
 import onnx
-from onnx import checker, utils
+from onnx import checker, inliner, utils
+from onnx.reference import ReferenceEvaluator
 
 
 class TestFunction:
@@ -219,3 +223,80 @@ class TestFunction:
             {func_add_name, func_identity_name, func_nested_identity_add_name},
             func_domain,
         )
+
+    @pytest.mark.parametrize("in_function", [False, True])
+    def test_extract_model_with_local_function_in_subgraph(
+        self, in_function: bool
+    ) -> None:
+        opsets = [
+            onnx.helper.make_opsetid("", 18),
+            onnx.helper.make_opsetid("local", 1),
+        ]
+        double = onnx.helper.make_function(
+            "local",
+            "Double",
+            ["x"],
+            ["y"],
+            [onnx.helper.make_node("Add", ["x", "x"], ["y"])],
+            opsets,
+        )
+        unused = onnx.helper.make_function(
+            "local",
+            "Unused",
+            ["x"],
+            ["y"],
+            [onnx.helper.make_node("Identity", ["x"], ["y"])],
+            opsets,
+        )
+        then_branch = onnx.helper.make_graph(
+            [onnx.helper.make_node("Double", ["X"], ["then_y"], domain="local")],
+            "then_branch",
+            [],
+            [onnx.helper.make_tensor_value_info("then_y", onnx.TensorProto.FLOAT, [2])],
+        )
+        else_branch = onnx.helper.make_graph(
+            [
+                onnx.helper.make_node("Neg", ["X"], ["neg_x"]),
+                onnx.helper.make_node("Double", ["neg_x"], ["else_y"], domain="local"),
+            ],
+            "else_branch",
+            [],
+            [onnx.helper.make_tensor_value_info("else_y", onnx.TensorProto.FLOAT, [2])],
+        )
+        node = onnx.helper.make_node(
+            "If", ["cond"], ["Y"], then_branch=then_branch, else_branch=else_branch
+        )
+        functions = [double, unused]
+        expected_functions = {"Double"}
+        if in_function:
+            functions.append(
+                onnx.helper.make_function(
+                    "local", "Wrapper", ["X", "cond"], ["Y"], [node], opsets
+                )
+            )
+            node = onnx.helper.make_node(
+                "Wrapper", ["X", "cond"], ["Y"], domain="local"
+            )
+            expected_functions.add("Wrapper")
+        graph = onnx.helper.make_graph(
+            [node],
+            "subgraph_local_function",
+            [
+                onnx.helper.make_tensor_value_info("X", onnx.TensorProto.FLOAT, [2]),
+                onnx.helper.make_tensor_value_info("cond", onnx.TensorProto.BOOL, []),
+            ],
+            [onnx.helper.make_tensor_value_info("Y", onnx.TensorProto.FLOAT, [2])],
+        )
+        model = onnx.helper.make_model(
+            graph, functions=functions, opset_imports=opsets, ir_version=9
+        )
+        checker.check_model(model)
+        extracted = utils.Extractor(model).extract_model(["X", "cond"], ["Y"])
+        self._verify_function_set(extracted, expected_functions, "local")
+        runner = ReferenceEvaluator(inliner.inline_local_functions(extracted))
+        x = np.array([1.0, -2.0], dtype=np.float32)
+        for condition in (True, False):
+            expected = x * 2 if condition else -x * 2
+            np.testing.assert_array_equal(
+                runner.run(None, {"X": x, "cond": np.array(condition)})[0], expected
+            )


### PR DESCRIPTION
### Motivation and Context

I've fixed model extraction dropping local functions called only inside a subgraph. A valid model with `local.Double` in an `If` branch currently extracts without that function definition, and execution fails with `NotImplementedError`.

The fix follows `GRAPH` and `GRAPHS` attributes while collecting functions, including subgraphs inside referenced function bodies. The existing deduplication is unchanged. The regressions exercise both `If` branches and check that unused functions stay excluded.

### Tests

- Python suite: 6832 passed, 4254 skipped, 2 xpassed, 41 warnings.
- Native suite: 152 passed.
- `lintrunner` passed.
- File-to-file extraction and a separate `GRAPHS` case passed.

Tested on Linux/CPU; no other-platform coverage.

Could a maintainer add `module: utility` or `topic: bug fix`? I can't apply labels here.

I used AI for this patch; this has been manually reviewed.
