### PR TITLE
docs: correct Normalizer L1 and L2 formulas

### DIFF
--- a/docs/Changelog-ml.md
+++ b/docs/Changelog-ml.md
@@ -462,12 +462,12 @@ This version of the operator has been available since version 1 of the 'ai.onnx.
 
 ### <a name="ai.onnx.ml.Normalizer-1"></a>**ai.onnx.ml.Normalizer-1**</a>
 
-  Normalize the input.  There are three normalization modes, which have the corresponding formulas,
-      defined using element-wise infix operators '/' and '^' and tensor-wide functions 'max' and 'sum':<br>
+  Normalize the input. There are three normalization modes, which have the corresponding formulas.
+      The function 'abs' and operator '^' are element-wise, while 'max' and 'sum' reduce along the normalization axis:<br>
   <br>
       Max: Y = X / max(X)<br>
-      L1:  Y = X / sum(X)<br>
-      L2:  Y = sqrt(X^2 / sum(X^2)}<br>
+      L1:  Y = X / sum(abs(X))<br>
+      L2:  Y = X / sqrt(sum(X^2))<br>
       In all modes, if the divisor is zero, Y == X.
   <br>
       For batches, that is, [N,C] tensors, normalization is done along the C axis. In other words, each row

--- a/docs/Operators-ml.md
+++ b/docs/Operators-ml.md
@@ -676,12 +676,12 @@ This version of the operator has been available since version 1 of the 'ai.onnx.
 
 ### <a name="ai.onnx.ml.Normalizer"></a><a name="ai.onnx.ml.normalizer">**ai.onnx.ml.Normalizer**</a>
 
-  Normalize the input.  There are three normalization modes, which have the corresponding formulas,
-      defined using element-wise infix operators '/' and '^' and tensor-wide functions 'max' and 'sum':<br>
+  Normalize the input. There are three normalization modes, which have the corresponding formulas.
+      The function 'abs' and operator '^' are element-wise, while 'max' and 'sum' reduce along the normalization axis:<br>
   <br>
       Max: Y = X / max(X)<br>
-      L1:  Y = X / sum(X)<br>
-      L2:  Y = sqrt(X^2 / sum(X^2)}<br>
+      L1:  Y = X / sum(abs(X))<br>
+      L2:  Y = X / sqrt(sum(X^2))<br>
       In all modes, if the divisor is zero, Y == X.
   <br>
       For batches, that is, [N,C] tensors, normalization is done along the C axis. In other words, each row

--- a/onnx/defs/doc_strings.cc
+++ b/onnx/defs/doc_strings.cc
@@ -6001,12 +6001,12 @@ const char kDoc_OneHotEncoder_ver1[] = R"DOC(
     to integers and the cats_int64s category list will be used for the lookups.
 )DOC";
 const char kDoc_Normalizer_ver1[] = R"DOC(
-    Normalize the input.  There are three normalization modes, which have the corresponding formulas,
-    defined using element-wise infix operators '/' and '^' and tensor-wide functions 'max' and 'sum':<br>
+    Normalize the input. There are three normalization modes, which have the corresponding formulas.
+    The function 'abs' and operator '^' are element-wise, while 'max' and 'sum' reduce along the normalization axis:<br>
 <br>
     Max: Y = X / max(X)<br>
-    L1:  Y = X / sum(X)<br>
-    L2:  Y = sqrt(X^2 / sum(X^2)}<br>
+    L1:  Y = X / sum(abs(X))<br>
+    L2:  Y = X / sqrt(sum(X^2))<br>
     In all modes, if the divisor is zero, Y == X.
 <br>
     For batches, that is, [N,C] tensors, normalization is done along the C axis. In other words, each row


### PR DESCRIPTION
### Description

Correct the mathematical formulas in the `ai.onnx.ml::Normalizer` documentation:

- L1 divides by `sum(abs(X))`, not the signed sum `sum(X)`;
- L2 divides `X` by `sqrt(sum(X^2))`, rather than taking the square root of the quotient.

The generated `Operators-ml.md` and `Changelog-ml.md` files are refreshed from the rebuilt schema.

The `MAX` formula is deliberately unchanged. Its absolute-value semantics differ between existing implementations and should not be altered as part of this unambiguous documentation correction.

### Motivation

The current L1 formula allows negative components to cancel and can make a nonzero vector's documented divisor zero. The current L2 expression also has a mismatched brace and places `X` inside the square root, so it does not describe L2 normalization.

The history isolates the regression: before PR #1076, the schema documentation correctly defined the L1 divisor as `sum |x_i|` and the L2 divisor as `sqrt(sum x_i^2)`. The expanded output formulas introduced in that 2018 documentation change lost the absolute value and misplaced the L2 square root.

Validation:

- rebuilt `onnx_cpp2py_export` from the changed C++ schema;
- regenerated the ML operator and changelog documents with `onnx/defs/gen_doc.py`;
- official `lintrunner` on all three changed files: no lint issues;
- `git diff --check`: clean.
