### PR TITLE
fix(reference): stabilize LpNormalization finite range

### DIFF
--- a/onnx/reference/ops/op_lp_normalization.py
+++ b/onnx/reference/ops/op_lp_normalization.py
@@ -12,8 +12,17 @@ class LpNormalization(OpRunUnaryNum):
     def _run(self, x, axis=None, p=None):
         axis = axis or self.axis
         p = p or self.p
-        norm = np.power(np.power(np.abs(x), p).sum(axis=axis), 1.0 / p)
-        norm = np.expand_dims(norm, axis)
-        # When norm is 0, return 0 instead of NaN (0/0 = 0)
-        result = np.where(norm == 0, 0, x / norm)
+        scale = np.max(np.abs(x), axis=axis, keepdims=True, initial=0)
+        safe_scale = np.where(
+            (scale == 0) | ~np.isfinite(scale),
+            np.array(1, dtype=x.dtype),
+            scale,
+        )
+        scaled = x / safe_scale
+        norm = np.power(
+            np.power(np.abs(scaled), p).sum(axis=axis, keepdims=True), 1.0 / p
+        )
+        safe_norm = np.where(norm == 0, np.array(1, dtype=x.dtype), norm)
+        # When all values along the axis are 0, return 0 instead of NaN.
+        result = np.where(scale == 0, 0, scaled / safe_norm)
         return (result.astype(x.dtype),)

--- a/tests/python/reference_evaluator_test.py
+++ b/tests/python/reference_evaluator_test.py
@@ -4505,6 +4505,35 @@ class TestReferenceEvaluator:
                 ref.run(None, {"X": data})
 
     @pytest.mark.parametrize(
+        ("p", "magnitude", "expected_value"),
+        [
+            (1, np.float32(3e38), np.float32(0.5)),
+            (2, np.float32(1e30), np.float32(2**-0.5)),
+            (2, np.float32(1e-30), np.float32(2**-0.5)),
+        ],
+    )
+    def test_lp_normalization_preserves_finite_extreme_inputs(
+        self, p: int, magnitude: np.float32, expected_value: np.float32
+    ) -> None:
+        node = make_node("LpNormalization", ["X"], ["Y"], axis=-1, p=p)
+        x = np.array([[magnitude, -magnitude], [0.0, 0.0]], dtype=np.float32)
+        (got,) = ReferenceEvaluator(node).run(None, {"X": x})
+        expected = np.array(
+            [[expected_value, -expected_value], [0.0, 0.0]], dtype=np.float32
+        )
+        assert_allclose(got, expected, rtol=2e-7, atol=0)
+
+    @pytest.mark.parametrize("p", [1, 2])
+    def test_lp_normalization_preserves_nonfinite_behavior(self, p: int) -> None:
+        node = make_node("LpNormalization", ["X"], ["Y"], axis=-1, p=p)
+        x = np.array([[np.inf, 1.0], [np.nan, 1.0]], dtype=np.float32)
+        with np.errstate(invalid="ignore"):
+            (got,) = ReferenceEvaluator(node).run(None, {"X": x})
+        assert np.isnan(got[0, 0])
+        assert got[0, 1] == 0
+        assert np.isnan(got[1]).all()
+
+    @pytest.mark.parametrize(
         ("shape", "size", "dtype", "elem_type"),
         [
             ((2, 3, 2, 2), 3, np.float32, TensorProto.FLOAT),


### PR DESCRIPTION
## Summary

- normalize a finite vector in a scale-free range before computing its L1 or L2 norm
- preserve the specified all-zero result and the prior behavior for nonfinite inputs
- add direct regressions for finite overflow and underflow cases

## Problem

`LpNormalization` currently forms `sum(abs(x))` or `sum(abs(x) ** 2)`
in the input's numerical range. Intermediate overflow or underflow therefore
turns ordinary finite normalized outputs into zeros.

Examples in float32:

| p | input | expected | current ReferenceEvaluator |
| ---: | --- | --- | --- |
| 1 | `[3e38, -3e38]` | `[0.5, -0.5]` | `[0, -0]` |
| 2 | `[1e30, -1e30]` | `[1/sqrt(2), -1/sqrt(2)]` | `[0, -0]` |
| 2 | `[1e-30, -1e-30]` | `[1/sqrt(2), -1/sqrt(2)]` | `[0, 0]` |

All input components and all expected outputs are representable. These are
violations of the scale invariance of normalization, not tolerance effects.

## Correction

The implementation first divides each normalization slice by its maximum
absolute finite component, computes the norm of that scaled slice, and divides
again. This avoids needing to represent either powers or the norm in the
original range.

The max reduction uses `initial=0`, so zero-extent axes retain their existing
empty output. A scale of zero still returns zeros. Nonfinite scales bypass the
range rescaling, retaining the previous `Inf`/`NaN` behavior.

## Validation

- full `tests/python/reference_evaluator_test.py`: 465 passed, 4 skipped
- mutation back to the previous implementation: all 3 finite-extreme regression cases fail
- direct nonfinite compatibility checks for p=1 and p=2
- `ruff check`: clean
- `ruff format --check`: clean
- `git diff --check`: clean

An
[independent reproducer](https://github.com/kadyrbekovhamit-cyber/gero-onnx-lpnormalization-range-audit)
also checks float32 and float64, positive and negative axis syntax,
analytical equal-pair results, and ordinary/zero controls. ONNX Runtime CPU
1.29.0 has the same finite-range defect; that runtime implementation is being
handled separately rather than used as the oracle for this PR.

Signed-off-by: kadyrbekovhamit-cyber <288885044+kadyrbekovhamit-cyber@users.noreply.github.com>
