### PR TITLE
fix(reference): handle Normalizer inputs stably

### DIFF
--- a/onnx/reference/ops/aionnxml/op_normalizer.py
+++ b/onnx/reference/ops/aionnxml/op_normalizer.py
@@ -10,24 +10,47 @@ from onnx.reference.ops.aionnxml._op_run_aionnxml import OpRunAiOnnxMl
 
 class Normalizer(OpRunAiOnnxMl):
     @staticmethod
+    def _scaled(x):
+        x_float = x.astype(np.float64, copy=False)
+        axis = 0 if x.ndim == 1 else 1
+        scale = np.max(np.abs(x_float), axis=axis, keepdims=True)
+        return np.divide(
+            x_float,
+            scale,
+            out=x_float.copy(),
+            where=scale != 0,
+        )
+
+    @staticmethod
     def norm_max(x):
         """Max normalization"""
-        div = np.abs(x).max(axis=1).reshape((x.shape[0], -1))
-        return x / np.maximum(div, 1e-30)
+        return Normalizer._scaled(x).astype(np.float32)
 
     @staticmethod
     def norm_l1(x):
         """L1 normalization"""
-        div = np.abs(x).sum(axis=1).reshape((x.shape[0], -1))
-        return x / np.maximum(div, 1e-30)
+        scaled = Normalizer._scaled(x)
+        axis = 0 if x.ndim == 1 else 1
+        norm = np.sum(np.abs(scaled), axis=axis, keepdims=True)
+        return np.divide(
+            scaled,
+            norm,
+            out=scaled.copy(),
+            where=norm != 0,
+        ).astype(np.float32)
 
     @staticmethod
     def norm_l2(x):
         """L2 normalization"""
-        xn = np.square(x).sum(axis=1)
-        np.sqrt(xn, out=xn)
-        norm = np.maximum(xn.reshape((x.shape[0], -1)), 1e-30)
-        return x / norm
+        scaled = Normalizer._scaled(x)
+        axis = 0 if x.ndim == 1 else 1
+        norm = np.sqrt(np.sum(np.square(scaled), axis=axis, keepdims=True))
+        return np.divide(
+            scaled,
+            norm,
+            out=scaled.copy(),
+            where=norm != 0,
+        ).astype(np.float32)
 
     def _run(self, x, norm=None):
         if norm == "MAX":

--- a/tests/python/reference_evaluator_ml_test.py
+++ b/tests/python/reference_evaluator_ml_test.py
@@ -215,6 +215,65 @@ class TestReferenceEvaluatorAiOnnxMl:
         got = sess.run(None, feeds)[0]
         assert_allclose(got, expected, atol=1e-6)
 
