### PR TITLE
fix(shape_inference): handle an empty optional SplitToSequence input

### DIFF
--- a/onnx/defs/sequence/utils.cc
+++ b/onnx/defs/sequence/utils.cc
@@ -66,10 +66,9 @@ std::function<void(OpSchema&)> SplitToSequenceOpGenerator(
             axis += r;
           }
 
-          size_t num_inputs = ctx.getNumInputs();
           int64_t splitSize = 1;
           int64_t keepdims = 1;
-          if (num_inputs == 1) {
+          if (!ctx.hasInput(1)) {
             // input split is omitted, default to split by 1.
             const auto* const attr_proto = ctx.getAttribute("keepdims");
             if (attr_proto) {

--- a/tests/python/shape_inference_test.py
+++ b/tests/python/shape_inference_test.py
@@ -9031,10 +9031,12 @@ class TestShapeInference(TestShapeInferenceHelper):
                 opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
             )
 
-    def test_split_to_sequence_keepdims(self) -> None:
+    @pytest.mark.parametrize("inputs", [["input"], ["input", ""]])
+    @pytest.mark.parametrize("version", all_versions_for("SplitToSequence"))
+    def test_split_to_sequence_keepdims(self, inputs: list[str], version: int) -> None:
         graph = self._make_graph(
             [("input", TensorProto.FLOAT, (6, 4))],
-            [make_node("SplitToSequence", ["input"], ["output_sequence"], keepdims=1)],
+            [make_node("SplitToSequence", inputs, ["output_sequence"], keepdims=1)],
             [],
         )
         self._assert_inferred(
@@ -9044,12 +9046,17 @@ class TestShapeInference(TestShapeInferenceHelper):
                     "output_sequence", TensorProto.FLOAT, (1, 4)
                 )
             ],
+            opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
-    def test_split_to_sequence_not_keepdims(self) -> None:
+    @pytest.mark.parametrize("inputs", [["input"], ["input", ""]])
+    @pytest.mark.parametrize("version", all_versions_for("SplitToSequence"))
+    def test_split_to_sequence_not_keepdims(
+        self, inputs: list[str], version: int
+    ) -> None:
         graph = self._make_graph(
             [("input", TensorProto.FLOAT, (6, 4))],
-            [make_node("SplitToSequence", ["input"], ["output_sequence"], keepdims=0)],
+            [make_node("SplitToSequence", inputs, ["output_sequence"], keepdims=0)],
             [],
         )
         self._assert_inferred(
@@ -9059,6 +9066,7 @@ class TestShapeInference(TestShapeInferenceHelper):
                     "output_sequence", TensorProto.FLOAT, (4,)
                 )
             ],
+            opset_imports=[helper.make_opsetid(ONNX_DOMAIN, version)],
         )
 
     def test_split_to_sequence_ignore_keepdims(self) -> None:


### PR DESCRIPTION
### Motivation and Context

SplitToSequence treats an empty name for its optional `split` input as a supplied input. With `keepdims=0`, this retains the split axis instead of removing it; with `keepdims=1`, its size becomes unknown instead of 1. Omitting the trailing input entirely already works.

Use `hasInput(1)` to recognize both representations of an omitted input. Extend the existing keepdims tests to cover both input lists across all supported SplitToSequence schema versions.

### Validation

Built the baseline and patched C++ sources on Linux with Python 3.12. The regression gives 4 failures and 4 passes before the fix. Afterward, the three shape-inference test modules give 1034 passes and 2 xpasses ([test run](https://github.com/Hanabi9248/onnx/actions/runs/34697564047/job/103563558091)).

After correcting a test signature line wrap, `lintrunner` passes for both changed files ([lint run](https://github.com/Hanabi9248/onnx/actions/runs/34699412449)). The C++ implementation and Python test AST are unchanged from the test run.