### PR TITLE
fix(reference): Honor normalization stash precision

### DIFF
--- a/onnx/reference/ops/op_layer_normalization.py
+++ b/onnx/reference/ops/op_layer_normalization.py
@@ -39,7 +39,7 @@ def _layer_normalization(
     # layer normalization is equivalent to conducting
     # standardization on each column vector (s.t. each
     # column has zero mean and unit variance).
-    x_mat = np.reshape(X, (row_number, col_number))
+    x_mat = np.reshape(X.astype(np.float32), (row_number, col_number))
     # This computes mean for every x_mat's column.
     x_mean = np.sum(x_mat, axis=1, keepdims=True) / col_number
     x_diff = x_mat - x_mean
@@ -53,7 +53,7 @@ def _layer_normalization(
     y_mat = x_diff * inv_std_dev
     # Apply affine transform on normalization outcome.
     # W is linear coefficient while B is bias.
-    Y = np.reshape(y_mat, X_shape) * W
+    Y = np.reshape(y_mat, X_shape).astype(X.dtype) * W
     if B is not None:
         Y = Y + B
     # Matrix-level operations' outputs should be reshaped
@@ -61,7 +61,7 @@ def _layer_normalization(
     X_mean = np.reshape(x_mean, reduction_shape)
     X_inv_std_dev = np.reshape(inv_std_dev, reduction_shape)
 
-    return (Y.astype(X.dtype), X_mean.astype(X.dtype), X_inv_std_dev.astype(X.dtype))
+    return (Y.astype(X.dtype), X_mean, X_inv_std_dev)
 
 
 class LayerNormalization(OpRun):

--- a/onnx/reference/ops/op_rms_normalization.py
+++ b/onnx/reference/ops/op_rms_normalization.py
@@ -23,16 +23,15 @@ def _rms_normalization(
         axis = axis + rank
 
     # This computes RMS for every x_mat's column.
-    x_squared = np.power(X, 2)
+    x_float = X.astype(np.float32)
+    x_squared = np.power(x_float, 2)
     x_squared_mean = np.mean(
         x_squared, axis=tuple(range(axis, len(shape))), keepdims=True
     )
     # epsilon adjustment to avoid divide-by-zero.
     rmseps = x_squared_mean + epsilon
     rms = np.sqrt(rmseps)
-    rms_reciprocal = np.reciprocal(rms)
-
-    y_mat = X * rms_reciprocal
+    y_mat = (x_float / rms).astype(X.dtype)
     # W is linear coefficient.
     Y = y_mat * W
 

--- a/tests/python/reference_evaluator_test.py
+++ b/tests/python/reference_evaluator_test.py
@@ -7103,6 +7103,76 @@ class TestReferenceEvaluator:
         assert_allclose(got[0].sum(), 1.0)
         assert_allclose(got[0], _softmax(x[:1])[0])
 
+    def test_rms_normalization_float16_uses_float32_stash(self):
+        model = make_model(
+            make_graph(
+                [
+                    make_node(
+                        "RMSNormalization",
+                        ["X", "Scale"],
+                        ["Y"],
+                        epsilon=0.0,
+                        stash_type=TensorProto.FLOAT,
+                    )
+                ],
+                "rms_normalization_float32_stash",
+                [
+                    make_tensor_value_info("X", TensorProto.FLOAT16, [1, 2]),
+                    make_tensor_value_info("Scale", TensorProto.FLOAT16, [2]),
+                ],
+                [make_tensor_value_info("Y", TensorProto.FLOAT16, [1, 2])],
+            ),
+            opset_imports=[make_opsetid("", 23)],
+        )
+        x = np.array([[256.0, 256.0]], dtype=np.float16)
+        scale = np.ones(2, dtype=np.float16)
+
+        (actual,) = ReferenceEvaluator(model).run(None, {"X": x, "Scale": scale})
+
+        assert actual.dtype == np.float16
+        assert_array_equal(actual, np.ones((1, 2), dtype=np.float16))
+
+    def test_layer_normalization_float16_uses_float32_stash(self):
+        model = make_model(
+            make_graph(
+                [
+                    make_node(
+                        "LayerNormalization",
+                        ["X", "Scale", "B"],
+                        ["Y", "Mean", "InvStdDev"],
+                        epsilon=0.0,
+                        stash_type=TensorProto.FLOAT,
+                    )
+                ],
+                "layer_normalization_float32_stash",
+                [
+                    make_tensor_value_info("X", TensorProto.FLOAT16, [1, 2]),
+                    make_tensor_value_info("Scale", TensorProto.FLOAT16, [2]),
+                    make_tensor_value_info("B", TensorProto.FLOAT16, [2]),
+                ],
+                [
+                    make_tensor_value_info("Y", TensorProto.FLOAT16, [1, 2]),
+                    make_tensor_value_info("Mean", TensorProto.FLOAT, [1, 1]),
+                    make_tensor_value_info("InvStdDev", TensorProto.FLOAT, [1, 1]),
+                ],
+            ),
+            opset_imports=[make_opsetid("", 23)],
+        )
+        x = np.array([[256.0, -256.0]], dtype=np.float16)
+        scale = np.ones(2, dtype=np.float16)
+        bias = np.zeros(2, dtype=np.float16)
+
+        actual, mean, inv_std_dev = ReferenceEvaluator(model).run(
+            None, {"X": x, "Scale": scale, "B": bias}
+        )
+
+        assert actual.dtype == np.float16
+        assert mean.dtype == np.float32
+        assert inv_std_dev.dtype == np.float32
+        assert_array_equal(actual, np.array([[1.0, -1.0]], dtype=np.float16))
+        assert_array_equal(mean, np.zeros((1, 1), dtype=np.float32))
+        assert_array_equal(inv_std_dev, np.array([[1.0 / 256.0]], dtype=np.float32))
+
     def test_center_crop_pad_no_change_when_shape_equals_dim(self):
         """Test CenterCropPad when target shape equals current dimension.
 


### PR DESCRIPTION
## Summary

- perform the normalization stage in float32 for the supported `stash_type=1` path
- cast the normalized tensor back to the input dtype before the affine stage
- keep LayerNormalization's saved Mean and InvStdDev outputs in the float32 stash dtype

## Problem

Both reference implementations currently square float16 inputs before converting them to the stash precision. For example, with `epsilon=0` and unit scale:

```text
RMSNormalization([[256, 256]])     reference [[0, 0]], expected [[1, 1]]
LayerNormalization([[256, -256]]) reference [[0, -0]], expected [[1, -1]]
```

The square of 256 overflows float16, although it is exactly representable in float32. The operator specifications require stage one to cast input variables to float32 when `stash_type=1`. LayerNormalization also declares Mean and InvStdDev with the stash type, but the reference implementation casts them back to the input dtype.

The reference runners currently implement only `stash_type=1`; this change preserves that scope.

## Validation

- two focused regression tests, including LayerNormalization output dtypes
- mutation check: both tests fail against the previous implementation
- `453 passed, 4 skipped` in `tests/python/reference_evaluator_test.py`
- `108 passed, 106 skipped` for normalization-selected reference backend tests
- official `lintrunner`: no issues
- independent staged-precision audit across float16, float32, float64 and multiple axes; primary cases also match ONNX Runtime and the generated schema functions
