### PR TITLE
fix(reference): handle BatchNormalization opset 9 modes

### DIFF
--- a/onnx/reference/ops/op_batch_normalization.py
+++ b/onnx/reference/ops/op_batch_normalization.py
@@ -34,7 +34,7 @@ def _batchnorm_training_mode(
     var: np.ndarray,
     momentum: float = 0.9,
     epsilon: float = 1e-5,
-) -> np.ndarray:
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     axis = tuple(np.delete(np.arange(len(x.shape)), 1))
     saved_mean = x.mean(axis=axis)
     saved_var = x.var(axis=axis)
@@ -74,18 +74,15 @@ class BatchNormalization_6(OpRun):
 
 class BatchNormalization_9(OpRun):
     def _run(self, x, scale, bias, mean, var, epsilon=None, momentum=None):
-        if momentum is None:
+        if len(self.onnx_node.output) == 1:
             res = _batchnorm_test_mode(x, scale, bias, mean, var, epsilon=epsilon)
             return (res,)
-        axis = tuple(np.delete(np.arange(len(x.shape)), 1))
-        saved_mean = x.mean(axis=axis)
-        saved_var = x.var(axis=axis)
-        output_mean = mean * momentum + saved_mean * (1 - momentum)
-        output_var = var * momentum + saved_var * (1 - momentum)
-        res = _batchnorm_test_mode(
-            x, scale, bias, output_mean, output_var, epsilon=epsilon
+        res, saved_mean, saved_var, output_mean, output_var = _batchnorm_training_mode(
+            x, scale, bias, mean, var, momentum=momentum, epsilon=epsilon
         )
-        return (res,)
+        # Opset 9's legacy fifth output stores the inverse standard deviation.
+        saved_inv_std = np.reciprocal(np.sqrt(saved_var + epsilon)).astype(x.dtype)
+        return res, output_mean, output_var, saved_mean, saved_inv_std
 
 
 class BatchNormalization_14(OpRun):

--- a/tests/python/reference_evaluator_test.py
+++ b/tests/python/reference_evaluator_test.py
@@ -4773,6 +4773,68 @@ class TestReferenceEvaluator:
         )[0]
         np.testing.assert_array_equal(actual, expected)
 
+    @pytest.mark.parametrize("momentum", [None, 0.5])
+    @pytest.mark.parametrize("training", [False, True])
+    def test_batch_normalization_opset9_modes(self, momentum, training):
+        x = np.array([[[1.0, 3.0]], [[5.0, 7.0]]], dtype=np.float32)
+        scale = np.array([2.0], dtype=np.float32)
+        bias = np.array([0.5], dtype=np.float32)
+        mean = np.array([10.0], dtype=np.float32)
+        var = np.array([4.0], dtype=np.float32)
+        feeds = {"X": x, "scale": scale, "B": bias, "mean": mean, "var": var}
+        inputs = [
+            make_tensor_value_info(name, TensorProto.FLOAT, list(value.shape))
+            for name, value in feeds.items()
+        ]
+        output_names = ["Y"]
+        outputs = [make_tensor_value_info("Y", TensorProto.FLOAT, list(x.shape))]
+        if training:
+            output_names.extend(
+                ["output_mean", "output_var", "saved_mean", "saved_var"]
+            )
+            outputs.extend(
+                make_tensor_value_info(name, TensorProto.FLOAT, [1])
+                for name in output_names[1:]
+            )
+        attributes = {"epsilon": 1e-5}
+        if momentum is not None:
+            attributes["momentum"] = momentum
+        node = make_node(
+            "BatchNormalization",
+            list(feeds),
+            output_names,
+            **attributes,
+        )
+        model = make_model(
+            make_graph([node], "g", inputs, outputs),
+            opset_imports=[make_opsetid("", 9)],
+        )
+
+        actual = ReferenceEvaluator(model).run(None, feeds)
+        if not training:
+            expected = scale.reshape(1, 1, 1) * (x - mean.reshape(1, 1, 1)) / np.sqrt(
+                var.reshape(1, 1, 1) + 1e-5
+            ) + bias.reshape(1, 1, 1)
+            np.testing.assert_allclose(actual[0], expected, rtol=1e-6, atol=1e-6)
+            return
+
+        batch_mean = x.mean(axis=(0, 2))
+        batch_var = x.var(axis=(0, 2))
+        expected_y = scale.reshape(1, 1, 1) * (
+            x - batch_mean.reshape(1, 1, 1)
+        ) / np.sqrt(batch_var.reshape(1, 1, 1) + 1e-5) + bias.reshape(1, 1, 1)
+        effective_momentum = 0.9 if momentum is None else momentum
+        expected = (
+            expected_y,
+            mean * effective_momentum + batch_mean * (1 - effective_momentum),
+            var * effective_momentum + batch_var * (1 - effective_momentum),
+            batch_mean,
+            # The legacy fifth output is the saved inverse standard deviation.
+            np.reciprocal(np.sqrt(batch_var + 1e-5)),
+        )
+        for got, want in zip(actual, expected, strict=True):
+            np.testing.assert_allclose(got, want, rtol=1e-6, atol=1e-6)
+
     @pytest.mark.parametrize("dim", [1, 2, 3, 4, 5, 6])
     def test_pad(self, dim):
         X = make_tensor_value_info("X", TensorProto.FLOAT, None)


### PR DESCRIPTION
### Motivation and Context

`BatchNormalization` before opset 14 uses its output count to distinguish test mode (one output) from training mode (five outputs). The opset-9 reference implementation instead used `momentum is None`. Because the schema supplies the default value `0.9`, even a one-output node entered the wrong path and normalized with blended running statistics. A five-output node returned only `Y`, so `ReferenceEvaluator` could not produce the four requested training outputs.

This change:

- selects the opset-9 mode from the node's output count;
- normalizes training data using the current batch statistics;
- returns updated running statistics and the two legacy saved values in schema order;
- preserves the legacy fifth-output inverse-standard-deviation behavior implemented by ONNX Runtime.

Regression coverage includes inference and training with both the default momentum and an explicit `0.5` value.

### Validation

- `455 passed, 4 skipped` in `tests/python/reference_evaluator_test.py`
- all four new cases match independent NumPy formulas
- all four modes match ONNX Runtime CPU within tolerance
- restoring the previous implementation makes all four new cases fail
- Ruff formatting/checks and `git diff --check` pass

I cannot assign labels as an external contributor. Suggested labels: `topic: bug fix`, `module: reference implementation`.
