### PR TITLE
fix(shape_inference): preserve custom callback lifetime

### DIFF
--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -501,7 +501,10 @@ NB_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) { // NOLINT(cppcoreguidelines-
           })
       .def(
           "set_type_and_shape_inference_function",
-          [](OpSchema& op, const std::function<void(InferenceContext*)>& func) -> OpSchema& {
+          // Keep the Python callable alive in the registered C++ inference
+          // function instead of converting it through nanobind's std::function
+          // caster. See https://github.com/onnx/onnx/issues/7508.
+          [](OpSchema& op, const nb::callable& func) -> OpSchema& {
             auto wrapper = [=](InferenceContext& ctx) { func(&ctx); };
             return op.TypeAndShapeInferenceFunction(wrapper);
           },

--- a/onnx/cpp2py_export.cc
+++ b/onnx/cpp2py_export.cc
@@ -501,11 +501,10 @@ NB_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) { // NOLINT(cppcoreguidelines-
           })
       .def(
           "set_type_and_shape_inference_function",
-          // Keep the Python callable alive in the registered C++ inference
-          // function instead of converting it through nanobind's std::function
-          // caster. See https://github.com/onnx/onnx/issues/7508.
-          [](OpSchema& op, const nb::callable& func) -> OpSchema& {
-            auto wrapper = [=](InferenceContext& ctx) { func(&ctx); };
+          [](OpSchema& op, std::function<void(InferenceContext*)> func) -> OpSchema& {
+            // Move nanobind's guarded Python-callable wrapper into the registered
+            // inference function so it remains valid after this binding returns.
+            auto wrapper = [func = std::move(func)](InferenceContext& ctx) { func(&ctx); };
             return op.TypeAndShapeInferenceFunction(wrapper);
           },
           nb::rv_policy::reference_internal)

--- a/tests/python/shape_inference_test.py
+++ b/tests/python/shape_inference_test.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import contextlib
+import gc
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -14021,6 +14022,48 @@ class TestCustomSchemaShapeInference(TestShapeInferenceHelper):
 
         # clean up
         onnx.defs.deregister_schema(schema.name, schema.since_version, schema.domain)
+
+    def test_custom_schema_shape_inference_callback_lifetime(self) -> None:
+        op_type = "MySoftmax"
+        domain = "com.example"
+
+        def register_schema() -> None:
+            schema = OpSchema(
+                op_type,
+                domain,
+                1,
+                inputs=[OpSchema.FormalParameter("input", "float")],
+                outputs=[OpSchema.FormalParameter("output", "float")],
+            )
+
+            def infer(ctx: onnx.shape_inference.InferenceContext) -> None:
+                ctx.set_output_type(0, ctx.get_input_type(0))
+
+            schema.set_type_and_shape_inference_function(infer)
+            onnx.defs.register_schema(schema)
+
+        graph = make_graph(
+            [make_node(op_type, ["input"], ["output"], domain=domain)],
+            "g",
+            [make_tensor_value_info("input", TensorProto.FLOAT, [1, 3])],
+            [make_tensor_value_info("output", TensorProto.FLOAT, None)],
+        )
+        model = make_model(
+            graph,
+            opset_imports=[make_opsetid(ONNX_DOMAIN, 17), make_opsetid(domain, 1)],
+        )
+
+        # The schema and callback are local to register_schema(). The registered
+        # inference function must remain callable after those Python references
+        # have been released.
+        register_schema()
+        try:
+            gc.collect()
+            inferred = onnx.shape_inference.infer_shapes(model)
+            output_shape = inferred.graph.output[0].type.tensor_type.shape
+            assert [dim.dim_value for dim in output_shape.dim] == [1, 3]
+        finally:
+            onnx.defs.deregister_schema(op_type, 1, domain)
 
     def test_dummy_graph_schema_shape_inference(self) -> None:
         # generate graph


### PR DESCRIPTION
Fixes #7508

### Summary
- move nanobind's converted `std::function` into the registered inference callback so the Python callable survives after the binding returns
- retain nanobind's guarded teardown/GIL behavior and the existing `None` conversion behavior
- add a regression test covering registration from a short-lived scope followed by `gc.collect()`

### Testing
- Linux native editable builds with GCC and nanobind on CPython 3.12 and CPython 3.13.15
- `pytest -q tests/python/shape_inference_test.py::TestCustomSchemaShapeInference::test_custom_schema_shape_inference_callback_lifetime` (passed on both interpreters)
- process-exit smoke test with a registered callback intentionally left in the global registry (clean exit on both interpreters)
- `lintrunner --output oneline onnx/cpp2py_export.cc tests/python/shape_inference_test.py` (passed)
- `git diff --check` (passed)

AI assistance: Codex was used to investigate the reported lifetime behavior and prepare the follow-up change; the author remains responsible for the contribution.