### PR TITLE
docs(defs): fix GroupNormalization divisibility condition

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -21568,8 +21568,8 @@ This version of the operator has been available since version 18 of the default 
   ```
   where the mean and variance are computed per instance per group of channels, and
   `scale` and `bias` should be specified for each group of channels. The number of
-  groups `num_groups` should be divisible by the number of channels so that there are
-  an equal number of channels per group.
+  channels should be divisible by `num_groups` so that there are an equal number of
+  channels per group.
 
   When the number of groups is the same as the number of channels, this operator is
   equivalent to InstanceNormalization. When there is only one group, this operator
@@ -24917,8 +24917,8 @@ This version of the operator has been available since version 21 of the default 
   ```
   where the mean and variance are computed per instance per group of channels, and
   `scale` and `bias` should be specified for each channel. The number of
-  groups `num_groups` should be divisible by the number of channels so that there are
-  an equal number of channels per group.
+  channels should be divisible by `num_groups` so that there are an equal number of
+  channels per group.
 
   The overall computation has two stages: the first stage normalizes the elements to
   have zero mean and unit variance for each instance in each group, and the second

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -18020,8 +18020,8 @@ expect(
   ```
   where the mean and variance are computed per instance per group of channels, and
   `scale` and `bias` should be specified for each channel. The number of
-  groups `num_groups` should be divisible by the number of channels so that there are
-  an equal number of channels per group.
+  channels should be divisible by `num_groups` so that there are an equal number of
+  channels per group.
 
   The overall computation has two stages: the first stage normalizes the elements to
   have zero mean and unit variance for each instance in each group, and the second

--- a/onnx/defs/doc_strings.cc
+++ b/onnx/defs/doc_strings.cc
@@ -2948,8 +2948,8 @@ y = scale * (x - mean) / sqrt(variance + epsilon) + bias,
 ```
 where the mean and variance are computed per instance per group of channels, and
 `scale` and `bias` should be specified for each channel. The number of
-groups `num_groups` should be divisible by the number of channels so that there are
-an equal number of channels per group.
+channels should be divisible by `num_groups` so that there are an equal number of
+channels per group.
 
 The overall computation has two stages: the first stage normalizes the elements to
 have zero mean and unit variance for each instance in each group, and the second
@@ -3276,8 +3276,8 @@ y = scale * (x - mean) / sqrt(variance + epsilon) + bias,
 ```
 where the mean and variance are computed per instance per group of channels, and
 `scale` and `bias` should be specified for each group of channels. The number of
-groups `num_groups` should be divisible by the number of channels so that there are
-an equal number of channels per group.
+channels should be divisible by `num_groups` so that there are an equal number of
+channels per group.
 
 When the number of groups is the same as the number of channels, this operator is
 equivalent to InstanceNormalization. When there is only one group, this operator


### PR DESCRIPTION
## Summary

The GroupNormalization summaries reverse the divisibility condition: they
imply `G % C == 0`, while equal non-empty channel groups require `C % G == 0`.
For example, four channels split into two groups are valid; two channels
cannot be split into four equal non-empty groups.

This corrects both the version 18 and version 21 source strings to match the
existing `num_groups` attribute description and regenerates the operator
documentation.

Closes #8422.

## Validation

- Rebuilt the ONNX extension and ran `python onnx/defs/gen_doc.py`.
- Ran the reproducer against both schema versions: eight valid CPU cases
  matched an independent float64 calculation and four invalid cases were
  rejected at reshape.
- `clang-format --dry-run --Werror onnx/defs/doc_strings.cc`.
- `git diff --check`.

This is documentation-only and does not change runtime behavior.