+    @pytest.mark.parametrize("norm", ["MAX", "L1", "L2"])
+    @pytest.mark.parametrize(
+        "x, tensor_type",
+        [
+            (np.array([3, 4], dtype=np.int32), TensorProto.INT32),
+            (
+                np.array([[3_000_000_000, 4_000_000_000]], dtype=np.int64),
+                TensorProto.INT64,
+            ),
+            (np.array([[-3.0, -4.0]], dtype=np.float64), TensorProto.DOUBLE),
+        ],
+    )
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    def test_normalizer_supported_input_types(self, norm, x, tensor_type):
+        X = make_tensor_value_info("X", tensor_type, list(x.shape))
+        Y = make_tensor_value_info("Y", TensorProto.FLOAT, list(x.shape))
+        node = make_node("Normalizer", ["X"], ["Y"], norm=norm, domain="ai.onnx.ml")
+        graph = make_graph([node], "ml", [X], [Y])
+        model = make_model_gen_version(graph, opset_imports=OPSETS)
+        onnx.checker.check_model(model)
+
+        x_float = x.astype(np.float64)
+        axis = 0 if x.ndim == 1 else 1
+        if norm == "MAX":
+            divisor = np.max(np.abs(x_float), axis=axis, keepdims=True)
+        elif norm == "L1":
+            divisor = np.sum(np.abs(x_float), axis=axis, keepdims=True)
+        else:
+            divisor = np.sqrt(np.sum(np.square(x_float), axis=axis, keepdims=True))
+        expected = (x_float / divisor).astype(np.float32)
+
+        got = ReferenceEvaluator(model).run(None, {"X": x})[0]
+        assert got.dtype == np.float32
+        assert_allclose(got, expected, rtol=1e-6)
+
+    @pytest.mark.parametrize(
+        "x",
+        [
+            np.array([[1e30, 1e30]], dtype=np.float32),
+            np.array([[1e-30, 1e-30]], dtype=np.float32),
+            np.array([[1e300, 1e300]], dtype=np.float64),
+            np.array([[1e-300, 1e-300]], dtype=np.float64),
+        ],
+    )
+    @pytest.mark.skipif(not ONNX_ML, reason="onnx not compiled with ai.onnx.ml")
+    def test_normalizer_l2_extreme_magnitudes(self, x):
+        tensor_type = TensorProto.FLOAT if x.dtype == np.float32 else TensorProto.DOUBLE
+        X = make_tensor_value_info("X", tensor_type, list(x.shape))
+        Y = make_tensor_value_info("Y", TensorProto.FLOAT, list(x.shape))
+        node = make_node("Normalizer", ["X"], ["Y"], norm="L2", domain="ai.onnx.ml")
+        graph = make_graph([node], "ml", [X], [Y])
+        model = make_model_gen_version(graph, opset_imports=OPSETS)
+        onnx.checker.check_model(model)
+
+        expected = np.full(x.shape, np.float32(1 / np.sqrt(2)), dtype=np.float32)
+        got = ReferenceEvaluator(model).run(None, {"X": x})[0]
+        assert got.dtype == np.float32
+        assert_allclose(got, expected, rtol=1e-6)
+
     @pytest.mark.parametrize(
         "inputdimensions, expected_value",
         [


### PR DESCRIPTION
## Summary

Make the `ai.onnx.ml::Normalizer` reference implementation honor the operator's declared input shape and type domain, and evaluate all three norms without avoidable overflow or underflow.

The schema accepts `[C]` and `[N,C]` inputs of `float`, `double`, `int32`, or `int64`, and always declares `tensor(float)` output. The previous implementation had four independent failures inside that domain:

- every one-dimensional `[C]` input raised `AxisError` because it always reduced over axis 1;
- `L2` on integer inputs raised `UFuncOutputCastingError` when `sqrt` tried to write into an integer array;
- `double` and integer inputs produced `float64` for `MAX`/`L1` (and for successful `L2` cases), despite the declared `tensor(float)` output;
- direct squaring and the fixed `1e-30` floor corrupted valid extreme-magnitude vectors. For example, `[1e30, 1e30]` became `[0, 0]` and `[1e-30, 1e-30]` became `[1, 1]` instead of approximately `[0.70710677, 0.70710677]`.

The new implementation first scales each row/vector by its largest absolute component, then evaluates the L1/L2 norm of the scaled values. This is algebraically equivalent for every nonzero input, avoids premature overflow/underflow, preserves zero rows, and casts the schema-defined output to `float32`.

## Validation

- `117 passed` in `tests/python/reference_evaluator_ml_test.py`
- `16 passed` in the focused `-k normalizer` run
- `lintrunner`: no lint issues
- mutation check: restoring the previous implementation makes all 13 new parameterized cases fail
- independently checked ordinary, zero, 1-D, integer, double, `1e30`/`1e-30` float32, and `1e300`/`1e-300` float64 inputs

## Notes

ONNX Runtime also loses finite L2 results at extreme float magnitudes; that is a separate runtime implementation issue and is intentionally not bundled here.

I cannot apply organization labels from an external fork. A maintainer will need to add the applicable reference-implementation label for `check-label`.

Signed-off-by: kadyrbekovhamit-cyber <288885044+kadyrbekovhamit-cyber@users.noreply.github.com>
