### PR TITLE
Fix ReferenceEvaluator ReduceMean finite-range overflow

### DIFF
--- a/onnx/reference/ops/op_reduce_mean.py
+++ b/onnx/reference/ops/op_reduce_mean.py
@@ -8,10 +8,31 @@ import numpy as np
 from onnx.reference.ops._op import OpRunReduceNumpy
 
 
+def _mean(data, axes, keepdims):
+    if data.size == 0 or not np.issubdtype(data.dtype, np.inexact):
+        return np.mean(data, axis=axes, keepdims=keepdims, dtype=data.dtype)
+
+    # Scaling keeps the intermediate sum in range without changing the mean.
+    # Use one as the scale for zero and non-finite slices so their prior NumPy
+    # semantics are preserved.
+    scale = np.max(np.abs(data), axis=axes, keepdims=True)
+    safe_scale = np.where(np.isfinite(scale) & (scale != 0), scale, 1)
+    result = (
+        np.mean(
+            data / safe_scale,
+            axis=axes,
+            keepdims=True,
+            dtype=data.dtype,
+        )
+        * safe_scale
+    )
+    return result if keepdims else np.squeeze(result, axis=axes)
+
+
 class ReduceMean_1(OpRunReduceNumpy):
     def _run(self, data, axes=None, keepdims=None):
         axes = tuple(axes) if axes is not None else None
-        res = np.mean(data, axis=axes, keepdims=keepdims, dtype=data.dtype)
+        res = _mean(data, axes=axes, keepdims=keepdims)
         if keepdims == 0 and not isinstance(res, np.ndarray):
             # The runtime must return a numpy array of a single float.
             res = np.array(res)
@@ -24,7 +45,7 @@ class ReduceMean_18(OpRunReduceNumpy):
 
         keepdims = keepdims != 0
         try:
-            res = np.mean(data, axis=axes, keepdims=keepdims, dtype=data.dtype)
+            res = _mean(data, axes=axes, keepdims=keepdims)
             if keepdims == 0 and not isinstance(res, np.ndarray):
                 # The runtime must return a numpy array of a single float.
                 res = np.array(res)

--- a/tests/python/reference_evaluator_test.py
+++ b/tests/python/reference_evaluator_test.py
@@ -3274,6 +3274,36 @@ class TestReferenceEvaluator:
         assert got.shape == (1, 1)
         assert got[0, 0] == 1
 
+    def test_reduce_mean_preserves_finite_range(self):
+        for opset in (17, 18):
+            for dtype, tensor_type, magnitude in (
+                (np.float32, TensorProto.FLOAT, 3.0e38),
+                (np.float64, TensorProto.DOUBLE, 1.0e308),
+            ):
+                X = make_tensor_value_info("X", tensor_type, [2, 2])
+                Y = make_tensor_value_info("Y", tensor_type, [2])
+                inputs = [X]
+                node_inputs = ["X"]
+                if opset >= 18:
+                    axes = make_tensor_value_info("axes", TensorProto.INT64, [1])
+                    inputs.append(axes)
+                    node_inputs.append("axes")
+                    node = make_node("ReduceMean", node_inputs, ["Y"], keepdims=0)
+                else:
+                    node = make_node(
+                        "ReduceMean", node_inputs, ["Y"], axes=[1], keepdims=0
+                    )
+
+                graph = make_graph([node], "g", inputs, [Y])
+                model = make_model(graph, opset_imports=[make_opsetid("", opset)])
+                feeds = {"X": np.full((2, 2), magnitude, dtype=dtype)}
+                if opset >= 18:
+                    feeds["axes"] = np.array([1], dtype=np.int64)
+
+                got = ReferenceEvaluator(model).run(None, feeds)[0]
+                expected = np.full((2,), magnitude, dtype=dtype)
+                np.testing.assert_array_equal(got, expected)
+
     @staticmethod
     def _cdist_model(opset, reduce_op="ReduceSumSquare"):
         # subgraph


### PR DESCRIPTION
### Description

The Python ReferenceEvaluator currently calls `np.mean(..., dtype=data.dtype)`. NumPy forms the sum in that dtype, so finite equal inputs can overflow even though their mean is finite and exactly equal to each input.

Examples on the current implementation:

| input | expected mean | current |
| --- | ---: | ---: |
| float32 `[3e38, 3e38]` | `3e38` | `inf` |
| float64 `[1e308, 1e308]` | `1e308` | `inf` |

This change scales each floating or complex reduction slice by its largest absolute value, evaluates the mean of the scaled slice, and restores the scale. Zero and non-finite slices use a safe scale of one so prior NumPy behavior is preserved. Empty and non-inexact inputs retain the existing direct path.

### Motivation and Context

The arithmetic mean is homogeneous and bounded by the largest absolute input. A finite set of identical representable values should not acquire an infinite mean solely because of an avoidable intermediate sum.

The same finite-range failure is reproducible in the released ONNX Runtime CPU provider; a separate Runtime correction will cover its distinct implementation.

### Testing

- Added float32 and float64 regressions for opsets 17 and 18.
- `tests/python/reference_evaluator_test.py`: 461 passed, 4 skipped.
- Additional local compatibility matrix: 41 checks covering float16/float32/float64, multiple axis combinations, both `keepdims` values, zero, non-finite and empty inputs.
- Mutation check: restoring the former direct `np.mean` call makes the new regression fail with `inf` instead of the finite expected output.
- Ruff check and format checks pass.

