### PR TITLE
fix(external_data): use len() instead of sys.getsizeof() for size threshold

### DIFF
--- a/onnx/external_data_helper.py
+++ b/onnx/external_data_helper.py
@@ -247,14 +247,14 @@ def convert_model_to_external_data(
         for tensor in tensors:
             if (
                 tensor.HasField("raw_data")
-                and sys.getsizeof(tensor.raw_data) >= size_threshold
+                and len(tensor.raw_data) >= size_threshold
             ):
                 set_external_data(tensor, file_name)
     else:
         for tensor in tensors:
             if (
                 tensor.HasField("raw_data")
-                and sys.getsizeof(tensor.raw_data) >= size_threshold
+                and len(tensor.raw_data) >= size_threshold
             ):
                 tensor_location = tensor.name
                 if not _is_valid_filename(tensor_location):

--- a/onnx/external_data_helper.py
+++ b/onnx/external_data_helper.py
@@ -245,17 +245,11 @@ def convert_model_to_external_data(
                 raise FileExistsError(f"External data file exists in {location}.")
             file_name = location
         for tensor in tensors:
-            if (
-                tensor.HasField("raw_data")
-                and len(tensor.raw_data) >= size_threshold
-            ):
+            if tensor.HasField("raw_data") and len(tensor.raw_data) >= size_threshold:
                 set_external_data(tensor, file_name)
     else:
         for tensor in tensors:
-            if (
-                tensor.HasField("raw_data")
-                and len(tensor.raw_data) >= size_threshold
-            ):
+            if tensor.HasField("raw_data") and len(tensor.raw_data) >= size_threshold:
                 tensor_location = tensor.name
                 if not _is_valid_filename(tensor_location):
                     tensor_location = str(uuid.uuid1())


### PR DESCRIPTION
## The bug

`convert_model_to_external_data` used `sys.getsizeof(tensor.raw_data) >= size_threshold` to decide whether a tensor's data should be externalized. On CPython, `sys.getsizeof` on a `bytes` object returns **33 + payload length**, not the data size. The documented contract says "Only when tensor's data is >= the size_threshold will it be converted", but a tensor with `len(raw_data) = 1000` and `size_threshold = 1024` was externalized anyway (getsizeof = 1033).

## Fix

Use `len(tensor.raw_data)` — the actual byte count.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>