### PR TITLE
fix(reference): correct ConvTranspose group>1 channel-slice indexing

### DIFF
--- a/onnx/reference/ops/op_conv_transpose.py
+++ b/onnx/reference/ops/op_conv_transpose.py
@@ -129,10 +129,13 @@ class ConvTranspose(OpRun):
                 group_output = np.array(group_output[0])
                 output_array.append(group_output)
 
+            channels_per_group = num_output_channels // group
             for image_id in range(X.shape[0]):
                 for group_id in range(group):
                     group_output = output_array[group_id]
-                    final[image_id, group_id : (group_id + 1), ...] = group_output[
+                    start_ch = group_id * channels_per_group
+                    end_ch = start_ch + channels_per_group
+                    final[image_id, start_ch:end_ch, ...] = group_output[
                         image_id, ...
                     ]
 


### PR DESCRIPTION
## The bug

In the ConvTranspose reference implementation, each per-group `_run` call returns `W.shape[1] = M/group` channels, but the reassembly wrote into a single-channel slot:

```python
final[image_id, group_id : (group_id + 1), ...] = group_output[image_id, ...]
```

This raised `ValueError: could not broadcast input array from shape (M/group, H, W) into shape (1, H, W)` whenever `M/group > 1`. The degenerate case (`W.shape[1]==1`) silently worked, which is why it went unnoticed. The sibling `op_conv.py` handles the same grouping correctly.

## Fix

Correct slicing: `group_id*(M/group) : (group_id+1)*(M/group)`.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>