### PR TITLE
test(reference): cover Unique unsorted negative axis

### DIFF
--- a/tests/python/reference_evaluator_test.py
+++ b/tests/python/reference_evaluator_test.py
@@ -7555,9 +7555,10 @@ class TestReferenceEvaluator:
         assert_array_equal(inverse, np.array([0, 1, 1, 2], dtype=np.int64))
         assert_array_equal(counts, np.array([1, 2, 1], dtype=np.int64))
 
-    def test_unique_not_sorted_with_axis(self) -> None:
+    @pytest.mark.parametrize("axis", [1, -1])
+    def test_unique_not_sorted_with_axis(self, axis: int) -> None:
         node = make_node(
-            "Unique", ["X"], ["Y", "indices", "inverse", "counts"], sorted=0, axis=1
+            "Unique", ["X"], ["Y", "indices", "inverse", "counts"], sorted=0, axis=axis
         )
         x = np.array([[3.0, 1.0, 3.0], [4.0, 2.0, 4.0]], dtype=np.float32)
         y, indices, inverse, counts = ReferenceEvaluator(node).run(None, {"X": x})


### PR DESCRIPTION
## Summary

- extend the existing ReferenceEvaluator regression for `Unique(sorted=0)` from `axis=1` to the equivalent negative axis `axis=-1`
- keep the operator implementation from current `main` unchanged

## Context

This PR originally carried the one-line implementation fix for unsorted `Unique` with a nonzero axis. While it was open, #8424 merged an equivalent and broader correction. The implementation change here is therefore redundant and has been removed.

The merged test covers `sorted=0, axis=1`, and the backend suite has a negative-axis case only for `sorted=1`. This reduced PR retains only the missing `sorted=0, axis=-1` coverage by parameterizing the existing direct ReferenceEvaluator test.

## Validation

- targeted test: 2 passed
- full `tests/python/reference_evaluator_test.py`: 461 passed, 4 skipped
- `ruff check`: clean
- `ruff format --check`: clean
- `git diff --check`: clean

Signed-off-by: kadyrbekovhamit-cyber <288885044+kadyrbekovhamit-cyber@users.noreply.github.com>
