### PR TITLE
fix(reference): preserve infinite ReduceLogSumExp results

### DIFF
--- a/onnx/reference/ops/op_reduce_log_sum_exp.py
+++ b/onnx/reference/ops/op_reduce_log_sum_exp.py
@@ -9,14 +9,13 @@ from onnx.reference.ops._op import OpRunReduceNumpy
 
 
 def compute_log_sum_exp(data, axes, keepdims):
-    data_max = data.copy()
-    ind = np.isinf(data_max)
-    data_max[ind] = -np.inf
-    mx = data_max.max(axis=axes, keepdims=True)
-    sub = np.subtract(data, mx)
-    exp = np.exp(sub, out=sub)
-    mxs = np.sum(exp, axis=axes, keepdims=True, dtype=data.dtype)
-    res = np.log(mxs) + mx
+    mx = data.max(axis=axes, keepdims=True)
+    shift = np.where(np.isfinite(mx), mx, np.zeros_like(mx))
+    with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
+        sub = np.subtract(data, shift)
+        exp = np.exp(sub, out=sub)
+        mxs = np.sum(exp, axis=axes, keepdims=True, dtype=data.dtype)
+        res = np.log(mxs) + shift
     if not keepdims:
         res = np.squeeze(res, axis=axes)
     return (res,)

--- a/tests/python/reference_evaluator_test.py
+++ b/tests/python/reference_evaluator_test.py
@@ -4773,6 +4773,29 @@ class TestReferenceEvaluator:
         )[0]
         np.testing.assert_array_equal(actual, expected)
 
+    @pytest.mark.parametrize("opset", [13, 18, onnx_opset_version()])
+    def test_reduce_log_sum_exp_infinite_inputs(self, opset):
+        X = make_tensor_value_info("X", TensorProto.FLOAT, [2, 2])
+        Y = make_tensor_value_info("Y", TensorProto.FLOAT, [2])
+        feeds = {
+            "X": np.array([[np.inf, -np.inf], [-np.inf, -np.inf]], dtype=np.float32)
+        }
+        expected = np.array([np.inf, -np.inf], dtype=np.float32)
+        if opset >= 18:
+            A = make_tensor_value_info("A", TensorProto.INT64, [1])
+            node = make_node("ReduceLogSumExp", ["X", "A"], ["Y"], keepdims=0)
+            inputs = [X, A]
+            feeds["A"] = np.array([1], dtype=np.int64)
+        else:
+            node = make_node("ReduceLogSumExp", ["X"], ["Y"], axes=[1], keepdims=0)
+            inputs = [X]
+        model = make_model(
+            make_graph([node], "g", inputs, [Y]),
+            opset_imports=[make_opsetid("", opset)],
+        )
+        got = ReferenceEvaluator(model).run(None, feeds)[0]
+        np.testing.assert_array_equal(got, expected)
+
     @pytest.mark.parametrize("dim", [1, 2, 3, 4, 5, 6])
     def test_pad(self, dim):
         X = make_tensor_value_info("X", TensorProto.FLOAT, None)


### PR DESCRIPTION
## Summary

`ReduceLogSumExp` replaces every infinite input with `-inf` when choosing its
stability shift. If a reduction slice contains no finite value, the shift is
therefore `-inf`, and subtracting it produces invalid `inf - inf` or
`-inf - -inf` intermediates.

For example, reducing these rows along axis 1 currently gives `[nan, nan]`:

```text
[[ inf, -inf],
 [-inf, -inf]]
```

The operator definition gives `[inf, -inf]`, which also matches NumPy
`logaddexp.reduce` and ONNX Runtime.

This change keeps the finite maximum as the usual stability shift, but uses
zero when that maximum is non-finite. The exponential/logarithm composition
then preserves the mathematically defined infinities without an invalid
subtraction.

## Validation

- Added a regression test for opsets 13, 18, and the current opset.
- Mutation check: restoring the old implementation makes all three new cases
  fail with `[nan, nan]` instead of `[inf, -inf]`.
- `tests/python/reference_evaluator_test.py`: 454 passed, 4 skipped.
- Independent differential sweep: 723 checks across float16, float32 and
  float64, multiple axes and both `keepdims` values, against NumPy
  `logaddexp.reduce`.
- Ruff format/check and `git diff --check` pass.

This is an ordinary reference-implementation correctness fix, not a security
change.

Reproducer and captured release/runtime/oracle output:
https://github.com/kadyrbekovhamit-cyber/gero-onnx-reducelogsumexp-infinity-audit

Maintainer note: as an external contributor I cannot assign repository labels;
suggested labels are `topic: bug fix` and `module: reference implementation`.
