### PR TITLE
Fix GroupNormalization doc: channels divisible by num_groups

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -24917,8 +24917,8 @@ This version of the operator has been available since version 21 of the default 
   ```
   where the mean and variance are computed per instance per group of channels, and
   `scale` and `bias` should be specified for each channel. The number of
-  groups `num_groups` should be divisible by the number of channels so that there are
-  an equal number of channels per group.
+  channels should be divisible by `num_groups` so that there are an equal number of
+  channels per group.
 
   The overall computation has two stages: the first stage normalizes the elements to
   have zero mean and unit variance for each instance in each group, and the second

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -18020,8 +18020,8 @@ expect(
   ```
   where the mean and variance are computed per instance per group of channels, and
   `scale` and `bias` should be specified for each channel. The number of
-  groups `num_groups` should be divisible by the number of channels so that there are
-  an equal number of channels per group.
+  channels should be divisible by `num_groups` so that there are an equal number of
+  channels per group.
 
   The overall computation has two stages: the first stage normalizes the elements to
   have zero mean and unit variance for each instance in each group, and the second

--- a/onnx/defs/doc_strings.cc
+++ b/onnx/defs/doc_strings.cc
@@ -2948,8 +2948,8 @@ y = scale * (x - mean) / sqrt(variance + epsilon) + bias,
 ```
 where the mean and variance are computed per instance per group of channels, and
 `scale` and `bias` should be specified for each channel. The number of
-groups `num_groups` should be divisible by the number of channels so that there are
-an equal number of channels per group.
+channels should be divisible by `num_groups` so that there are an equal number of
+channels per group.
 
 The overall computation has two stages: the first stage normalizes the elements to
 have zero mean and unit variance for each instance in each group, and the second


### PR DESCRIPTION
## Description

Fixes the reversed divisibility condition in the `GroupNormalization` v21 documentation (issue #8422).

The docs stated that `num_groups` should be divisible by the number of channels. The direction is reversed: to form equal, non-empty channel groups, the number of **channels must be divisible by `num_groups`**.

Example contradiction from the issue:
- `channels=4, num_groups=2` is valid (`4 % 2 == 0`), but the old wording would reject it (`2 % 4 != 0`).
- `channels=2, num_groups=4` satisfies the old wording (`4 % 2 == 0`) yet cannot form four equal non-empty groups.

## Changes

- `onnx/defs/doc_strings.cc`: corrected the v21 doc string.
- `docs/Operators.md` and `docs/Changelog.md`: regenerated (word change only).

The v18 (frozen) doc is intentionally left unchanged.

Closes #8422.