### PR TITLE
fix(reference): support GatherElements subshapes

### DIFF
--- a/onnx/reference/ops/op_gather_elements.py
+++ b/onnx/reference/ops/op_gather_elements.py
@@ -8,32 +8,13 @@ import numpy as np
 from onnx.reference.op_run import OpRun
 
 
-def gather_numpy_2(self: np.ndarray, index: np.ndarray) -> np.ndarray:
-    res = []
-    for a, b in zip(self, index, strict=True):
-        res.append(a[b[0]])
-    return np.array(res, dtype=self.dtype).reshape(index.shape)
-
-
 def gather_numpy(self: np.ndarray, dim: int, index: np.ndarray) -> np.ndarray:
-    idx_xsection_shape = index.shape[:dim] + index.shape[dim + 1 :]
-    self_xsection_shape = self.shape[:dim] + self.shape[dim + 1 :]
-    if idx_xsection_shape != self_xsection_shape:
-        raise ValueError(
-            f"Except for dimension {dim!r}, all dimensions of "
-            f"index and self should be the same size."
-        )
-    data_swapped = np.swapaxes(self, 0, dim)
-    index_swapped = np.swapaxes(index, 0, dim)
-
-    try:
-        gathered = np.choose(index_swapped, data_swapped, mode="wrap")
-    except ValueError:
-        if len(index_swapped.shape) == 2 and len(data_swapped.shape) == 2:
-            return gather_numpy_2(self, index)
-        raise  # pragma: no cover
-
-    return np.swapaxes(gathered, 0, dim)
+    dim %= self.ndim
+    data_slices = tuple(
+        slice(None) if axis == dim else slice(0, size)
+        for axis, size in enumerate(index.shape)
+    )
+    return np.take_along_axis(self[data_slices], index, axis=dim)
 
 
 class GatherElements(OpRun):

--- a/tests/python/reference_evaluator_test.py
+++ b/tests/python/reference_evaluator_test.py
@@ -4722,6 +4722,57 @@ class TestReferenceEvaluator:
         # specific message is on the chained cause rather than the exception itself.
         assert "does not support integer input" in str(exc_info.value.__cause__)
 
+    @pytest.mark.parametrize(
+        ("data", "indices", "axis", "expected"),
+        [
+            (
+                np.array([[10, 11, 12], [20, 21, 22]], dtype=np.int64),
+                np.array([[2, 0]], dtype=np.int64),
+                1,
+                np.array([[12, 10]], dtype=np.int64),
+            ),
+            (
+                np.array([[10, 11], [20, 21], [30, 31]], dtype=np.int64),
+                np.array([[2], [0]], dtype=np.int64),
+                0,
+                np.array([[30], [10]], dtype=np.int64),
+            ),
+            (
+                np.arange(12, dtype=np.int64).reshape(2, 2, 3),
+                np.array([[[2, 0], [1, 2]]], dtype=np.int64),
+                -1,
+                np.array([[[2, 0], [4, 5]]], dtype=np.int64),
+            ),
+        ],
+    )
+    def test_gather_elements_accepts_smaller_non_axis_dimensions(
+        self, data, indices, axis, expected
+    ):
+        node = make_node("GatherElements", ["data", "indices"], ["output"], axis=axis)
+        model = make_model(
+            make_graph(
+                [node],
+                "g",
+                [
+                    make_tensor_value_info("data", TensorProto.INT64, list(data.shape)),
+                    make_tensor_value_info(
+                        "indices", TensorProto.INT64, list(indices.shape)
+                    ),
+                ],
+                [
+                    make_tensor_value_info(
+                        "output", TensorProto.INT64, list(indices.shape)
+                    )
+                ],
+            ),
+            opset_imports=[make_opsetid("", 13)],
+        )
+
+        actual = ReferenceEvaluator(model).run(
+            None, {"data": data, "indices": indices}
+        )[0]
+        np.testing.assert_array_equal(actual, expected)
+
     @pytest.mark.parametrize("dim", [1, 2, 3, 4, 5, 6])
     def test_pad(self, dim):
         X = make_tensor_value_info("X", TensorProto.FLOAT, None)


### PR DESCRIPTION
### Motivation and Context

`GatherElements` requires `data` and `indices` to have the same rank, but the non-axis dimensions of `indices` may be smaller than the corresponding `data` dimensions. The output has exactly the shape of `indices`.

The reference implementation instead requires every non-axis dimension to be equal. It rejects valid inputs such as `data.shape=(2, 3)`, `indices.shape=(1, 2)`, `axis=1`, for which the specified output is `[[12, 10]]`.

This change slices `data` to the index-domain extent on non-gather axes and delegates the actual gather to `numpy.take_along_axis`. It supports positive and negative axes, smaller valid subshapes, negative indices, and all previously supported equal-shape cases.

### Validation

- full `tests/python/reference_evaluator_test.py`: 454 passed, 4 skipped
- three regression cases cover axes 0, 1 and -1 in two and three dimensions
- 36 additional differential cases cover equal/smaller shapes, positive/negative axes and positive/negative indices; all match ONNX Runtime exactly
- restoring the previous implementation makes all three new regression cases fail with its shape-equality error
- Ruff formatting/checks and `git diff --check` pass
- ONNX issue/PR searches found no matching report

I cannot assign labels as an external contributor. Suggested labels: `topic: bug fix`, `module: reference implementation`.
